### PR TITLE
✨ CORE: Fix bindToDocumentTimeline driver sync

### DIFF
--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v2.6.1
+- ✅ Completed: Fix bindToDocumentTimeline Sync - Updated `Helios.bindToDocumentTimeline` to propagate time updates to the active `TimeDriver`, ensuring media synchronization when driven externally.
+
 ## CORE v2.6.0
 - ✅ Completed: Implement DomDriver Media Attributes - Implemented `data-helios-offset` and `data-helios-seek` support in `DomDriver` for accurate in-browser preview timing.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 2.6.0
+**Version**: 2.6.1
 
 - **Status**: Active
 - **Current Focus**: Maintenance and Optimization
-- **Last Updated**: 2026-04-10
+- **Last Updated**: 2026-04-12
 
+[v2.6.1] ✅ Completed: Fix bindToDocumentTimeline Sync - Updated `Helios.bindToDocumentTimeline` to propagate time updates to the active `TimeDriver`, ensuring media synchronization when driven externally.
 [v2.6.0] ✅ Completed: Implement DomDriver Media Attributes - Implemented `data-helios-offset` and `data-helios-seek` support in `DomDriver` for accurate in-browser preview timing.
 [v2.5.0] ✅ Completed: Maintenance and Robustness - Fixed memory leak in Helios constructor, enhanced color schema validation, and synced package version.
 [v2.4.0] ✅ Completed: Implement Spring Duration - Added `calculateSpringDuration` utility and exported `DEFAULT_SPRING_CONFIG` in `packages/core`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/core",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "type": "module",
   "description": "Core library for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -160,6 +160,30 @@ describe('Helios Core', () => {
 
         helios.unbindFromDocumentTimeline();
     });
+
+    it('should propagate document timeline updates to driver', async () => {
+        const mockDriver: TimeDriver = {
+           init: vi.fn(),
+           update: vi.fn(),
+           waitUntilStable: vi.fn().mockResolvedValue(undefined)
+        };
+
+        const helios = new Helios({ duration: 10, fps: 30, driver: mockDriver });
+        helios.bindToDocumentTimeline();
+
+        // Simulate time passing in document.timeline
+        (document.timeline as any).currentTime = 1000; // 1 second
+
+        // Wait for polling loop
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        // Expect driver update to be called with correct time
+        expect(mockDriver.update).toHaveBeenCalledWith(1000, expect.objectContaining({
+            isPlaying: false
+        }));
+
+        helios.unbindFromDocumentTimeline();
+    });
   });
 
   describe('WAAPI Synchronization', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -613,6 +613,13 @@ export class Helios {
             if (frame !== this._currentFrame.peek()) {
                  this._currentFrame.value = frame;
             }
+
+            this.driver.update(currentTime, {
+                isPlaying: false,
+                playbackRate: this._playbackRate.peek(),
+                volume: this._volume.peek(),
+                muted: this._muted.peek()
+            });
         }
         requestAnimationFrame(poll);
     };


### PR DESCRIPTION
Updated `Helios.bindToDocumentTimeline()` to propagate time updates to the active `TimeDriver`.
This ensures that when `Helios` is following `document.timeline` (e.g. during rendering), attached drivers like `DomDriver` correctly seek their media elements (`<audio>`, `<video>`).

Includes:
- Fix in `packages/core/src/index.ts`
- New test case in `packages/core/src/index.test.ts`
- Version bump to `2.6.1`
- Documentation updates


---
*PR created automatically by Jules for task [2307785731189973063](https://jules.google.com/task/2307785731189973063) started by @BintzGavin*