### PR TITLE
✨ RENDERER: SeekTimeDriver Initialization

### DIFF
--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,5 +1,8 @@
 # RENDERER Progress Log
 
+## RENDERER v1.19.1
+- ✅ Completed: SeekTimeDriver Initialization - Added `init(page)` to `TimeDriver` interface and updated `SeekTimeDriver` to inject polyfills before `page.goto`, ensuring deterministic time for `requestAnimationFrame` and `Date.now` from the first frame.
+
 ## RENDERER v1.19.0
 - ✅ Completed: H.264 WebCodecs Support - Updated `CanvasStrategy` to support `avc1` (H.264) intermediate codec by skipping IVF container and using raw Annex B format, enabling direct stream copy to FFmpeg for better performance.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.19.0
+**Version**: 1.19.1
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.19.1] ✅ Completed: SeekTimeDriver Initialization - Added `init(page)` to `TimeDriver` interface and updated `SeekTimeDriver` to inject polyfills before `page.goto`, ensuring deterministic time for `requestAnimationFrame` and `Date.now` from the first frame.
 - [1.19.0] ✅ Completed: H.264 WebCodecs Support - Updated `CanvasStrategy` to support `avc1` (H.264) intermediate codec by skipping IVF container and using raw Annex B format, enabling direct stream copy to FFmpeg for better performance.
 - [1.18.0] ✅ Completed: Audio Mixing - Added `audioTracks` to `RendererOptions` and implemented `FFmpegBuilder` to support mixing multiple audio tracks using the `amix` filter, enabling background music and voiceover mixing.
 - [1.17.0] ✅ Completed: Enable Transparent Canvas - Updated `CanvasStrategy` to infer transparency from `pixelFormat` (e.g., `yuva420p`) and configure `VideoEncoder` with `alpha: 'keep'`, enabling transparent video rendering in Canvas mode.

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -5,6 +5,10 @@ export class CdpTimeDriver implements TimeDriver {
   private client: CDPSession | null = null;
   private currentTime: number = 0;
 
+  async init(page: Page): Promise<void> {
+    // No-op for CdpTimeDriver
+  }
+
   async prepare(page: Page): Promise<void> {
     this.client = await page.context().newCDPSession(page);
     // Initialize virtual time policy to 'pause' to take control of the clock.

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -2,7 +2,7 @@ import { Page } from 'playwright';
 import { TimeDriver } from './TimeDriver';
 
 export class SeekTimeDriver implements TimeDriver {
-  async prepare(page: Page): Promise<void> {
+  async init(page: Page): Promise<void> {
     await page.addInitScript(() => {
       // Initialize virtual time
       (window as any).__HELIOS_VIRTUAL_TIME__ = 0;
@@ -26,6 +26,10 @@ export class SeekTimeDriver implements TimeDriver {
         });
       };
     });
+  }
+
+  async prepare(page: Page): Promise<void> {
+    // No-op for SeekTimeDriver, but required by interface
   }
 
   async setTime(page: Page, timeInSeconds: number): Promise<void> {

--- a/packages/renderer/src/drivers/TimeDriver.ts
+++ b/packages/renderer/src/drivers/TimeDriver.ts
@@ -2,7 +2,13 @@ import { Page } from 'playwright';
 
 export interface TimeDriver {
   /**
-   * Prepares the driver (e.g., setting up CDP session or initial overrides).
+   * Initialize the driver before navigation (e.g., injecting scripts).
+   * @param page The Playwright page instance.
+   */
+  init(page: Page): Promise<void>;
+
+  /**
+   * Prepares the driver after navigation (e.g., setting up CDP session or initial overrides).
    */
   prepare(page: Page): Promise<void>;
 

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -103,6 +103,9 @@ export class Renderer {
         await page.addInitScript(`window.__HELIOS_PROPS__ = ${serializedProps};`);
       }
 
+      console.log('Initializing time driver...');
+      await this.timeDriver.init(page);
+
       await page.goto(compositionUrl, { waitUntil: 'networkidle' });
       console.log('Page loaded.');
 

--- a/packages/renderer/tests/verify-seek-driver-determinism.ts
+++ b/packages/renderer/tests/verify-seek-driver-determinism.ts
@@ -8,7 +8,7 @@ async function verifyDeterminism() {
   const page = await browser.newPage();
 
   const driver = new SeekTimeDriver();
-  await driver.prepare(page);
+  await driver.init(page);
 
   // Define a simple animation page that logs performance.now()
   const htmlContent = `
@@ -41,6 +41,7 @@ async function verifyDeterminism() {
   `;
 
   await page.goto(`data:text/html,${encodeURIComponent(htmlContent)}`);
+  await driver.prepare(page);
 
   const fps = 30;
   const frameDuration = 1 / fps;


### PR DESCRIPTION
Introduced `init(page)` lifecycle method to `TimeDriver` and updated `SeekTimeDriver` to inject deterministic polyfills (`Date.now`, `performance.now`, `requestAnimationFrame`) before page navigation. This ensures that JavaScript-driven animations start with a deterministic time baseline from the very first frame, eliminating drift and jitter. Validated with `verify-seek-driver-determinism.ts` and `npm run render:canvas-example`.

---
*PR created automatically by Jules for task [2141824973175770481](https://jules.google.com/task/2141824973175770481) started by @BintzGavin*