### PR TITLE
📋 RENDERER: CdpTimeDriver Media Sync Plan

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -100,3 +100,7 @@
 ## [2025-05-22] - Verification Gap in Run-All Script
 **Learning:** The `packages/renderer/tests/run-all.ts` script (executed by `npm test`) only runs a subset of available verification scripts. Critical tests for Concatenation, Stream Copy, and Audio Codecs are present in the directory but ignored by CI.
 **Action:** Created a plan to enable all valid verification scripts in `run-all.ts` to ensure full coverage of implemented features.
+
+## [2026-03-27] - CdpTimeDriver Event Loop Deadlock
+**Learning:** In `CdpTimeDriver` (using `Emulation.setVirtualTimePolicy` with `pause`), waiting for async events like `seeked` or `setTimeout` causes a deadlock because the browser task runner is effectively frozen.
+**Action:** When implementing media sync in `CdpTimeDriver`, set `currentTime` synchronously but DO NOT await `seeked` events. Accept that "frame readiness" is best-effort in Canvas mode, unlike the stricter `SeekTimeDriver` used for DOM mode.

--- a/.sys/plans/2026-03-27-RENDERER-CdpTimeDriver-Media-Sync.md
+++ b/.sys/plans/2026-03-27-RENDERER-CdpTimeDriver-Media-Sync.md
@@ -1,0 +1,36 @@
+# RENDERER: Implement CdpTimeDriver Media Sync
+
+#### 1. Context & Goal
+- **Objective**: Implement manual synchronization for `<video>` and `<audio>` elements in `CdpTimeDriver` to respect `data-helios-offset` and `data-helios-seek` attributes during Canvas rendering.
+- **Trigger**: Vision gap (Canvas/DOM parity) and observed inability to use video textures with offsets in Canvas mode.
+- **Impact**: Enables correct playback of offset/seeked media elements in hybrid Canvas/DOM compositions. Also fixes a workspace dependency mismatch blocking test execution.
+
+#### 2. File Inventory
+- **Create**: `packages/renderer/tests/verify-cdp-media-offsets.ts` (Verification test)
+- **Modify**:
+  - `packages/renderer/src/drivers/CdpTimeDriver.ts` (Implement sync logic)
+  - `packages/renderer/package.json` (Bump `@helios-project/core` to `2.7.1`)
+  - `packages/player/package.json` (Bump `@helios-project/core` to `2.7.1`)
+- **Read-Only**: `packages/renderer/src/drivers/SeekTimeDriver.ts` (Reference implementation)
+
+#### 3. Implementation Spec
+- **Architecture**:
+  - In `CdpTimeDriver.setTime(time)`:
+    - After advancing virtual time via CDP (`Emulation.setVirtualTimePolicy`), inject a script to manually synchronize media elements.
+    - **Logic**:
+      1. Find all `video`, `audio` elements.
+      2. Pause them (to take manual control).
+      3. Parse `data-helios-offset` and `data-helios-seek`.
+      4. Calculate `targetTime = globalTime - offset + seek`.
+      5. Set `el.currentTime = targetTime`.
+      6. **Crucial**: Do NOT await `seeked` or `canplay` events loop, as CDP virtual time 'pause' effectively freezes the task runner, causing a deadlock if we wait for async events. Assume `currentTime` setter is sufficient for visual update (best effort for Canvas mode).
+- **Dependency Fix**:
+  - Update `packages/renderer/package.json` and `packages/player/package.json` dependencies on `@helios-project/core` from `2.7.0` to `2.7.1` to match the local workspace version and fix `npm install`/test execution.
+
+#### 4. Test Plan
+- **Verification**: `npx tsx packages/renderer/tests/verify-cdp-media-offsets.ts`
+  - **Setup**: Create a test page with `<video>` elements using offsets/seeks.
+  - **Action**: Use `CdpTimeDriver` to advance time to `1.0` and `3.0`.
+  - **Assert**: Check `el.currentTime` matches expected offset math (e.g., `t=1, offset=2` -> `currentTime=0`).
+- **Success Criteria**: All assertions pass.
+- **Regression**: `npx tsx packages/renderer/tests/verify-cdp-driver.ts` should still pass.


### PR DESCRIPTION
This submission includes the Architecture Plan for implementing media synchronization in `CdpTimeDriver`.

**Plan Details:**
- **Goal:** Enable `data-helios-offset` and `data-helios-seek` support in Canvas mode.
- **Strategy:** Update `CdpTimeDriver.setTime` to manually set `currentTime` on media elements.
- **Critical Decision:** Explicitly decided NOT to await `seeked` events due to CDP virtual time pausing the task runner, which causes deadlocks. This is a documented trade-off for Canvas mode.
- **Dependency Fix:** Plan includes steps to resolve `@helios-project/core` version mismatch (2.7.0 vs 2.7.1) in renderer/player packages.

**Artifacts:**
- `/.sys/plans/2026-03-27-RENDERER-CdpTimeDriver-Media-Sync.md`
- `.jules/RENDERER.md` (Updated with learnings)


---
*PR created automatically by Jules for task [6671839180081045582](https://jules.google.com/task/6671839180081045582) started by @BintzGavin*