### PR TITLE
Enable DOM Transparency Support in Renderer

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -15,6 +15,7 @@ The Renderer uses the Strategy pattern to support two distinct rendering modes:
     *   Optimized for HTML/CSS animations.
     *   Uses `SeekTimeDriver` (WAAPI) to advance time.
     *   Captures frames using `page.screenshot()` (currently, pending `Element.capture` or similar).
+    *   **Transparent Video Export**: Supports transparency (alpha channel) by detecting `yuva` or `rgba` pixel formats and configuring Playwright to `omitBackground`.
     *   Injects polyfills via `SeekTimeDriver.init()` to ensure `requestAnimationFrame`, `Date.now`, and `performance.now` are deterministic from frame 0.
     *   **Deep DOM Discovery**: Automatically detects `<audio>` and `<video>` elements, and preloads fonts/images across **all frames** (including iframes), aggregating audio tracks for the final render.
     *   **Media Attributes**: Respects `data-helios-offset`, `data-helios-seek`, and `muted` attributes on media elements for precise timing and volume control.

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,5 +1,8 @@
 # RENDERER Progress Log
 
+## RENDERER v1.33.0
+- ✅ Completed: Enable DOM Transparency - Updated `DomStrategy` to support transparent video export by using `omitBackground: true` in Playwright when `pixelFormat` suggests alpha (e.g. `yuva420p`, `rgba`), allowing creation of transparent overlays and lower-thirds.
+
 ## RENDERER v1.32.0
 - ✅ Completed: FFmpeg Diagnostics - Implemented `FFmpegInspector` and updated `Renderer.diagnose()` to return comprehensive diagnostics including FFmpeg version, supported encoders (like `libx264`), and filters, resolving the Vision Gap.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.32.0
