### PR TITLE
✨ RENDERER: Fix FFmpeg Diagnostics Dependencies

### DIFF
--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,5 +1,8 @@
 # RENDERER Progress Log
 
+## RENDERER v1.33.1
+- ✅ Completed: Fix FFmpeg Diagnostics Dependencies - Fixed dependency version mismatch for `@helios-project/core` in `packages/renderer` and `packages/player` and verified FFmpeg diagnostics implementation.
+
 ## RENDERER v1.33.0
 - ✅ Completed: Enable DOM Transparency - Updated `DomStrategy` to support transparent video export by using `omitBackground: true` in Playwright when `pixelFormat` suggests alpha (e.g. `yuva420p`, `rgba`), allowing creation of transparent overlays and lower-thirds.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.33.0
+**Version**: 1.33.1
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.33.1] ✅ Completed: Fix FFmpeg Diagnostics Dependencies - Fixed dependency version mismatch for `@helios-project/core` in `packages/renderer` and `packages/player` and verified FFmpeg diagnostics implementation.
 - [1.33.0] ✅ Completed: Enable DOM Transparency - Updated `DomStrategy` to support transparent video export by using `omitBackground: true` in Playwright when `pixelFormat` suggests alpha (e.g. `yuva420p`, `rgba`), allowing creation of transparent overlays and lower-thirds.
 - [1.32.0] ✅ Completed: FFmpeg Diagnostics - Implemented `FFmpegInspector` and updated `Renderer.diagnose()` to return comprehensive diagnostics including FFmpeg version, supported encoders (like `libx264`), and filters, resolving the Vision Gap.
 - [1.31.0] ✅ Completed: DomStrategy Media Attributes - Updated `DomStrategy` to discover and respect `data-helios-offset`, `data-helios-seek`, and the `muted` attribute on `<audio>` and `<video>` elements, enabling precise timing and volume control from the DOM.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7560,7 +7560,7 @@
     },
     "packages/core": {
       "name": "@helios-project/core",
-      "version": "0.0.1",
+      "version": "2.5.0",
       "license": "ELv2",
       "devDependencies": {
         "typescript": "^5.0.0"
@@ -7571,7 +7571,7 @@
       "version": "0.5.1",
       "license": "ELv2",
       "dependencies": {
-        "@helios-project/core": "0.0.1",
+        "@helios-project/core": "2.5.0",
         "mp4-muxer": "^2.0.1",
         "webm-muxer": "^5.1.4"
       },
@@ -7587,7 +7587,7 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/core": "0.0.1",
+        "@helios-project/core": "2.5.0",
         "playwright": "^1.42.1"
       },
       "devDependencies": {

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -30,7 +30,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@helios-project/core": "0.0.1",
+    "@helios-project/core": "2.5.0",
     "mp4-muxer": "^2.0.1",
     "webm-muxer": "^5.1.4"
   },

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "0.0.1",
+    "@helios-project/core": "2.5.0",
     "playwright": "^1.42.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixed a critical dependency version mismatch where `packages/renderer` and `packages/player` depended on `@helios-project/core@0.0.1` while the actual workspace version was `2.5.0`. This prevented `npm install` and verification tests from running correctly. Also verified the `FFmpegInspector` implementation and updated documentation.

---
*PR created automatically by Jules for task [17411202827630157818](https://jules.google.com/task/17411202827630157818) started by @BintzGavin*