### PR TITLE
feat(studio): Implement Keyboard Shortcuts Dialog

### DIFF
--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.30.0] ✅ Completed: Keyboard Shortcuts Dialog - Implemented a modal dialog listing all keyboard shortcuts, accessible via `?` key or sidebar button, improving usability.
 - [v0.29.0] ✅ Completed: Schema-Aware Props Editor - Implemented specialized UI inputs (Enum, Range, Color, Boolean) driven by `HeliosSchema`, with fallback to standard inputs.
 - [v0.28.0] ✅ Completed: Captions Panel - Implemented SRT import panel and timeline markers for captions using Core's `parseSrt` and `inputProps` injection.
 - [v0.27.1] ✅ Fixed: Snapshot - Fixed type error in "Take Snapshot" implementation where `captureFrame` return value was mishandled.

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -7,6 +7,7 @@ import { PropsEditor } from './components/PropsEditor'
 import { PlaybackControls } from './components/Controls/PlaybackControls'
 import { StudioProvider, useStudio } from './context/StudioContext'
 import { CompositionSwitcher } from './components/CompositionSwitcher'
+import { KeyboardShortcutsModal } from './components/KeyboardShortcutsModal'
 import { useKeyboardShortcut } from './hooks/useKeyboardShortcut'
 import { Stage } from './components/Stage/Stage'
 import { Sidebar } from './components/Sidebar/Sidebar'
