### PR TITLE
✨ STUDIO: Safe Area Guides

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -22,6 +22,9 @@ packages/studio/
       Layout/
       Sidebar/
       Stage/
+        Stage.tsx
+        Stage.css
+        StageToolbar.tsx
       CreateCompositionModal.tsx
       GlobalShortcuts.tsx
       KeyboardShortcutsModal.tsx
@@ -52,7 +55,8 @@ Options:
 ## D. UI Components
 - **Timeline**: Visual track of the video, supports markers, captions, zooming.
 - **PropsEditor**: Auto-generated inputs based on composition schema (supports Asset selection, Drag & Drop).
-- **Stage**: Renders the `<helios-player>` or canvas.
+- **Stage**: Renders the `<helios-player>` or canvas. Supports Safe Area Guides and Transparency Grid.
+- **StageToolbar**: Controls for Zoom, Fit, Transparency Grid, Snapshot, and Safe Area Guides.
 - **GlobalShortcuts**: Headless component managing keyboard interactions.
 - **CompositionSwitcher**: Modal to switch between compositions (Cmd+K), supports deletion.
 - **PlaybackControls**: Buttons for play, pause, seek, loop, volume.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.47.0
+- ✅ Completed: Safe Area Guides - Implemented toggleable Safe Area Guides (Action Safe, Title Safe, Crosshair) in the Studio Stage with toolbar button and keyboard shortcut.
+
 ## STUDIO v0.46.0
 - ✅ Completed: Verify Audio Controls - Added unit tests for PlaybackControls to verify volume and mute functionality.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.46.0
