### PR TITLE
📋 RENDERER: Plan to Enable Missing Verification Scripts

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -96,3 +96,7 @@
 ## [2026-03-27] - Role Violation Check
 **Learning:** I acted as a Builder by implementing `SeekTimeDriver` offset logic instead of just planning it. This violates strict Planner boundaries.
 **Action:** When the system identity says "PLANNER", I must ONLY produce `.md` files in `/.sys/plans/`. I must never modify `packages/` or run implementation code.
+
+## [2025-05-22] - Verification Gap in Run-All Script
+**Learning:** The `packages/renderer/tests/run-all.ts` script (executed by `npm test`) only runs a subset of available verification scripts. Critical tests for Concatenation, Stream Copy, and Audio Codecs are present in the directory but ignored by CI.
+**Action:** Created a plan to enable all valid verification scripts in `run-all.ts` to ensure full coverage of implemented features.

--- a/.sys/plans/2025-05-22-RENDERER-Enable-Missing-Tests.md
+++ b/.sys/plans/2025-05-22-RENDERER-Enable-Missing-Tests.md
@@ -1,0 +1,46 @@
+# 2025-05-22-RENDERER-Enable-Missing-Tests.md
+
+## 1. Context & Goal
+- **Objective**: Activate missing verification scripts in the renderer's test runner to ensure comprehensive coverage of the rendering pipeline.
+- **Trigger**: `packages/renderer/tests/run-all.ts` currently excludes over 50% of the available test scripts (e.g., `verify-concat.ts`, `verify-stream-copy.ts`), leaving critical features like distributed rendering and codec selection unverified in CI.
+- **Impact**: Ensures that critical features (Concatenation, Bitrate Control, Stream Copy, CDP Driver) are verified during the build process, preventing regressions.
+
+## 2. File Inventory
+- **Modify**: `packages/renderer/tests/run-all.ts` (Add missing test files to the `tests` array)
+- **Read-Only**: `packages/renderer/tests/*.ts` (To confirm filenames)
+
+## 3. Implementation Spec
+- **Architecture**: No architectural changes. Just updating the test registry.
+- **Pseudo-Code**:
+  ```typescript
+  // packages/renderer/tests/run-all.ts
+  const tests = [
+    'tests/test-canvas-strategy.ts', // Add Unit Test
+    'tests/test-cdp-driver.ts',      // Add Unit Test
+    'tests/verify-audio-codecs.ts',  // Add Verification
+    'tests/verify-bitrate.ts',       // Add Verification
+    'tests/verify-captions.ts',      // Existing
+    'tests/verify-codecs.ts',        // Add Verification
+    'tests/verify-concat.ts',        // Add Verification (Distributed Rendering)
+    'tests/verify-deep-dom.ts',      // Existing
+    'tests/verify-diagnose-ffmpeg.ts', // Existing
+    'tests/verify-dom-media-attributes.ts', // Existing
+    'tests/verify-dom-transparency.ts', // Existing
+    'tests/verify-iframe-sync.ts',   // Existing
+    'tests/verify-implicit-audio.ts', // Existing
+    'tests/verify-media-sync.ts',    // Existing
+    'tests/verify-range-render.ts',  // Add Verification
+    'tests/verify-seek-driver-determinism.ts', // Existing
+    'tests/verify-seek-driver-offsets.ts', // Add Verification
+    'tests/verify-smart-codec-selection.ts', // Existing
+    'tests/verify-stream-copy.ts',   // Add Verification (Optimization)
+    'scripts/verify-error-handling.ts', // Existing
+  ];
+  ```
+- **Dependencies**: None.
+
+## 4. Test Plan
+- **Verification**: Run `npm test -w packages/renderer`
+- **Success Criteria**: All tests (existing + new) pass with exit code 0.
+- **Edge Cases**:
+    - `verify-concat.ts` requires `examples/simple-canvas-animation` to be built or present. The script handles this by falling back to source if build artifact is missing.


### PR DESCRIPTION
This plan addresses a critical gap where over 50% of the renderer's verification scripts (including distributed rendering and stream copy tests) are excluded from the `npm test` command.

The plan involves updating `packages/renderer/tests/run-all.ts` to include all valid test files found in the directory.

No source code was modified in this PR. Only the plan file and journal were updated.

---
*PR created automatically by Jules for task [11617917505965227520](https://jules.google.com/task/11617917505965227520) started by @BintzGavin*