### PR TITLE
✨ PLAYER: Polish Click-To-Play & Fix Z-Index

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.32.2
+- ✅ Completed: Polish Click-To-Play & Fix Z-Index - Fixed bug where controls were blocked by click-layer and ensured player grabs focus on click.
+
 ## PLAYER v0.32.1
 - ✅ Completed: Fix Player Dependencies - Updated @helios-project/core dependency and fixed build environment to enable verification.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.32.1
+**Version**: v0.32.2
 
 # Status: PLAYER
 
@@ -33,6 +33,7 @@
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.32.2] ✅ Completed: Polish Click-To-Play & Fix Z-Index - Fixed bug where controls were blocked by click-layer and ensured player grabs focus on click.
 [v0.32.1] ✅ Completed: Fix Player Dependencies - Updated @helios-project/core dependency and fixed build environment to enable verification.
 [v0.32.0] ✅ Completed: Implement Standard Media States - Added `readyState`, `networkState` properties and constants, along with lifecycle events (`loadstart`, `loadedmetadata`, `canplay`, `canplaythrough`) to `<helios-player>`.
 [v0.31.0] ✅ Completed: Implement Standard Media API properties - Added missing properties `src`, `autoplay`, `loop`, `controls`, `poster`, `preload` to `HeliosPlayer` class to fully comply with HTMLMediaElement interface expectations. Updated `observedAttributes` to include `preload`. Updated dependencies to fix build issues.

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -28,6 +28,7 @@ template.innerHTML = `
       padding: 8px;
       color: white;
       transition: opacity 0.3s;
+      z-index: 2;
     }
     :host(:not([controls])) .controls {
       display: none;
@@ -550,7 +551,10 @@ export class HeliosPlayer extends HTMLElement {
         this.bigPlayBtn = this.shadowRoot.querySelector(".big-play-btn");
         this.retryAction = () => this.retryConnection();
         this.retryBtn.onclick = () => this.retryAction();
-        this.clickLayer.addEventListener("click", () => this.togglePlayPause());
+        this.clickLayer.addEventListener("click", () => {
+            this.focus();
+            this.togglePlayPause();
+        });
         this.clickLayer.addEventListener("dblclick", () => this.toggleFullscreen());
         this.resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -33,6 +33,7 @@ template.innerHTML = `
       padding: 8px;
       color: white;
       transition: opacity 0.3s;
+      z-index: 2;
     }
     :host(:not([controls])) .controls {
       display: none;
@@ -595,7 +596,10 @@ export class HeliosPlayer extends HTMLElement {
     this.retryAction = () => this.retryConnection();
     this.retryBtn.onclick = () => this.retryAction();
 
-    this.clickLayer.addEventListener("click", () => this.togglePlayPause());
+    this.clickLayer.addEventListener("click", () => {
+      this.focus();
+      this.togglePlayPause();
+    });
     this.clickLayer.addEventListener("dblclick", () => this.toggleFullscreen());
 
     this.resizeObserver = new ResizeObserver((entries) => {

--- a/packages/player/src/interaction.test.ts
+++ b/packages/player/src/interaction.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { HeliosPlayer } from './index';
+
+// Mock ResizeObserver
+global.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as any;
+
+describe('HeliosPlayer Interaction Fixes', () => {
+  let player: HeliosPlayer;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    player = new HeliosPlayer();
+    document.body.appendChild(player);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('should focus the player when click-layer is clicked', () => {
+    const clickLayer = player.shadowRoot!.querySelector('.click-layer') as HTMLDivElement;
+    expect(clickLayer).toBeTruthy();
+
+    // Ensure player is not focused initially
+    if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+    }
+    expect(document.activeElement).not.toBe(player);
+
+    // Click
+    clickLayer.click();
+
+    // Expect player to be focused
+    expect(document.activeElement).toBe(player);
+  });
+});


### PR DESCRIPTION
This PR addresses usability issues in the Helios Player component.

**Changes:**
- **CSS Fix**: Added `z-index: 2` to `.controls` to ensure they sit above the `.click-layer` (z-index: 1). Previously, the transparent click layer (used for click-to-play) was blocking clicks on the control bar.
- **Focus Management**: Updated the `.click-layer` click handler to explicitly call `this.focus()`. This ensures that when a user clicks the video to play/pause, the component gains focus, allowing subsequent keyboard shortcuts (like Space for pause, F for fullscreen) to work without needing an extra tab navigation.
- **Testing**: Added `packages/player/src/interaction.test.ts` to verify focus behavior and regression test interaction logic.

**Verification:**
- `npm test -w packages/player` passes.
- Frontend verification script confirmed correct focus behavior and z-index application.


---
*PR created automatically by Jules for task [14630026949648352048](https://jules.google.com/task/14630026949648352048) started by @BintzGavin*