### PR TITLE
✨ STUDIO: Drag & Drop Assets to Props

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -46,12 +46,12 @@ Options:
 
 ## D. UI Components
 - **Timeline**: Visual track of the video, supports markers, captions, zooming.
-- **PropsEditor**: Auto-generated inputs based on composition schema (supports Asset selection).
+- **PropsEditor**: Auto-generated inputs based on composition schema (supports Asset selection, Drag & Drop).
 - **Stage**: Renders the `<helios-player>` or canvas.
 - **GlobalShortcuts**: Headless component managing keyboard interactions.
 - **PlaybackControls**: Buttons for play, pause, seek, loop, volume.
 - **KeyboardShortcutsModal**: Displays available shortcuts.
-- **AssetsPanel**: Drag-and-drop asset management.
+- **AssetsPanel**: Drag-and-drop asset management (upload & drag to props).
 - **RendersPanel**: Render job management and client-side export.
 - **DiagnosticsPanel**: Environment checks.
 

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.42.0
+- ✅ Completed: Drag & Drop Assets - Implemented drag and drop support from Assets Panel to Props Editor inputs (typed and generic).
+
 ## STUDIO v0.41.0
 - ✅ Completed: Asset Input - Implemented `AssetInput` in Props Editor with asset discovery integration.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.41.0
+**Version**: 0.42.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.42.0] ✅ Completed: Drag & Drop Assets - Implemented drag and drop support from Assets Panel to Props Editor inputs (typed and generic).
 - [v0.41.0] ✅ Completed: Asset Input - Implemented `AssetInput` in Props Editor with asset discovery integration (autocomplete via datalist) for image, video, audio, and font types.
 - [v0.40.1] ✅ Completed: Documentation & Verification - Added package README, updated version, and implemented Playwright-based verification script.
 - [v0.40.0] ✅ Completed: Global Shortcuts Refactor - Centralized all keyboard shortcuts into `GlobalShortcuts.tsx` and added Loop Toggle ('L').

--- a/packages/studio/src/components/AssetsPanel/AssetItem.tsx
+++ b/packages/studio/src/components/AssetsPanel/AssetItem.tsx
@@ -84,6 +84,12 @@ export const AssetItem: React.FC<AssetItemProps> = ({ asset }) => {
       }
   };
 
+  const handleDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.setData('application/helios-asset', JSON.stringify(asset));
+    e.dataTransfer.setData('text/plain', asset.url);
+    e.dataTransfer.effectAllowed = 'copy';
+  };
+
   const renderPreview = () => {
     switch (asset.type) {
         case 'image':
@@ -130,6 +136,8 @@ export const AssetItem: React.FC<AssetItemProps> = ({ asset }) => {
     <div
       className="asset-item"
       title={asset.name}
+      draggable={true}
+      onDragStart={handleDragStart}
       onMouseEnter={asset.type === 'video' ? handleVideoEnter : () => setIsHovering(true)}
       onMouseLeave={asset.type === 'video' ? handleVideoLeave : () => setIsHovering(false)}
     >

--- a/packages/studio/src/components/PropsEditor.css
+++ b/packages/studio/src/components/PropsEditor.css
@@ -113,3 +113,9 @@
   flex: 1;
   cursor: pointer;
 }
+
+.prop-input.drag-over {
+  border-color: #3296ff;
+  background-color: rgba(50, 150, 255, 0.1);
+  box-shadow: 0 0 0 2px rgba(50, 150, 255, 0.2);
+}

--- a/packages/studio/src/components/PropsEditor.tsx
+++ b/packages/studio/src/components/PropsEditor.tsx
@@ -98,6 +98,7 @@ const JsonPropInput: React.FC<{ value: any, onChange: (val: any) => void }> = ({
 
 const PropInput: React.FC<{ value: any, onChange: (val: any) => void }> = ({ value, onChange }) => {
   const type = typeof value;
+  const [isDragOver, setIsDragOver] = useState(false);
 
   if (value === null) {
       return <JsonPropInput value={value} onChange={onChange} />;
@@ -150,9 +151,17 @@ const PropInput: React.FC<{ value: any, onChange: (val: any) => void }> = ({ val
      return (
        <input
          type="text"
-         className="prop-input"
+         className={`prop-input ${isDragOver ? 'drag-over' : ''}`}
          value={value}
          onChange={(e) => onChange(e.target.value)}
+         onDragOver={(e) => { e.preventDefault(); setIsDragOver(true); }}
+         onDragLeave={() => setIsDragOver(false)}
+         onDrop={(e) => {
+             e.preventDefault();
+             setIsDragOver(false);
+             const text = e.dataTransfer.getData('text/plain');
+             if (text) onChange(text);
+         }}
        />
      );
   }

--- a/packages/studio/src/components/SchemaInputs.tsx
+++ b/packages/studio/src/components/SchemaInputs.tsx
@@ -47,18 +47,52 @@ const AssetInput: React.FC<{ type: PropType; value: string; onChange: (val: stri
 }) => {
   const { assets } = useStudio();
   const listId = React.useId();
+  const [isDragOver, setIsDragOver] = React.useState(false);
 
   const filteredAssets = assets.filter((a) => a.type === type);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = () => {
+    setIsDragOver(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+
+    const assetData = e.dataTransfer.getData('application/helios-asset');
+    if (assetData) {
+        try {
+            const asset = JSON.parse(assetData);
+            if (asset.type === type) {
+                onChange(asset.url);
+            }
+        } catch (e) {
+            console.error('Invalid asset data', e);
+        }
+    } else {
+        // Fallback for generic text
+        const text = e.dataTransfer.getData('text/plain');
+        if (text) onChange(text);
+    }
+  };
 
   return (
     <>
       <input
         type="text"
         list={listId}
-        className="prop-input"
+        className={`prop-input ${isDragOver ? 'drag-over' : ''}`}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={`Select ${type} or enter URL...`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
       />
       <datalist id={listId}>
         {filteredAssets.map((asset) => (
@@ -153,12 +187,33 @@ const ColorInput: React.FC<{ value: string, onChange: (val: string) => void }> =
 };
 
 const StringInput: React.FC<{ value: string, onChange: (val: string) => void }> = ({ value, onChange }) => {
+  const [isDragOver, setIsDragOver] = React.useState(false);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = () => {
+    setIsDragOver(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    const text = e.dataTransfer.getData('text/plain');
+    if (text) onChange(text);
+  };
+
   return (
     <input
       type="text"
-      className="prop-input"
+      className={`prop-input ${isDragOver ? 'drag-over' : ''}`}
       value={value}
       onChange={(e) => onChange(e.target.value)}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
     />
   );
 };

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -124,7 +124,7 @@ interface StudioContextType {
   cancelExport: () => void;
 }
 
-const StudioContext = createContext<StudioContextType | undefined>(undefined);
+export const StudioContext = createContext<StudioContextType | undefined>(undefined);
 
 export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [compositions, setCompositions] = useState<Composition[]>([]);


### PR DESCRIPTION
💡 **What**: Implemented drag and drop support from the Assets Panel to Props Editor inputs.
🎯 **Why**: To streamline the workflow of using assets in compositions, replacing the need to copy-paste URLs.
📊 **Impact**: Improved UX for asset management.
🔬 **Verification**: verified drag events and drop handling on AssetInput and StringInput using a temporary test file. Manual verification logic confirms data transfer formats (`application/helios-asset` and `text/plain`) are handled correctly.

---
*PR created automatically by Jules for task [16252597344558302628](https://jules.google.com/task/16252597344558302628) started by @BintzGavin*