### PR TITLE
✨ PLAYER: Implement Standard Media API properties

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -47,5 +47,11 @@
 - `muted`: boolean (get/set)
 - `playbackRate`: number (get/set)
 - `interactive`: boolean (get/set)
+- `src`: string (get/set)
+- `autoplay`: boolean (get/set)
+- `loop`: boolean (get/set)
+- `controls`: boolean (get/set)
+- `poster`: string (get/set)
+- `preload`: string (get/set)
 - `inputProps`: Record<string, any> (get/set)
 - `getController(): HeliosController | null`

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,11 @@
 # PLAYER Progress Log
 
+## PLAYER v0.31.0
+- ✅ Completed: Implement Standard Media API properties - Added missing properties `src`, `autoplay`, `loop`, `controls`, `poster`, `preload` to `HeliosPlayer` class to fully comply with HTMLMediaElement interface expectations. Updated `observedAttributes` to include `preload`. Updated dependencies to fix build issues.
+
+## PLAYER v0.30.0
+- ✅ Completed: Audio Export Enhancements - Implemented `loop` and `startTime` support for client-side audio export, plus declarative `volume` attribute parsing.
+
 ## PLAYER v0.29.0
 - ✅ Completed: Interactive Mode - Implemented `interactive` attribute to toggle between standard video controls and direct iframe interaction.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.30.0
+**Version**: v0.31.0
 
 # Status: PLAYER
 
@@ -27,7 +27,12 @@
 - Supports declarative data binding via `input-props` attribute (JSON string) and property, enabling dynamic composition updates.
 - Supports `poster` and `preload` attributes. `preload="none"` defers iframe loading until the user interacts with the new "Big Play Button".
 - Implements responsive controls using `ResizeObserver`, adapting UI layout for smaller widths (hiding volume/speed controls).
