### PR TITLE
Implement Advanced Audio Mixing (Volume, Offset) in Renderer

### DIFF
--- a/packages/renderer/scripts/verify-advanced-audio.ts
+++ b/packages/renderer/scripts/verify-advanced-audio.ts
@@ -1,0 +1,104 @@
+import { DomStrategy } from '../src/strategies/DomStrategy';
+import { RendererOptions } from '../src/types';
+
+const assert = (condition: boolean, message: string) => {
+  if (!condition) {
+    throw new Error(`Assertion failed: ${message}`);
+  }
+};
+
+const runTest = () => {
+  console.log('Verifying Advanced Audio Arguments Generation...');
+
+  const outputPath = 'output.mp4';
+  const domStrategy = new DomStrategy();
+
+  // Test Case 1: Volume Control
+  // Track 1: Volume 0.5
+  const optionsVolume: RendererOptions = {
+    width: 1920, height: 1080, fps: 30, durationInSeconds: 5,
+    audioTracks: [
+      { path: 'audio.mp3', volume: 0.5 }
+    ]
+  };
+
+  const argsVolume = domStrategy.getFFmpegArgs(optionsVolume, outputPath);
+  console.log('Testing Volume Control...');
+  // Expect: [1:a]aformat=channel_layouts=stereo,volume=0.5[a0]
+  const filterGraphIdx = argsVolume.indexOf('-filter_complex');
+  assert(filterGraphIdx !== -1, 'Should include -filter_complex');
+  const filterGraphVolume = argsVolume[filterGraphIdx + 1];
+  assert(filterGraphVolume.includes('volume=0.5'), 'Should include volume filter');
+  assert(filterGraphVolume.includes('aformat=channel_layouts=stereo'), 'Should include stereo format');
+
+  // Test Case 2: Offset (Delay)
+  // Track 1: Offset 2s (Delay 2000ms)
+  const optionsDelay: RendererOptions = {
+    width: 1920, height: 1080, fps: 30, durationInSeconds: 5,
+    audioTracks: [
+      { path: 'audio.mp3', offset: 2 }
+    ]
+  };
+
+  const argsDelay = domStrategy.getFFmpegArgs(optionsDelay, outputPath);
+  console.log('Testing Audio Delay...');
+  const filterGraphIdxDelay = argsDelay.indexOf('-filter_complex');
+  assert(filterGraphIdxDelay !== -1, 'Should include -filter_complex');
+  const filterGraphDelay = argsDelay[filterGraphIdxDelay + 1];
+  assert(filterGraphDelay.includes('adelay=2000|2000'), 'Should include adelay filter');
+
+  // Test Case 3: StartFrame + Offset Interaction
+  // StartFrame = 30 (1s). Offset = 2s.
+  // Delay should be (2 - 1) * 1000 = 1000ms.
+  const optionsStartFrameDelay: RendererOptions = {
+    width: 1920, height: 1080, fps: 30, durationInSeconds: 5,
+    startFrame: 30,
+    audioTracks: [
+      { path: 'audio.mp3', offset: 2 }
+    ]
+  };
+
+  const argsSFDelay = domStrategy.getFFmpegArgs(optionsStartFrameDelay, outputPath);
+  console.log('Testing StartFrame + Delay...');
+  const filterGraphSFDelay = argsSFDelay[argsSFDelay.indexOf('-filter_complex') + 1];
+  assert(filterGraphSFDelay.includes('adelay=1000|1000'), `Should calculate correct relative delay (expected 1000, got graph: ${filterGraphSFDelay})`);
+
+  // Test Case 4: StartFrame > Offset (Seeking)
+  // StartFrame = 60 (2s). Offset = 1s.
+  // Delay = 0. Seek = 2 - 1 = 1s.
+  const optionsSFSeek: RendererOptions = {
+    width: 1920, height: 1080, fps: 30, durationInSeconds: 5,
+    startFrame: 60,
+    audioTracks: [
+      { path: 'audio.mp3', offset: 1 }
+    ]
+  };
+
+  const argsSFSeek = domStrategy.getFFmpegArgs(optionsSFSeek, outputPath);
+  console.log('Testing StartFrame + Seek...');
+  // Check for -ss 1 before -i audio.mp3
+  const inputIdx = argsSFSeek.indexOf('audio.mp3');
+  const ssIdx = argsSFSeek.lastIndexOf('-ss', inputIdx);
+  assert(ssIdx !== -1, 'Should include -ss before input');
+  assert(argsSFSeek[ssIdx + 1] === '1', 'Should include seek time 1');
+
+  // Test Case 5: Multiple Tracks (Mixing)
+  const optionsMix: RendererOptions = {
+    width: 1920, height: 1080, fps: 30, durationInSeconds: 5,
+    audioTracks: [
+      { path: 'music.mp3', volume: 0.5 },
+      { path: 'sfx.mp3', offset: 3 }
+    ]
+  };
+
+  const argsMix = domStrategy.getFFmpegArgs(optionsMix, outputPath);
+  console.log('Testing Mixing...');
+  const filterGraphMix = argsMix[argsMix.indexOf('-filter_complex') + 1];
+  assert(filterGraphMix.includes('volume=0.5'), 'Should include volume');
+  assert(filterGraphMix.includes('adelay=3000|3000'), 'Should include delay');
+  assert(filterGraphMix.includes('amix=inputs=2'), 'Should include amix');
+
+  console.log('✅ Advanced Audio Verification Passed!');
+};
+
+runTest();

