### PR TITLE
✨ PLAYER: Interactive Mode

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -16,6 +16,7 @@ The `<helios-player>` component uses a Shadow DOM with the following structure:
 - `.status-overlay`: Displays loading, error, and connection states (hidden by default).
 - `.poster-container`: Displays the poster image and a "Big Play Button" for deferred loading.
 - `iframe`: The sandboxed iframe that loads the composition.
+- `.click-layer`: Transparent overlay that intercepts clicks (standard video behavior) or allows them to pass through (interactive mode).
 - `.captions-container`: Overlay for rendering caption cues.
 - `.controls`: The playback control bar (Play/Pause, Volume, Captions, Export, Speed, Scrubber, Time, Fullscreen).
 
@@ -43,6 +44,7 @@ The `<helios-player>` observes the following attributes:
 - `poster`: URL of an image to show before loading or playing.
 - `preload`: `auto` (default) or `none` (defer loading until interaction).
 - `muted`: Mute the audio by default.
+- `interactive`: Enable direct interaction with the composition content.
 
 ## Public API
 The `HeliosPlayer` class exposes the following properties and methods:
@@ -58,4 +60,5 @@ The `HeliosPlayer` class exposes the following properties and methods:
 - `playbackRate`: number (get/set)
 - `fps`: number (readonly)
 - `inputProps`: Record<string, any> | null (get/set)
+- `interactive`: boolean (get/set)
 - `load(): void`

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.29.0
+- ✅ Completed: Interactive Mode - Implemented `interactive` attribute to toggle between standard video controls and direct iframe interaction.
+
 ## PLAYER v0.28.0
 - ✅ Completed: Harden Player Connection - Implemented polling logic for Direct Mode connection to handle asynchronous composition initialization.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.28.0
+**Version**: v0.29.0
 
 # Status: PLAYER
 
@@ -32,6 +32,7 @@
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.29.0] ✅ Completed: Interactive Mode - Implemented `interactive` attribute to toggle between standard video controls and direct iframe interaction.
 [v0.28.0] ✅ Completed: Harden Player Connection - Implemented polling logic for Direct Mode connection to handle asynchronous composition initialization.
 [v0.27.0] ✅ Completed: Implement Muted Attribute - Added support for the `muted` attribute to `<helios-player>`, enabling declarative control of audio mute state.
 [v0.26.1] ✅ Completed: Poster Visibility - Refined logic to prioritize poster visibility over "Loading/Connecting" status overlay during initialization.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -64,6 +64,7 @@ The player will automatically attempt to access `window.helios` on the iframe's 
 | `poster` | URL of an image to display before playback starts. | - |
 | `preload` | `auto` or `none`. If `none`, defers loading the iframe until interaction. | `auto` |
 | `input-props` | JSON string of properties to pass to the composition. | - |
+| `interactive` | Enable direct interaction with the composition (disables click-to-pause). | `false` |
 
 ## Standard Media API
 

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -19,6 +19,7 @@ export declare class HeliosPlayer extends HTMLElement {
     private captionsContainer;
     private ccBtn;
     private showCaptions;
+    private clickLayer;
     private posterContainer;
     private posterImage;
     private bigPlayBtn;
@@ -46,6 +47,8 @@ export declare class HeliosPlayer extends HTMLElement {
     set volume(val: number);
     get muted(): boolean;
     set muted(val: boolean);
+    get interactive(): boolean;
+    set interactive(val: boolean);
     get playbackRate(): number;
     set playbackRate(val: number);
     get fps(): number;


### PR DESCRIPTION
Implemented an `interactive` attribute on `<helios-player>`. When enabled, the default click-to-pause behavior is disabled, and mouse events are allowed to pass through to the iframe.

- Added `.click-layer` to Shadow DOM.
- Added `:host([interactive]) .click-layer { pointer-events: none; }` style.
- Added `interactive` getter/setter and observed attribute.
- Updated tests and documentation.

---
*PR created automatically by Jules for task [674931908849622167](https://jules.google.com/task/674931908849622167) started by @BintzGavin*