### PR TITLE
CORE: Stability API Spec

### DIFF
--- a/.jules/CORE.md
+++ b/.jules/CORE.md
@@ -73,3 +73,7 @@
 ## 2026-01-26 - Time Discrepancy in Status Files
 **Learning:** `docs/status/CORE.md` contains entries dated in the future (e.g., March 2026) relative to the system date (January 2026). This causes confusion when naming plan files sequentially.
 **Action:** Trust the system date (`date` command) for new plan filenames to ensure accuracy to the current execution context, regardless of the "future" status logs.
+
+## 2026-01-28 - Hybrid Composition Stability Gap
+**Learning:** `Helios.waitUntilStable()` delegated strictly to the active driver (usually `DomDriver`), which meant Canvas/WebGL or async data fetches were ignored during stability checks, risking render artifacts.
+**Action:** Planned `2026-01-28-CORE-StabilityAPI.md` to introduce `registerStabilityCheck`, enabling a hybrid stability model (Driver + Custom Checks).

--- a/.sys/plans/2026-01-28-CORE-StabilityAPI.md
+++ b/.sys/plans/2026-01-28-CORE-StabilityAPI.md
@@ -1,0 +1,57 @@
+# 2026-01-28-CORE-StabilityAPI.md
+
+#### 1. Context & Goal
+- **Objective**: Implement a `registerStabilityCheck` API in `Helios` to allow external systems (e.g. Three.js loaders, Data Fetchers) to delay the `waitUntilStable` promise.
+- **Trigger**: "Headless Logic Engine" vision requires deterministic rendering for *all* content types, not just DOM (which is currently handled by `DomDriver`).
+- **Impact**: Enables robust "Client-Side Export" and "Hybrid Composition" rendering by ensuring all assets are ready before frame capture.
+
+#### 2. File Inventory
+- **Modify**: `packages/core/src/helios.ts` (Implement logic)
+- **Create**: `packages/core/src/stability.test.ts` (Verify logic)
+- **Read-Only**: `packages/core/src/drivers/TimeDriver.ts` (Interface reference)
+
+#### 3. Implementation Spec
+- **Architecture**: Observer Pattern. `Helios` maintains a `Set` of async functions.
+- **Pseudo-Code**:
+  ```typescript
+  class Helios {
+    private _stabilityChecks = new Set<() => Promise<void>>();
+
+    /**
+     * Registers a custom stability check.
+     * The check function should return a Promise that resolves when the custom system is stable.
+     * @returns A disposal function to unregister the check.
+     */
+    public registerStabilityCheck(check: () => Promise<void>): () => void {
+      this._stabilityChecks.add(check);
+      return () => this._stabilityChecks.delete(check);
+    }
+
+    public async waitUntilStable() {
+      // 1. Wait for the primary driver (e.g., DomDriver)
+      await this.driver.waitUntilStable();
+
+      // 2. Wait for all custom checks in parallel
+      if (this._stabilityChecks.size > 0) {
+        await Promise.all(Array.from(this._stabilityChecks).map(check => check()));
+      }
+    }
+
+    public dispose() {
+       // ... existing disposal ...
+       this._stabilityChecks.clear();
+    }
+  }
+  ```
+- **Public API Changes**: New public method `registerStabilityCheck`.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm test -w packages/core`
+- **Success Criteria**:
+    - `packages/core/src/stability.test.ts` passes.
+    - Test case: Register a check that delays for 50ms. `waitUntilStable` takes > 50ms.
+    - Test case: Unregister check. `waitUntilStable` takes < 50ms.
+    - Test case: `dispose()` clears checks.
+- **Edge Cases**:
+    - Verify error propagation: If a custom check rejects, `waitUntilStable` should reject.


### PR DESCRIPTION
This spec defines the addition of `registerStabilityCheck` to the `Helios` class. This allows external systems (like Three.js or data fetchers) to register async promises that `waitUntilStable` must wait for, ensuring robust frame capture for Client-Side Export.

---
*PR created automatically by Jules for task [14589853420811951955](https://jules.google.com/task/14589853420811951955) started by @BintzGavin*