### PR TITLE
✨ DEMO: Fix Podcast Visualizer logic error

### DIFF
--- a/.sys/llmdocs/context-demo.md
+++ b/.sys/llmdocs/context-demo.md
@@ -55,4 +55,4 @@
 ## C. E2E Tests
 - **File**: `tests/e2e/verify-render.ts`
 - **Methodology**: Builds all examples using `vite.build-example.config.js`, then uses `Renderer` (headless browser + FFmpeg) to render a 5-second video for each.
-- **Verification**: Checks that render completes without error and output file exists.
+- **Verification**: Checks that render completes without error and output file exists. Does NOT verify visual content correctness (opacity, etc).

--- a/docs/PROGRESS-DEMO.md
+++ b/docs/PROGRESS-DEMO.md
@@ -123,3 +123,6 @@
 
 ## DEMO v1.49.0
 - ✅ Completed: Solid Canvas Example - Created `examples/solid-canvas-animation` demonstrating integration with SolidJS and `createHeliosSignal` adapter.
+
+## DEMO v1.57.0
+- ✅ Completed: Verify Podcast Visualizer - Found and fixed a bug in `examples/podcast-visualizer` (incorrect usage of `state.currentTime`) and re-verified visual correctness with a custom script.

--- a/docs/status/DEMO.md
+++ b/docs/status/DEMO.md
@@ -1,5 +1,5 @@
 # Status: DEMO (Executor)
-**Version**: 1.56.0
+**Version**: 1.57.0
 
 ## Vision
 To provide comprehensive, idiomatic examples for every major framework (React, Vue, Svelte, Vanilla) and robust end-to-end testing to ensure the Helios engine delivers on its "Use What You Know" promise.
@@ -82,6 +82,7 @@ To provide comprehensive, idiomatic examples for every major framework (React, V
 None.
 
 ## Log
+- [v1.57.0] ✅ Completed: Verify Podcast Visualizer - Found and fixed a bug in `examples/podcast-visualizer` (incorrect usage of `state.currentTime`) and re-verified visual correctness with a custom script.
 - [v1.56.0] ✅ Completed: Solid Animation Helpers Example - Created `examples/solid-animation-helpers` demonstrating idiomatic Sequence component composition in SolidJS.
 - [v1.55.0] ✅ Completed: Svelte Runes Animation Example - Created `examples/svelte-runes-animation` demonstrating Svelte 5 Runes (`$state`, `$derived`) integration.
 - [v1.54.0] ✅ Completed: Text Effects Animation Example - Created `examples/text-effects-animation` demonstrating Typewriter and Staggered Reveal effects.

--- a/examples/podcast-visualizer/composition.html
+++ b/examples/podcast-visualizer/composition.html
@@ -143,7 +143,8 @@
     // Subscribe to update visual indicators
     helios.subscribe((state) => {
       // Voice Indicator Logic: Visible after 2 seconds
-      if (state.currentTime >= 2) {
+      const currentTime = state.currentFrame / state.fps;
+      if (currentTime >= 2) {
         voiceVisual.style.opacity = 1;
       } else {
         voiceVisual.style.opacity = 0;


### PR DESCRIPTION
💡 **What**: Fixed a logic error in `examples/podcast-visualizer/composition.html` where `state.currentTime` was used (undefined) instead of calculating it from `currentFrame` and `fps`.
🎯 **Why**: The example was visually broken (Voice indicator never showed up) despite passing crash tests.
📊 **Impact**: The example now correctly visualizes the voice track at the 2-second mark.
🔬 **Verification**: Ran a custom Playwright script (`verify-custom.ts`) that mocked the timing environment and asserted the opacity of the visual element. Standard E2E tests (`verify-render.ts`) pass but do not check visual state.

---
*PR created automatically by Jules for task [332564816060613396](https://jules.google.com/task/332564816060613396) started by @BintzGavin*