### PR TITLE
✨ STUDIO: Complete Global Shortcuts & Frame Stepping

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -1,67 +1,73 @@
-# Helios Studio Context
+# Context: Studio Domain
 
 ## A. Architecture
 
-Helios Studio is a browser-based development environment for creating video compositions. It is built as a Vite-based React application that runs locally.
+The Studio is a browser-based development environment (IDE) for Helios video compositions. It allows users to:
+1.  **Preview** compositions in real-time.
+2.  **Edit** input props via a visual editor.
+3.  **Render** videos to disk (via backend integration).
+4.  **Manage** rendering jobs and assets.
 
-### Components
-1.  **CLI Wrapper**: The `studio` command (in `@helios-project/cli`) launches the Studio. It injects the `HELIOS_PROJECT_ROOT` environment variable to point Studio to the user's project directory.
-2.  **Dev Server (Vite)**: serves the Studio UI and provides a backend API via `vite-plugin-studio-api.ts`.
-3.  **Backend API**:
-    -   Discovery: Scans the file system for compositions (`composition.html`) and assets.
-    -   Rendering: Manages `Renderer` instances to export video files. Supports job cancellation and deletion.
-4.  **Frontend (React)**:
-    -   **StudioContext**: Centralized state management for player, active composition, and render jobs.
-    -   **HeliosPlayer**: The `<helios-player>` web component is used for previewing compositions.
+It consists of:
+-   **CLI**: `@helios-project/cli` (via `npx helios studio`) starts the development server.
+-   **Server**: A Vite development server with custom middleware (`vite-plugin-studio-api`) that serves the UI and handles API requests (rendering, file listing).
+-   **UI**: A React-based Single Page Application (SPA) that consumes the `Helios` core and player.
 
 ## B. File Tree
 
 ```
 packages/studio/
+├── bin/
+│   └── studio.js          # CLI entry point
 ├── src/
-│   ├── components/
-│   │   ├── AssetsPanel/
-│   │   ├── PropsEditor/
-│   │   ├── RendersPanel/
-│   │   ├── Stage/
-│   │   └── Timeline/
+│   ├── cli.ts             # CLI implementation (starts Vite server)
+│   ├── server.ts          # Vite server configuration & API middleware
+│   ├── vite-plugin-studio-api.ts # Backend API implementation
+│   ├── render-manager.ts  # Render job queue & FFmpeg management
+│   ├── main.tsx           # React entry point
+│   ├── App.tsx            # Main application layout & global shortcuts
 │   ├── context/
-│   │   └── StudioContext.tsx
-│   ├── server/
-│   │   ├── discovery.ts
-│   │   └── render-manager.ts
-│   ├── App.tsx
-│   └── main.tsx
-├── vite-plugin-studio-api.ts
-├── vite.config.ts
+│   │   └── StudioContext.tsx # Global state (active composition, player state, render jobs)
+│   ├── components/
+│   │   ├── Layout/        # Layout components (Panel, StudioLayout)
+│   │   ├── Controls/      # Playback controls (Play, Pause, Step, Loop)
+│   │   ├── Stage/         # Canvas/Player wrapper with Zoom/Pan
+│   │   ├── Timeline.tsx   # Scrubbable timeline with In/Out markers
+│   │   ├── PropsEditor.tsx# JSON/Form editor for input props
+│   │   ├── CompositionSwitcher.tsx # Cmd+K switcher
+│   │   ├── RendersPanel/  # Render job list & configuration
+│   │   └── AssetsPanel/   # Asset browser
+│   └── hooks/
+│       └── useKeyboardShortcut.ts
 └── package.json
 ```
 
 ## C. CLI Interface
 
-The Studio is typically launched via the CLI package:
-
+Run the studio from your project root:
 ```bash
 npx helios studio
 ```
-
--   **Environment Variables**:
-    -   `HELIOS_PROJECT_ROOT`: Specifies the root directory to scan for compositions. Defaults to `process.cwd()` if set by the CLI, otherwise internal examples.
+This starts the local development server (default port 5173) and opens the browser.
+Env vars:
+- `HELIOS_PROJECT_ROOT`: Path to the project root (default: current working directory).
 
 ## D. UI Components
 
--   **Stage**: The central preview area containing the `<helios-player>`. Supports pan/zoom and resolution visualization.
--   **Timeline**: Provides playback controls (Play, Pause, Scrub), time display, and range markers (In/Out points).
--   **Props Editor**: A dynamic form/JSON editor that allows users to modify the `inputProps` passed to the composition in real-time.
--   **Renders Panel**: Displays a list of active and completed render jobs with progress bars. Supports cancelling active jobs and deleting completed/failed jobs.
--   **Assets Panel**: Lists available assets (images, video, audio) found in the project.
--   **Render Configuration**: UI controls for setting output resolution, framerate, video bitrate, codec, and format.
+-   **Stage**: The main preview area. Wraps `<helios-player>`. Supports Pan, Zoom, Transparency Grid, and Resolution presets.
+-   **Timeline**: Shows current playback position. Supports scrubbing, In/Out point setting (I/O keys), and frame-accurate seeking.
+-   **PlaybackControls**: Play/Pause, Rewind, Previous/Next Frame (< / >), Loop, and Playback Speed.
+-   **PropsEditor**: Auto-generates form inputs based on the composition's `inputProps`. Supports rich JSON editing.
+-   **Sidebar**:
+    -   **Assets**: Lists image/video assets in the project.
+    -   **Renders**: Configures render settings (Mode, Bitrate, Codec), starts render jobs, and lists job status (Queued, Rendering, Done, Failed).
+-   **CompositionSwitcher**: A global command palette (Cmd+K) to switch between detected compositions.
 
 ## E. Integration
 
