### PR TITLE
✨ PLAYER: WebM Export Support

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -40,6 +40,7 @@ The component observes the following attributes:
 | `controls` | boolean | If present, shows the UI controls overlay. |
 | `export-mode` | string | `auto` (default), `canvas`, or `dom`. Controls the capture strategy. |
 | `canvas-selector`| string | CSS selector for the canvas element (default: `canvas`). Used in `canvas` mode. |
+| `export-format` | string | `mp4` (default) or `webm`. Output video format. |
 
 ## Keyboard Shortcuts
 | Key | Action |
@@ -54,7 +55,7 @@ The component observes the following attributes:
 ## Architecture
 - **Controllers**: Abstraction layer (`DirectController` vs `BridgeController`) to unify local and cross-origin interaction.
 - **Bridge**: Uses `postMessage` for communication. The child page uses `connectToParent(helios)` helper to establish connection.
-- **ClientSideExporter**: Modular export logic supporting WebCodecs (VideoEncoder, AudioEncoder) and DOM Snapshotting. Supports AAC audio mixing from `<audio>` elements.
+- **ClientSideExporter**: Modular export logic supporting WebCodecs (VideoEncoder, AudioEncoder) and DOM Snapshotting. Supports MP4 (H.264/AAC) and WebM (VP9/Opus) output.
 - **UI Locking**: Prevents race conditions by disabling playback controls and keyboard shortcuts during client-side export.
 - **Scrubber Logic**: Manages internal `isScrubbing` state to pause playback during interaction and prevent the update loop from overwriting the scrubber position. Supports both Mouse and Touch events for mobile compatibility.
 - **DOM Capture**: Robust implementation using `XMLSerializer`, SVG `<foreignObject>`, and asset inlining (stylesheets, images, backgrounds, CSS `url()` assets, and `<canvas>` snapshots) for high-fidelity HTML exports.

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.18.0
+- ✅ Completed: WebM Export - Implemented `export-format` attribute to support WebM (VP9/Opus) video export alongside MP4.
+
 ## PLAYER v0.17.1
 - ✅ Completed: Touch Support - Added touch event listeners to the scrubber to support smooth seeking on mobile devices.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: 0.17.1
+**Version**: 0.18.0
 
 # Status: PLAYER
 
@@ -19,11 +19,13 @@
 - Supports frame-by-frame navigation via `.` and `,` keys, and Shift modifier for 10-frame jumps.
 - Displays actionable error messages with "Dismiss" option for failed client-side exports.
 - Supports Volume and Mute controls via UI and Bridge.
-- **New**: Supports caption rendering overlay with toggleable "CC" button.
+- Supports caption rendering overlay with toggleable "CC" button.
+- **New**: Supports WebM (VP9/Opus) client-side export via `export-format` attribute.
 
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.18.0] ✅ Completed: WebM Export - Implemented `export-format` attribute to support WebM (VP9/Opus) video export alongside MP4.
 [v0.17.1] ✅ Completed: Touch Support - Added touch event listeners to the scrubber to support smooth seeking on mobile devices.
 [v0.17.0] ✅ Completed: Implement Captions - Added caption rendering overlay and "CC" toggle button to `<helios-player>`, leveraging `activeCaptions` from core state.
 [v0.16.0] ✅ Completed: Volume Controls - Implemented volume slider and mute button in UI, updated controllers and bridge protocol.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3637,6 +3637,17 @@
         "node": ">=20"
       }
     },
