### PR TITLE
📋 RENDERER: Fix SeekTimeDriver Initialization

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -63,3 +63,7 @@
 ## [2026-03-09] - FFmpeg Logic Duplication
 **Learning:** `CanvasStrategy` and `DomStrategy` contain nearly identical logic for generating FFmpeg arguments (especially for audio inputs and output flags). This duplication violates DRY and increases the risk of inconsistent behavior (e.g. one strategy supporting a feature while the other doesn't).
 **Action:** Centralize FFmpeg argument generation into a `FFmpegBuilder` or similar utility to ensure consistency and maintainability.
+
+## [2026-03-10] - SeekTimeDriver Initialization Timing
+**Learning:** `page.addInitScript` must be called *before* `page.goto` to affect the page load. `SeekTimeDriver.prepare` uses it, but `Renderer.ts` calls `prepare` after `goto`, rendering the polyfill ineffective for the initial state.
+**Action:** Split `TimeDriver` initialization into `init` (pre-load) and `prepare` (post-load) to handle script injection correctly.

--- a/.sys/plans/2026-03-10-RENDERER-SeekTimeDriver-Init.md
+++ b/.sys/plans/2026-03-10-RENDERER-SeekTimeDriver-Init.md
@@ -1,0 +1,69 @@
+# Context & Goal
+- **Objective**: Fix `SeekTimeDriver` initialization to ensure deterministic time polyfills are injected before page load.
+- **Trigger**: The current implementation of `SeekTimeDriver.prepare` calls `page.addInitScript` *after* `page.goto` (in `Renderer.ts`), which makes the polyfill ineffective for the initial page load.
+- **Impact**: Enables truly deterministic rendering for DOM-based animations (WAAPI, `requestAnimationFrame`, `Date.now`, `performance.now`).
+
+# File Inventory
+- **Create**: None
+- **Modify**:
+    - `packages/renderer/src/drivers/TimeDriver.ts`: Add `init(page: Page): Promise<void>` to the interface.
+    - `packages/renderer/src/drivers/SeekTimeDriver.ts`: Implement `init` by moving `page.addInitScript` logic from `prepare`.
+    - `packages/renderer/src/drivers/CdpTimeDriver.ts`: Implement empty `init` method.
+    - `packages/renderer/src/index.ts`: Update `Renderer` class to call `timeDriver.init(page)` before `page.goto`.
+    - `packages/renderer/tests/verify-seek-driver-determinism.ts`: Update test usage to call `driver.init(page)` before navigation.
+- **Read-Only**: `packages/renderer/src/strategies/DomStrategy.ts`
+
+# Implementation Spec
+- **Architecture**: Extend `TimeDriver` with a pre-load initialization hook (`init`) to handle script injection, separating it from post-load setup (`prepare`).
+- **Pseudo-Code**:
+    ```typescript
+    // In TimeDriver.ts
+    interface TimeDriver {
+      init(page: Page): Promise<void>; // New method
+      prepare(page: Page): Promise<void>; // Existing
+      setTime(page: Page, time: number): Promise<void>; // Existing
+    }
+
+    // In SeekTimeDriver.ts
+    class SeekTimeDriver implements TimeDriver {
+      async init(page: Page) {
+        // Move logic from prepare() here:
+        await page.addInitScript(() => { ... });
+      }
+      async prepare(page: Page) {
+        // Empty or lightweight check
+      }
+    }
+
+    // In CdpTimeDriver.ts
+    class CdpTimeDriver implements TimeDriver {
+      async init(page: Page) {
+        // No-op
+      }
+      async prepare(page: Page) {
+        // Existing CDP session setup
+      }
+    }
+
+    // In Renderer.ts (index.ts)
+    // ...
+    if (this.options.inputProps) { ... }
+
+    // Call init before navigation
+    await this.timeDriver.init(page);
+
+    await page.goto(compositionUrl, ...);
+
+    // ...
+    // Call prepare after navigation (as before)
+    await this.timeDriver.prepare(page);
+    await this.strategy.prepare(page);
+    ```
+
+- **Public API Changes**: `TimeDriver` interface gains `init` method. No changes to `RendererOptions` or external API.
+- **Dependencies**: None.
+
+# Test Plan
+- **Verification**: Run `npx ts-node packages/renderer/tests/verify-seek-driver-determinism.ts`.
+- **Success Criteria**: The test passes (exits with 0) and verifies that `Date.now()` / `performance.now()` values match the deterministic time set by the driver.
+- **Edge Cases**: Verify `CdpTimeDriver` still works by running `npx ts-node packages/renderer/tests/test-cdp-driver.ts`.


### PR DESCRIPTION
Created spec file /.sys/plans/2026-03-10-RENDERER-SeekTimeDriver-Init.md to address the issue of SeekTimeDriver polyfills being injected too late (post-load).

---
*PR created automatically by Jules for task [12452860466835147416](https://jules.google.com/task/12452860466835147416) started by @BintzGavin*