--   **Core**: Studio does not directly import Core; instead, it serves compositions that use Core.
--   **Player**: Studio wraps `@helios-project/player` (`<helios-player>`) to handle composition playback and state synchronization.
--   **Renderer**: Studio's backend (`render-manager.ts`) imports `@helios-project/renderer` to execute video rendering tasks.
-    -   **Data Flow**: UI -> `StudioContext` -> `POST /api/render` -> `render-manager` -> `Renderer`.
-    -   **Input Props**: Studio injects `inputProps` into the render job, which the Renderer injects into the browser context.
-    -   **Job Management**: `StudioContext` exposes `cancelRender` and `deleteRender` methods which call `POST /api/jobs/:id/cancel` and `DELETE /api/jobs/:id`.
+-   **Core**: Consumes `Helios` types and logic.
+-   **Player**: Embeds `<helios-player>` web component. Controls it via `HeliosController`.
+-   **Renderer**: The backend (`render-manager.ts`) uses `@helios-project/renderer` to execute render jobs using FFmpeg or Headless Chrome.
+-   **Communication**:
+    -   **Frontend -> Backend**: HTTP calls to `/api/assets`, `/api/compositions`, `/api/render`.
+    -   **Backend -> Frontend**: Vite HMR for code updates; Polling for render job status.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,5 +1,8 @@
 # Studio Progress Log
 
+## STUDIO v0.22.0
+- ✅ Completed: Global Shortcuts & Frame Stepping - Added Shift+Arrow shortcuts (10-frame jump) and Prev/Next Frame buttons to the UI.
+
 ## STUDIO v0.21.0
 - ✅ Completed: Implement Render Job Management - Added ability to Cancel and Delete render jobs via UI and API, including aborting FFmpeg processes.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.21.0
+**Version**: 0.22.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.22.0] ✅ Completed: Global Shortcuts & Frame Stepping - Added Shift+Arrow shortcuts (10-frame jump) and Prev/Next Frame buttons to the UI.
 - [v0.21.0] ✅ Completed: Implement Render Job Management - Added ability to Cancel and Delete render jobs via UI and API, including aborting FFmpeg processes.
 - [v0.20.0] ✅ Completed: Pass inputProps to Render Job - Updated `StudioContext` and `render-manager` to forward `inputProps` from the player state to the backend and Renderer.
 - [v0.19.0] ✅ Completed: Hot Reload State Preservation - Implemented state restoration (frame, playback status) for `Stage` when HMR triggers a controller reload.

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -39,14 +39,16 @@ function AppContent() {
     }
   }, { ignoreInput: true, preventDefault: true });
 
-  useKeyboardShortcut('ArrowLeft', () => {
+  useKeyboardShortcut('ArrowLeft', (e) => {
     if (!controller) return;
-    controller.seek(Math.max(0, playerState.currentFrame - 1));
+    const amount = e.shiftKey ? 10 : 1;
+    controller.seek(Math.max(0, playerState.currentFrame - amount));
   }, { ignoreInput: true, preventDefault: true });
 
-  useKeyboardShortcut('ArrowRight', () => {
+  useKeyboardShortcut('ArrowRight', (e) => {
     if (!controller) return;
-    controller.seek(playerState.currentFrame + 1);
+    const amount = e.shiftKey ? 10 : 1;
+    controller.seek(playerState.currentFrame + amount);
   }, { ignoreInput: true, preventDefault: true });
 
   useKeyboardShortcut('Home', () => {

--- a/packages/studio/src/components/Controls/PlaybackControls.tsx
+++ b/packages/studio/src/components/Controls/PlaybackControls.tsx
@@ -32,6 +32,18 @@ export const PlaybackControls: React.FC = () => {
     }
   };
 
+  const handlePrevFrame = () => {
+    if (controller) {
+      controller.seek(Math.max(0, currentFrame - 1));
+    }
+  };
+
+  const handleNextFrame = () => {
+    if (controller) {
+      controller.seek(currentFrame + 1);
+    }
+  };
+
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
       <button
@@ -50,6 +62,21 @@ export const PlaybackControls: React.FC = () => {
         ⏮
       </button>
       <button
+        onClick={handlePrevFrame}
+        disabled={!controller}
+        title="Previous Frame (Left Arrow)"
+        style={{
+           cursor: controller ? 'pointer' : 'not-allowed',
+           padding: '4px 8px',
+           background: 'none',
+           border: '1px solid #444',
+           borderRadius: '4px',
+           color: 'white'
+        }}
+      >
+        {'<'}
+      </button>
+      <button
         onClick={handlePlayPause}
         disabled={!controller}
         title="Play / Pause (Space)"
@@ -64,6 +91,21 @@ export const PlaybackControls: React.FC = () => {
         }}
       >
         {isPlaying ? '❚❚' : '▶'}
+      </button>
+      <button
+        onClick={handleNextFrame}
+        disabled={!controller}
+        title="Next Frame (Right Arrow)"
+        style={{
+           cursor: controller ? 'pointer' : 'not-allowed',
+           padding: '4px 8px',
+           background: 'none',
+           border: '1px solid #444',
+           borderRadius: '4px',
+           color: 'white'
+        }}
+      >
+        {'>'}
       </button>
       <button
         onClick={toggleLoop}


### PR DESCRIPTION
Implemented missing global shortcuts for frame navigation (Shift+Arrows for 10-frame jump) and added explicit UI buttons for single-frame stepping (Previous/Next) to the Helios Studio playback controls. This addresses a usability gap identified in the 2025-02-12 plan.

---
*PR created automatically by Jules for task [17554818899996651074](https://jules.google.com/task/17554818899996651074) started by @BintzGavin*