### PR TITLE
✨ STUDIO: Client-Side Export

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -4,7 +4,7 @@
 The Studio is a Vite-based single-page application (SPA) that serves as the development environment for Helios compositions. It allows users to:
 1. Preview compositions with real-time feedback.
 2. Edit props, captions, and timeline markers.
-3. Manage assets and render jobs.
+3. Manage assets, render jobs, and client-side exports.
 4. Diagnose environment capabilities.
 
 It consists of:
@@ -53,6 +53,7 @@ Run via `npx helios studio` (or `npm run dev` in `packages/studio` during develo
 
 ## D. UI Components
 - **Sidebar**: Navigation tabs (Assets, Captions, Renders) and tools (Diagnostics, Help).
+- **RendersPanel**: Manages server-side render jobs and initiates client-side exports (WebCodecs).
 - **Stage**: The main preview area containing the `<helios-player>`. Supports pan/zoom.
 - **Timeline**: Visual timeline for scrubbing, playback control, and marker management.
 - **PropsEditor**: Schema-aware editor for composition input props.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.36.0
+- ✅ Completed: Client-Side Export - Implemented in-browser MP4/WebM export functionality in Renders Panel using WebCodecs.
+
 ## STUDIO v0.35.0
 - ✅ Completed: Assets Extension - Added support for discovering and displaying 3D models (.glb, .gltf), JSON data (.json), and Shaders (.glsl, .vert, .frag) in the Assets Panel.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -78,6 +78,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - If this is a new version, create the section at the top of the file (after any existing content)
 - Group multiple completions under the same version section if they're part of the same release
 
+### STUDIO v0.36.0
+- ✅ Completed: Client-Side Export - Implemented in-browser MP4/WebM export functionality in Renders Panel using WebCodecs.
+
 ### STUDIO v0.35.0
 - ✅ Completed: Assets Extension - Added support for discovering and displaying 3D models (.glb, .gltf), JSON data (.json), and Shaders (.glsl, .vert, .frag) in the Assets Panel.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.35.0
+**Version**: 0.36.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.36.0] ✅ Completed: Client-Side Export - Implemented in-browser MP4/WebM export functionality in Renders Panel using WebCodecs.
 - [v0.35.0] ✅ Completed: Assets Extension - Added support for discovering and displaying 3D models (.glb, .gltf), JSON data (.json), and Shaders (.glsl, .vert, .frag) in the Assets Panel.
 - [v0.34.0] ✅ Completed: Diagnostics Panel - Implemented system diagnostics panel showing both Client (Preview) and Server (Renderer) capabilities, accessible via Sidebar.
 - [v0.33.1] ✅ Verified: Test Environment - Fixed test environment configuration by adding module aliases for Core and Player in Vite/Vitest, ensuring all tests pass.

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -1,4 +1,6 @@
 import type { HeliosController } from "./controllers";
+import { ClientSideExporter } from "./features/exporter";
+export { ClientSideExporter };
 export type { HeliosController };
 export declare class HeliosPlayer extends HTMLElement {
     private iframe;

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -1,5 +1,6 @@
 import { DirectController, BridgeController } from "./controllers";
 import { ClientSideExporter } from "./features/exporter";
+export { ClientSideExporter };
 const template = document.createElement("template");
 template.innerHTML = `
   <style>
@@ -284,7 +285,7 @@ template.innerHTML = `
       display: none;
     }
   </style>
-  <div class="status-overlay" part="overlay">
+  <div class="status-overlay hidden" part="overlay">
     <div class="status-text">Connecting...</div>
     <button class="retry-btn" style="display: none">Retry</button>
   </div>

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -3,6 +3,7 @@ import { DirectController, BridgeController } from "./controllers";
 import type { HeliosController } from "./controllers";
 import { ClientSideExporter } from "./features/exporter";
 
+export { ClientSideExporter };
 export type { HeliosController };
 
 const template = document.createElement("template");

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/studio",
-  "version": "0.0.1",
+  "version": "0.36.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/studio/src/components/RendersPanel/RendersPanel.tsx
+++ b/packages/studio/src/components/RendersPanel/RendersPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useStudio } from '../../context/StudioContext';
 import { RenderConfig } from './RenderConfig';
 import './RendersPanel.css';
