### PR TITLE
✨ STUDIO: Implement Editable Captions Panel

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -39,7 +39,7 @@ The studio is launched via the `@helios-project/cli` package.
 - **PlaybackControls**: Includes Play/Pause, Frame Step, Loop, Audio (Volume/Mute), and Speed controls.
 - **PropsEditor**: Schema-aware property editor with fallback to JSON/Form inputs.
 - **AssetsPanel**: Drag-and-drop asset management with rich previews for Video, Audio, and Fonts.
-- **CaptionsPanel**: SRT import and visualization panel (synced with Helios Core state).
+- **CaptionsPanel**: SRT import, editing (Add/Edit/Delete), and visualization panel (synced with Helios Core state).
 - **RendersPanel**: Render job management (start, cancel, download).
 - **Stage**: Canvas/DOM preview area with Pan/Zoom, Transparency Grid, and Snapshot controls.
 - **KeyboardShortcutsModal**: Modal dialog displaying available keyboard shortcuts.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,4 +1,5 @@
-# Studio Progress Log
+## STUDIO v0.32.0
+- ✅ Completed: Editable Captions Panel - Implemented editable inputs for captions (time/text), add/delete functionality, and syncing with Core via `controller.setCaptions` or `inputProps`.
 
 ## STUDIO v0.31.0
 - ✅ Completed: Integrate Core Captions - Updated Studio to use `HeliosState.captions` for Timeline and Captions Panel, ensuring full sync with Core's caption logic.

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.31.0
+**Version**: 0.32.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.32.0] ✅ Completed: Editable Captions Panel - Implemented editable inputs for captions (time/text), add/delete functionality, and syncing with Core via `controller.setCaptions` or `inputProps`.
 - [v0.31.0] ✅ Completed: Integrate Core Captions - Updated Studio to use `HeliosState.captions` for Timeline and Captions Panel, ensuring full sync with Core's caption logic.
 - [v0.30.1] ✅ Verified: Keyboard Shortcuts & Snapshot - Added unit tests for KeyboardShortcutsModal and StudioContext snapshot logic.
 - [v0.30.0] ✅ Completed: Keyboard Shortcuts Dialog - Implemented a modal dialog listing all keyboard shortcuts, accessible via `?` key or sidebar button, improving usability.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -408,7 +408,8 @@ describe('Helios Core', () => {
         muted: false,
         captions: [],
         activeCaptions: [],
-        loop: false
+        loop: false,
+        markers: []
       };
 
       const subscriber: HeliosSubscriber = (s: HeliosState) => {

--- a/packages/studio/src/components/CaptionsPanel/CaptionsPanel.css
+++ b/packages/studio/src/components/CaptionsPanel/CaptionsPanel.css
@@ -7,12 +7,57 @@
   overflow: hidden;
 }
 
-.captions-panel h2 {
-  font-size: 16px;
-  margin-top: 0;
+.captions-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 10px;
   border-bottom: 1px solid #444;
   padding-bottom: 5px;
+}
+
+.captions-header h2 {
+  font-size: 16px;
+  margin: 0;
+  border: none;
+  padding: 0;
+}
+
+.captions-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.add-button {
+    background: #007bff;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-size: 12px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.add-button:hover {
+    background: #0069d9;
+}
+
+.clear-button {
+    background: #333;
+    color: #aaa;
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.clear-button:hover {
+    background: #444;
+    color: #eee;
 }
 
 .upload-section {
@@ -38,30 +83,107 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  padding-right: 4px;
+}
+
+/* Scrollbar styling */
+.captions-list::-webkit-scrollbar {
+    width: 6px;
+}
+.captions-list::-webkit-scrollbar-track {
+    background: #1a1a1a;
+}
+.captions-list::-webkit-scrollbar-thumb {
+    background: #444;
+    border-radius: 3px;
 }
 
 .caption-item {
   background: #2a2a2a;
   padding: 8px;
   border-radius: 4px;
-  font-size: 12px;
   border-left: 3px solid #007bff;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.caption-time {
-  color: #888;
-  font-family: monospace;
-  margin-bottom: 4px;
-  font-size: 11px;
+.caption-times {
+    display: flex;
+    align-items: center;
+    gap: 6px;
 }
 
-.caption-text {
-  white-space: pre-wrap;
+.time-input {
+    background: #1a1a1a;
+    border: 1px solid #333;
+    color: #bbb;
+    font-family: monospace;
+    font-size: 11px;
+    padding: 2px 4px;
+    border-radius: 3px;
+    width: 85px;
+    text-align: center;
+}
+
+.time-input:focus {
+    border-color: #007bff;
+    color: white;
+    outline: none;
+}
+
+.time-separator {
+    color: #555;
+    font-size: 12px;
+}
+
+.caption-content {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+}
+
+.text-input {
+    flex: 1;
+    background: #1a1a1a;
+    border: 1px solid #333;
+    color: #e0e0e0;
+    font-family: inherit;
+    font-size: 12px;
+    padding: 6px;
+    border-radius: 3px;
+    resize: vertical;
+    min-height: 20px;
+    line-height: 1.4;
+}
+
+.text-input:focus {
+    border-color: #007bff;
+    outline: none;
+    background: #111;
+}
+
+.delete-button {
+    background: transparent;
+    border: none;
+    color: #666;
+    cursor: pointer;
+    font-size: 18px;
+    padding: 2px 4px;
+    line-height: 1;
+    opacity: 0.6;
+    margin-top: 2px;
+}
+
+.delete-button:hover {
+    color: #ff4444;
+    opacity: 1;
 }
 
 .no-captions {
   color: #666;
   font-style: italic;
   text-align: center;
-  margin-top: 20px;
+  margin-top: 40px;
+  font-size: 13px;
 }

--- a/packages/studio/src/components/CaptionsPanel/CaptionsPanel.test.tsx
+++ b/packages/studio/src/components/CaptionsPanel/CaptionsPanel.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { CaptionsPanel } from './CaptionsPanel';
+import * as StudioContext from '../../context/StudioContext';
+
+// Mock the context
+vi.mock('../../context/StudioContext', () => ({
+  useStudio: vi.fn(),
+}));
+
+describe('CaptionsPanel', () => {
+  const mockSetInputProps = vi.fn();
+  const mockSetCaptions = vi.fn();
+
+  const defaultPlayerState = {
+    currentFrame: 30, // 1 second
+    duration: 10,
+    fps: 30,
+    playbackRate: 1,
+    isPlaying: false,
+    inputProps: {},
+    captions: []
+  };
+
+  const defaultContext = {
+    controller: {
+        setInputProps: mockSetInputProps,
+        instance: {
+            setCaptions: mockSetCaptions
+        }
+    },
+    playerState: defaultPlayerState,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (StudioContext.useStudio as any).mockReturnValue(defaultContext);
+  });
+
+  it('renders "No captions loaded" when empty', () => {
+    render(<CaptionsPanel />);
+    expect(screen.getByText('No captions loaded')).toBeInTheDocument();
+  });
+
+  it('renders existing captions correctly', () => {
+    const captions = [
+        { startTime: 0, endTime: 1000, text: 'Hello' },
+        { startTime: 2000, endTime: 3000, text: 'World' }
+    ];
+
+    (StudioContext.useStudio as any).mockReturnValue({
+        ...defaultContext,
+        playerState: { ...defaultPlayerState, captions }
+    });
+
+    render(<CaptionsPanel />);
+
+    expect(screen.getByDisplayValue('Hello')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('World')).toBeInTheDocument();
+    // 0ms -> 00:00.000
+    expect(screen.getByDisplayValue('00:00.000')).toBeInTheDocument();
+    // 1000ms -> 00:01.000
+    expect(screen.getByDisplayValue('00:01.000')).toBeInTheDocument();
+  });
+
+  it('adds a new caption when Add button is clicked', () => {
+     render(<CaptionsPanel />);
+     const addButton = screen.getByText('+ Add');
+     fireEvent.click(addButton);
+
+     // Should call setCaptions with one new caption
+     expect(mockSetCaptions).toHaveBeenCalledTimes(1);
+     const newCaptions = mockSetCaptions.mock.calls[0][0];
+     expect(newCaptions).toHaveLength(1);
+     expect(newCaptions[0].text).toBe('New Caption');
+     expect(newCaptions[0].startTime).toBe(1000); // 30 frames @ 30fps = 1000ms
+  });
+
+  it('updates a caption on blur', () => {
+    const captions = [
+        { startTime: 0, endTime: 1000, text: 'Hello' }
+    ];
+
+    (StudioContext.useStudio as any).mockReturnValue({
+        ...defaultContext,
+        playerState: { ...defaultPlayerState, captions }
+    });
+
+    render(<CaptionsPanel />);
+
+    const textInput = screen.getByDisplayValue('Hello');
+    fireEvent.change(textInput, { target: { value: 'Hello Updated' } });
+    fireEvent.blur(textInput);
+
+    expect(mockSetCaptions).toHaveBeenCalledTimes(1);
+    const updated = mockSetCaptions.mock.calls[0][0];
+    expect(updated[0].text).toBe('Hello Updated');
+  });
+
+  it('deletes a caption', () => {
+    const captions = [
+        { startTime: 0, endTime: 1000, text: 'Hello' }
+    ];
+
+    (StudioContext.useStudio as any).mockReturnValue({
+        ...defaultContext,
+        playerState: { ...defaultPlayerState, captions }
+    });
+
+    render(<CaptionsPanel />);
+
+    const deleteButton = screen.getByTitle('Delete caption');
+    fireEvent.click(deleteButton);
+
+    expect(mockSetCaptions).toHaveBeenCalledWith([]);
+  });
+
+  it('falls back to setInputProps if setCaptions is missing', () => {
+      const contextWithoutInstance = {
+          ...defaultContext,
+          controller: {
+              setInputProps: mockSetInputProps,
+              // No instance
+          }
+      };
+
+      (StudioContext.useStudio as any).mockReturnValue(contextWithoutInstance);
+
+      render(<CaptionsPanel />);
+      const addButton = screen.getByText('+ Add');
+      fireEvent.click(addButton);
+
+      expect(mockSetInputProps).toHaveBeenCalledTimes(1);
+      const props = mockSetInputProps.mock.calls[0][0];
+      expect(props.captions).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
💡 **What**: Implemented editable inputs for captions in the Captions Panel, allowing users to add, edit (text/time), and delete caption cues. Syncs changes with Helios Core via `controller.setCaptions` or `inputProps`.
🎯 **Why**: To close the gap between read-only caption visualization and a full editing workflow in Studio.
📊 **Impact**: Users can now create and refine subtitles directly within the Studio interface.
🔬 **Verification**: Added unit tests in `CaptionsPanel.test.tsx` covering add/edit/delete flows. Verified tests pass with `npm test`. Verified `npx helios studio` launch.

---
*PR created automatically by Jules for task [8082967965364604962](https://jules.google.com/task/8082967965364604962) started by @BintzGavin*