### PR TITLE
✨ CORE: Implement RenderSession

### DIFF
--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,9 @@
 # CORE Progress Log
 
+## CORE v2.10.0
+- ✅ Completed: Implement RenderSession - Added RenderSession class for standardized frame iteration and stability orchestration.
+# CORE Progress Log
+
 ## CORE v2.9.0
 - ✅ Completed: Synchronize Version - Updated `package.json` to 2.9.0 and fixed flaky stability test.
 - ✅ Completed: Implement Recursive Schema - Updated `PropDefinition` to support `items` and `properties` for nested array/object validation, and refactored `validateProps`.

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,6 +1,6 @@
 # Status: CORE
 
-**Version**: 2.9.0
+**Version**: 2.10.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
@@ -66,3 +66,5 @@
 **Next Steps**:
 - Maintain version alignment with Player and Renderer.
 - Note: Added plan `/.sys/plans/2026-01-29-CORE-Bind-Virtual-Time.md` to ensure `bindToDocumentTimeline` prefers `__HELIOS_VIRTUAL_TIME__` when present (DOM render sync).
+
+[v2.10.0] ✅ Completed: Implement RenderSession - Added RenderSession class for standardized frame iteration and stability orchestration.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -743,3 +743,4 @@ export class Helios {
     });
   }
 }
+export * from './render-session.js';

