### PR TITLE
✨ PLAYER: ControlsList Support

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -1,54 +1,49 @@
 # Context: PLAYER
 
-## Identity
-- **Role**: Frontend / Player Agent
-- **Domain**: `packages/player`
-- **Responsibility**: `<helios-player>` Web Component, UI controls, iframe bridge.
-
 ## A. Component Structure
-The `<helios-player>` component uses a Shadow DOM with the following structure:
-- **Style**: Scoped CSS.
-- **Status Overlay**: Displays "Connecting...", "Loading...", or Error messages.
-- **Poster Container**: Displays poster image and "Big Play Button".
-- **Iframe**: Sandbox for the composition (`allow-scripts allow-same-origin`).
-- **Click Layer**: Transparent overlay for click-to-play/pause interactions.
-- **Captions Container**: Overlays active captions.
-- **Controls**:
-    - Play/Pause Button
-    - Volume Control (Mute Button + Slider)
-    - CC Button (Toggle Captions)
-    - Export Button (Client-side WebCodecs export)
-    - Speed Selector (0.25x - 2x)
-    - Scrubber (Range input)
-    - Time Display (Current / Total)
-    - Fullscreen Button
+The `<helios-player>` component uses a Shadow DOM to encapsulate its styles and structure.
+
+**Shadow Root:**
+- `<style>`: Encapsulated CSS.
+- `.status-overlay`: Displays loading, connecting, and error states.
+- `.poster-container`: Displays the poster image and "Big Play Button".
+- `<iframe>`: Hosts the Helios composition (sandboxed).
+- `.click-layer`: Captures clicks for play/pause and double-clicks for fullscreen.
+- `.captions-container`: Displays active captions.
+- `.controls` (role="toolbar"): Contains playback controls (Play/Pause, Volume, Captions, Export, Speed, Scrubber, Time Display, Fullscreen).
 
 ## B. Events
 The component dispatches standard HTMLMediaElement events:
-- **Playback**: `play`, `pause`, `ended`, `seeking`, `seeked`
-- **Time**: `timeupdate`, `durationchange`
-- **State**: `ratechange`, `volumechange`
-- **Lifecycle**: `loadstart`, `loadedmetadata`, `loadeddata`, `canplay`, `canplaythrough`
-- **Error**: `error`
+
+- `play`: Playback has started.
+- `pause`: Playback has paused.
+- `ended`: Playback has reached the end.
+- `timeupdate`: The `currentTime` has changed.
+- `volumechange`: Volume or muted state has changed.
+- `ratechange`: Playback rate has changed.
+- `durationchange`: Duration has changed.
+- `seeking`: A seek operation has started.
+- `seeked`: A seek operation has completed.
+- `loadstart`: Loading has started.
+- `loadedmetadata`: Metadata (duration, dimensions) is loaded.
+- `loadeddata`: Initial data is loaded.
+- `canplay`: The player can start playing.
+- `canplaythrough`: The player can play through without buffering.
+- `error`: An error occurred.
 
 ## C. Attributes
-- **src**: URL of the composition (iframe source).
-- **width**: Player width (pixels).
-- **height**: Player height (pixels).
-- **autoplay**: Boolean attribute (starts playback automatically).
-- **loop**: Boolean attribute (loops playback).
-- **controls**: Boolean attribute (shows/hides UI).
-- **muted**: Boolean attribute (initial mute state).
-- **poster**: URL of image to show before playback.
-- **preload**: `auto` | `none` (defaults to `auto`).
-- **interactive**: Boolean attribute (disables click layer to allow iframe interaction).
-- **input-props**: JSON string of properties to pass to the composition.
-- **export-format**: `mp4` | `webm` (defaults to `mp4`).
-- **canvas-selector**: CSS selector for canvas to capture (export mode).
+The component observes the following attributes:
 
