### PR TITLE
✨ PLAYER: Native Loop Support

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.39.0
+- ✅ Completed: Native Loop Support - Refactored `HeliosController` and `bridge` to use `helios.setLoop()` natively, removing manual client-side looping logic.
+
 ## PLAYER v0.38.0
 - ✅ Completed: Visualize Playback Range - Implemented visual indicator for playback range on the timeline scrubber using CSS gradients and `updateUI` logic.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.38.0
+**Version**: v0.39.0
 
 # Status: PLAYER
 
@@ -32,10 +32,12 @@
 - Implements Deep API Parity (`videoWidth`, `videoHeight`, `buffered`, `seekable`, `seeking`) to support integration with standard video wrappers.
 - Implements `controlslist` attribute support (`nodownload`, `nofullscreen`) to customize UI visibility.
 - Implements CSS Variables (custom properties) for theming the player UI (`--helios-controls-bg`, `--helios-accent-color`, etc.).
+- Supports Native Loop via `setLoop` in Controller/Bridge, removing client-side loop hacks.
 
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.39.0] ✅ Completed: Native Loop Support - Refactored `HeliosController` and `bridge` to use `helios.setLoop()` natively, removing manual client-side looping logic.
 [v0.38.0] ✅ Completed: Visualize Playback Range - Implemented visual indicator for playback range on the timeline scrubber using CSS gradients and `updateUI` logic.
 [v0.37.0] ✅ Completed: CSS Variables for Theming - Exposed CSS variables to enable theming of the player controls and UI.
 [v0.36.0] ✅ Completed: ControlsList Support - Implemented `controlslist` attribute support to allow hiding Export and Fullscreen buttons (`nodownload`, `nofullscreen`).

--- a/packages/player/dist/bridge.js
+++ b/packages/player/dist/bridge.js
@@ -50,6 +50,11 @@ export function connectToParent(helios) {
                     helios.setAudioMuted(event.data.muted);
                 }
                 break;
