### PR TITLE
Expose Schema via HeliosPlayer API

### DIFF
--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -249,4 +249,19 @@ describe('HeliosPlayer API Parity', () => {
     (player as any).loadIframe("new.html");
     expect(player.error).toBeNull();
   });
+
+  it('should support getSchema', async () => {
+    const mockSchema = { prop: { type: 'string' } };
+    const mockController = {
+        getState: () => ({}),
+        pause: vi.fn(),
+        dispose: vi.fn(),
+        getSchema: vi.fn().mockResolvedValue(mockSchema)
+    };
+    (player as any).controller = mockController;
+
+    const schema = await player.getSchema();
+    expect(schema).toBe(mockSchema);
+    expect(mockController.getSchema).toHaveBeenCalled();
+  });
 });

--- a/packages/player/src/bridge.ts
+++ b/packages/player/src/bridge.ts
@@ -62,6 +62,9 @@ export function connectToParent(helios: Helios) {
             helios.setInputProps(event.data.props);
         }
         break;
+      case 'HELIOS_GET_SCHEMA':
+        window.parent.postMessage({ type: 'HELIOS_SCHEMA', schema: helios.schema }, '*');
+        break;
       case 'HELIOS_CAPTURE_FRAME':
         handleCaptureFrame(helios, event.data);
         break;

--- a/packages/player/src/controllers.test.ts
+++ b/packages/player/src/controllers.test.ts
@@ -51,6 +51,7 @@ describe('DirectController', () => {
                  return vi.fn();
             }),
             getState: vi.fn().mockReturnValue({ fps: 30, duration: 10, currentFrame: 0 }),
+            schema: { someProp: { type: 'string' } },
         };
 
         (Helios as unknown as any).mockImplementation(function() {
@@ -123,6 +124,11 @@ describe('DirectController', () => {
 
         controller.clearPlaybackRange();
         expect(mockHeliosInstance.clearPlaybackRange).toHaveBeenCalled();
+    });
+
+    it('should return schema', async () => {
+        const schema = await controller.getSchema();
+        expect(schema).toEqual({ someProp: { type: 'string' } });
     });
 
     it('should capture DOM frame', async () => {
@@ -272,6 +278,17 @@ describe('BridgeController', () => {
         triggerMessage({ type: 'HELIOS_STATE', state: newState });
 
         expect(spy).toHaveBeenCalledWith(newState);
+    });
+
+    it('should get schema via bridge', async () => {
+        const promise = controller.getSchema();
+
+        expect(mockWindow.postMessage).toHaveBeenCalledWith({ type: 'HELIOS_GET_SCHEMA' }, '*');
+
+        triggerMessage({ type: 'HELIOS_SCHEMA', schema: { foo: 'bar' } });
+
+        const result = await promise;
+        expect(result).toEqual({ foo: 'bar' });
     });
 
     it('should notify error subscribers on HELIOS_ERROR', () => {

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1,4 +1,4 @@
-import { Helios } from "@helios-project/core";
+import { Helios, HeliosSchema } from "@helios-project/core";
 import { DirectController, BridgeController } from "./controllers";
 import type { HeliosController } from "./controllers";
 import { ClientSideExporter } from "./features/exporter";
@@ -1387,6 +1387,13 @@ export class HeliosPlayer extends HTMLElement {
 
   public getController(): HeliosController | null {
     return this.controller;
+  }
+
+  public async getSchema(): Promise<HeliosSchema | undefined> {
+    if (this.controller) {
+      return this.controller.getSchema();
+    }
+    return undefined;
   }
 
   private retryConnection() {


### PR DESCRIPTION
Exposed the `HeliosSchema` from the core engine through the `HeliosPlayer` component API. This involved updating the bridge protocol to support a `HELIOS_GET_SCHEMA` request/response cycle, adding the method to the controller abstraction, and exposing it publicly on the `HeliosPlayer` element. This feature is a prerequisite for building property editors in hosting applications like Helios Studio.

---
*PR created automatically by Jules for task [257531027519802308](https://jules.google.com/task/257531027519802308) started by @BintzGavin*