### PR TITLE
✨ PLAYER: Export Burn-In Captions

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -1,65 +1,69 @@
-# Context: PLAYER
+# Module Context: PLAYER
 
-## Overview
-The `@helios-project/player` package provides the `<helios-player>` Web Component, a drop-in UI for reviewing and exporting Helios compositions. It bridges the gap between the raw composition (in an iframe) and the user, providing playback controls, timeline scrubbing, and client-side export capabilities.
+## 1. Module Overview
+- **Package**: `@helios-project/player`
+- **Domain**: Web Component and Player UI
+- **Responsibility**: Renders the `<helios-player>` component, managing the preview iframe, UI controls, and communication bridge.
 
-## Architecture
-- **Web Component**: `<helios-player>` (Shadow DOM)
-- **Controller**: `HeliosController` (Interface for `DirectController` and `BridgeController`)
-- **Exporter**: `ClientSideExporter` (WebCodecs-based export, supports Canvas/DOM modes with asset inlining (CSS, Images, Canvas, Video), MP4/WebM formats, and audio mixing with volume control)
-- **Bridge**: `postMessage` protocol for cross-origin communication
+## 2. Key Components
 
-## Component Structure
-The Shadow DOM consists of:
-- **Overlay**: Status messages ("Connecting...", "Error") and retry button.
-- **Iframe**: The composition container (`sandbox="allow-scripts allow-same-origin"`).
-- **Captions**: Overlay container for rendering active captions.
-- **Controls**:
-  - Play/Pause button
-  - Volume/Mute controls
-  - CC (Captions) toggle
-  - Export button (cancels during export)
-  - Speed selector (0.25x - 2x)
-  - Scrubber (range input)
-  - Time display (Current / Total)
-  - Fullscreen toggle
+### A. Component Structure
+- **Shadow DOM**:
+  - `<iframe>`: Renders the user's composition (sandboxed).
+  - `.status-overlay`: Displays loading/error states.
+  - `.controls`: Overlay UI for playback (play, seek, volume, speed, fullscreen, captions, export).
+  - `.captions-container`: Overlay for rendering burn-in style captions during preview.
 
-## Events
-The component dispatches standard HTML5 Media Events:
-- `play`: Playback started.
-- `pause`: Playback paused.
-- `ended`: Playback reached the end.
-- `timeupdate`: Current frame changed.
-- `volumechange`: Volume or mute state changed.
-- `ratechange`: Playback rate changed.
-- `durationchange`: Duration changed.
+### B. Events (Dispatched by `<helios-player>`)
+- `play`: Fired when playback starts.
+- `pause`: Fired when playback pauses.
+- `ended`: Fired when playback reaches the end.
+- `timeupdate`: Fired when the current frame changes.
+- `volumechange`: Fired when volume or mute state changes.
+- `ratechange`: Fired when playback rate changes.
+- `durationchange`: Fired when duration changes.
 
-## Attributes
-| Attribute | Description | Default |
-|---|---|---|
-| `src` | URL of the composition page. | (Required) |
-| `width` | Width for aspect ratio. | - |
-| `height` | Height for aspect ratio. | - |
-| `autoplay` | Auto-play on connect. | `false` |
-| `loop` | Loop playback. | `false` |
-| `controls` | Show UI controls. | `false` |
-| `export-mode` | Export strategy (`auto`, `canvas`, `dom`). | `auto` |
-| `canvas-selector`| CSS selector for canvas capture. | `canvas` |
-| `export-format` | Export format (`mp4`, `webm`). | `mp4` |
+### C. Attributes
+- `src`: URL of the composition to load in the iframe.
+- `width`: Aspect ratio width.
+- `height`: Aspect ratio height.
+- `autoplay`: Auto-start playback on load.
+- `loop`: Loop playback.
+- `controls`: Show/hide default UI controls.
+- `export-mode`: `auto` | `canvas` | `dom` (default: `auto`).
+- `canvas-selector`: CSS selector for the canvas element (default: `canvas`).
+- `export-format`: `mp4` | `webm` (default: `mp4`).
 
-## Public API
-The `<helios-player>` element exposes the following properties:
-- `currentTime` (number): Current playback time in seconds.
-- `duration` (readonly number): Total duration in seconds.
-- `paused` (readonly boolean): Whether playback is paused.
-- `ended` (readonly boolean): Whether playback has finished.
-- `volume` (number): Audio volume (0.0 - 1.0).
-- `muted` (boolean): Audio mute state.
-- `playbackRate` (number): Playback speed.
-- `currentFrame` (number): Current frame index.
-- `fps` (readonly number): Frames per second.
+## 3. Interfaces & Public API
 
