### PR TITLE
✨ STUDIO: Assets Extension

### DIFF
--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.35.0
+- ✅ Completed: Assets Extension - Added support for discovering and displaying 3D models (.glb, .gltf), JSON data (.json), and Shaders (.glsl, .vert, .frag) in the Assets Panel.
+
 ## STUDIO v0.34.0
 - ✅ Completed: Diagnostics Panel - Implemented system diagnostics panel showing both Client (Preview) and Server (Renderer) capabilities, accessible via Sidebar.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -78,6 +78,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - If this is a new version, create the section at the top of the file (after any existing content)
 - Group multiple completions under the same version section if they're part of the same release
 
+### STUDIO v0.35.0
+- ✅ Completed: Assets Extension - Added support for discovering and displaying 3D models (.glb, .gltf), JSON data (.json), and Shaders (.glsl, .vert, .frag) in the Assets Panel.
+
 ### STUDIO v0.34.0
 - ✅ Completed: Diagnostics Panel - Implemented system diagnostics panel showing both Client (Preview) and Server (Renderer) capabilities, accessible via Sidebar.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.34.0
+**Version**: 0.35.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.35.0] ✅ Completed: Assets Extension - Added support for discovering and displaying 3D models (.glb, .gltf), JSON data (.json), and Shaders (.glsl, .vert, .frag) in the Assets Panel.
 - [v0.34.0] ✅ Completed: Diagnostics Panel - Implemented system diagnostics panel showing both Client (Preview) and Server (Renderer) capabilities, accessible via Sidebar.
 - [v0.33.1] ✅ Verified: Test Environment - Fixed test environment configuration by adding module aliases for Core and Player in Vite/Vitest, ensuring all tests pass.
 - [v0.33.0] ✅ Completed: SRT Export - Implemented functionality to export current captions as an SRT file from the Captions Panel, adding a client-side utility and "Export SRT" button.

--- a/packages/studio/src/components/AssetsPanel/AssetItem.test.tsx
+++ b/packages/studio/src/components/AssetsPanel/AssetItem.test.tsx
@@ -111,4 +111,22 @@ describe('AssetItem', () => {
     fireEvent.click(deleteBtn!);
     expect(mockDeleteAsset).toHaveBeenCalledWith('1');
   });
+
+  it('renders new asset types (model, json, shader) correctly', () => {
+    const model: Asset = { id: 'm1', name: 'box.glb', url: '/box.glb', type: 'model' };
+    const json: Asset = { id: 'j1', name: 'data.json', url: '/data.json', type: 'json' };
+    const shader: Asset = { id: 's1', name: 'frag.glsl', url: '/frag.glsl', type: 'shader' };
+
+    const { rerender } = render(<AssetItem asset={model} />);
+    expect(screen.getByText('📦')).toBeInTheDocument();
+    expect(screen.getByTitle('3D Model')).toBeInTheDocument();
+
+    rerender(<AssetItem asset={json} />);
+    expect(screen.getByText('{}')).toBeInTheDocument();
+    expect(screen.getByTitle('JSON Data')).toBeInTheDocument();
+
+    rerender(<AssetItem asset={shader} />);
+    expect(screen.getByText('⚡')).toBeInTheDocument();
+    expect(screen.getByTitle('Shader')).toBeInTheDocument();
+  });
 });

--- a/packages/studio/src/components/AssetsPanel/AssetItem.tsx
+++ b/packages/studio/src/components/AssetsPanel/AssetItem.tsx
@@ -115,6 +115,12 @@ export const AssetItem: React.FC<AssetItemProps> = ({ asset }) => {
                     Aa
                 </div>
             );
+        case 'model':
+            return <div style={{ color: '#aaa', fontSize: '24px' }} title="3D Model">📦</div>;
+        case 'json':
+            return <div style={{ color: '#aaa', fontSize: '24px' }} title="JSON Data">{`{}`}</div>;
+        case 'shader':
+            return <div style={{ color: '#aaa', fontSize: '24px' }} title="Shader">⚡</div>;
         default:
              return <div style={{ color: '#666', fontSize: '24px' }}>📄</div>;
     }

