### PR TITLE
✨ CORE: Implement Spring Duration

### DIFF
--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v2.4.0
+- ✅ Completed: Implement Spring Duration - Added `calculateSpringDuration` utility and exported `DEFAULT_SPRING_CONFIG` in `packages/core`.
+
 ## CORE v2.3.0
 - ✅ Completed: Implement Transitions Library - Implemented standard transition and crossfade functions, and corrected README installation instructions.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 2.3.0
+**Version**: 2.4.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance and Optimization
 - **Last Updated**: 2026-03-31
 
+[v2.4.0] ✅ Completed: Implement Spring Duration - Added `calculateSpringDuration` utility and exported `DEFAULT_SPRING_CONFIG` in `packages/core`.
 [v2.3.0] ✅ Completed: Implement Transitions Library - Implemented standard transition and crossfade functions, and corrected README installation instructions.
 [v2.2.0] ✅ Completed: Implement Playback Range - Added `playbackRange` to `HeliosState`, enabling loop and clamp behavior within a specific frame range.
 [v2.1.0] ✅ Completed: ESM Compliance - Converted package to native ESM with "type": "module", "moduleResolution": "node16", and explicit .js extensions.


### PR DESCRIPTION
* 💡 **What**: Implemented `calculateSpringDuration` utility and exported `DEFAULT_SPRING_CONFIG`.
* 🎯 **Why**: To allow users and tools to determine the duration of a spring animation for sequencing purposes (e.g. "wait until settled").
* 📊 **Impact**: Improves sequencing capabilities (`sequence`, `series`) by removing guesswork for spring durations.
* 🔬 **Verification**: Added unit tests in `packages/core/src/animation.test.ts` covering various damping ratios and clamping. Ran `npm test -w packages/core`.

---
*PR created automatically by Jules for task [4089247816171353495](https://jules.google.com/task/4089247816171353495) started by @BintzGavin*