### PR TITLE
📋 RENDERER: Enable Stream Copy in FFmpegBuilder

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -67,3 +67,7 @@
 ## [2026-03-10] - SeekTimeDriver Initialization Timing
 **Learning:** `page.addInitScript` must be called *before* `page.goto` to affect the page load. `SeekTimeDriver.prepare` uses it, but `Renderer.ts` calls `prepare` after `goto`, rendering the polyfill ineffective for the initial state.
 **Action:** Split `TimeDriver` initialization into `init` (pre-load) and `prepare` (post-load) to handle script injection correctly.
+
+## [2026-03-12] - FFmpegBuilder Stream Copy Limitation
+**Learning:** `FFmpegBuilder` forces encoding flags (`-pix_fmt`, etc.) even when `videoCodec` is set to `'copy'`, preventing efficient H.264 passthrough from WebCodecs.
+**Action:** Refactor `FFmpegBuilder` to conditionally omit incompatible flags when `videoCodec === 'copy'`.

--- a/.sys/plans/2026-03-12-RENDERER-Enable-Stream-Copy.md
+++ b/.sys/plans/2026-03-12-RENDERER-Enable-Stream-Copy.md
@@ -1,0 +1,38 @@
+#### 1. Context & Goal
+- **Objective**: Update `FFmpegBuilder` to support `videoCodec: 'copy'` (Stream Copy) by conditionally omitting incompatible encoding flags.
+- **Trigger**: Current `FFmpegBuilder` implementation blindly appends `-pix_fmt`, `-crf`, and `-b:v` even when the user requests `copy`, causing FFmpeg to fail or re-encode inefficiently.
+- **Impact**: Unlocks the "Dual-Path Architecture" promise of high-performance rendering by allowing H.264 streams from WebCodecs to be piped directly to the output container without CPU-intensive re-encoding.
+
+#### 2. File Inventory
+- **Modify**: `packages/renderer/src/utils/FFmpegBuilder.ts` (Add logic to skip encoding flags for `copy` codec)
+- **Create**: `packages/renderer/tests/verify-stream-copy.ts` (Unit test for FFmpeg args generation)
+- **Read-Only**: `packages/renderer/src/types.ts` (Reference for options)
+
+#### 3. Implementation Spec
+- **Architecture**:
+  - The `FFmpegBuilder` will act as a "smart builder" that respects the "Stream Copy" intent.
+  - When `options.videoCodec` is exactly `'copy'`, the builder switches to a "Passthrough Mode" for video arguments.
+- **Pseudo-Code**:
+  - IN `FFmpegBuilder.getArgs`:
+    - GET `videoCodec` from options (default to `libx264`).
+    - IF `videoCodec` IS `'copy'`:
+      - SET `encodingArgs` to `['-c:v', 'copy']`.
+      - DO NOT append `-pix_fmt`.
+      - DO NOT append `-crf`, `-preset`, or `-b:v`.
+      - KEEP `-movflags +faststart` (valid for MP4 container).
+    - ELSE:
+      - SET `encodingArgs` to `['-c:v', videoCodec]`.
+      - APPEND `-pix_fmt`, `-crf`, `-preset`, `-b:v` as per existing logic.
+    - RETURN combined arguments (including audio args).
+- **Public API Changes**: None (Existing `videoCodec` string option supports `'copy'` value).
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npx ts-node packages/renderer/tests/verify-stream-copy.ts`
+- **Success Criteria**:
+  - The test instantiates `FFmpegBuilder` with `{ videoCodec: 'copy' }`.
+  - The returned args array MUST contain `'-c:v', 'copy'`.
+  - The returned args array MUST NOT contain `'-pix_fmt'`, `'-crf'`, `'-preset'`, or `'-b:v'`.
+  - The test also instantiates with default options and confirms standard flags ARE present.
+- **Edge Cases**:
+  - Verify that `audioTracks` (audio mixing) still generates correct audio filters (audio is re-encoded to AAC by default, which is compatible with video stream copy).


### PR DESCRIPTION
Created a detailed specification to enable stream copying in `FFmpegBuilder`. This change will allow the renderer to bypass re-encoding when the input stream (e.g., H.264 from WebCodecs) matches the output container, significantly improving performance and reducing CPU usage. The plan includes strict architectural guidelines and a pseudo-code implementation spec.

---
*PR created automatically by Jules for task [10055952448815585445](https://jules.google.com/task/10055952448815585445) started by @BintzGavin*