### PR TITLE
Enable Full Verification Coverage in Renderer Tests

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -104,3 +104,7 @@
 ## [2026-03-27] - CdpTimeDriver Event Loop Deadlock
 **Learning:** In `CdpTimeDriver` (using `Emulation.setVirtualTimePolicy` with `pause`), waiting for async events like `seeked` or `setTimeout` causes a deadlock because the browser task runner is effectively frozen.
 **Action:** When implementing media sync in `CdpTimeDriver`, set `currentTime` synchronously but DO NOT await `seeked` events. Accept that "frame readiness" is best-effort in Canvas mode, unlike the stricter `SeekTimeDriver` used for DOM mode.
+
+## [1.44.0] - CdpTimeDriver Shadow DOM Gap
+**Learning:** While `SeekTimeDriver` (DOM mode) was updated to support Shadow DOM media sync, `CdpTimeDriver` (Canvas mode) still uses `document.querySelectorAll` and fails to synchronize media inside Shadow DOMs.
+**Action:** Future task: Update `CdpTimeDriver` to use the recursive `scanForAudioTracks`-style media discovery logic.

--- a/.sys/plans/2026-03-31-RENDERER-Verification-Coverage.md
+++ b/.sys/plans/2026-03-31-RENDERER-Verification-Coverage.md
@@ -1,0 +1,38 @@
+# Context & Goal
+- **Objective**: Include all valid, self-contained verification scripts in `packages/renderer/tests/run-all.ts` to ensure full test coverage.
+- **Trigger**: "Verification Gap in Run-All Script" identified in `.jules/RENDERER.md` and confirmed by file analysis.
+- **Impact**: Prevents silent regressions in WAAPI sync, Shadow DOM audio discovery, CDP offsets, and Browser config by ensuring these tests run in CI/local test loop.
+
+# File Inventory
+- **Modify**: `packages/renderer/tests/run-all.ts`
+- **Read-Only**:
+  - `packages/renderer/tests/verify-browser-config.ts`
+  - `packages/renderer/tests/verify-cdp-media-offsets.ts`
+  - `packages/renderer/tests/verify-shadow-dom-audio.ts`
+  - `packages/renderer/tests/verify-waapi-sync.ts`
+
+# Implementation Spec
+- **Architecture**: Update the `tests` array in `run-all.ts` to include the missing test files. These files are self-contained and do not depend on external build artifacts (like `example-build`).
+- **Pseudo-Code**:
+  ```typescript
+  // In packages/renderer/tests/run-all.ts
+
+  const tests = [
+    // ... keep existing tests ...
+    // Add the following:
+    'tests/verify-browser-config.ts',
+    'tests/verify-cdp-media-offsets.ts',
+    'tests/verify-shadow-dom-audio.ts',
+    'tests/verify-waapi-sync.ts',
+    // ... keep existing scripts ...
+  ];
+  ```
+
+# Test Plan
+- **Verification**: Run `npm test` inside `packages/renderer`.
+- **Success Criteria**:
+  - All 4 new tests run and pass (output shows `✅ PASSED: ...`).
+  - The overall test suite completes with exit code 0.
+- **Edge Cases**:
+  - Ensure `tests/verify-shadow-dom-audio.ts` properly mocks the audio request (it does via `page.route`).
+  - Ensure `tests/verify-waapi-sync.ts` passes within tolerance (it has a tolerance check).


### PR DESCRIPTION
Created execution plan at `.sys/plans/2026-03-31-RENDERER-Verification-Coverage.md` to enable full verification coverage in `run-all.ts` by adding missing self-contained tests (WAAPI, Shadow DOM, CDP offsets).

---
*PR created automatically by Jules for task [5309346552047543747](https://jules.google.com/task/5309346552047543747) started by @BintzGavin*