### PR TITLE
Configurable Stability Timeout for Renderer

### DIFF
--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -22,7 +22,7 @@ export class Renderer {
     this.options = options;
     if (this.options.mode === 'dom') {
       this.strategy = new DomStrategy(this.options);
-      this.timeDriver = new SeekTimeDriver();
+      this.timeDriver = new SeekTimeDriver(this.options.stabilityTimeout);
     } else {
       this.strategy = new CanvasStrategy(this.options);
       this.timeDriver = new CdpTimeDriver();

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -134,6 +134,12 @@ export interface RendererOptions {
   ffmpegPath?: string;
 
   /**
+   * Timeout in milliseconds to wait for the frame to stabilize (e.g., loading fonts, images, custom hooks).
+   * Defaults to 30000ms.
+   */
+  stabilityTimeout?: number;
+
+  /**
    * Optional props to inject into the composition.
    * These will be available as `window.__HELIOS_PROPS__`.
    */


### PR DESCRIPTION
Implemented configurable stability timeout for SeekTimeDriver in the renderer.

- Added `stabilityTimeout` to `RendererOptions` in `packages/renderer/src/types.ts`.
- Updated `SeekTimeDriver` in `packages/renderer/src/drivers/SeekTimeDriver.ts` to accept the timeout in its constructor and use it in the client-side script.
- Updated `Renderer` in `packages/renderer/src/index.ts` to pass the option.
- Added comprehensive tests in `packages/renderer/tests/verify-seek-driver-stability.ts`.

---
*PR created automatically by Jules for task [2819883691262308300](https://jules.google.com/task/2819883691262308300) started by @BintzGavin*