### PR TITLE
✨ RENDERER: Integrate waitUntilStable in CdpTimeDriver

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -9,7 +9,7 @@ The Renderer uses the Strategy pattern to support two distinct rendering modes:
     *   Encoding happens in-browser, and encoded chunks are piped to FFmpeg.
     *   **Smart Codec Selection**: Automatically prioritizes `avc1` (H.264 Annex B) when `videoCodec: 'copy'` is requested to enable direct stream copy, falling back to `vp8` (IVF) if unsupported.
     *   Supports `avc1` (H.264), `vp9`, and `av01` (AV1) intermediate codecs.
-    *   Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise, deterministic time control.
+    *   Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise, deterministic time control, including support for `window.helios.waitUntilStable()` to await custom stability checks.
 
 2.  **DOM Strategy**:
     *   Optimized for HTML/CSS animations.

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.37.0
+- ✅ Completed: CdpTimeDriver Stability - Updated `CdpTimeDriver` to detect and await `window.helios.waitUntilStable()`, enabling robust synchronization with custom stability checks for Canvas-based rendering.
+
 ## RENDERER v1.36.0
 - ✅ Completed: Enable Full Test Coverage - Updated `run-all.ts` to include all verification scripts, refactored `verify-concat.ts` to be self-contained using Data URIs, and improved `CanvasStrategy` robustness against `esbuild` artifacts by using string-based evaluation.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.36.0
+**Version**: 1.37.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.37.0] ✅ Completed: CdpTimeDriver Stability - Updated `CdpTimeDriver` to detect and await `window.helios.waitUntilStable()`, enabling robust synchronization with custom stability checks for Canvas-based rendering.
 - [1.36.0] ✅ Completed: Enable Full Test Coverage - Updated `run-all.ts` to include all verification scripts, refactored `verify-concat.ts` to be self-contained using Data URIs, and improved `CanvasStrategy` robustness against `esbuild` artifacts by using string-based evaluation.
 - [1.35.0] ✅ Completed: Support Helios Stability Registry - Updated `SeekTimeDriver` to detect and await `window.helios.waitUntilStable()`, enabling robust synchronization with custom stability checks registered in the core engine.
 - [1.34.0] ✅ Completed: Seek Driver Offsets - Updated `SeekTimeDriver` to respect `data-helios-offset` and `data-helios-seek` attributes, calculating correct `currentTime` for visual media synchronization.

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -38,5 +38,16 @@ export class CdpTimeDriver implements TimeDriver {
     });
 
     this.currentTime = timeInSeconds;
+
+    // Wait for custom stability checks
+    // We use a string-based evaluation to avoid build-tool artifacts
+    const script = `
+      (async () => {
+        if (typeof window.helios !== 'undefined' && typeof window.helios.waitUntilStable === 'function') {
+          await window.helios.waitUntilStable();
+        }
+      })()
+    `;
+    await page.evaluate(script);
   }
 }

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -7,6 +7,7 @@ const tests = [
   'tests/verify-canvas-strategy.ts',
   'tests/verify-captions.ts',
   'tests/verify-cdp-driver.ts',
+  'tests/verify-cdp-driver-stability.ts',
   'tests/verify-codecs.ts',
   'tests/verify-concat.ts',
   'tests/verify-deep-dom.ts',

--- a/packages/renderer/tests/verify-cdp-driver-stability.ts
+++ b/packages/renderer/tests/verify-cdp-driver-stability.ts
@@ -1,0 +1,45 @@
+import { chromium } from 'playwright';
+import { CdpTimeDriver } from '../src/drivers/CdpTimeDriver.js';
+
+async function test() {
+  console.log('Starting CdpTimeDriver Stability test...');
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const driver = new CdpTimeDriver();
+  await driver.prepare(page);
+
+  console.log('Driver prepared.');
+
+  // Inject mock helios object with waitUntilStable
+  // Use string evaluation to avoid esbuild artifacts (__name)
+  await page.evaluate(`
+    window.helios = {
+      waitUntilStable: async () => {
+        window.__STABILITY_CHECK_CALLED__ = true;
+        return Promise.resolve();
+      }
+    };
+  `);
+
+  console.log('Advancing time to 1.0s...');
+  await driver.setTime(page, 1.0);
+
+  // Check if the stability check was called
+  const wasCalled = await page.evaluate(`window.__STABILITY_CHECK_CALLED__`);
+
+  if (wasCalled) {
+    console.log('✅ Stability check was awaited.');
+  } else {
+    console.error('❌ Stability check was NOT awaited.');
+    process.exit(1);
+  }
+
+  await browser.close();
+}
+
+test().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
💡 **What**: Updated `CdpTimeDriver` to detect and await `window.helios.waitUntilStable()` after advancing virtual time using `page.evaluate` with a string-based script injection.
🎯 **Why**: To address a gap in the stability registry implementation where Canvas-based rendering (which uses `CdpTimeDriver`) ignored custom stability checks, leading to race conditions.
📊 **Impact**: Enables robust, deterministic Canvas rendering for compositions that rely on the stability registry (e.g., waiting for data fetch, map load).
🔬 **Verification**:
- Ran `npx tsx packages/renderer/tests/verify-cdp-driver-stability.ts` - Passed.
- Ran `packages/renderer/tests/run-all.ts` - Passed.

---
*PR created automatically by Jules for task [7287794317485729453](https://jules.google.com/task/7287794317485729453) started by @BintzGavin*