### PR TITLE
Refine burn-in captions with multiline support

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -3,7 +3,7 @@
 ## 1. Module Overview
 - **Package**: `@helios-project/player`
 - **Domain**: Web Component and Player UI
-- **Responsibility**: Renders the `<helios-player>` component, managing the preview iframe, UI controls, and communication bridge.
+- **Responsibility**: Renders the `<helios-player>` component, managing the preview iframe, UI controls, and communication bridge. Handles client-side export with burn-in captions.
 
 ## 2. Key Components
 

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.25.1
+- ✅ Completed: Refine Burn-In Captions - Added multiline caption support and respect for player caption visibility toggle during client-side export.
+
 ## PLAYER v0.25.0
 - ✅ Completed: Responsive Controls - Implemented `ResizeObserver` to adapt player controls for smaller widths (compact/tiny modes) to prevent overflow.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.25.0
+**Version**: v0.25.1
 
 # Status: PLAYER
 
@@ -31,6 +31,7 @@
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.25.1] ✅ Completed: Refine Burn-In Captions - Added multiline caption support and respect for player caption visibility toggle during client-side export.
 [v0.25.0] ✅ Completed: Responsive Controls - Implemented `ResizeObserver` to adapt player controls for smaller widths (compact/tiny modes) to prevent overflow.
 [v0.24.1] ✅ Completed: Documentation Update - Added missing attributes (poster, preload, input-props), Standard Media API, and Events documentation to README.
 [v0.24.0] ✅ Completed: Implement Poster and Preload - Implemented `poster` attribute for custom preview images and `preload` attribute to control loading behavior (including deferred loading with "Big Play Button").

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1081,7 +1081,8 @@ export class HeliosPlayer extends HTMLElement {
             signal: this.abortController.signal,
             mode: exportMode,
             canvasSelector: canvasSelector,
-            format: exportFormat
+            format: exportFormat,
+            includeCaptions: this.showCaptions
         });
     } catch (e: any) {
         if (e.message !== "Export aborted") {


### PR DESCRIPTION
- Updated `ClientSideExporter` to handle multiline captions by splitting text and stacking cues bottom-up.
- Added `includeCaptions` option to `ClientSideExporter.export`.
- Updated `HeliosPlayer` to pass `this.showCaptions` to the exporter.
- Added unit tests for multiline support and caption toggling.

---
*PR created automatically by Jules for task [5811852984387336134](https://jules.google.com/task/5811852984387336134) started by @BintzGavin*