### PR TITLE
✨ CORE: Implement relative audio volume mixing in DomDriver

### DIFF
--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -7,7 +7,7 @@ The `packages/core` module is the heart of the Helios system. It implements a **
 - **Store**: The `Helios` class holds the state (`currentFrame`, `isPlaying`, `inputProps`, `playbackRate`, `volume`, `muted`, `activeCaptions`, `width`, `height`) using **Signals** (observable state primitives).
 - **Actions**: Methods like `play()`, `pause()`, `seek()`, `setInputProps()`, `setAudioVolume()`, `setCaptions()`, `setSize()` modify the state.
 - **Subscribers**: The UI (Studio, Player) and Drivers subscribe to state changes to update the DOM or other outputs.
-- **Drivers**: `TimeDriver` implementations (like `DomDriver`) synchronize the internal timeline with external systems (like WAAPI or HTMLMediaElements).
+- **Drivers**: `TimeDriver` implementations (like `DomDriver`) synchronize the internal timeline with external systems (like WAAPI or HTMLMediaElements). `DomDriver` supports relative audio mixing, preserving user-set volume levels while applying master scaling.
 - **Ticker**: A `Ticker` (RafTicker or TimeoutTicker) drives the frame advancement loop when playing.
 - **Schema**: An optional `HeliosSchema` defines the structure and types of `inputProps` for validation.
 

--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v1.24.0
+- ✅ Completed: Implement Relative Audio Mixing - Implemented relative volume and mute handling in `DomDriver`.
+
 ## CORE v1.23.0
 - ✅ Completed: Implement Resolution Awareness - Added `width`/`height` to state/options, `setSize` method, and `INVALID_RESOLUTION` error.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 1.23.0
+**Version**: 1.24.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance and Optimization
 - **Last Updated**: 2026-03-03
 
+[v1.24.0] ✅ Completed: Implement Relative Audio Mixing - Implemented relative volume and mute handling in `DomDriver`, allowing master volume/mute to mix with user-set values instead of overriding them.
 [v1.23.0] ✅ Completed: Implement Resolution Awareness - Added `width`/`height` to state/options, `setSize` method, and `INVALID_RESOLUTION` error.
 [v1.22.0] ✅ Completed: Expand Input Schema Validation - Added `minimum`, `maximum`, and `enum` constraints to `HeliosSchema` and updated `validateProps`.
 [v1.21.0] ✅ Completed: Implement Deterministic Randomness - Added `random` utility with Mulberry32 PRNG and string seeding support.


### PR DESCRIPTION
Implemented relative audio mixing in `DomDriver` using a `WeakMap` to track base volume/mute states. This allows the global Helios volume to act as a master fader, scaling individual track volumes instead of overwriting them. Also ensures master mute overrides track mute while preserving the original state.

---
*PR created automatically by Jules for task [6122000928185014212](https://jules.google.com/task/6122000928185014212) started by @BintzGavin*