### PR TITLE
✨ PLAYER: Implement muted attribute

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -36,6 +36,7 @@ The `<helios-player>` observes the following attributes:
 - `input-props`: JSON string of input properties to pass to the composition.
 - `poster`: URL of an image to show before loading or playing.
 - `preload`: `auto` (default) or `none` (defer loading until interaction).
+- `muted`: Mute the audio by default.
 
 ## Public API
 The `HeliosPlayer` class exposes the following properties and methods:

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.27.0
+- ✅ Completed: Implement Muted Attribute - Added support for the `muted` attribute to `<helios-player>`, enabling declarative control of audio mute state.
+
 ## PLAYER v0.26.0
 - ✅ Completed: Bridge Error Propagation - Implemented global error handling in `bridge.ts` and `HeliosController`, enabling the player UI to display runtime errors from the composition.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.26.1
+**Version**: v0.27.0
 
 # Status: PLAYER
 
@@ -27,11 +27,12 @@
 - Supports declarative data binding via `input-props` attribute (JSON string) and property, enabling dynamic composition updates.
 - Supports `poster` and `preload` attributes. `preload="none"` defers iframe loading until the user interacts with the new "Big Play Button".
 - Implements responsive controls using `ResizeObserver`, adapting UI layout for smaller widths (hiding volume/speed controls).
-- **New**: Refined Poster Visibility logic ensures user-defined poster images are not obscured by "Loading/Connecting" status overlays during initialization.
+- **New**: Implemented `muted` attribute support on `<helios-player>` to control initial mute state and reflect changes, closing a Standard Media API gap.
 
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.27.0] ✅ Completed: Implement Muted Attribute - Added support for the `muted` attribute to `<helios-player>`, enabling declarative control of audio mute state.
 [v0.26.1] ✅ Completed: Poster Visibility - Refined logic to prioritize poster visibility over "Loading/Connecting" status overlay during initialization.
 [v0.26.0] ✅ Completed: Bridge Error Propagation - Implemented global error handling in `bridge.ts` and `HeliosController`, enabling the player UI to display runtime errors from the composition.
 [v0.25.2] ✅ Completed: Polish Burn-In Captions - Added text shadow to exported captions to match player UI styling and improved code hygiene by preventing canvas state leaks.

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -1007,4 +1007,51 @@ describe('HeliosPlayer', () => {
         expect(overlay!.classList.contains('hidden')).toBe(true);
     });
   });
+
+  describe('Muted Attribute', () => {
+    let mockController: any;
+
+    beforeEach(() => {
+        mockController = {
+            getState: vi.fn().mockReturnValue({ currentFrame: 0, duration: 10, fps: 30, isPlaying: false, muted: false }),
+            play: vi.fn(),
+            pause: vi.fn(),
+            seek: vi.fn(),
+            setAudioVolume: vi.fn(),
+            setAudioMuted: vi.fn(),
+            setPlaybackRate: vi.fn(),
+            subscribe: vi.fn().mockReturnValue(() => {}),
+            onError: vi.fn().mockReturnValue(() => {}),
+            dispose: vi.fn(),
+            setInputProps: vi.fn(),
+            captureFrame: vi.fn(),
+            getAudioTracks: vi.fn()
+        };
+    });
+
+    it('should set muted on controller when attribute is present during initialization', () => {
+        player.setAttribute('muted', '');
+        (player as any).setController(mockController);
+        expect(mockController.setAudioMuted).toHaveBeenCalledWith(true);
+    });
+
+    it('should set muted on controller when attribute is added dynamically', () => {
+        (player as any).setController(mockController);
+        player.setAttribute('muted', '');
+        expect(mockController.setAudioMuted).toHaveBeenCalledWith(true);
+    });
+
+    it('should unmute on controller when attribute is removed dynamically', () => {
+        player.setAttribute('muted', '');
+        (player as any).setController(mockController);
+        mockController.setAudioMuted.mockClear();
+
+        player.removeAttribute('muted');
+        expect(mockController.setAudioMuted).toHaveBeenCalledWith(false);
+    });
+
+    it('should observe muted attribute', () => {
+        expect(HeliosPlayer.observedAttributes).toContain('muted');
+    });
+  });
 });

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -456,7 +456,7 @@ export class HeliosPlayer extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ["src", "width", "height", "autoplay", "loop", "controls", "export-format", "input-props", "poster"];
+    return ["src", "width", "height", "autoplay", "loop", "controls", "export-format", "input-props", "poster", "muted"];
   }
 
   constructor() {
@@ -531,6 +531,12 @@ export class HeliosPlayer extends HTMLElement {
         }
       } catch (e) {
         console.warn("HeliosPlayer: Invalid JSON in input-props", e);
+      }
+    }
+
+    if (name === "muted") {
+      if (this.controller) {
+        this.controller.setAudioMuted(this.hasAttribute("muted"));
       }
     }
   }
@@ -771,6 +777,10 @@ export class HeliosPlayer extends HTMLElement {
 
       if (this.pendingProps) {
         this.controller.setInputProps(this.pendingProps);
+      }
+
+      if (this.hasAttribute("muted")) {
+        this.controller.setAudioMuted(true);
       }
 
       const state = this.controller.getState();


### PR DESCRIPTION
💡 What: Implemented the `muted` attribute on the `<helios-player>` Web Component.
🎯 Why: To close a gap in the Standard Media API and allow declarative muting.
📊 Impact: Users can now mute the player via HTML attribute (e.g. `<helios-player muted>`).
🔬 Verification: Added unit tests in `index.test.ts` to verify attribute observation and controller sync.

---
*PR created automatically by Jules for task [1939608447542188962](https://jules.google.com/task/1939608447542188962) started by @BintzGavin*