### PR TITLE
✨ STUDIO: Snapshot Feature

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -39,7 +39,7 @@ The studio is launched via the `@helios-project/cli` package.
 - **PropsEditor**: JSON/Form editor for composition props.
 - **AssetsPanel**: Drag-and-drop asset management with rich previews for Video, Audio, and Fonts.
 - **RendersPanel**: Render job management (start, cancel, download).
-- **Stage**: Canvas/DOM preview area.
+- **Stage**: Canvas/DOM preview area with Pan/Zoom, Transparency Grid, and Snapshot controls.
 
 ## E. Integration
 - **Core**: Consumes `Helios` class for state management.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,5 +1,8 @@
 # Studio Progress Log
 
+## STUDIO v0.27.0
+- ✅ Completed: Snapshot - Implemented "Take Snapshot" feature in Stage Toolbar to capture and download current frame as PNG.
+
 ## STUDIO v0.26.0
 - ✅ Completed: Audio Controls - Added Volume slider and Mute button to Playback Controls, updating `StudioContext` to track audio state.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.26.0
+**Version**: 0.27.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.27.0] ✅ Completed: Snapshot - Implemented "Take Snapshot" feature in Stage Toolbar to capture and download current frame as PNG.
 - [v0.26.0] ✅ Completed: Audio Controls - Added Volume slider and Mute button to Playback Controls, updating `StudioContext` to track audio state.
 - [v0.25.0] ✅ Completed: Enhance Asset Previews - Implemented rich previews for video (hover-play), audio (click-play), and fonts (custom sample) in Assets Panel.
 - [v0.24.0] ✅ Completed: Scaffold Unit Tests - Added Vitest, JSDOM, and Testing Library infrastructure; implemented initial tests for Timeline component.

--- a/packages/studio/src/components/Stage/Stage.tsx
+++ b/packages/studio/src/components/Stage/Stage.tsx
@@ -13,7 +13,7 @@ interface HeliosPlayerElement extends HTMLElement {
 }
 
 export const Stage: React.FC<StageProps> = ({ src }) => {
-  const { setController, canvasSize, setCanvasSize, playerState, controller } = useStudio();
+  const { setController, canvasSize, setCanvasSize, playerState, controller, takeSnapshot } = useStudio();
   const playerRef = useRef<HeliosPlayerElement>(null);
 
   // State
@@ -156,6 +156,7 @@ export const Stage: React.FC<StageProps> = ({ src }) => {
             onToggleTransparent={() => setIsTransparent(!isTransparent)}
             canvasSize={canvasSize}
             onCanvasSizeChange={setCanvasSize}
+            onSnapshot={takeSnapshot}
         />
     </div>
   );

--- a/packages/studio/src/components/Stage/StageToolbar.tsx
+++ b/packages/studio/src/components/Stage/StageToolbar.tsx
@@ -8,6 +8,7 @@ interface StageToolbarProps {
   onToggleTransparent: () => void;
   canvasSize: { width: number; height: number };
   onCanvasSizeChange: (size: { width: number; height: number }) => void;
+  onSnapshot: () => void;
 }
 
 export const StageToolbar: React.FC<StageToolbarProps> = ({
@@ -17,7 +18,8 @@ export const StageToolbar: React.FC<StageToolbarProps> = ({
   isTransparent,
   onToggleTransparent,
   canvasSize,
-  onCanvasSizeChange
+  onCanvasSizeChange,
+  onSnapshot
 }) => {
   const styles = {
     container: {
@@ -153,6 +155,10 @@ export const StageToolbar: React.FC<StageToolbarProps> = ({
       <span style={styles.text}>{Math.round(zoom * 100)}%</span>
       <button style={styles.button} onClick={handleZoomIn} title="Zoom In">
         +
+      </button>
+      <div style={{ width: '1px', background: '#555', margin: '0 4px' }} />
+      <button style={styles.button} onClick={onSnapshot} title="Take Snapshot">
+        📷
       </button>
       <div style={{ width: '1px', background: '#555', margin: '0 4px' }} />
       <button


### PR DESCRIPTION
💡 **What**: Implemented a "Take Snapshot" feature in the Studio Stage.
🎯 **Why**: To allow users to instantly download the current frame as a PNG image for quick verification and sharing.
📊 **Impact**: Enables WYSIWYG verification of frames without running a full render job.
🔬 **Verification**:
- `npm run build` in `packages/studio` passed.
- `npm test` in `packages/studio` passed.
- Verified button visibility and clickability using Playwright script.

---
*PR created automatically by Jules for task [923016475028731035](https://jules.google.com/task/923016475028731035) started by @BintzGavin*