### PR TITLE
📋 PLAYER: Standard Media Properties Spec

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -17,3 +17,7 @@
 ## 2026-03-01 - Memory Hallucination
 **Learning:** The memory stated that `interactive` attribute was implemented, but the code lacked it. Memories can hallucinate features.
 **Action:** Always verify "known" features against the actual codebase (`read_file`) before assuming they exist.
+
+## 2026-01-28 - Standard Media API Completeness
+**Learning:** "Standard Media API" compliance requires both methods (play, pause) AND properties (src, loop, autoplay) that reflect attributes. Missing properties force developers to use `setAttribute`, breaking expected patterns.
+**Action:** When auditing standard compliance, check `HTMLMediaElement` interface for both methods and properties.

--- a/.sys/plans/2026-01-28-PLAYER-Standard-Media-Props.md
+++ b/.sys/plans/2026-01-28-PLAYER-Standard-Media-Props.md
@@ -1,0 +1,80 @@
+# Context & Goal
+- **Objective**: Implement standard `HTMLMediaElement` properties (`src`, `loop`, `autoplay`, `controls`, `preload`, `poster`) on the `HeliosPlayer` class to match the `HTMLVideoElement` interface.
+- **Trigger**: Vision gap identified—standard media attributes are not exposed as properties on the DOM element, preventing standard programmatic usage.
+- **Impact**: Improves interoperability and allows developers to use familiar patterns (e.g., `player.loop = true`) instead of `setAttribute`.
+
+# File Inventory
+- **Modify**: `packages/player/src/index.ts`
+  - Add getters and setters for the missing properties.
+- **Modify**: `packages/player/src/index.test.ts`
+  - Add unit tests to verify the new properties reflect attributes correctly.
+- **Read-Only**: `packages/player/src/controllers.ts`
+
+# Implementation Spec
+- **Architecture**: Use standard Custom Element attribute reflection pattern.
+- **Public API Changes**:
+  - `get/set src` (string): Reflects `src` attribute.
+  - `get/set loop` (boolean): Reflects `loop` attribute.
+  - `get/set autoplay` (boolean): Reflects `autoplay` attribute.
+  - `get/set controls` (boolean): Reflects `controls` attribute.
+  - `get/set preload` (string): Reflects `preload` attribute (defaults to "auto").
+  - `get/set poster` (string): Reflects `poster` attribute.
+- **Pseudo-Code**:
+  ```typescript
+  // In HeliosPlayer class
+
+  get loop() {
+    return this.hasAttribute("loop");
+  }
+  set loop(val) {
+    if (val) this.setAttribute("loop", "");
+    else this.removeAttribute("loop");
+  }
+
+  get autoplay() {
+    return this.hasAttribute("autoplay");
+  }
+  set autoplay(val) {
+    if (val) this.setAttribute("autoplay", "");
+    else this.removeAttribute("autoplay");
+  }
+
+  get controls() {
+    return this.hasAttribute("controls");
+  }
+  set controls(val) {
+    if (val) this.setAttribute("controls", "");
+    else this.removeAttribute("controls");
+  }
+
+  get src() {
+    return this.getAttribute("src") || "";
+  }
+  set src(val) {
+    this.setAttribute("src", val);
+  }
+
+  get poster() {
+    return this.getAttribute("poster") || "";
+  }
+  set poster(val) {
+    this.setAttribute("poster", val);
+  }
+
+  get preload() {
+    return this.getAttribute("preload") || "auto";
+  }
+  set preload(val) {
+    this.setAttribute("preload", val);
+  }
+  ```
+- **Dependencies**: None.
+
+# Test Plan
+- **Verification**: `npm test -w packages/player`
+- **Success Criteria**:
+  - New tests in `index.test.ts` pass.
+  - Properties correctly update attributes.
+  - Attributes correctly update properties.
+- **Edge Cases**:
+  - Setting `src` to null/undefined (should handle gracefully or let native behavior persist).


### PR DESCRIPTION
This spec addresses a vision gap where standard media attributes were not exposed as properties on the DOM element. The plan outlines adding getters and setters to `HeliosPlayer` to reflect these attributes, improving interoperability and developer experience.

---
*PR created automatically by Jules for task [800504494574367101](https://jules.google.com/task/800504494574367101) started by @BintzGavin*