### PR TITLE
✨ RENDERER: Configurable Audio Codecs

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -41,6 +41,8 @@ The `RendererOptions` interface controls the rendering process:
 - `pixelFormat`: Output pixel format (e.g., `'yuv420p'`, `'yuva420p'`).
 - `intermediateVideoCodec`: Codec for WebCodecs capture (e.g., `'avc1'`, `'vp9'`, `'av01'`).
 - `videoBitrate`: Target bitrate (e.g., `2500000`).
+- `audioCodec`: Output audio codec (e.g., `'aac'`, `'libvorbis'`).
+- `audioBitrate`: Output audio bitrate (e.g., `'192k'`).
 - `audioFilePath`: Path to background audio file.
 - `audioTracks`: Array of audio tracks for mixing.
 - `inputProps`: Object injected into the page as `window.__HELIOS_PROPS__`.

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,5 +1,8 @@
 # RENDERER Progress Log
 
+## RENDERER v1.21.0
+- ✅ Completed: Configurable Audio Codecs - Added `audioCodec` and `audioBitrate` to `RendererOptions` and updated `FFmpegBuilder` to support smart defaults (e.g., auto-switching to `libvorbis` for WebM) and custom configurations.
+
 ## RENDERER v1.20.0
 - ✅ Completed: Enable Stream Copy - Updated `FFmpegBuilder` to conditionally omit encoding flags (`-pix_fmt`, `-crf`, `-preset`) when `videoCodec` is `'copy'`, enabling efficient stream passthrough for H.264 WebCodecs.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.20.1