+**Version**: 1.33.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.33.0] ✅ Completed: Enable DOM Transparency - Updated `DomStrategy` to support transparent video export by using `omitBackground: true` in Playwright when `pixelFormat` suggests alpha (e.g. `yuva420p`, `rgba`), allowing creation of transparent overlays and lower-thirds.
 - [1.32.0] ✅ Completed: FFmpeg Diagnostics - Implemented `FFmpegInspector` and updated `Renderer.diagnose()` to return comprehensive diagnostics including FFmpeg version, supported encoders (like `libx264`), and filters, resolving the Vision Gap.
 - [1.31.0] ✅ Completed: DomStrategy Media Attributes - Updated `DomStrategy` to discover and respect `data-helios-offset`, `data-helios-seek`, and the `muted` attribute on `<audio>` and `<video>` elements, enabling precise timing and volume control from the DOM.
 - [1.30.0] ✅ Completed: Deep Dom Strategy - Updated `DomStrategy` to perform asset preloading (fonts, images, media) and audio track discovery across all frames (including iframes), ensuring robust rendering for nested compositions.

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -155,11 +155,22 @@ export class DomStrategy implements RenderStrategy {
   async capture(page: Page, frameTime: number): Promise<Buffer> {
     const format = this.options.intermediateImageFormat || 'png';
     const quality = this.options.intermediateImageQuality;
+    const pixelFormat = this.options.pixelFormat || 'yuv420p';
 
     if (format === 'jpeg') {
       return await page.screenshot({ type: 'jpeg', quality: quality });
     } else {
-      return await page.screenshot({ type: 'png' });
+      // Check if the requested pixel format supports alpha
+      const hasAlpha = pixelFormat.includes('yuva') ||
+                       pixelFormat.includes('rgba') ||
+                       pixelFormat.includes('bgra') ||
+                       pixelFormat.includes('argb') ||
+                       pixelFormat.includes('abgr');
+
+      return await page.screenshot({
+        type: 'png',
+        omitBackground: hasAlpha
+      });
     }
   }
 

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -9,6 +9,7 @@ const tests = [
   'tests/verify-implicit-audio.ts',
   'tests/verify-deep-dom.ts',
   'tests/verify-dom-media-attributes.ts',
+  'tests/verify-dom-transparency.ts',
   'tests/verify-smart-codec-selection.ts',
   'tests/verify-captions.ts',
   'scripts/verify-error-handling.ts',

--- a/packages/renderer/tests/verify-dom-transparency.ts
+++ b/packages/renderer/tests/verify-dom-transparency.ts
@@ -1,0 +1,91 @@
+import { Renderer, RendererOptions } from '../src/index.js';
+import * as path from 'path';
+import * as fs from 'fs';
+import { spawnSync } from 'child_process';
+import ffmpeg from '@ffmpeg-installer/ffmpeg';
+
+async function verifyTransparency() {
+  const outputPath = path.join(process.cwd(), 'test-transparency.mov');
+
+  // Clean up previous run
+  if (fs.existsSync(outputPath)) {
+    fs.unlinkSync(outputPath);
+  }
+
+  const options: RendererOptions = {
+    width: 128,
+    height: 128,
+    fps: 1,
+    durationInSeconds: 1,
+    mode: 'dom',
+    pixelFormat: 'rgba',
+    videoCodec: 'png',
+    ffmpegPath: ffmpeg.path
+  };
+
+  const renderer = new Renderer(options);
+
+  console.log('Rendering transparent video...');
+
+  // Capture logs
+  const logs: string[] = [];
+  const originalError = console.error;
+  const originalLog = console.log;
+
+  console.error = (...args) => {
+    logs.push(args.join(' '));
+    originalError(...args);
+  };
+
+  // Renderer uses console.error for ffmpeg stderr output
+
+  const compositionUrl = 'data:text/html,<html><body style="background: transparent; margin: 0;"></body></html>';
+
+  try {
+    await renderer.render(compositionUrl, outputPath);
+    originalLog('Render complete.');
+  } catch (e) {
+    originalError('Render failed:', e);
+    process.exit(1);
+  } finally {
+    console.error = originalError;
+    console.log = originalLog;
+  }
+
+  // Analyze logs for Input stream format
+  const logContent = logs.join('\n');
+
+  // Look for: "Stream #0:0: Video: png, rgb24(pc)" (Opaque)
+  // vs "Stream #0:0: Video: png, rgba(pc)" (Transparent)
+  // The regex should match the Input stream section.
+
+  // We need to be careful not to match the Output stream which might be forced to rgba.
+  // Input stream is usually "Input #0, image2pipe"
+
+  const inputMatch = logContent.match(/Input #0, image2pipe[\s\S]*?Stream #0:0: Video: png, (\w+)/);
+
+  if (inputMatch) {
+      const pixelFormat = inputMatch[1];
+      console.log(`Detected Input Pixel Format: ${pixelFormat}`);
+
+      if (pixelFormat.startsWith('rgba') || pixelFormat.startsWith('yuva') || pixelFormat.startsWith('pal8')) {
+          console.log('✅ Transparency verified (Input has alpha).');
+          // Cleanup
+          if (fs.existsSync(outputPath)) {
+            fs.unlinkSync(outputPath);
+          }
+          process.exit(0);
+      } else if (pixelFormat.startsWith('rgb24') || pixelFormat.startsWith('yuv')) {
+          console.error(`❌ Transparency Check Failed. Input format is ${pixelFormat} (Opaque).`);
+          process.exit(1);
+      } else {
+          console.warn(`⚠️ Unknown input format: ${pixelFormat}. Assuming failure.`);
+          process.exit(1);
+      }
+  } else {
+      console.error('❌ Could not find Input stream info in ffmpeg logs.');
+      process.exit(1);
+  }
+}
+
+verifyTransparency();


### PR DESCRIPTION
Implemented transparency support in `DomStrategy` by detecting alpha-capable pixel formats and enabling `omitBackground` in Playwright. Added verification test.

---
*PR created automatically by Jules for task [5627556169048204103](https://jules.google.com/task/5627556169048204103) started by @BintzGavin*