### PR TITLE
Plan: Interactive Mode for Player

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -13,3 +13,7 @@
 ## 2026-03-01 - Interactive Mode Default
 **Learning:** Defaulting to standard video behavior (click-to-pause) is safer for a "Player" component to align with user expectations, even if it changes existing behavior (clicks passing through), provided an opt-out (`interactive` attribute) is available.
 **Action:** When refining UI components, prioritize standard UX patterns over incidental behaviors (like click-through), but provide configuration for the alternative.
+
+## 2026-03-01 - Memory Hallucination
+**Learning:** The memory stated that `interactive` attribute was implemented, but the code lacked it. Memories can hallucinate features.
+**Action:** Always verify "known" features against the actual codebase (`read_file`) before assuming they exist.

--- a/.sys/plans/2026-03-01-PLAYER-InteractiveMode.md
+++ b/.sys/plans/2026-03-01-PLAYER-InteractiveMode.md
@@ -1,0 +1,52 @@
+# Context & Goal
+- **Objective**: Implement the `interactive` attribute and a click-to-toggle overlay for `<helios-player>`.
+- **Trigger**: Vision gap where standard video player behavior (click to pause) is missing, but direct interaction with the composition is sometimes needed.
+- **Impact**: Improves UX by providing familiar video controls (click-to-pause, double-click-to-fullscreen) while retaining the ability to support interactive compositions via an opt-out mechanism.
+
+# File Inventory
+- **Modify**: `packages/player/src/index.ts` (Add overlay HTML/CSS, attribute logic, event listeners).
+- **Modify**: `packages/player/src/index.test.ts` (Add unit tests for `interactive` attribute and overlay behavior).
+- **Read-Only**: `packages/player/src/controllers.ts` (No changes needed to controller interface).
+
+# Implementation Spec
+- **Architecture**:
+    -   Introduce a transparent `div.click-layer` within the Shadow DOM, absolutely positioned to cover the `iframe` but sit below the `.controls` and `.poster-container`.
+    -   Use CSS `pointer-events` to toggle the active state of this layer based on the `interactive` attribute.
+-   **Pseudo-Code**:
+    -   **Template Changes**:
+        -   Add `<div class="click-layer" part="click-layer"></div>` to the shadow root HTML.
+        -   CSS:
+            ```css
+            .click-layer {
+                position: absolute;
+                inset: 0;
+                z-index: 1; /* Above iframe (0), below controls/poster/overlay */
+                /* Optional: cursor: pointer; if we want to indicate clickable */
+            }
+            :host([interactive]) .click-layer {
+                pointer-events: none;
+                display: none; /* Optimization */
+            }
+            ```
+    -   **Logic Changes**:
+        -   Add `interactive` to `observedAttributes`.
+        -   Implement `get/set interactive` property reflecting the attribute.
+        -   In `connectedCallback`:
+            -   Add `click` listener to `.click-layer`: calls `togglePlayPause()`.
+            -   Add `dblclick` listener to `.click-layer`: calls `toggleFullscreen()`.
+            -   (Ensure listeners are removed in `disconnectedCallback`).
+-   **Public API Changes**:
+    -   New Attribute: `interactive` (boolean).
+    -   New Property: `interactive` (boolean).
+-   **Dependencies**: None.
+
+# Test Plan
+-   **Verification**: Run `npm test -w packages/player`.
+-   **Success Criteria**:
+    -   Verify `interactive` attribute creates/removes the attribute on the host.
+    -   Verify clicking the overlay calls `play()` or `pause()` on the controller.
+    -   Verify double-clicking the overlay calls `requestFullscreen()`.
+    -   Verify that when `interactive` is present, the overlay is effectively disabled (check `pointer-events` style or simulation).
+-   **Edge Cases**:
+    -   Ensure clicking controls (Play/Pause buttons) does not trigger the overlay click handler (propagation logic, though separate elements usually handles this naturally).
+    -   Ensure overlay does not block the "Big Play Button" or "Status Overlay" (z-index management).


### PR DESCRIPTION
This plan specifies the addition of an `interactive` attribute to `<helios-player>`. This feature closes a gap where standard video player behavior (click-to-pause) was missing, while allowing an opt-out for interactive compositions. The spec details the CSS overlay approach, event listeners, and comprehensive test plan.

---
*PR created automatically by Jules for task [11656192317969400452](https://jules.google.com/task/11656192317969400452) started by @BintzGavin*