@@ -13,8 +13,14 @@ export const RendersPanel: React.FC = () => {
     renderConfig,
     setRenderConfig,
     cancelRender,
-    deleteRender
+    deleteRender,
+    isExporting,
+    exportProgress,
+    exportVideo,
+    cancelExport
   } = useStudio();
+
+  const [exportFormat, setExportFormat] = useState<'mp4' | 'webm'>('mp4');
 
   const handleTestRender = () => {
     if (activeComposition) {
@@ -24,13 +30,56 @@ export const RendersPanel: React.FC = () => {
 
   return (
     <div className="renders-panel">
-      <RenderConfig config={renderConfig} onChange={setRenderConfig} />
-      <button className="start-render-btn" onClick={handleTestRender} disabled={!activeComposition}>
-        Start Test Render
-      </button>
+      {/* Client-Side Export Section */}
+      <div className="client-export-section" style={{ padding: '10px', borderBottom: '1px solid #333', marginBottom: '10px', background: '#1e1e1e', borderRadius: '4px' }}>
+          <h3 style={{ margin: '0 0 8px 0', fontSize: '12px', color: '#ccc', fontWeight: 'bold' }}>Client-Side Export</h3>
+          <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
+              <select
+                  value={exportFormat}
+                  onChange={(e) => setExportFormat(e.target.value as 'mp4' | 'webm')}
+                  disabled={isExporting}
+                  style={{ flex: 1, background: '#222', color: 'white', border: '1px solid #444', borderRadius: '4px', padding: '4px' }}
+              >
+                  <option value="mp4">MP4 (H.264)</option>
+                  <option value="webm">WebM (VP9)</option>
+              </select>
+              {isExporting ? (
+                  <button
+                      onClick={cancelExport}
+                      style={{ background: '#d32f2f', color: 'white', border: 'none', borderRadius: '4px', padding: '4px 12px', cursor: 'pointer' }}
+                  >
+                      Cancel
+                  </button>
+              ) : (
+                  <button
+                      onClick={() => exportVideo(exportFormat)}
+                      disabled={!activeComposition}
+                      style={{ background: '#007bff', color: 'white', border: 'none', borderRadius: '4px', padding: '4px 12px', cursor: 'pointer', opacity: !activeComposition ? 0.5 : 1 }}
+                  >
+                      Export
+                  </button>
+              )}
+          </div>
+          {isExporting && (
+             <div className="render-progress-bar">
+               <div
+                 className="render-progress-fill"
+                 style={{ width: `${exportProgress * 100}%` }}
+               />
+             </div>
+          )}
+      </div>
 
-      <div style={{ fontSize: '10px', color: '#888', marginBottom: '8px', textAlign: 'center' }}>
-        Range: {inPoint} - {outPoint}
+      <div style={{ borderTop: '1px solid #333', paddingTop: '10px', marginTop: '10px' }}>
+          <h3 style={{ margin: '0 0 8px 0', fontSize: '12px', color: '#ccc', fontWeight: 'bold' }}>Server-Side Render</h3>
+          <RenderConfig config={renderConfig} onChange={setRenderConfig} />
+          <button className="start-render-btn" onClick={handleTestRender} disabled={!activeComposition}>
+            Start Render Job
+          </button>
+
+          <div style={{ fontSize: '10px', color: '#888', marginBottom: '8px', textAlign: 'center' }}>
+            Range: {inPoint} - {outPoint}
+          </div>
       </div>
 
       {renderJobs.length === 0 && (


### PR DESCRIPTION
💡 **What**: Implemented in-browser video export (MP4/WebM) using WebCodecs in Studio Renders Panel.
🎯 **Why**: To provide a faster, local export alternative to server-side rendering, fulfilling the "Client-Side WebCodecs as Primary Export" vision.
📊 **Impact**: Users can now export compositions directly from their browser without needing FFmpeg setup on the server for simple use cases.
🔬 **Verification**: Ran manual verification script `verify_client_export.py` which confirmed UI visibility and interactions. Verified unit tests passed.

---
*PR created automatically by Jules for task [15312286180021735976](https://jules.google.com/task/15312286180021735976) started by @BintzGavin*