### PR TITLE
✨ RENDERER: Fix Workspace Dependency

### DIFF
--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.37.1
+- ✅ Completed: Fix Workspace Dependency - Updated `@helios-project/core` dependency to `2.7.0` in `packages/renderer/package.json` to match local workspace version, restoring verification environment.
+
 ## RENDERER v1.37.0
 - ✅ Completed: CdpTimeDriver Stability - Updated `CdpTimeDriver` to detect and await `window.helios.waitUntilStable()`, enabling robust synchronization with custom stability checks for Canvas-based rendering.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.37.0
+**Version**: 1.37.1
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.37.1] ✅ Completed: Fix Workspace Dependency - Updated `@helios-project/core` dependency to `2.7.0` in `packages/renderer/package.json` to match local workspace version, restoring verification environment.
 - [1.37.0] ✅ Completed: CdpTimeDriver Stability - Updated `CdpTimeDriver` to detect and await `window.helios.waitUntilStable()`, enabling robust synchronization with custom stability checks for Canvas-based rendering.
 - [1.36.0] ✅ Completed: Enable Full Test Coverage - Updated `run-all.ts` to include all verification scripts, refactored `verify-concat.ts` to be self-contained using Data URIs, and improved `CanvasStrategy` robustness against `esbuild` artifacts by using string-based evaluation.
 - [1.35.0] ✅ Completed: Support Helios Stability Registry - Updated `SeekTimeDriver` to detect and await `window.helios.waitUntilStable()`, enabling robust synchronization with custom stability checks registered in the core engine.

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "2.6.1",
+    "@helios-project/core": "2.7.0",
     "playwright": "^1.42.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated @helios-project/core dependency to 2.7.0 in packages/renderer/package.json to match local workspace version. This fixes `npm install` failures due to version mismatch. Also updated documentation to reflect the change. Verified by running all renderer tests.

---
*PR created automatically by Jules for task [6015661042264364493](https://jules.google.com/task/6015661042264364493) started by @BintzGavin*