+    "node_modules/webm-muxer": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/webm-muxer/-/webm-muxer-5.1.4.tgz",
+      "integrity": "sha512-ditzgFVFbfqPaugkIr4mGhAdob5K9HY6Rzlh7TRsA368yA1sp/m5O7nQCcMLdgFDeNGtFPg8B+MeXLtpzKWX6Q==",
+      "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "^0.1.4",
+        "@types/wicg-file-system-access": "^2020.9.5"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
@@ -3767,7 +3778,8 @@
       "version": "0.5.1",
       "dependencies": {
         "@helios-project/core": "0.0.1",
-        "mp4-muxer": "^2.0.1"
+        "mp4-muxer": "^2.0.1",
+        "webm-muxer": "^5.1.4"
       },
       "devDependencies": {
         "jsdom": "^27.4.0",

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -60,6 +60,7 @@ The player will automatically attempt to access `window.helios` on the iframe's 
 | `controls` | Show the UI controls overlay. | `false` |
 | `export-mode` | Strategy for client-side export: `auto`, `canvas`, or `dom`. | `auto` |
 | `canvas-selector` | CSS selector for the canvas element (used in `canvas` export mode). | `canvas` |
+| `export-format` | Output video format: `mp4` (H.264/AAC) or `webm` (VP9/Opus). | `mp4` |
 
 ## Client-Side Export
 
@@ -75,5 +76,6 @@ Configuration:
 <helios-player
   src="..."
   export-mode="dom"
+  export-format="webm"
 ></helios-player>
 ```

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -283,7 +283,7 @@ export class HeliosPlayer extends HTMLElement {
     isScrubbing = false;
     wasPlayingBeforeScrub = false;
     static get observedAttributes() {
-        return ["src", "width", "height", "autoplay", "loop", "controls"];
+        return ["src", "width", "height", "autoplay", "loop", "controls", "export-format"];
     }
     constructor() {
         super();
@@ -722,6 +722,7 @@ export class HeliosPlayer extends HTMLElement {
         const exporter = new ClientSideExporter(this.controller, this.iframe);
         const exportMode = (this.getAttribute("export-mode") || "auto");
         const canvasSelector = this.getAttribute("canvas-selector") || "canvas";
+        const exportFormat = (this.getAttribute("export-format") || "mp4");
         try {
             await exporter.export({
                 onProgress: (p) => {
@@ -729,7 +730,8 @@ export class HeliosPlayer extends HTMLElement {
                 },
                 signal: this.abortController.signal,
                 mode: exportMode,
-                canvasSelector: canvasSelector
+                canvasSelector: canvasSelector,
+                format: exportFormat
             });
         }
         catch (e) {

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@helios-project/core": "0.0.1",
-    "mp4-muxer": "^2.0.1"
+    "mp4-muxer": "^2.0.1",
+    "webm-muxer": "^5.1.4"
   },
   "devDependencies": {
     "jsdom": "^27.4.0",

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -291,7 +291,7 @@ export class HeliosPlayer extends HTMLElement {
   private wasPlayingBeforeScrub: boolean = false;
 
   static get observedAttributes() {
-    return ["src", "width", "height", "autoplay", "loop", "controls"];
+    return ["src", "width", "height", "autoplay", "loop", "controls", "export-format"];
   }
 
   constructor() {
@@ -779,6 +779,7 @@ export class HeliosPlayer extends HTMLElement {
 
     const exportMode = (this.getAttribute("export-mode") || "auto") as "auto" | "canvas" | "dom";
     const canvasSelector = this.getAttribute("canvas-selector") || "canvas";
+    const exportFormat = (this.getAttribute("export-format") || "mp4") as "mp4" | "webm";
 
     try {
         await exporter.export({
@@ -787,7 +788,8 @@ export class HeliosPlayer extends HTMLElement {
             },
             signal: this.abortController.signal,
             mode: exportMode,
-            canvasSelector: canvasSelector
+            canvasSelector: canvasSelector,
+            format: exportFormat
         });
     } catch (e: any) {
         if (e.message !== "Export aborted") {


### PR DESCRIPTION
💡 **What**: Added support for exporting compositions as WebM (VP9/Opus) videos via client-side export.
🎯 **Why**: Users need royalty-free, open-standard video export options beyond MP4.
📊 **Impact**: Enables high-quality WebM export directly in the browser using the `export-format="webm"` attribute.
🔬 **Verification**: Verified with unit tests mocking VideoEncoder and webm-muxer. Run `npm test -w packages/player`.

Ref: `.sys/plans/2026-03-10-PLAYER-webm-export.md`

---
*PR created automatically by Jules for task [11625386818041283632](https://jules.google.com/task/11625386818041283632) started by @BintzGavin*