-Methods:
-- `play()`: Promise<void>
-- `pause()`: void
-- `getController()`: HeliosController | null
+### HeliosController
+```typescript
+interface HeliosController {
+  play(): void;
+  pause(): void;
+  seek(frame: number): void;
+  setAudioVolume(volume: number): void;
+  setAudioMuted(muted: boolean): void;
+  setPlaybackRate(rate: number): void;
+  setInputProps(props: Record<string, any>): void;
+  subscribe(callback: (state: any) => void): () => void;
+  getState(): any;
+  dispose(): void;
+  captureFrame(frame: number, options?: CaptureOptions): Promise<{ frame: VideoFrame, captions: CaptionCue[] } | null>;
+  getAudioTracks(): Promise<AudioAsset[]>;
+}
+```
+
+### Bridge Protocol
+- **Parent -> Iframe**:
+  - `HELIOS_CONNECT`, `HELIOS_PLAY`, `HELIOS_PAUSE`, `HELIOS_SEEK`
+  - `HELIOS_SET_VOLUME`, `HELIOS_SET_MUTED`, `HELIOS_SET_PLAYBACK_RATE`
+  - `HELIOS_SET_PROPS`, `HELIOS_CAPTURE_FRAME`, `HELIOS_GET_AUDIO_TRACKS`
+- **Iframe -> Parent**:
+  - `HELIOS_READY`, `HELIOS_STATE`
+  - `HELIOS_FRAME_DATA` (includes `bitmap` and `captions`)
+  - `HELIOS_AUDIO_DATA`
+
+## 4. Dependencies
+- **Internal**: `@helios-project/core` (types, `Helios` class for Direct mode).
+- **External**: `mp4-muxer`, `webm-muxer`.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -108,3 +108,7 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### RENDERER v1.20.1
 - ✅ Completed: Optimize Canvas Quality - Updated `CanvasStrategy` to auto-calculate intermediate bitrate based on resolution/FPS (e.g. ~100Mbps for 4K) and wait for fonts to load, ensuring high-quality output and no font glitches.
+
+
+### PLAYER v0.22.0
+- ✅ Completed: Export Burn-In Captions - Implemented caption rendering (burn-in) for client-side export using intermediate OffscreenCanvas.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: 0.21.0
+**Version**: v0.22.0
 
 # Status: PLAYER
 
@@ -28,6 +28,7 @@
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.22.0] ✅ Completed: Export Burn-In Captions - Implemented caption rendering (burn-in) for client-side export using intermediate OffscreenCanvas.
 [v0.21.0] ✅ Completed: Video Inlining - Implemented `inlineVideos` to capture `<video>` elements as images during client-side export, ensuring visual fidelity.
 [v0.20.1] ✅ Completed: Project Cleanup - Added explicit `vitest` dependency and removed obsolete plan file.
 [v0.20.0] ✅ Completed: Client Side Audio Volume - Updated exporter to respect `volume` and `muted` attributes of audio elements during client-side export.

--- a/packages/player/dist/bridge.js
+++ b/packages/player/dist/bridge.js
@@ -65,6 +65,8 @@ async function handleCaptureFrame(helios, data) {
     helios.seek(frame);
     // 2. Wait for render (double RAF to be safe and ensure paint)
     await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => r())));
+    const state = helios.getState();
+    const captions = state.activeCaptions || [];
     // 3. DOM Mode
     if (mode === 'dom') {
         try {
@@ -73,7 +75,8 @@ async function handleCaptureFrame(helios, data) {
                 type: 'HELIOS_FRAME_DATA',
                 frame,
                 success: true,
-                bitmap
+                bitmap,
+                captions
             }, '*', [bitmap]);
         }
         catch (e) {
@@ -105,7 +108,8 @@ async function handleCaptureFrame(helios, data) {
             type: 'HELIOS_FRAME_DATA',
             frame,
             success: true,
-            bitmap
+            bitmap,
+            captions
         }, '*', [bitmap]);
     }
     catch (e) {

--- a/packages/player/src/bridge.ts
+++ b/packages/player/src/bridge.ts
@@ -73,6 +73,9 @@ async function handleCaptureFrame(helios: Helios, data: any) {
     // 2. Wait for render (double RAF to be safe and ensure paint)
     await new Promise<void>(r => requestAnimationFrame(() => requestAnimationFrame(() => r())));
 
+    const state = helios.getState();
+    const captions = state.activeCaptions || [];
+
     // 3. DOM Mode
     if (mode === 'dom') {
         try {
@@ -81,7 +84,8 @@ async function handleCaptureFrame(helios: Helios, data: any) {
                 type: 'HELIOS_FRAME_DATA',
                 frame,
                 success: true,
-                bitmap
+                bitmap,
+                captions
             }, '*', [bitmap]);
         } catch (e: any) {
             window.parent.postMessage({
@@ -115,7 +119,8 @@ async function handleCaptureFrame(helios: Helios, data: any) {
             type: 'HELIOS_FRAME_DATA',
             frame,
             success: true,
-            bitmap
+            bitmap,
+            captions
         }, '*', [bitmap]);
     } catch (e: any) {
         window.parent.postMessage({


### PR DESCRIPTION
Implemented burn-in captions for client-side export by:
- Updating `HeliosController.captureFrame` to return `captions` alongside `VideoFrame`.
- Modifying `DirectController` and `BridgeController` to populate this data from `HeliosState.activeCaptions`.
- Updating `ClientSideExporter` to composite captions onto the video frame using an intermediate `OffscreenCanvas` (with DOM fallback) before encoding.
- Adding tests to verify the flow and updated interfaces.

---
*PR created automatically by Jules for task [7278273638331195655](https://jules.google.com/task/7278273638331195655) started by @BintzGavin*