### PR TITLE
Spec: Implement Missing Asset Types in Core

### DIFF
--- a/.jules/CORE.md
+++ b/.jules/CORE.md
@@ -5,3 +5,7 @@
 ## [2.10.0] - Plan Specificity
 **Learning:** When using `set_plan` or `request_plan_review` to create a spec file, the plan step must explicitly contain the full text content of the file to be created, rather than just a description of what it will contain.
 **Action:** Always include the full Markdown content in the plan step description when the task is to create a specific file.
+
+## [2.13.0] - Missing Asset Types
+**Learning:** Found that `packages/studio` supports `model`, `json`, `shader` asset types, but `packages/core` schema validation rejected them.
+**Action:** When defining schemas in Core, always cross-reference with Studio's supported asset discovery types to ensure compatibility.

--- a/.sys/plans/2026-04-21-CORE-Implement-Missing-Asset-Types.md
+++ b/.sys/plans/2026-04-21-CORE-Implement-Missing-Asset-Types.md
@@ -1,0 +1,33 @@
+# 📋 Spec: Implement Missing Asset Types
+
+## 1. Context & Goal
+- **Objective**: Add `model`, `json`, and `shader` to the supported `PropType` values in `packages/core`.
+- **Trigger**: Vision gap - `packages/studio` supports these asset types for discovery, but `packages/core` schema validation rejects them.
+- **Impact**: Enables Studio to correctly define and pass these asset types to compositions without runtime errors.
+
+## 2. File Inventory
+- **Modify**: `packages/core/src/schema.ts` (Update `PropType` and validation logic)
+- **Modify**: `packages/core/src/schema.test.ts` (Add test cases)
+
+## 3. Implementation Spec
+- **Architecture**: Extend the `PropType` union type and update the `validateValue` function to treat these new types as strings (URLs/paths), similar to `image`, `video`, etc.
+- **Pseudo-Code**:
+  ```typescript
+  // schema.ts
+  export type PropType = ... | 'model' | 'json' | 'shader';
+
+  function validateValue(...) {
+    // ...
+    // Include new types in the string check
+    if (['color', 'image', 'video', 'audio', 'font', 'model', 'json', 'shader'].includes(def.type)) {
+       if (typeof val !== 'string') throwError(...);
+    }
+    // ...
+  }
+  ```
+- **Dependencies**: None.
+
+## 4. Test Plan
+- **Verification**: Run `npm test -w packages/core`.
+- **Success Criteria**: New test cases for `model`, `json`, `shader` pass. Existing tests pass.
+- **Edge Cases**: Validate that invalid values (non-strings) for these types throw errors.


### PR DESCRIPTION
Created spec file .sys/plans/2026-04-21-CORE-Implement-Missing-Asset-Types.md to add support for 'model', 'json', and 'shader' asset types in Core schema, aligning with Studio capabilities. Updated .jules/CORE.md with learning.

---
*PR created automatically by Jules for task [12612985092180607958](https://jules.google.com/task/12612985092180607958) started by @BintzGavin*