-## D. Properties
-The component implements the `HTMLMediaElement` interface (partial):
-- **Playback**: `play()`, `pause()`, `currentTime`, `duration`, `paused`, `ended`, `playbackRate`, `loop`, `autoplay`, `muted`, `volume`
-- **State**: `readyState`, `networkState`, `error`, `src`, `currentSrc`, `preload`, `buffered`, `seekable`, `seeking`, `played`
-- **Video**: `videoWidth`, `videoHeight`, `poster`
-- **Helios Specific**: `currentFrame`, `fps`, `interactive`, `inputProps`
+- `src`: URL of the Helios composition to load.
+- `width`: Width of the player (aspect-ratio calculation).
+- `height`: Height of the player (aspect-ratio calculation).
+- `autoplay`: Boolean attribute to start playback automatically.
+- `loop`: Boolean attribute to loop playback.
+- `controls`: Boolean attribute to show/hide controls.
+- `muted`: Boolean attribute to start muted.
+- `interactive`: Boolean attribute to allow direct interaction with the iframe.
+- `poster`: URL of the poster image to show before loading/playing.
+- `preload`: Hint for preloading behavior (`auto`, `metadata`, `none`).
+- `export-format`: Format for client-side export (`mp4`, `webm`).
+- `input-props`: JSON string of properties to pass to the composition.
+- `controlslist`: Space-separated tokens to customize UI (`nodownload`, `nofullscreen`).

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.36.0
+- ✅ Completed: ControlsList Support - Implemented `controlslist` attribute support to allow hiding Export and Fullscreen buttons (`nodownload`, `nofullscreen`).
+
 ## PLAYER v0.35.1
 - ✅ Completed: Implement error and currentSrc properties - Added `error` and `currentSrc` getters to `HeliosPlayer` to complete HTMLMediaElement parity.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.35.1
+**Version**: v0.36.0
 
 # Status: PLAYER
 
@@ -30,10 +30,12 @@
 - Fully implemented Standard Media API properties (`src`, `autoplay`, `loop`, `controls`, `poster`, `preload`) as getters/setters on `HeliosPlayer`.
 - Implemented `readyState` and `networkState` properties and standard lifecycle events (`loadstart`, `loadedmetadata`, `canplay`, etc.), aligning with HTMLMediaElement specifications.
 - Implements Deep API Parity (`videoWidth`, `videoHeight`, `buffered`, `seekable`, `seeking`) to support integration with standard video wrappers.
+- Implements `controlslist` attribute support (`nodownload`, `nofullscreen`) to customize UI visibility.
 
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.36.0] ✅ Completed: ControlsList Support - Implemented `controlslist` attribute support to allow hiding Export and Fullscreen buttons (`nodownload`, `nofullscreen`).
 [v0.35.1] ✅ Completed: Implement error and currentSrc properties - Added `error` and `currentSrc` getters to `HeliosPlayer` to complete HTMLMediaElement parity.
 [v0.35.0] ✅ Completed: Implement Playback Range - Implemented setPlaybackRange and clearPlaybackRange in HeliosController and Bridge protocol.
 [v0.34.0] ✅ Completed: Implement Seeking Events & Played Property - Implemented seeking/seeked events and played property to complete HTMLMediaElement parity.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7594,7 +7594,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.33.1",
+      "version": "0.35.1",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "2.7.2",

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -2,6 +2,14 @@ import type { HeliosController } from "./controllers";
 import { ClientSideExporter } from "./features/exporter";
 export { ClientSideExporter };
 export type { HeliosController };
