### PR TITLE
✨ PLAYER: Implement Poster and Preload

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -10,6 +10,7 @@
 ### A. Component Structure
 - **Shadow DOM**:
   - `<iframe>`: Renders the user's composition (sandboxed).
+  - `.poster-container`: Overlay displaying custom preview image and play button (when `preload="none"`).
   - `.status-overlay`: Displays loading/error states.
   - `.controls`: Overlay UI for playback (play, seek, volume, speed, fullscreen, captions, export).
   - `.captions-container`: Overlay for rendering burn-in style captions during preview.
@@ -30,6 +31,8 @@
 - `autoplay`: Auto-start playback on load.
 - `loop`: Loop playback.
 - `controls`: Show/hide default UI controls.
+- `poster`: URL of the poster image to display before loading.
+- `preload`: `auto` | `none`. Defaults to `auto`. If `none`, defers iframe loading.
 - `export-mode`: `auto` | `canvas` | `dom` (default: `auto`).
 - `canvas-selector`: CSS selector for the canvas element (default: `canvas`).
 - `export-format`: `mp4` | `webm` (default: `mp4`).

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.24.0
+- ✅ Completed: Implement Poster and Preload - Implemented `poster` attribute for custom preview images and `preload` attribute to control loading behavior (including deferred loading with "Big Play Button").
+
 ## PLAYER v0.23.0
 - ✅ Completed: Implement Input Props - Implemented `input-props` attribute/property on `<helios-player>` to pass dynamic data to the composition controller.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.23.0
+**Version**: v0.24.0
 
 # Status: PLAYER
 
@@ -24,11 +24,13 @@
 - Implements Standard Media API (play, pause, currentTime, events) for better interoperability.
 - Client-side audio export respects `volume` and `muted` properties of audio elements.
 - Client-side export (DOM mode) now inlines `<video>` elements as static images, ensuring they are visible in the exported output.
-- **New**: Supports declarative data binding via `input-props` attribute (JSON string) and property, enabling dynamic composition updates.
+- Supports declarative data binding via `input-props` attribute (JSON string) and property, enabling dynamic composition updates.
+- **New**: Supports `poster` and `preload` attributes. `preload="none"` defers iframe loading until the user interacts with the new "Big Play Button".
 
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.24.0] ✅ Completed: Implement Poster and Preload - Implemented `poster` attribute for custom preview images and `preload` attribute to control loading behavior (including deferred loading with "Big Play Button").
 [v0.23.0] ✅ Completed: Implement Input Props - Implemented `input-props` attribute/property on `<helios-player>` to pass dynamic data to the composition controller.
 [v0.22.0] ✅ Completed: Export Burn-In Captions - Implemented caption rendering (burn-in) for client-side export using intermediate OffscreenCanvas.
 [v0.21.0] ✅ Completed: Video Inlining - Implemented `inlineVideos` to capture `<video>` elements as images during client-side export, ensuring visual fidelity.

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -17,6 +17,11 @@ export declare class HeliosPlayer extends HTMLElement {
     private captionsContainer;
     private ccBtn;
     private showCaptions;
+    private posterContainer;
+    private posterImage;
+    private bigPlayBtn;
+    private pendingSrc;
+    private isLoaded;
     private controller;
     private directHelios;
     private unsubscribe;
@@ -42,6 +47,7 @@ export declare class HeliosPlayer extends HTMLElement {
     set playbackRate(val: number);
     get fps(): number;
     play(): Promise<void>;
+    load(): void;
     pause(): void;
     static get observedAttributes(): string[];
     constructor();
@@ -50,6 +56,9 @@ export declare class HeliosPlayer extends HTMLElement {
     set inputProps(val: Record<string, any> | null);
     connectedCallback(): void;
     disconnectedCallback(): void;
+    private loadIframe;
+    private handleBigPlayClick;
+    private updatePosterVisibility;
     private setControlsDisabled;
     private lockPlaybackControls;
     private handleIframeLoad;


### PR DESCRIPTION
💡 **What**: Implemented `poster` and `preload` attributes for `<helios-player>`.
- `preload="none"` defers iframe loading until user interaction.
- `poster` displays a custom preview image and a "Big Play Button".
- Clicking the play button triggers loading and auto-starts playback.
- Updated `play()` method to handle deferred loading transparently.

🎯 **Why**: To improve initial page load performance when multiple players are present, and to provide better visual previews ("Click-to-Load").

📊 **Impact**: Reduces network and resource usage on initial load for pages with embedded players. Improves UX with custom thumbnails.

🔬 **Verification**:
- Added unit tests in `packages/player/src/index.test.ts` verifying attribute logic and interaction.
- Visually verified using Playwright script (`packages/player/verification/verify_poster.py`) confirming poster visibility and hiding behavior.
- Ran all tests: `npm run test -w packages/player`.

---
*PR created automatically by Jules for task [15513054299122570449](https://jules.google.com/task/15513054299122570449) started by @BintzGavin*