### PR TITLE
✨ CORE: Implement Dynamic Timing (setDuration, setFps)

### DIFF
--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -131,6 +131,10 @@ export enum HeliosErrorCode {
 
 ```typescript
 export class Helios {
+  // Constants (Getters)
+  public get duration(): number;
+  public get fps(): number;
+
   // Readonly Signals
   public get currentFrame(): ReadonlySignal<number>;
   public get isPlaying(): ReadonlySignal<boolean>;
@@ -155,6 +159,8 @@ export class Helios {
 
   // Actions
   public setSize(width: number, height: number): void;
+  public setDuration(seconds: number): void;
+  public setFps(fps: number): void;
   public setInputProps(props: Record<string, any>): void;
   public setPlaybackRate(rate: number): void;
   public setAudioVolume(volume: number): void;

--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v1.28.0
+- ✅ Completed: Implement Dynamic Timing - Implemented `setDuration` and `setFps` methods in `Helios` class, allowing runtime updates to composition timing.
+
 ## CORE v1.27.0
 - ✅ Completed: Expose Captions - Exposed full caption list in `HeliosState` and enabled array input for captions in constructor and `setCaptions`.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 1.27.0
+**Version**: 1.28.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance and Optimization
-- **Last Updated**: 2026-03-16
+- **Last Updated**: 2026-03-18
 
+[v1.28.0] ✅ Completed: Implement Dynamic Timing - Implemented `setDuration` and `setFps` methods in `Helios` class, allowing runtime updates to composition timing.
 [v1.27.0] ✅ Completed: Expose Captions - Exposed full caption list in `HeliosState` and enabled array input for captions in constructor and `setCaptions`.
 [v1.26.2] ✅ Completed: Restore Context File - Restored missing `/.sys/llmdocs/context-core.md` and verified package integrity.
 [v1.26.1] ✅ Completed: Verify Core Package Integrity - Verified build, tests, and artifacts for `packages/core`.


### PR DESCRIPTION
💡 **What**: Implemented `setDuration` and `setFps` methods in `Helios` class and refactored `duration` and `fps` properties to be getters backed by reactive signals.

🎯 **Why**: To allow runtime updates to composition timing (duration and frame rate) without destroying and recreating the engine instance. This is essential for advanced use cases like the Studio's resize controls.

📊 **Impact**: Consumers can now dynamically adjust the timeline duration and frame rate. `setDuration` clamps the playhead if needed. `setFps` preserves the current playback time (seconds) while adjusting the frame number.

🔬 **Verification**: Added a new test suite "Dynamic Timing" in `packages/core/src/index.test.ts`. Run `npm test -w packages/core` to verify.

---
*PR created automatically by Jules for task [4171831265129733018](https://jules.google.com/task/4171831265129733018) started by @BintzGavin*