+**Version**: 1.21.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.21.0] ✅ Completed: Configurable Audio Codecs - Added `audioCodec` and `audioBitrate` to `RendererOptions` and updated `FFmpegBuilder` to support smart defaults (e.g., auto-switching to `libvorbis` for WebM) and custom configurations.
 - [1.20.1] ✅ Completed: Optimize Canvas Quality - Updated `CanvasStrategy` to auto-calculate intermediate bitrate based on resolution/FPS (e.g. ~100Mbps for 4K) and wait for fonts to load, ensuring high-quality output and no font glitches.
 - [1.20.0] ✅ Completed: Enable Stream Copy - Updated `FFmpegBuilder` to conditionally omit encoding flags (`-pix_fmt`, `-crf`, `-preset`) when `videoCodec` is `'copy'`, enabling efficient stream passthrough for H.264 WebCodecs.
 - [1.19.1] ✅ Completed: SeekTimeDriver Initialization - Added `init(page)` to `TimeDriver` interface and updated `SeekTimeDriver` to inject polyfills before `page.goto`, ensuring deterministic time for `requestAnimationFrame` and `Date.now` from the first frame.

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -57,6 +57,18 @@ export interface RendererOptions {
   audioTracks?: (string | AudioTrackConfig)[];
 
   /**
+   * The audio codec to use.
+   * Defaults to 'aac' (unless videoCodec implies WebM, then 'libvorbis').
+   */
+  audioCodec?: string;
+
+  /**
+   * The audio bitrate (e.g., '128k', '192k').
+   * If not provided, FFmpeg defaults will be used.
+   */
+  audioBitrate?: string;
+
+  /**
    * The video codec to use. Defaults to 'libx264'.
    */
   videoCodec?: string;

--- a/packages/renderer/src/utils/FFmpegBuilder.ts
+++ b/packages/renderer/src/utils/FFmpegBuilder.ts
@@ -74,8 +74,23 @@ export class FFmpegBuilder {
 
     let audioOutputArgs: string[] = [];
     if (tracks.length > 0) {
+      // Determine Audio Codec
+      let audioCodec = options.audioCodec;
+      if (!audioCodec) {
+        const videoCodec = options.videoCodec || 'libx264';
+        if (videoCodec.startsWith('libvpx')) {
+          audioCodec = 'libvorbis';
+        } else {
+          audioCodec = 'aac';
+        }
+      }
+
       // Common audio encoding args
-      audioOutputArgs.push('-c:a', 'aac', '-t', options.durationInSeconds.toString());
+      audioOutputArgs.push('-c:a', audioCodec, '-t', options.durationInSeconds.toString());
+
+      if (options.audioBitrate) {
+        audioOutputArgs.push('-b:a', options.audioBitrate);
+      }
 
       if (tracks.length === 1) {
         // Single track: Just map the processed stream

--- a/packages/renderer/tests/verify-audio-codecs.ts
+++ b/packages/renderer/tests/verify-audio-codecs.ts
@@ -1,0 +1,72 @@
+import { FFmpegBuilder } from '../src/utils/FFmpegBuilder';
+import { RendererOptions } from '../src/types';
+
+function runTests() {
+  console.log('Running Audio Codec Verification...');
+  let hasError = false;
+
+  const baseOptions: RendererOptions = {
+    width: 1920,
+    height: 1080,
+    fps: 30,
+    durationInSeconds: 1,
+    audioFilePath: 'audio.mp3', // Trigger audio logic
+    mode: 'canvas',
+  };
+
+  const dummyInputArgs = ['-f', 'image2pipe', '-i', '-'];
+  const outputPath = 'output.mp4';
+
+  // Test 1: Default (AAC)
+  console.log('\nTest 1: Default Audio Codec');
+  const args1 = FFmpegBuilder.getArgs(baseOptions, outputPath, dummyInputArgs);
+  if (!args1.includes('aac')) {
+     console.error('❌ Failed: Expected default audio codec to be aac');
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  // Test 2: Explicit Audio Codec
+  console.log('\nTest 2: Explicit Audio Codec (libopus)');
+  const options2 = { ...baseOptions, audioCodec: 'libopus' };
+  const args2 = FFmpegBuilder.getArgs(options2, outputPath, dummyInputArgs);
+  if (!args2.includes('libopus')) {
+     console.error('❌ Failed: Expected audio codec to be libopus');
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  // Test 3: WebM Default (libvorbis)
+  console.log('\nTest 3: WebM Default (libvpx implies libvorbis)');
+  const options3 = { ...baseOptions, videoCodec: 'libvpx-vp9' };
+  const args3 = FFmpegBuilder.getArgs(options3, 'output.webm', dummyInputArgs);
+  if (!args3.includes('libvorbis')) {
+     console.error('❌ Failed: Expected audio codec to be libvorbis when video is libvpx');
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  // Test 4: Audio Bitrate
+  console.log('\nTest 4: Audio Bitrate');
+  const options4 = { ...baseOptions, audioBitrate: '192k' };
+  const args4 = FFmpegBuilder.getArgs(options4, outputPath, dummyInputArgs);
+  if (!args4.includes('-b:a') || !args4.includes('192k')) {
+     console.error('❌ Failed: Expected -b:a 192k');
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  if (hasError) {
+    console.error('\n❌ Verification Failed.');
+    process.exit(1);
+  } else {
+    console.log('\n✅ All verification tests passed!');
+    process.exit(0);
+  }
+}
+
+runTests();


### PR DESCRIPTION
This change enables configurable audio codecs in the renderer, addressing the need for non-MP4 output formats like WebM. It adds `audioCodec` and `audioBitrate` to `RendererOptions` and implements intelligent defaulting in `FFmpegBuilder` (e.g., using `libvorbis` when the video codec suggests a WebM container).

Impact:
- Users can now specify audio codecs (e.g., 'libopus', 'libvorbis') and bitrates.
- WebM rendering is now fully supported with correct audio codec defaults.

Verification:
- Run `npx ts-node packages/renderer/tests/verify-audio-codecs.ts` to verify codec selection logic.

---
*PR created automatically by Jules for task [14401814007256622597](https://jules.google.com/task/14401814007256622597) started by @BintzGavin*