--- a/packages/renderer/scripts/verify-audio-args.ts
+++ b/packages/renderer/scripts/verify-audio-args.ts
@@ -38,7 +38,8 @@ const runTest = () => {
   assert(argsDomWithAudio.includes('/path/to/audio.mp3'), 'DomStrategy should include audio path');
   assert(argsDomWithAudio.includes('-c:a'), 'DomStrategy should include -c:a');
   assert(argsDomWithAudio.includes('-map'), 'DomStrategy should include -map');
-  assert(argsDomWithAudio.includes('1:a'), 'DomStrategy should map audio stream 1:a');
+  // With complex filter implementation, we map [a0] instead of 1:a directly
+  assert(argsDomWithAudio.includes('[a0]'), 'DomStrategy should map audio stream [a0]');
   assert(argsDomWithAudio.includes('-t'), 'DomStrategy should include -t');
   assert(argsDomWithAudio.includes('5'), 'DomStrategy should include duration 5');
   assert(!argsDomWithAudio.includes('-shortest'), 'DomStrategy should NOT include -shortest');
@@ -52,7 +53,7 @@ const runTest = () => {
 
 
   // Test CanvasStrategy
-  const canvasStrategy = new CanvasStrategy();
+  const canvasStrategy = new CanvasStrategy(optionsWithAudio);
 
   // Case 3: CanvasStrategy with Audio
   const argsCanvasWithAudio = canvasStrategy.getFFmpegArgs(optionsWithAudio, outputPath);
@@ -61,7 +62,8 @@ const runTest = () => {
   assert(argsCanvasWithAudio.includes('/path/to/audio.mp3'), 'CanvasStrategy should include audio path');
   assert(argsCanvasWithAudio.includes('-c:a'), 'CanvasStrategy should include -c:a');
   assert(argsCanvasWithAudio.includes('-map'), 'CanvasStrategy should include -map');
-  assert(argsCanvasWithAudio.includes('1:a'), 'CanvasStrategy should map audio stream 1:a');
+  // With complex filter implementation, we map [a0] instead of 1:a directly
+  assert(argsCanvasWithAudio.includes('[a0]'), 'CanvasStrategy should map audio stream [a0]');
   assert(argsCanvasWithAudio.includes('-t'), 'CanvasStrategy should include -t');
   assert(argsCanvasWithAudio.includes('5'), 'CanvasStrategy should include duration 5');
   assert(!argsCanvasWithAudio.includes('-shortest'), 'CanvasStrategy should NOT include -shortest');

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -1,3 +1,28 @@
+export interface AudioTrackConfig {
+  /**
+   * Path to the audio file.
+   */
+  path: string;
+
+  /**
+   * Volume multiplier (0.0 to 1.0).
+   * Defaults to 1.0.
+   */
+  volume?: number;
+
+  /**
+   * Time in seconds when this track should start in the composition.
+   * Defaults to 0.
+   */
+  offset?: number;
+
+  /**
+   * Time in seconds to seek into the source file before playing.
+   * Defaults to 0.
+   */
+  seek?: number;
+}
+
 export interface RendererOptions {
   width: number;
   height: number;
@@ -25,10 +50,11 @@ export interface RendererOptions {
   audioFilePath?: string;
 
   /**
-   * List of paths to audio files to include in the output video.
+   * List of audio tracks to include in the output video.
+   * Can be a simple file path string or a configuration object.
    * If provided, these will be mixed with the video.
    */
-  audioTracks?: string[];
+  audioTracks?: (string | AudioTrackConfig)[];
 
   /**
    * The video codec to use. Defaults to 'libx264'.

--- a/packages/renderer/src/utils/FFmpegBuilder.ts
+++ b/packages/renderer/src/utils/FFmpegBuilder.ts
@@ -1,48 +1,101 @@
-import { RendererOptions } from '../types';
+import { RendererOptions, AudioTrackConfig } from '../types';
 
 export class FFmpegBuilder {
   static getArgs(options: RendererOptions, outputPath: string, videoInputArgs: string[]): string[] {
-    const audioInputs: string[] = [];
+    // 1. Normalize inputs into AudioTrackConfig objects
+    const tracks: AudioTrackConfig[] = [];
 
-    // Prioritize audioTracks if present, otherwise use audioFilePath
     if (options.audioTracks && options.audioTracks.length > 0) {
-      audioInputs.push(...options.audioTracks);
+      options.audioTracks.forEach(track => {
+        if (typeof track === 'string') {
+          tracks.push({ path: track, volume: 1.0, offset: 0, seek: 0 });
+        } else {
+          tracks.push({
+            path: track.path,
+            volume: track.volume ?? 1.0,
+            offset: track.offset ?? 0,
+            seek: track.seek ?? 0
+          });
+        }
+      });
     } else if (options.audioFilePath) {
-      audioInputs.push(options.audioFilePath);
+      tracks.push({ path: options.audioFilePath, volume: 1.0, offset: 0, seek: 0 });
     }
 
-    let audioInputArgs: string[] = [];
+    const audioInputArgs: string[] = [];
+    const audioFilterChains: string[] = [];
+    const renderStartTime = (options.startFrame || 0) / options.fps;
 
-    // Add audio inputs with seek time if needed
-    for (const audioPath of audioInputs) {
-      if (options.startFrame && options.startFrame > 0) {
-        const startTime = options.startFrame / options.fps;
-        audioInputArgs.push('-ss', startTime.toString(), '-i', audioPath);
+    // 2. Process each track to generate inputs and filters
+    tracks.forEach((track, index) => {
+      // Calculate effective seek and delay relative to render start
+      const globalStart = track.offset || 0;
+      let delayMs = 0;
+      let inputSeek = track.seek || 0;
+
+      if (globalStart > renderStartTime) {
+        // Track starts after the render window begins
+        // We need to delay the audio start relative to the video start
+        delayMs = (globalStart - renderStartTime) * 1000;
+        // inputSeek remains as configured (start playing from user's seek point)
       } else {
-        audioInputArgs.push('-i', audioPath);
+        // Track starts before or at the render window
+        // We need to skip the part of the track that happened before renderStart
+        delayMs = 0;
+        inputSeek = (track.seek || 0) + (renderStartTime - globalStart);
       }
-    }
+
+      // Add input arguments
+      // Note: -ss before -i for fast seeking
+      audioInputArgs.push('-ss', inputSeek.toString(), '-i', track.path);
+
+      // Build filter chain for this input
+      // Input index is index + 1 (since 0 is video)
+      const inputId = `${index + 1}:a`;
+      const outputLabel = `a${index}`;
+      const filters: string[] = [];
+
+      // Always force stereo to ensure channel consistency for mixing and delay
+      filters.push('aformat=channel_layouts=stereo');
+
+      if (delayMs > 0) {
+        // Use adelay. We assume stereo (2 channels) due to aformat.
+        // Format: adelay=L|R. We apply same delay to both.
+        filters.push(`adelay=${delayMs}|${delayMs}`);
+      }
+
+      if (track.volume !== undefined && track.volume !== 1.0) {
+        filters.push(`volume=${track.volume}`);
+      }
+
+      // Construct the chain: [in]filter,filter[out]
+      audioFilterChains.push(`[${inputId}]${filters.join(',')}[${outputLabel}]`);
+    });
 
     let audioOutputArgs: string[] = [];
-    if (audioInputs.length > 0) {
+    if (tracks.length > 0) {
       // Common audio encoding args
       audioOutputArgs.push('-c:a', 'aac', '-t', options.durationInSeconds.toString());
 
-      if (audioInputs.length === 1) {
-        // Map the single audio stream
-        // 0:v is video, 1:a is audio (since video input is index 0, and we have 1 audio input at index 1)
-        audioOutputArgs.push('-map', '0:v', '-map', '1:a');
+      if (tracks.length === 1) {
+        // Single track: Just map the processed stream
+        const filterGraph = audioFilterChains[0];
+        audioOutputArgs.push(
+          '-filter_complex', filterGraph,
+          '-map', '0:v',
+          '-map', '[a0]'
+        );
       } else {
-        // Mix multiple audio streams
-        // Inputs are 1, 2, ..., N (since 0 is video)
-        // amix filter: inputs=N:duration=longest
-        // Note: duration=longest makes sure we use the duration of the longest input,
-        // but we clamp it with -t anyway.
-        const numAudioInputs = audioInputs.length;
-        const filterComplex = `amix=inputs=${numAudioInputs}:duration=longest[aout]`;
+        // Multiple tracks: Mix them using amix
+        let filterGraph = audioFilterChains.join(';');
+
+        // Mix step: combine all [aX] outputs
+        const mixInputs = tracks.map((_, i) => `[a${i}]`).join('');
+        // inputs=N:duration=longest
+        filterGraph += `;${mixInputs}amix=inputs=${tracks.length}:duration=longest[aout]`;
 
         audioOutputArgs.push(
-          '-filter_complex', filterComplex,
+          '-filter_complex', filterGraph,
           '-map', '0:v',
           '-map', '[aout]'
         );


### PR DESCRIPTION
Implemented advanced audio mixing capabilities in the Renderer package. This change updates `RendererOptions` to support per-track volume control and start time offsets/seeking. It refactors `FFmpegBuilder` to generate complex FFmpeg filter graphs using `adelay` for delays, `volume` for attenuation, and `aformat` to enforce stereo consistency. Added comprehensive verification scripts.

---
*PR created automatically by Jules for task [3726008847215868564](https://jules.google.com/task/3726008847215868564) started by @BintzGavin*