@@ -15,6 +16,7 @@ function AppContent() {
   const {
     activeComposition,
     setSwitcherOpen,
+    setHelpOpen,
     controller,
     playerState,
     setPlayerState,
@@ -28,6 +30,12 @@ function AppContent() {
     e.preventDefault();
     setSwitcherOpen(true);
   }, { ctrlOrCmd: true });
+
+  // Open Help with ?
+  useKeyboardShortcut('?', (e) => {
+    e.preventDefault();
+    setHelpOpen(true);
+  }, { ignoreInput: true });
 
   // Playback Shortcuts
   useKeyboardShortcut(' ', () => {
@@ -134,6 +142,7 @@ function AppContent() {
         }
       />
       <CompositionSwitcher />
+      <KeyboardShortcutsModal />
     </>
   )
 }

--- a/packages/studio/src/components/KeyboardShortcutsModal.css
+++ b/packages/studio/src/components/KeyboardShortcutsModal.css
@@ -1,0 +1,113 @@
+.shortcuts-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+  backdrop-filter: blur(2px);
+}
+
+.shortcuts-modal {
+  background-color: #1e1e1e;
+  width: 600px;
+  max-width: 90vw;
+  max-height: 80vh;
+  border-radius: 8px;
+  border: 1px solid #333;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.shortcuts-modal-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid #333;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #252526;
+}
+
+.shortcuts-modal-header h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #fff;
+}
+
+.shortcuts-modal-close {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 24px;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.shortcuts-modal-close:hover {
+  color: #fff;
+}
+
+.shortcuts-modal-content {
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.shortcuts-section {
+  margin-bottom: 24px;
+}
+
+.shortcuts-section:last-child {
+  margin-bottom: 0;
+}
+
+.shortcuts-section h3 {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid #333;
+  padding-bottom: 8px;
+}
+
+.shortcut-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.shortcut-row:last-child {
+  border-bottom: none;
+}
+
+.shortcut-description {
+  color: #ccc;
+  font-size: 14px;
+}
+
+.shortcut-keys {
+  display: flex;
+  gap: 4px;
+}
+
+.kbd {
+  background-color: #333;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-family: monospace;
+  font-size: 12px;
+  color: #fff;
+  min-width: 20px;
+  text-align: center;
+  box-shadow: 0 2px 0 #222;
+}

--- a/packages/studio/src/components/KeyboardShortcutsModal.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect } from 'react';
+import { useStudio } from '../context/StudioContext';
+import './KeyboardShortcutsModal.css';
+
+interface ShortcutDef {
+  description: string;
+  keys: string[];
+}
+
+interface ShortcutSection {
+  title: string;
+  shortcuts: ShortcutDef[];
+}
+
+const SHORTCUTS: ShortcutSection[] = [
+  {
+    title: 'Playback',
+    shortcuts: [
+      { description: 'Play / Pause', keys: ['Space'] },
+      { description: 'Restart / Rewind', keys: ['Home'] },
+      { description: 'Toggle Loop', keys: ['L'] },
+    ]
+  },
+  {
+    title: 'Navigation',
+    shortcuts: [
+      { description: 'Previous Frame', keys: ['←'] },
+      { description: 'Next Frame', keys: ['→'] },
+      { description: 'Back 10 Frames', keys: ['Shift', '←'] },
+      { description: 'Forward 10 Frames', keys: ['Shift', '→'] },
+    ]
+  },
+  {
+    title: 'Timeline',
+    shortcuts: [
+      { description: 'Set In Point', keys: ['I'] },
+      { description: 'Set Out Point', keys: ['O'] },
+    ]
+  },
+  {
+    title: 'General',
+    shortcuts: [
+      { description: 'Switch Composition', keys: ['⌘', 'K'] },
+      { description: 'Show Shortcuts', keys: ['?'] },
+    ]
+  }
+];
+
+export const KeyboardShortcutsModal: React.FC = () => {
+  const { isHelpOpen, setHelpOpen } = useStudio();
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isHelpOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setHelpOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isHelpOpen, setHelpOpen]);
+
+  if (!isHelpOpen) return null;
+
+  return (
+    <div className="shortcuts-modal-overlay" onClick={() => setHelpOpen(false)}>
+      <div className="shortcuts-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="shortcuts-modal-header">
+          <h2>Keyboard Shortcuts</h2>
+          <button className="shortcuts-modal-close" onClick={() => setHelpOpen(false)}>
+            ×
+          </button>
+        </div>
+        <div className="shortcuts-modal-content">
+          {SHORTCUTS.map((section) => (
+            <div key={section.title} className="shortcuts-section">
+              <h3>{section.title}</h3>
+              {section.shortcuts.map((shortcut, i) => (
+                <div key={i} className="shortcut-row">
+                  <div className="shortcut-description">{shortcut.description}</div>
+                  <div className="shortcut-keys">
+                    {shortcut.keys.map((key, k) => (
+                      <span key={k} className="kbd">{key}</span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/studio/src/components/Sidebar/Sidebar.css
+++ b/packages/studio/src/components/Sidebar/Sidebar.css
@@ -42,3 +42,32 @@
   overflow: hidden;
   position: relative;
 }
+
+.sidebar-footer {
+  padding: 8px;
+  border-top: 1px solid #333;
+  display: flex;
+  justify-content: flex-end;
+  background-color: #252526;
+}
+
+.sidebar-help-button {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid #444;
+  background: none;
+  color: #888;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.sidebar-help-button:hover {
+  border-color: #666;
+  color: #fff;
+  background-color: #333;
+}

--- a/packages/studio/src/components/Sidebar/Sidebar.tsx
+++ b/packages/studio/src/components/Sidebar/Sidebar.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
+import { useStudio } from '../../context/StudioContext';
 import './Sidebar.css';
 import { AssetsPanel } from '../AssetsPanel/AssetsPanel';
 import { RendersPanel } from '../RendersPanel/RendersPanel';
 import { CaptionsPanel } from '../CaptionsPanel/CaptionsPanel';
 
 export const Sidebar: React.FC = () => {
+  const { setHelpOpen } = useStudio();
   const [activeTab, setActiveTab] = useState<'assets' | 'renders' | 'captions'>('assets');
 
   return (
@@ -33,6 +35,15 @@ export const Sidebar: React.FC = () => {
         {activeTab === 'assets' && <AssetsPanel />}
         {activeTab === 'captions' && <CaptionsPanel />}
         {activeTab === 'renders' && <RendersPanel />}
+      </div>
+      <div className="sidebar-footer">
+        <button
+          className="sidebar-help-button"
+          onClick={() => setHelpOpen(true)}
+          title="Keyboard Shortcuts (?)"
+        >
+          ?
+        </button>
       </div>
     </div>
   );

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -66,6 +66,9 @@ interface StudioContextType {
   isSwitcherOpen: boolean;
   setSwitcherOpen: (isOpen: boolean) => void;
 
+  isHelpOpen: boolean;
+  setHelpOpen: (isOpen: boolean) => void;
+
   // Assets
   assets: Asset[];
   uploadAsset: (file: File) => Promise<void>;
@@ -112,6 +115,7 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [assets, setAssets] = useState<Asset[]>([]);
   const [activeComposition, setActiveComposition] = useState<Composition | null>(null);
   const [isSwitcherOpen, setSwitcherOpen] = useState(false);
+  const [isHelpOpen, setHelpOpen] = useState(false);
   const [canvasSize, setCanvasSize] = useState({ width: 1920, height: 1080 });
   const [renderConfig, setRenderConfig] = useState<RenderConfig>({ mode: 'canvas' });
 
@@ -312,6 +316,8 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         setActiveComposition,
         isSwitcherOpen,
         setSwitcherOpen,
+        isHelpOpen,
+        setHelpOpen,
         renderJobs,
         startRender,
         cancelRender,


### PR DESCRIPTION
Implemented a Keyboard Shortcuts Dialog to improve usability and discoverability of Studio features. The dialog is accessible via the `?` key or a new button in the Sidebar footer. Verified with unit tests and visual inspection via Playwright.

---
*PR created automatically by Jules for task [15516829694865922606](https://jules.google.com/task/15516829694865922606) started by @BintzGavin*