--- a/packages/core/src/render-session.test.ts
+++ b/packages/core/src/render-session.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RenderSession } from './render-session.js';
+import type { Helios } from './index.js';
+
+describe('RenderSession', () => {
+  it('should iterate through frames from start to end', async () => {
+    const mockHelios = {
+      seek: vi.fn(),
+      waitUntilStable: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Helios;
+
+    const session = new RenderSession(mockHelios, {
+      startFrame: 0,
+      endFrame: 2,
+    });
+
+    const frames: number[] = [];
+    for await (const frame of session) {
+      frames.push(frame);
+    }
+
+    expect(frames).toEqual([0, 1, 2]);
+    expect(mockHelios.seek).toHaveBeenCalledTimes(3);
+    expect(mockHelios.seek).toHaveBeenNthCalledWith(1, 0);
+    expect(mockHelios.seek).toHaveBeenNthCalledWith(2, 1);
+    expect(mockHelios.seek).toHaveBeenNthCalledWith(3, 2);
+    expect(mockHelios.waitUntilStable).toHaveBeenCalledTimes(3);
+  });
+
+  it('should handle single frame range', async () => {
+    const mockHelios = {
+      seek: vi.fn(),
+      waitUntilStable: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Helios;
+
+    const session = new RenderSession(mockHelios, {
+      startFrame: 5,
+      endFrame: 5,
+    });
+
+    const frames: number[] = [];
+    for await (const frame of session) {
+      frames.push(frame);
+    }
+
+    expect(frames).toEqual([5]);
+    expect(mockHelios.seek).toHaveBeenCalledWith(5);
+  });
+
+  it('should stop iteration when aborted via AbortSignal', async () => {
+    const mockHelios = {
+      seek: vi.fn(),
+      waitUntilStable: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Helios;
+
+    const controller = new AbortController();
+    const session = new RenderSession(mockHelios, {
+      startFrame: 0,
+      endFrame: 10,
+      abortSignal: controller.signal,
+    });
+
+    const frames: number[] = [];
+    let count = 0;
+    for await (const frame of session) {
+      frames.push(frame);
+      count++;
+      if (count === 2) {
+        controller.abort();
+      }
+    }
+
+    // Should yield 0, 1. Then abort.
+    expect(frames).toEqual([0, 1]);
+    expect(mockHelios.seek).toHaveBeenCalledTimes(2);
+  });
+
+  it('should check for abort after waitUntilStable', async () => {
+    const controller = new AbortController();
+    const mockHelios = {
+      seek: vi.fn(),
+      waitUntilStable: vi.fn().mockImplementation(async () => {
+        // Abort during wait
+        controller.abort();
+      }),
+    } as unknown as Helios;
+
+    const session = new RenderSession(mockHelios, {
+      startFrame: 0,
+      endFrame: 10,
+      abortSignal: controller.signal,
+    });
+
+    const frames: number[] = [];
+    for await (const frame of session) {
+      frames.push(frame);
+    }
+
+    // Should yield nothing because it aborted during the first wait
+    expect(frames).toEqual([]);
+    expect(mockHelios.seek).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not start if already aborted', async () => {
+    const mockHelios = {
+      seek: vi.fn(),
+      waitUntilStable: vi.fn(),
+    } as unknown as Helios;
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const session = new RenderSession(mockHelios, {
+      startFrame: 0,
+      endFrame: 10,
+      abortSignal: controller.signal,
+    });
+
+    const frames: number[] = [];
+    for await (const frame of session) {
+      frames.push(frame);
+    }
+
+    expect(frames).toEqual([]);
+    expect(mockHelios.seek).not.toHaveBeenCalled();
+  });
+
+  it('should throw error for invalid range', () => {
+    const mockHelios = {} as unknown as Helios;
+
+    expect(() => {
+      new RenderSession(mockHelios, {
+        startFrame: 10,
+        endFrame: 5,
+      });
+    }).toThrow(/Invalid range/);
+  });
+
+  it('should throw error for negative startFrame', () => {
+    const mockHelios = {} as unknown as Helios;
+
+    expect(() => {
+      new RenderSession(mockHelios, {
+        startFrame: -1,
+        endFrame: 5,
+      });
+    }).toThrow(/Invalid startFrame/);
+  });
+});

--- a/packages/core/src/render-session.ts
+++ b/packages/core/src/render-session.ts
@@ -1,0 +1,48 @@
+import type { Helios } from './index.js';
+
+export interface RenderSessionOptions {
+  startFrame: number;
+  endFrame: number;
+  abortSignal?: AbortSignal;
+}
+
+export class RenderSession implements AsyncIterable<number> {
+  constructor(
+    private helios: Helios,
+    private options: RenderSessionOptions
+  ) {
+    if (options.startFrame < 0) {
+      throw new Error(`Invalid startFrame: ${options.startFrame}. Must be non-negative.`);
+    }
+    if (options.endFrame < options.startFrame) {
+      throw new Error(
+        `Invalid range: startFrame (${options.startFrame}) > endFrame (${options.endFrame}).`
+      );
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<number> {
+    const { startFrame, endFrame, abortSignal } = this.options;
+
+    // Check aborted before starting
+    if (abortSignal?.aborted) {
+      return;
+    }
+
+    for (let frame = startFrame; frame <= endFrame; frame++) {
+      if (abortSignal?.aborted) {
+        return;
+      }
+
+      this.helios.seek(frame);
+      await this.helios.waitUntilStable();
+
+      // Check aborted after waiting (in case it was aborted during wait)
+      if (abortSignal?.aborted) {
+        return;
+      }
+
+      yield frame;
+    }
+  }
+}


### PR DESCRIPTION
💡 **What**: Implemented `RenderSession` class in `packages/core` to standardize frame-by-frame rendering orchestration.
🎯 **Why**: To provide a shared, robust mechanism for iterating frames and ensuring stability (via `waitUntilStable`) for both client-side and server-side exports, addressing the 'Render Session API' plan.
📊 **Impact**: Enables `packages/player` and `packages/renderer` to use the same logic for rendering, ensuring consistent behavior and reducing code duplication.
🔬 **Verification**: Ran `npm test -w packages/core`. Verified new tests in `packages/core/src/render-session.test.ts` pass.

---
*PR created automatically by Jules for task [7306863014928806657](https://jules.google.com/task/7306863014928806657) started by @BintzGavin*