### PR TITLE
✨ PLAYER: Implement Input Props Attribute

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -33,6 +33,7 @@
 - `export-mode`: `auto` | `canvas` | `dom` (default: `auto`).
 - `canvas-selector`: CSS selector for the canvas element (default: `canvas`).
 - `export-format`: `mp4` | `webm` (default: `mp4`).
+- `input-props`: JSON string of dynamic properties to pass to the composition.
 
 ## 3. Interfaces & Public API
 

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,11 @@
 # PLAYER Progress Log
 
+## PLAYER v0.23.0
+- ✅ Completed: Implement Input Props - Implemented `input-props` attribute/property on `<helios-player>` to pass dynamic data to the composition controller.
+
+## PLAYER v0.22.0
+- ✅ Completed: Export Burn-In Captions - Implemented caption rendering (burn-in) for client-side export using intermediate OffscreenCanvas.
+
 ## PLAYER v0.21.0
 - ✅ Completed: Video Inlining - Implemented `inlineVideos` to capture `<video>` elements as images during client-side export, ensuring visual fidelity.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.22.0
+**Version**: v0.23.0
 
 # Status: PLAYER
 
@@ -23,11 +23,13 @@
 - Supports WebM (VP9/Opus) client-side export via `export-format` attribute.
 - Implements Standard Media API (play, pause, currentTime, events) for better interoperability.
 - Client-side audio export respects `volume` and `muted` properties of audio elements.
-- **New**: Client-side export (DOM mode) now inlines `<video>` elements as static images, ensuring they are visible in the exported output.
+- Client-side export (DOM mode) now inlines `<video>` elements as static images, ensuring they are visible in the exported output.
+- **New**: Supports declarative data binding via `input-props` attribute (JSON string) and property, enabling dynamic composition updates.
 
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.23.0] ✅ Completed: Implement Input Props - Implemented `input-props` attribute/property on `<helios-player>` to pass dynamic data to the composition controller.
 [v0.22.0] ✅ Completed: Export Burn-In Captions - Implemented caption rendering (burn-in) for client-side export using intermediate OffscreenCanvas.
 [v0.21.0] ✅ Completed: Video Inlining - Implemented `inlineVideos` to capture `<video>` elements as images during client-side export, ensuring visual fidelity.
 [v0.20.1] ✅ Completed: Project Cleanup - Added explicit `vitest` dependency and removed obsolete plan file.

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -26,6 +26,7 @@ export declare class HeliosPlayer extends HTMLElement {
     private isScrubbing;
     private wasPlayingBeforeScrub;
     private lastState;
+    private pendingProps;
     get currentTime(): number;
     set currentTime(val: number);
     get currentFrame(): number;
@@ -45,6 +46,8 @@ export declare class HeliosPlayer extends HTMLElement {
     static get observedAttributes(): string[];
     constructor();
     attributeChangedCallback(name: string, oldVal: string, newVal: string): void;
+    get inputProps(): Record<string, any> | null;
+    set inputProps(val: Record<string, any> | null);
     connectedCallback(): void;
     disconnectedCallback(): void;
     private setControlsDisabled;

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -806,4 +806,71 @@ describe('HeliosPlayer', () => {
         expect(spy).toHaveBeenCalled();
     });
   });
+
+  describe('Input Props', () => {
+    let mockController: any;
+
+    beforeEach(() => {
+        mockController = {
+            getState: vi.fn().mockReturnValue({ currentFrame: 0, duration: 10, fps: 30, isPlaying: false }),
+            play: vi.fn(),
+            pause: vi.fn(),
+            seek: vi.fn(),
+            setAudioVolume: vi.fn(),
+            setAudioMuted: vi.fn(),
+            setPlaybackRate: vi.fn(),
+            subscribe: vi.fn().mockReturnValue(() => {}),
+            dispose: vi.fn(),
+            setInputProps: vi.fn(),
+            captureFrame: vi.fn(),
+            getAudioTracks: vi.fn()
+        };
+        // Reset player pending props
+        player.inputProps = null;
+    });
+
+    it('should set input props via attribute', () => {
+        (player as any).setController(mockController);
+
+        const props = { text: 'Hello' };
+        player.setAttribute('input-props', JSON.stringify(props));
+
+        expect(mockController.setInputProps).toHaveBeenCalledWith(props);
+        expect(player.inputProps).toEqual(props);
+    });
+
+    it('should set input props via property', () => {
+        (player as any).setController(mockController);
+
+        const props = { text: 'World' };
+        player.inputProps = props;
+
+        expect(mockController.setInputProps).toHaveBeenCalledWith(props);
+        expect(player.inputProps).toEqual(props);
+    });
+
+    it('should store pending props if controller is not ready', () => {
+        const props = { text: 'Pending' };
+        player.inputProps = props;
+
+        expect(player.inputProps).toEqual(props);
+        // Controller not set yet
+
+        (player as any).setController(mockController);
+        expect(mockController.setInputProps).toHaveBeenCalledWith(props);
+    });
+
+    it('should handle invalid JSON in attribute', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        player.setAttribute('input-props', '{ invalid json }');
+
+        expect(warnSpy).toHaveBeenCalled();
+        expect(player.inputProps).toBeNull();
+        warnSpy.mockRestore();
+    });
+
+    it('should observe input-props', () => {
+        expect(HeliosPlayer.observedAttributes).toContain('input-props');
+    });
+  });
 });


### PR DESCRIPTION
Implemented `input-props` support in `<helios-player>`.
- Added `input-props` to `observedAttributes`.
- implemented logic to parse JSON from the attribute and pass it to the controller.
- Added a public `inputProps` getter/setter.
- Implemented `pendingProps` to handle cases where props are set before the controller is ready.
- Added comprehensive unit tests in `packages/player/src/index.test.ts`.
- Updated documentation.

---
*PR created automatically by Jules for task [6426105315507649770](https://jules.google.com/task/6426105315507649770) started by @BintzGavin*