+            case 'HELIOS_SET_LOOP':
+                if (typeof event.data.loop === 'boolean') {
+                    helios.setLoop(event.data.loop);
+                }
+                break;
             case 'HELIOS_SET_PROPS':
                 if (event.data.props) {
                     helios.setInputProps(event.data.props);

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -662,6 +662,11 @@ export class HeliosPlayer extends HTMLElement {
         if (name === "width" || name === "height") {
             this.updateAspectRatio();
         }
+        if (name === "loop") {
+            if (this.controller) {
+                this.controller.setLoop(this.hasAttribute("loop"));
+            }
+        }
         if (name === "input-props") {
             try {
                 const props = JSON.parse(newVal);
@@ -958,6 +963,9 @@ export class HeliosPlayer extends HTMLElement {
         if (this.hasAttribute("muted")) {
             this.controller.setAudioMuted(true);
         }
+        if (this.hasAttribute("loop")) {
+            this.controller.setLoop(true);
+        }
         const state = this.controller.getState();
         if (state) {
             this.scrubber.max = String(state.duration * state.fps);
@@ -1171,14 +1179,6 @@ export class HeliosPlayer extends HTMLElement {
         }
         this.lastState = state;
         const isFinished = state.currentFrame >= state.duration * state.fps - 1;
-        if (isFinished && this.hasAttribute("loop")) {
-            // Prevent infinite loop if something goes wrong, only restart if we stopped
-            if (!state.isPlaying) {
-                this.controller.seek(0);
-                this.controller.play();
-                return;
-            }
-        }
         if (isFinished) {
             this.playPauseBtn.textContent = "🔄"; // Restart button
             this.playPauseBtn.setAttribute("aria-label", "Restart");

--- a/packages/player/src/bridge.ts
+++ b/packages/player/src/bridge.ts
@@ -52,6 +52,11 @@ export function connectToParent(helios: Helios) {
             helios.setAudioMuted(event.data.muted);
         }
         break;
+      case 'HELIOS_SET_LOOP':
+        if (typeof event.data.loop === 'boolean') {
+            helios.setLoop(event.data.loop);
+        }
+        break;
       case 'HELIOS_SET_PROPS':
         if (event.data.props) {
             helios.setInputProps(event.data.props);

--- a/packages/player/src/controllers.test.ts
+++ b/packages/player/src/controllers.test.ts
@@ -42,6 +42,7 @@ describe('DirectController', () => {
             seek: vi.fn(),
             setAudioVolume: vi.fn(),
             setAudioMuted: vi.fn(),
+            setLoop: vi.fn(),
             setPlaybackRate: vi.fn(),
             setPlaybackRange: vi.fn(),
             clearPlaybackRange: vi.fn(),
@@ -109,6 +110,11 @@ describe('DirectController', () => {
 
         controller.setAudioMuted(true);
         expect(mockHeliosInstance.setAudioMuted).toHaveBeenCalledWith(true);
+    });
+
+    it('should set loop', () => {
+        controller.setLoop(true);
+        expect(mockHeliosInstance.setLoop).toHaveBeenCalledWith(true);
     });
 
     it('should set playback range', () => {
@@ -233,6 +239,11 @@ describe('BridgeController', () => {
 
         controller.setAudioMuted(true);
         expect(mockWindow.postMessage).toHaveBeenCalledWith({ type: 'HELIOS_SET_MUTED', muted: true }, '*');
+    });
+
+    it('should post messages for loop', () => {
+        controller.setLoop(true);
+        expect(mockWindow.postMessage).toHaveBeenCalledWith({ type: 'HELIOS_SET_LOOP', loop: true }, '*');
     });
 
     it('should post messages for playback range', () => {

--- a/packages/player/src/controllers.ts
+++ b/packages/player/src/controllers.ts
@@ -8,6 +8,7 @@ export interface HeliosController {
   seek(frame: number): void;
   setAudioVolume(volume: number): void;
   setAudioMuted(muted: boolean): void;
+  setLoop(loop: boolean): void;
   setPlaybackRate(rate: number): void;
   setPlaybackRange(startFrame: number, endFrame: number): void;
   clearPlaybackRange(): void;
@@ -27,6 +28,7 @@ export class DirectController implements HeliosController {
   seek(frame: number) { this.instance.seek(frame); }
   setAudioVolume(volume: number) { this.instance.setAudioVolume(volume); }
   setAudioMuted(muted: boolean) { this.instance.setAudioMuted(muted); }
+  setLoop(loop: boolean) { this.instance.setLoop(loop); }
   setPlaybackRate(rate: number) { this.instance.setPlaybackRate(rate); }
   setPlaybackRange(start: number, end: number) { this.instance.setPlaybackRange(start, end); }
   clearPlaybackRange() { this.instance.clearPlaybackRange(); }
@@ -142,6 +144,7 @@ export class BridgeController implements HeliosController {
   seek(frame: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SEEK', frame }, '*'); }
   setAudioVolume(volume: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_VOLUME', volume }, '*'); }
   setAudioMuted(muted: boolean) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_MUTED', muted }, '*'); }
+  setLoop(loop: boolean) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_LOOP', loop }, '*'); }
   setPlaybackRate(rate: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_PLAYBACK_RATE', rate }, '*'); }
   setPlaybackRange(start: number, end: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_PLAYBACK_RANGE', start, end }, '*'); }
   clearPlaybackRange() { this.iframeWindow.postMessage({ type: 'HELIOS_CLEAR_PLAYBACK_RANGE' }, '*'); }

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -724,6 +724,12 @@ export class HeliosPlayer extends HTMLElement {
       this.updateAspectRatio();
     }
 
+    if (name === "loop") {
+      if (this.controller) {
+        this.controller.setLoop(this.hasAttribute("loop"));
+      }
+    }
+
     if (name === "input-props") {
       try {
         const props = JSON.parse(newVal);
@@ -1055,6 +1061,10 @@ export class HeliosPlayer extends HTMLElement {
         this.controller.setAudioMuted(true);
       }
 
+      if (this.hasAttribute("loop")) {
+        this.controller.setLoop(true);
+      }
+
       const state = this.controller.getState();
       if (state) {
           this.scrubber.max = String(state.duration * state.fps);
@@ -1288,15 +1298,6 @@ export class HeliosPlayer extends HTMLElement {
       this.lastState = state;
 
       const isFinished = state.currentFrame >= state.duration * state.fps - 1;
-
-      if (isFinished && this.hasAttribute("loop")) {
-        // Prevent infinite loop if something goes wrong, only restart if we stopped
-        if (!state.isPlaying) {
-             this.controller!.seek(0);
-             this.controller!.play();
-             return;
-        }
-      }
 
       if (isFinished) {
         this.playPauseBtn.textContent = "🔄"; // Restart button


### PR DESCRIPTION
This change replaces the legacy client-side looping logic in `<helios-player>` with the native `setLoop` capability of the Helios core engine. This improves playback reliability and synchronization by delegating loop logic to the engine (Direct or via Bridge).

The `HeliosController` interface was updated to include `setLoop(loop: boolean): void`. Both `DirectController` and `BridgeController` were updated to implement this method. A new bridge message `HELIOS_SET_LOOP` was added to propagate the loop state to the iframe. The `HeliosPlayer` component was updated to use `controller.setLoop()` and remove the manual "rewind if finished" logic.

Unit tests were added to `packages/player/src/controllers.test.ts` to verify the new functionality.
All tests passed.

---
*PR created automatically by Jules for task [6051148094060356226](https://jules.google.com/task/6051148094060356226) started by @BintzGavin*