+interface MediaError {
+    readonly code: number;
+    readonly message: string;
+    readonly MEDIA_ERR_ABORTED: number;
+    readonly MEDIA_ERR_NETWORK: number;
+    readonly MEDIA_ERR_DECODE: number;
+    readonly MEDIA_ERR_SRC_NOT_SUPPORTED: number;
+}
 export declare class HeliosPlayer extends HTMLElement {
     private iframe;
     private playPauseBtn;
@@ -36,6 +44,7 @@ export declare class HeliosPlayer extends HTMLElement {
     private wasPlayingBeforeScrub;
     private lastState;
     private pendingProps;
+    private _error;
     static readonly HAVE_NOTHING = 0;
     static readonly HAVE_METADATA = 1;
     static readonly HAVE_CURRENT_DATA = 2;
@@ -49,6 +58,8 @@ export declare class HeliosPlayer extends HTMLElement {
     private _networkState;
     get readyState(): number;
     get networkState(): number;
+    get error(): MediaError | null;
+    get currentSrc(): string;
     get seeking(): boolean;
     get buffered(): TimeRanges;
     get seekable(): TimeRanges;
@@ -89,6 +100,7 @@ export declare class HeliosPlayer extends HTMLElement {
     static get observedAttributes(): string[];
     constructor();
     attributeChangedCallback(name: string, oldVal: string, newVal: string): void;
+    private updateControlsVisibility;
     get inputProps(): Record<string, any> | null;
     set inputProps(val: Record<string, any> | null);
     connectedCallback(): void;

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.35.1",
+  "version": "0.36.0",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -1214,4 +1214,61 @@ describe('HeliosPlayer', () => {
         expect(loadStartSpy).toHaveBeenCalled();
     });
   });
+
+  describe('ControlsList', () => {
+    it('should hide export button when controlslist="nodownload"', () => {
+        player.setAttribute('controlslist', 'nodownload');
+        const exportBtn = player.shadowRoot!.querySelector('.export-btn') as HTMLButtonElement;
+        expect(exportBtn.style.display).toBe('none');
+    });
+
+    it('should hide fullscreen button when controlslist="nofullscreen"', () => {
+        player.setAttribute('controlslist', 'nofullscreen');
+        const fullscreenBtn = player.shadowRoot!.querySelector('.fullscreen-btn') as HTMLButtonElement;
+        expect(fullscreenBtn.style.display).toBe('none');
+    });
+
+    it('should support multiple tokens', () => {
+        player.setAttribute('controlslist', 'nodownload nofullscreen');
+        const exportBtn = player.shadowRoot!.querySelector('.export-btn') as HTMLButtonElement;
+        const fullscreenBtn = player.shadowRoot!.querySelector('.fullscreen-btn') as HTMLButtonElement;
+
+        expect(exportBtn.style.display).toBe('none');
+        expect(fullscreenBtn.style.display).toBe('none');
+    });
+
+    it('should restore buttons when attribute is removed', () => {
+        // 1. Hide
+        player.setAttribute('controlslist', 'nodownload nofullscreen');
+        const exportBtn = player.shadowRoot!.querySelector('.export-btn') as HTMLButtonElement;
+        const fullscreenBtn = player.shadowRoot!.querySelector('.fullscreen-btn') as HTMLButtonElement;
+
+        expect(exportBtn.style.display).toBe('none');
+        expect(fullscreenBtn.style.display).toBe('none');
+
+        // 2. Remove
+        player.removeAttribute('controlslist');
+
+        expect(exportBtn.style.display).toBe('');
+        expect(fullscreenBtn.style.display).toBe('');
+    });
+
+    it('should be case insensitive', () => {
+        player.setAttribute('controlslist', 'NoDownload NOFULLSCREEN');
+        const exportBtn = player.shadowRoot!.querySelector('.export-btn') as HTMLButtonElement;
+        const fullscreenBtn = player.shadowRoot!.querySelector('.fullscreen-btn') as HTMLButtonElement;
+
+        expect(exportBtn.style.display).toBe('none');
+        expect(fullscreenBtn.style.display).toBe('none');
+    });
+
+    it('should handle extra whitespace', () => {
+        player.setAttribute('controlslist', '  nodownload   nofullscreen  ');
+        const exportBtn = player.shadowRoot!.querySelector('.export-btn') as HTMLButtonElement;
+        const fullscreenBtn = player.shadowRoot!.querySelector('.fullscreen-btn') as HTMLButtonElement;
+
+        expect(exportBtn.style.display).toBe('none');
+        expect(fullscreenBtn.style.display).toBe('none');
+    });
+  });
 });

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -642,7 +642,7 @@ export class HeliosPlayer extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ["src", "width", "height", "autoplay", "loop", "controls", "export-format", "input-props", "poster", "muted", "interactive", "preload"];
+    return ["src", "width", "height", "autoplay", "loop", "controls", "export-format", "input-props", "poster", "muted", "interactive", "preload", "controlslist"];
   }
 
   constructor() {
@@ -732,6 +732,29 @@ export class HeliosPlayer extends HTMLElement {
         this.controller.setAudioMuted(this.hasAttribute("muted"));
       }
     }
+
+    if (name === "controlslist") {
+      this.updateControlsVisibility();
+    }
+  }
+
+  private updateControlsVisibility() {
+    if (!this.exportBtn || !this.fullscreenBtn) return;
+
+    const attr = this.getAttribute("controlslist") || "";
+    const tokens = attr.toLowerCase().split(/\s+/);
+
+    if (tokens.includes("nodownload")) {
+      this.exportBtn.style.display = "none";
+    } else {
+      this.exportBtn.style.removeProperty("display");
+    }
+
+    if (tokens.includes("nofullscreen")) {
+      this.fullscreenBtn.style.display = "none";
+    } else {
+      this.fullscreenBtn.style.removeProperty("display");
+    }
   }
 
   public get inputProps(): Record<string, any> | null {
@@ -785,6 +808,7 @@ export class HeliosPlayer extends HTMLElement {
     // Ensure aspect ratio is correct on connect
     this.updateAspectRatio();
 
+    this.updateControlsVisibility();
     this.resizeObserver.observe(this);
   }
 


### PR DESCRIPTION
Implemented `controlslist` attribute support to allow developers to customize the player UI by hiding specific controls (Export and Fullscreen buttons). This aligns with the Standard Media API pattern and provides greater flexibility for embedding scenarios.

---
*PR created automatically by Jules for task [2326452658626233443](https://jules.google.com/task/2326452658626233443) started by @BintzGavin*