### PR TITLE
✨ RENDERER: Support Helios Stability Registry

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -21,7 +21,7 @@ The Renderer uses the Strategy pattern to support two distinct rendering modes:
     *   **Media Attributes**: Respects `data-helios-offset`, `data-helios-seek`, and `muted` attributes on media elements for precise timing and volume control.
     *   **Media Synchronization**: Manually syncs `<video>` and `<audio>` elements to the virtual timeline in SeekTimeDriver, respecting offset and seek attributes.
     *   **Frame Synchronization**: `SeekTimeDriver` iterates over all attached frames (including iframes) to inject polyfills and synchronize virtual time, ensuring complex compositions render correctly.
-    *   **Stability Wait**: Waits for `document.fonts.ready` and media element `seeked` events (with timeout) after every seek to ensure deterministic frame capture without artifacts.
+    *   **Stability Wait**: Waits for `document.fonts.ready`, media element `seeked` events, and `helios.waitUntilStable()` (if available) after every seek, ensuring deterministic frame capture that respects custom stability checks.
 
 ## B. File Tree
 ```

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,5 +1,8 @@
 # RENDERER Progress Log
 
+## RENDERER v1.35.0
+- ✅ Completed: Support Helios Stability Registry - Updated `SeekTimeDriver` to detect and await `window.helios.waitUntilStable()`, enabling robust synchronization with custom stability checks registered in the core engine.
+
 ## RENDERER v1.34.0
 - ✅ Completed: Seek Driver Offsets - Updated `SeekTimeDriver` to respect `data-helios-offset` and `data-helios-seek` attributes, calculating correct `currentTime` for visual media synchronization.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.34.0
+**Version**: 1.35.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.35.0] ✅ Completed: Support Helios Stability Registry - Updated `SeekTimeDriver` to detect and await `window.helios.waitUntilStable()`, enabling robust synchronization with custom stability checks registered in the core engine.
 - [1.34.0] ✅ Completed: Seek Driver Offsets - Updated `SeekTimeDriver` to respect `data-helios-offset` and `data-helios-seek` attributes, calculating correct `currentTime` for visual media synchronization.
 - [1.33.0] ✅ Completed: Enable DOM Transparency - Updated `DomStrategy` to support transparent video export by using `omitBackground: true` in Playwright when `pixelFormat` suggests alpha (e.g. `yuva420p`, `rgba`), allowing creation of transparent overlays and lower-thirds.
 - [1.32.0] ✅ Completed: FFmpeg Diagnostics - Implemented `FFmpegInspector` and updated `Renderer.diagnose()` to return comprehensive diagnostics including FFmpeg version, supported encoders (like `libx264`), and filters, resolving the Vision Gap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7560,7 +7560,7 @@
     },
     "packages/core": {
       "name": "@helios-project/core",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "ELv2",
       "devDependencies": {
         "typescript": "^5.0.0"
@@ -7571,7 +7571,7 @@
       "version": "0.5.1",
       "license": "ELv2",
       "dependencies": {
-        "@helios-project/core": "2.6.0",
+        "@helios-project/core": "2.6.1",
         "mp4-muxer": "^2.0.1",
         "webm-muxer": "^5.1.4"
       },
@@ -7587,7 +7587,7 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/core": "2.6.0",
+        "@helios-project/core": "2.6.1",
         "playwright": "^1.42.1"
       },
       "devDependencies": {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "2.6.0",
+    "@helios-project/core": "2.6.1",
     "playwright": "^1.42.1"
   },
   "devDependencies": {

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -92,7 +92,12 @@ export class SeekTimeDriver implements TimeDriver {
           }
         });
 
-        // 3. Wait for stability with a safety timeout
+        // 3. Wait for Helios Stability (Custom Checks)
+        if (typeof window.helios !== 'undefined' && typeof window.helios.waitUntilStable === 'function') {
+          promises.push(window.helios.waitUntilStable());
+        }
+
+        // 4. Wait for stability with a safety timeout
         const allReady = Promise.all(promises);
         const timeout = new Promise((resolve) => setTimeout(resolve, 3000));
         await Promise.race([allReady, timeout]);

--- a/packages/renderer/tests/verify-seek-driver-stability.ts
+++ b/packages/renderer/tests/verify-seek-driver-stability.ts
@@ -1,0 +1,75 @@
+import { chromium } from 'playwright';
+import { SeekTimeDriver } from '../src/drivers/SeekTimeDriver.js';
+
+async function verifyStability() {
+  console.log('Starting SeekTimeDriver stability verification...');
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  const driver = new SeekTimeDriver();
+  await driver.init(page);
+
+  // Define a page that mocks window.helios
+  const htmlContent = `
+    <!DOCTYPE html>
+    <html>
+    <body>
+      <script>
+        // Mock Helios
+        window.helios = {
+          waitUntilStable: () => {
+             // Set a flag that we were called
+             window.__helios_stable_called = true;
+             // Simulate work
+             return new Promise(resolve => setTimeout(resolve, 500));
+          }
+        };
+        window.__helios_stable_called = false;
+      </script>
+    </body>
+    </html>
+  `;
+
+  await page.goto(`data:text/html,${encodeURIComponent(htmlContent)}`);
+
+  const startTime = Date.now();
+  console.log('Setting time to 1.0s...');
+  await driver.setTime(page, 1.0);
+  const endTime = Date.now();
+  const elapsed = endTime - startTime;
+
+  console.log(`setTime took ${elapsed}ms`);
+
+  // Assertions
+  const wasCalled = await page.evaluate(() => (window as any).__helios_stable_called);
+
+  let failures = 0;
+
+  if (!wasCalled) {
+    console.error('❌ FAILURE: window.helios.waitUntilStable() was NOT called.');
+    failures++;
+  } else {
+    console.log('✅ window.helios.waitUntilStable() was called.');
+  }
+
+  if (elapsed < 450) { // Allow some jitter, but should be close to 500ms
+    console.error(`❌ FAILURE: setTime returned too quickly (${elapsed}ms). Expected > 500ms.`);
+    failures++;
+  } else {
+    console.log('✅ setTime waited for stability check.');
+  }
+
+  await browser.close();
+
+  if (failures > 0) {
+    process.exit(1);
+  } else {
+    console.log('✅ SUCCESS: SeekTimeDriver respects helios.waitUntilStable()');
+  }
+}
+
+verifyStability().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
- **What**: Integrated `window.helios.waitUntilStable()` into `SeekTimeDriver.setTime()`.
- **Why**: To support the "Headless Logic Engine" vision where compositions define their own stability criteria (loading assets, settling physics) that the renderer must respect.
- **Impact**: Deterministic rendering for compositions that use the new Stability Registry API.
- **Verification**: `npx tsx packages/renderer/tests/verify-seek-driver-stability.ts` passed. Full renderer test suite passed.

---
*PR created automatically by Jules for task [8564724291115394729](https://jules.google.com/task/8564724291115394729) started by @BintzGavin*