+**Version**: 0.47.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.47.0] ✅ Completed: Safe Area Guides - Implemented toggleable Safe Area Guides (Action Safe, Title Safe, Crosshair) in the Studio Stage with toolbar button and keyboard shortcut.
 - [v0.46.0] ✅ Completed: Verify Audio Controls - Added unit tests for PlaybackControls to verify volume and mute functionality.
 - [v0.45.0] ✅ Completed: Delete Composition - Implemented ability to delete compositions from the UI with backend support and confirmation.
 - [v0.44.0] ✅ Completed: Enable Production Preview - Configured `vite-plugin-studio-api` to serve project files in preview mode and updated verification scripts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7642,7 +7642,7 @@
     },
     "packages/studio": {
       "name": "@helios-project/studio",
-      "version": "0.40.1",
+      "version": "0.46.0",
       "dependencies": {
         "@helios-project/core": "*",
         "@helios-project/player": "*",

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -49,6 +49,11 @@ export declare class HeliosPlayer extends HTMLElement {
     private _networkState;
     get readyState(): number;
     get networkState(): number;
+    get seeking(): boolean;
+    get buffered(): TimeRanges;
+    get seekable(): TimeRanges;
+    get videoWidth(): number;
+    get videoHeight(): number;
     get currentTime(): number;
     set currentTime(val: number);
     get currentFrame(): number;

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -1,6 +1,27 @@
 import { DirectController, BridgeController } from "./controllers";
 import { ClientSideExporter } from "./features/exporter";
 export { ClientSideExporter };
+class StaticTimeRange {
+    startVal;
+    endVal;
+    constructor(startVal, endVal) {
+        this.startVal = startVal;
+        this.endVal = endVal;
+    }
+    get length() {
+        return this.endVal > 0 ? 1 : 0;
+    }
+    start(index) {
+        if (index !== 0 || this.length === 0)
+            throw new Error("IndexSizeError");
+        return this.startVal;
+    }
+    end(index) {
+        if (index !== 0 || this.length === 0)
+            throw new Error("IndexSizeError");
+        return this.endVal;
+    }
+}
 const template = document.createElement("template");
 template.innerHTML = `
   <style>
@@ -380,6 +401,31 @@ export class HeliosPlayer extends HTMLElement {
         return this._networkState;
     }
     // --- Standard Media API ---
+    get seeking() {
+        return this.isScrubbing;
+    }
+    get buffered() {
+        return new StaticTimeRange(0, this.duration);
+    }
+    get seekable() {
+        return new StaticTimeRange(0, this.duration);
+    }
+    get videoWidth() {
+        if (this.controller) {
+            const state = this.controller.getState();
+            if (state.width)
+                return state.width;
+        }
+        return parseFloat(this.getAttribute("width") || "0");
+    }
+    get videoHeight() {
+        if (this.controller) {
+            const state = this.controller.getState();
+            if (state.height)
+                return state.height;
+        }
+        return parseFloat(this.getAttribute("height") || "0");
+    }
     get currentTime() {
         if (!this.controller)
             return 0;

--- a/packages/studio/src/components/Stage/Stage.css
+++ b/packages/studio/src/components/Stage/Stage.css
@@ -28,3 +28,52 @@
   background-size: 20px 20px;
   background-position: 0 0, 10px 10px;
 }
+
+/* Safe Area Guides */
+.stage-guides-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.guide-action-safe {
+  position: absolute;
+  top: 5%;
+  left: 5%;
+  width: 90%;
+  height: 90%;
+  border: 1px dashed cyan;
+  box-sizing: border-box;
+  opacity: 0.5;
+}
+
+.guide-title-safe {
+  position: absolute;
+  top: 10%;
+  left: 10%;
+  width: 80%;
+  height: 80%;
+  border: 1px dashed yellow;
+  box-sizing: border-box;
+  opacity: 0.5;
+}
+
+.guide-crosshair-x {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 0;
+  height: 100%;
+  border-left: 1px dashed rgba(255, 255, 255, 0.5);
+}
+
+.guide-crosshair-y {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 0;
+  border-top: 1px dashed rgba(255, 255, 255, 0.5);
+}

--- a/packages/studio/src/components/Stage/Stage.tsx
+++ b/packages/studio/src/components/Stage/Stage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, MouseEvent, WheelEvent } from 'reac
 import type { HeliosController } from '@helios-project/player';
 import { useStudio } from '../../context/StudioContext';
 import { StageToolbar } from './StageToolbar';
+import { useKeyboardShortcut } from '../../hooks/useKeyboardShortcut';
 import './Stage.css';
 
 interface StageProps {
@@ -20,8 +21,11 @@ export const Stage: React.FC<StageProps> = ({ src }) => {
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [isTransparent, setIsTransparent] = useState(true);
+  const [showGuides, setShowGuides] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+
+  useKeyboardShortcut("'", () => setShowGuides(p => !p), { ignoreInput: true });
 
   // HMR State Preservation
   const lastStateRef = useRef({ frame: 0, isPlaying: false, src: '' });
@@ -133,17 +137,33 @@ export const Stage: React.FC<StageProps> = ({ src }) => {
             }}
         >
             {src ? (
-              <helios-player
-                ref={playerRef}
-                key={src}
-                src={src}
-                style={{
-                  width: `${canvasSize.width}px`,
-                  height: `${canvasSize.height}px`,
-                  display: 'block',
-                  boxShadow: '0 0 20px rgba(0,0,0,0.5)'
-                }}
-              ></helios-player>
+              <>
+                <helios-player
+                  ref={playerRef}
+                  key={src}
+                  src={src}
+                  style={{
+                    width: `${canvasSize.width}px`,
+                    height: `${canvasSize.height}px`,
+                    display: 'block',
+                    boxShadow: '0 0 20px rgba(0,0,0,0.5)'
+                  }}
+                ></helios-player>
+                {showGuides && (
+                  <div
+                    className="stage-guides-overlay"
+                    style={{
+                      width: `${canvasSize.width}px`,
+                      height: `${canvasSize.height}px`
+                    }}
+                  >
+                    <div className="guide-action-safe" />
+                    <div className="guide-title-safe" />
+                    <div className="guide-crosshair-x" />
+                    <div className="guide-crosshair-y" />
+                  </div>
+                )}
+              </>
             ) : (
                 <div style={{ color: '#888' }}>No composition selected</div>
             )}
@@ -157,6 +177,8 @@ export const Stage: React.FC<StageProps> = ({ src }) => {
             canvasSize={canvasSize}
             onCanvasSizeChange={setCanvasSize}
             onSnapshot={takeSnapshot}
+            showGuides={showGuides}
+            onToggleGuides={() => setShowGuides(!showGuides)}
         />
     </div>
   );

--- a/packages/studio/src/components/Stage/StageToolbar.tsx
+++ b/packages/studio/src/components/Stage/StageToolbar.tsx
@@ -9,6 +9,8 @@ interface StageToolbarProps {
   canvasSize: { width: number; height: number };
   onCanvasSizeChange: (size: { width: number; height: number }) => void;
   onSnapshot: () => void;
+  showGuides: boolean;
+  onToggleGuides: () => void;
 }
 
 export const StageToolbar: React.FC<StageToolbarProps> = ({
@@ -19,7 +21,9 @@ export const StageToolbar: React.FC<StageToolbarProps> = ({
   onToggleTransparent,
   canvasSize,
   onCanvasSizeChange,
-  onSnapshot
+  onSnapshot,
+  showGuides,
+  onToggleGuides
 }) => {
   const styles = {
     container: {
@@ -167,6 +171,14 @@ export const StageToolbar: React.FC<StageToolbarProps> = ({
         title="Toggle Transparency Grid"
       >
         🏁
+      </button>
+      <div style={{ width: '1px', background: '#555', margin: '0 4px' }} />
+      <button
+        style={{ ...styles.button, background: showGuides ? '#444' : 'transparent' }}
+        onClick={onToggleGuides}
+        title="Toggle Safe Area Guides (')"
+      >
+        #
       </button>
     </div>
   );


### PR DESCRIPTION
Implemented Safe Area Guides in Studio Stage.

- Added `showGuides` state to `Stage.tsx`.
- Implemented keyboard shortcut `'` (Quote) to toggle guides.
- Added "Guides" toggle button to `StageToolbar`.
- Added CSS styles for Action Safe, Title Safe, and Crosshairs overlays.
- Verified via unit tests and build.

---
*PR created automatically by Jules for task [1927523562958428422](https://jules.google.com/task/1927523562958428422) started by @BintzGavin*