-- **New**: Implemented `muted` attribute support on `<helios-player>` to control initial mute state and reflect changes, closing a Standard Media API gap.
+- **New**: Fully implemented Standard Media API properties (`src`, `autoplay`, `loop`, `controls`, `poster`, `preload`) as getters/setters on `HeliosPlayer`, reflecting to attributes and ensuring `preload` is observed.
+
+## Critical Task
+- **None**: Recent task completed.
+
+[v0.31.0] ✅ Completed: Implement Standard Media API properties - Added missing properties `src`, `autoplay`, `loop`, `controls`, `poster`, `preload` to `HeliosPlayer` class to fully comply with HTMLMediaElement interface expectations. Updated `observedAttributes` to include `preload`. Updated dependencies to fix build issues.
 
 ## Critical Task
 - **None**: Recent task completed.

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -52,6 +52,18 @@ export declare class HeliosPlayer extends HTMLElement {
     get playbackRate(): number;
     set playbackRate(val: number);
     get fps(): number;
+    get src(): string;
+    set src(val: string);
+    get autoplay(): boolean;
+    set autoplay(val: boolean);
+    get loop(): boolean;
+    set loop(val: boolean);
+    get controls(): boolean;
+    set controls(val: boolean);
+    get poster(): string;
+    set poster(val: string);
+    get preload(): string;
+    set preload(val: string);
     play(): Promise<void>;
     load(): void;
     pause(): void;

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -433,6 +433,57 @@ export class HeliosPlayer extends HTMLElement {
     get fps() {
         return this.controller ? this.controller.getState().fps : 0;
     }
+    get src() {
+        return this.getAttribute("src") || "";
+    }
+    set src(val) {
+        this.setAttribute("src", val);
+    }
+    get autoplay() {
+        return this.hasAttribute("autoplay");
+    }
+    set autoplay(val) {
+        if (val) {
+            this.setAttribute("autoplay", "");
+        }
+        else {
+            this.removeAttribute("autoplay");
+        }
+    }
+    get loop() {
+        return this.hasAttribute("loop");
+    }
+    set loop(val) {
+        if (val) {
+            this.setAttribute("loop", "");
+        }
+        else {
+            this.removeAttribute("loop");
+        }
+    }
+    get controls() {
+        return this.hasAttribute("controls");
+    }
+    set controls(val) {
+        if (val) {
+            this.setAttribute("controls", "");
+        }
+        else {
+            this.removeAttribute("controls");
+        }
+    }
+    get poster() {
+        return this.getAttribute("poster") || "";
+    }
+    set poster(val) {
+        this.setAttribute("poster", val);
+    }
+    get preload() {
+        return this.getAttribute("preload") || "auto";
+    }
+    set preload(val) {
+        this.setAttribute("preload", val);
+    }
     async play() {
         if (!this.isLoaded) {
             this.setAttribute("autoplay", "");

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -30,7 +30,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@helios-project/core": "0.0.1",
+    "@helios-project/core": "2.5.0",
     "mp4-muxer": "^2.0.1",
     "webm-muxer": "^5.1.4"
   },

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { HeliosPlayer } from './index';
+
+// Mock ResizeObserver
+global.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as any;
+
+describe('HeliosPlayer API Parity', () => {
+  let player: HeliosPlayer;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    player = new HeliosPlayer();
+    document.body.appendChild(player);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should reflect src attribute as property', () => {
+    player.setAttribute('src', 'test.html');
+    expect(player.src).toBe('test.html');
+
+    player.src = 'other.html';
+    expect(player.getAttribute('src')).toBe('other.html');
+  });
+
+  it('should reflect autoplay attribute as boolean property', () => {
+    expect(player.autoplay).toBe(false);
+
+    player.setAttribute('autoplay', '');
+    expect(player.autoplay).toBe(true);
+
+    player.removeAttribute('autoplay');
+    expect(player.autoplay).toBe(false);
+
+    player.autoplay = true;
+    expect(player.hasAttribute('autoplay')).toBe(true);
+
+    player.autoplay = false;
+    expect(player.hasAttribute('autoplay')).toBe(false);
+  });
+
+  it('should reflect loop attribute as boolean property', () => {
+    expect(player.loop).toBe(false);
+
+    player.setAttribute('loop', '');
+    expect(player.loop).toBe(true);
+
+    player.loop = true;
+    expect(player.hasAttribute('loop')).toBe(true);
+
+    player.loop = false;
+    expect(player.hasAttribute('loop')).toBe(false);
+  });
+
+  it('should reflect controls attribute as boolean property', () => {
+    expect(player.controls).toBe(false);
+
+    player.setAttribute('controls', '');
+    expect(player.controls).toBe(true);
+
+    player.controls = true;
+    expect(player.hasAttribute('controls')).toBe(true);
+
+    player.controls = false;
+    expect(player.hasAttribute('controls')).toBe(false);
+  });
+
+  it('should reflect poster attribute as property', () => {
+    player.setAttribute('poster', 'image.jpg');
+    expect(player.poster).toBe('image.jpg');
+
+    player.poster = 'other.jpg';
+    expect(player.getAttribute('poster')).toBe('other.jpg');
+  });
+
+  it('should reflect preload attribute as property', () => {
+    // Default is usually auto, but let's check what attribute says
+    expect(player.preload).toBe('auto'); // Assuming default return if missing
+
+    player.setAttribute('preload', 'none');
+    expect(player.preload).toBe('none');
+
+    player.preload = 'auto';
+    expect(player.getAttribute('preload')).toBe('auto');
+  });
+});

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -456,6 +456,66 @@ export class HeliosPlayer extends HTMLElement {
     return this.controller ? this.controller.getState().fps : 0;
   }
 
+  public get src(): string {
+    return this.getAttribute("src") || "";
+  }
+
+  public set src(val: string) {
+    this.setAttribute("src", val);
+  }
+
+  public get autoplay(): boolean {
+    return this.hasAttribute("autoplay");
+  }
+
+  public set autoplay(val: boolean) {
+    if (val) {
+      this.setAttribute("autoplay", "");
+    } else {
+      this.removeAttribute("autoplay");
+    }
+  }
+
+  public get loop(): boolean {
+    return this.hasAttribute("loop");
+  }
+
+  public set loop(val: boolean) {
+    if (val) {
+      this.setAttribute("loop", "");
+    } else {
+      this.removeAttribute("loop");
+    }
+  }
+
+  public get controls(): boolean {
+    return this.hasAttribute("controls");
+  }
+
+  public set controls(val: boolean) {
+    if (val) {
+      this.setAttribute("controls", "");
+    } else {
+      this.removeAttribute("controls");
+    }
+  }
+
+  public get poster(): string {
+    return this.getAttribute("poster") || "";
+  }
+
+  public set poster(val: string) {
+    this.setAttribute("poster", val);
+  }
+
+  public get preload(): string {
+    return this.getAttribute("preload") || "auto";
+  }
+
+  public set preload(val: string) {
+    this.setAttribute("preload", val);
+  }
+
   public async play(): Promise<void> {
     if (!this.isLoaded) {
       this.setAttribute("autoplay", "");
@@ -480,7 +540,7 @@ export class HeliosPlayer extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ["src", "width", "height", "autoplay", "loop", "controls", "export-format", "input-props", "poster", "muted", "interactive"];
+    return ["src", "width", "height", "autoplay", "loop", "controls", "export-format", "input-props", "poster", "muted", "interactive", "preload"];
   }
 
   constructor() {


### PR DESCRIPTION
Implemented standard HTMLMediaElement properties (`src`, `autoplay`, `loop`, `controls`, `poster`, `preload`) as getters and setters on the `HeliosPlayer` class.
These properties reflect their corresponding attributes, ensuring full API parity and enabling programmatic control (e.g., `player.src = '...'`).
Added `preload` to `observedAttributes` to ensure consistent reactivity.
Updated documentation to reflect the new API.
Fixed a dependency version mismatch for `@helios-project/core` in `packages/player/package.json`.

---
*PR created automatically by Jules for task [17883651991692650907](https://jules.google.com/task/17883651991692650907) started by @BintzGavin*