### PR TITLE
✨ PLAYER: Standard Media API Gap Fill

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -47,6 +47,7 @@ The component observes the following attributes:
 - `export-format`: Format for client-side export (`mp4`, `webm`).
 - `input-props`: JSON string of properties to pass to the composition.
 - `controlslist`: Space-separated tokens to customize UI (`nodownload`, `nofullscreen`).
+- `crossorigin`: CORS setting for the element (`anonymous`, `use-credentials`).
 
 ## D. Styling
 The component exposes the following CSS variables for theming:

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.41.0
+- ✅ Completed: Standard Media API Gap Fill - Implemented `canPlayType`, `defaultMuted`, `defaultPlaybackRate`, `preservesPitch`, `srcObject`, and `crossOrigin` for fuller `HTMLMediaElement` parity.
+
 ## PLAYER v0.40.0
 - ✅ Completed: Range-Based Export - Client-side export now respects the active 'playbackRange' (loop region), exporting only the selected portion of the timeline.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.40.0
+**Version**: v0.41.0
 
 # Status: PLAYER
 
@@ -37,6 +37,7 @@
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.41.0] ✅ Completed: Standard Media API Gap Fill - Implemented `canPlayType`, `defaultMuted`, `defaultPlaybackRate`, `preservesPitch`, `srcObject`, and `crossOrigin` for fuller `HTMLMediaElement` parity.
 [v0.40.0] ✅ Completed: Range-Based Export - Client-side export now respects the active 'playbackRange' (loop region), exporting only the selected portion of the timeline.
 [v0.39.0] ✅ Completed: Native Loop Support - Refactored `HeliosController` and `bridge` to use `helios.setLoop()` natively, removing manual client-side looping logic.
 [v0.38.0] ✅ Completed: Visualize Playback Range - Implemented visual indicator for playback range on the timeline scrubber using CSS gradients and `updateUI` logic.

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -264,4 +264,64 @@ describe('HeliosPlayer API Parity', () => {
     expect(schema).toBe(mockSchema);
     expect(mockController.getSchema).toHaveBeenCalled();
   });
+
+  it('should support defaultMuted property', () => {
+    expect(player.defaultMuted).toBe(false);
+
+    player.defaultMuted = true;
+    expect(player.hasAttribute('muted')).toBe(true);
+    expect(player.defaultMuted).toBe(true);
+
+    player.defaultMuted = false;
+    expect(player.hasAttribute('muted')).toBe(false);
+    expect(player.defaultMuted).toBe(false);
+  });
+
+  it('should support defaultPlaybackRate property', () => {
+    const rateSpy = vi.fn();
+    player.addEventListener('ratechange', rateSpy);
+
+    expect(player.defaultPlaybackRate).toBe(1.0);
+
+    player.defaultPlaybackRate = 2.0;
+    expect(player.defaultPlaybackRate).toBe(2.0);
+    expect(rateSpy).toHaveBeenCalledTimes(1);
+
+    // Setting same value should not dispatch event
+    player.defaultPlaybackRate = 2.0;
+    expect(rateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should support preservesPitch property', () => {
+    expect(player.preservesPitch).toBe(true);
+
+    player.preservesPitch = false;
+    expect(player.preservesPitch).toBe(false);
+  });
+
+  it('should support srcObject property', () => {
+    const consoleSpy = vi.spyOn(console, 'warn');
+    expect(player.srcObject).toBeNull();
+
+    player.srcObject = {} as any;
+    expect(consoleSpy).toHaveBeenCalledWith("HeliosPlayer does not support srcObject");
+    expect(player.srcObject).toBeNull();
+  });
+
+  it('should support crossOrigin property', () => {
+    expect(player.crossOrigin).toBeNull();
+
+    player.crossOrigin = "anonymous";
+    expect(player.getAttribute("crossorigin")).toBe("anonymous");
+    expect(player.crossOrigin).toBe("anonymous");
+
+    player.crossOrigin = null;
+    expect(player.hasAttribute("crossorigin")).toBe(false);
+    expect(player.crossOrigin).toBeNull();
+  });
+
+  it('should support canPlayType method', () => {
+    expect(player.canPlayType("video/mp4")).toBe("");
+    expect(player.canPlayType("application/json")).toBe("");
+  });
 });

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -442,6 +442,65 @@ export class HeliosPlayer extends HTMLElement {
 
   // --- Standard Media API ---
 
+  public canPlayType(type: string): CanPlayTypeResult {
+    // We strictly play Helios compositions, not standard video MIME types.
+    // Return empty string to be spec-compliant for video/mp4 etc.
+    return "";
+  }
+
+  public get defaultMuted(): boolean {
+    return this.hasAttribute("muted");
+  }
+
+  public set defaultMuted(val: boolean) {
+    if (val) {
+      this.setAttribute("muted", "");
+    } else {
+      this.removeAttribute("muted");
+    }
+  }
+
+  private _defaultPlaybackRate = 1.0;
+  public get defaultPlaybackRate(): number {
+    return this._defaultPlaybackRate;
+  }
+
+  public set defaultPlaybackRate(val: number) {
+    if (this._defaultPlaybackRate !== val) {
+      this._defaultPlaybackRate = val;
+      this.dispatchEvent(new Event("ratechange"));
+    }
+  }
+
+  private _preservesPitch = true;
+  public get preservesPitch(): boolean {
+    return this._preservesPitch;
+  }
+
+  public set preservesPitch(val: boolean) {
+    this._preservesPitch = val;
+  }
+
+  public get srcObject(): MediaProvider | null {
+    return null;
+  }
+
+  public set srcObject(val: MediaProvider | null) {
+    console.warn("HeliosPlayer does not support srcObject");
+  }
+
+  public get crossOrigin(): string | null {
+    return this.getAttribute("crossorigin");
+  }
+
+  public set crossOrigin(val: string | null) {
+    if (val !== null) {
+      this.setAttribute("crossorigin", val);
+    } else {
+      this.removeAttribute("crossorigin");
+    }
+  }
+
   public get seeking(): boolean {
     // Return internal scrubbing state as seeking
     return this.isScrubbing;


### PR DESCRIPTION
Implemented missing HTMLMediaElement properties (canPlayType, defaultMuted, defaultPlaybackRate, preservesPitch, srcObject, crossOrigin) to achieve fuller API parity.

💡 What: Added missing properties to HeliosPlayer class.
🎯 Why: To allow HeliosPlayer to be used as a drop-in replacement in video wrapper libraries that expect these standard properties.
📊 Impact: Improves compatibility with third-party libraries.
🔬 Verification: Verified via `npm test -w packages/player` with new tests in `api_parity.test.ts`.

---
*PR created automatically by Jules for task [6156908361792556415](https://jules.google.com/task/6156908361792556415) started by @BintzGavin*