--- a/packages/studio/src/components/CaptionsPanel/CaptionsPanel.test.tsx
+++ b/packages/studio/src/components/CaptionsPanel/CaptionsPanel.test.tsx
@@ -45,8 +45,8 @@ describe('CaptionsPanel', () => {
 
   it('renders existing captions correctly', () => {
     const captions = [
-        { startTime: 0, endTime: 1000, text: 'Hello' },
-        { startTime: 2000, endTime: 3000, text: 'World' }
+        { id: '1', startTime: 0, endTime: 1000, text: 'Hello' },
+        { id: '2', startTime: 2000, endTime: 3000, text: 'World' }
     ];
 
     (StudioContext.useStudio as any).mockReturnValue({
@@ -79,7 +79,7 @@ describe('CaptionsPanel', () => {
 
   it('updates a caption on blur', () => {
     const captions = [
-        { startTime: 0, endTime: 1000, text: 'Hello' }
+        { id: '1', startTime: 0, endTime: 1000, text: 'Hello' }
     ];
 
     (StudioContext.useStudio as any).mockReturnValue({
@@ -100,7 +100,7 @@ describe('CaptionsPanel', () => {
 
   it('deletes a caption', () => {
     const captions = [
-        { startTime: 0, endTime: 1000, text: 'Hello' }
+        { id: '1', startTime: 0, endTime: 1000, text: 'Hello' }
     ];
 
     (StudioContext.useStudio as any).mockReturnValue({
@@ -138,8 +138,8 @@ describe('CaptionsPanel', () => {
 
   it('exports captions as SRT', () => {
     const captions = [
-        { startTime: 0, endTime: 1000, text: 'Hello' },
-        { startTime: 2000, endTime: 3000, text: 'World' }
+        { id: '1', startTime: 0, endTime: 1000, text: 'Hello' },
+        { id: '2', startTime: 2000, endTime: 3000, text: 'World' }
     ];
 
     (StudioContext.useStudio as any).mockReturnValue({
@@ -175,7 +175,7 @@ describe('CaptionsPanel', () => {
     fireEvent.click(exportButton);
 
     expect(createObjectURLMock).toHaveBeenCalledTimes(1);
-    const blob = createObjectURLMock.mock.calls[0][0];
+    const blob = (createObjectURLMock.mock.calls[0] as any)[0];
     expect(blob).toBeInstanceOf(Blob);
 
     // Verify click was called on the anchor

--- a/packages/studio/src/components/CaptionsPanel/CaptionsPanel.tsx
+++ b/packages/studio/src/components/CaptionsPanel/CaptionsPanel.tsx
@@ -100,6 +100,7 @@ export const CaptionsPanel: React.FC = () => {
   const handleAdd = () => {
       const currentTime = Math.round((playerState.currentFrame / playerState.fps) * 1000) || 0;
       const newCue: CaptionCue = {
+          id: Date.now().toString(),
           startTime: currentTime,
           endTime: currentTime + 2000,
           text: "New Caption"

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -13,7 +13,7 @@ export interface Asset {
   id: string;
   name: string;
   url: string;
-  type: 'image' | 'video' | 'audio' | 'font' | 'other';
+  type: 'image' | 'video' | 'audio' | 'font' | 'model' | 'json' | 'shader' | 'other';
 }
 
 export interface RenderConfig {

--- a/packages/studio/src/server/discovery.test.ts
+++ b/packages/studio/src/server/discovery.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { findAssets } from './discovery';
+import fs from 'fs';
+import path from 'path';
+
+vi.mock('fs');
+
+describe('findAssets', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Set explicit project root to control the path
+    process.env = { ...originalEnv, HELIOS_PROJECT_ROOT: path.resolve('/mock/project') };
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should discover supported asset types including new extensions', () => {
+    const mockFiles = [
+      { name: 'image.png', isDirectory: () => false },
+      { name: 'model.glb', isDirectory: () => false },
+      { name: 'data.json', isDirectory: () => false },
+      { name: 'shader.frag', isDirectory: () => false },
+      { name: 'notes.txt', isDirectory: () => false },
+    ];
+
+    // Mock readdirSync
+    // We use mockImplementation to handle the path resolution correctly
+    vi.mocked(fs.readdirSync).mockImplementation((dir) => {
+        // We accept any call because getProjectRoot does some path resolution
+        return mockFiles as any;
+    });
+
+    const assets = findAssets('.');
+
+    // Verify we found the expected assets with correct types
+    const assetNames = assets.map(a => a.name).sort();
+
+    // This expectation defines our goal: finding these new types
+    expect(assetNames).toEqual(expect.arrayContaining(['data.json', 'image.png', 'model.glb', 'shader.frag']));
+    expect(assetNames).not.toContain('notes.txt');
+
+    const assetMap = new Map(assets.map(a => [a.name, a.type]));
+    expect(assetMap.get('image.png')).toBe('image');
+
+    // These assertions will fail until we implement the changes
+    expect(assetMap.get('model.glb')).toBe('model');
+    expect(assetMap.get('data.json')).toBe('json');
+    expect(assetMap.get('shader.frag')).toBe('shader');
+  });
+});

--- a/packages/studio/src/server/discovery.ts
+++ b/packages/studio/src/server/discovery.ts
@@ -12,7 +12,7 @@ export interface AssetInfo {
   id: string;
   name: string;
   url: string;
-  type: 'image' | 'video' | 'audio' | 'font' | 'other';
+  type: 'image' | 'video' | 'audio' | 'font' | 'model' | 'json' | 'shader' | 'other';
 }
 
 export function getProjectRoot(cwd: string): string {
@@ -63,11 +63,17 @@ function getAssetType(ext: string): AssetInfo['type'] {
   const videos = ['.mp4', '.webm', '.mov'];
   const audio = ['.mp3', '.wav', '.aac', '.ogg'];
   const fonts = ['.ttf', '.otf', '.woff', '.woff2'];
+  const models = ['.glb', '.gltf'];
+  const json = ['.json'];
+  const shaders = ['.glsl', '.vert', '.frag'];
 
   if (images.includes(ext)) return 'image';
   if (videos.includes(ext)) return 'video';
   if (audio.includes(ext)) return 'audio';
   if (fonts.includes(ext)) return 'font';
+  if (models.includes(ext)) return 'model';
+  if (json.includes(ext)) return 'json';
+  if (shaders.includes(ext)) return 'shader';
   return 'other';
 }
 


### PR DESCRIPTION
Extended Studio Assets Panel to support discovering and displaying 3D models (.glb, .gltf), JSON data (.json), and Shaders (.glsl, .vert, .frag).
Updated `discovery.ts` (server) and `StudioContext.tsx` (client) to include new types.
Updated `AssetItem.tsx` to render generic icons (📦, {}, ⚡) for these types.
Added unit tests and verified frontend with Playwright.
Fixed minor type errors in CaptionsPanel related to recent Core updates.


---
*PR created automatically by Jules for task [14753437637392369967](https://jules.google.com/task/14753437637392369967) started by @BintzGavin*