### PR TITLE
✨ CORE: Formalize WaitUntilStable Interface

### DIFF
--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -96,7 +96,7 @@ export interface DiagnosticReport {
 export interface TimeDriver {
   init(scope: HTMLElement | Document): void;
   update(timeInMs: number, options?: { isPlaying: boolean; playbackRate: number; volume?: number; muted?: boolean }): void;
-  waitUntilStable?(): Promise<void>;
+  waitUntilStable(): Promise<void>;
   dispose?(): void;
 }
 ```

--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v2.0.0
+- ✅ Completed: WaitUntilStable Interface - Made `waitUntilStable` required in `TimeDriver` interface and strict in `Helios` to ensure reliable rendering.
+
 ## CORE v1.32.1
 - ✅ Completed: Document Dynamic Timing - Verified implementation, added JSDoc, and cleaned up plan artifacts.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -153,3 +153,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ## PLAYER v0.26.0
 - ✅ Completed: Bridge Error Propagation - Implemented global error handling in `bridge.ts` and `HeliosController`.
+
+## CORE v2.0.0
+- ✅ Completed: WaitUntilStable Interface - Made `waitUntilStable` required in `TimeDriver` interface and strict in `Helios` to ensure reliable rendering.

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 1.33.0
+**Version**: 2.0.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance and Optimization
 - **Last Updated**: 2026-03-26
 
+[v2.0.0] ✅ Completed: WaitUntilStable Interface - Made `waitUntilStable` required in `TimeDriver` interface and strict in `Helios` to ensure reliable rendering.
 [v1.33.0] ✅ Completed: Implement WaitUntilStable - Implemented `waitUntilStable` in `Helios` and `DomDriver` to ensure deterministic rendering by waiting for fonts, images, and media readiness.
 [v1.32.1] ✅ Completed: Document Dynamic Timing - Verified implementation, added JSDoc, and cleaned up plan artifacts.
 [v1.32.0] ✅ Completed: Implement Schema Asset Types - Added `image`, `video`, `audio`, `font` to `PropType` and validation, enabling asset selection in Studio.

--- a/packages/core/src/audio.test.ts
+++ b/packages/core/src/audio.test.ts
@@ -8,7 +8,8 @@ describe('Helios Audio', () => {
   beforeEach(() => {
     mockDriver = {
       init: vi.fn(),
-      update: vi.fn()
+      update: vi.fn(),
+      waitUntilStable: vi.fn().mockResolvedValue(undefined)
     };
   });
 

--- a/packages/core/src/drivers/TimeDriver.ts
+++ b/packages/core/src/drivers/TimeDriver.ts
@@ -1,6 +1,6 @@
 export interface TimeDriver {
   init(scope: HTMLElement | Document): void;
   update(timeInMs: number, options?: { isPlaying: boolean; playbackRate: number; volume?: number; muted?: boolean }): void;
-  waitUntilStable?(): Promise<void>;
+  waitUntilStable(): Promise<void>;
   dispose?(): void;
 }

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -353,7 +353,8 @@ describe('Helios Core', () => {
     beforeEach(() => {
        mockDriver = {
          init: vi.fn(),
-         update: vi.fn()
+         update: vi.fn(),
+         waitUntilStable: vi.fn().mockResolvedValue(undefined)
        };
     });
 
@@ -674,7 +675,8 @@ Updated`;
     it('should sync driver with initialFrame', () => {
       const mockDriver: TimeDriver = {
          init: vi.fn(),
-         update: vi.fn()
+         update: vi.fn(),
+         waitUntilStable: vi.fn().mockResolvedValue(undefined)
       };
 
       new Helios({ duration: 10, fps: 30, initialFrame: 30, driver: mockDriver });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -547,7 +547,7 @@ export class Helios {
    * Useful for deterministic rendering.
    */
   public async waitUntilStable(): Promise<void> {
-    return this.driver.waitUntilStable?.() ?? Promise.resolve();
+    return this.driver.waitUntilStable();
   }
 
   /**


### PR DESCRIPTION
💡 What: Made 'waitUntilStable' required in 'TimeDriver' interface and removed optional chaining in 'Helios.waitUntilStable'.
🎯 Why: To ensure deterministic rendering by mandating stability checks across all drivers (Core v2.0.0).
📊 Impact: Guarantees that the renderer can reliably wait for frame readiness (fonts, images, media) regardless of the driver used.
🔬 Verification: Verified build passed and 504 tests passed in 'packages/core'. Bumped CORE version to 2.0.0.

---
*PR created automatically by Jules for task [3413352463386604873](https://jules.google.com/task/3413352463386604873) started by @BintzGavin*