### PR TITLE
✨ CORE: Implement Missing Asset Types

### DIFF
--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -97,7 +97,10 @@ export type PropType =
   | 'image'
   | 'video'
   | 'audio'
-  | 'font';
+  | 'font'
+  | 'model'
+  | 'json'
+  | 'shader';
 
 export interface PropDefinition {
   type: PropType;

--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v2.14.0
+- ✅ Completed: Implement Missing Asset Types - Added `model`, `json`, and `shader` to supported `PropType` values and validation logic.
+
 ## CORE v2.13.0
 - ✅ Completed: Validate Schema Defaults - Implemented `validateSchema` to ensure schema defaults match their defined types, adding `INVALID_SCHEMA` error code.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 2.13.0
+**Version**: 2.14.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
-- **Last Updated**: 2026-04-20
+- **Last Updated**: 2026-04-21
 
+[v2.14.0] ✅ Completed: Implement Missing Asset Types - Added `model`, `json`, and `shader` to supported `PropType` values and validation logic.
 [v2.13.0] ✅ Completed: Validate Schema Defaults - Implemented `validateSchema` to ensure schema defaults match their defined types, adding `INVALID_SCHEMA` error code.
 [v2.12.0] ✅ Completed: Schema Enhancements - Added `step` and `format` properties to `PropDefinition` to support UI generation hints.
 [v2.11.0] ✅ Completed: Recursive Animation & Media Discovery - Implemented robust recursive Shadow DOM discovery in `DomDriver` with dynamic `MutationObserver` support.

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -252,6 +252,24 @@ describe('validateProps', () => {
     expect(() => validateProps({ fnt: [] }, schema)).toThrow(HeliosError);
   });
 
+  it('should validate new asset types (model, json, shader)', () => {
+    const schema = {
+      mdl: { type: 'model' as const },
+      dat: { type: 'json' as const },
+      shd: { type: 'shader' as const },
+    };
+    const valid = {
+      mdl: 'path/to/model.glb',
+      dat: 'path/to/data.json',
+      shd: 'path/to/shader.glsl',
+    };
+    expect(validateProps(valid, schema)).toEqual(valid);
+
+    expect(() => validateProps({ mdl: 123 }, schema)).toThrow(HeliosError);
+    expect(() => validateProps({ dat: {} }, schema)).toThrow(HeliosError);
+    expect(() => validateProps({ shd: true }, schema)).toThrow(HeliosError);
+  });
+
   it('should validate color formats', () => {
     const schema = {
         col: { type: 'color' as const }

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -11,7 +11,10 @@ export type PropType =
   | 'image'
   | 'video'
   | 'audio'
-  | 'font';
+  | 'font'
+  | 'model'
+  | 'json'
+  | 'shader';
 
 export interface PropDefinition {
   type: PropType;
@@ -108,7 +111,7 @@ function validateValue(val: any, def: PropDefinition, keyPath: string): any {
 
   // Color and Assets are treated as strings for runtime check
   if (
-    ['color', 'image', 'video', 'audio', 'font'].includes(def.type) &&
+    ['color', 'image', 'video', 'audio', 'font', 'model', 'json', 'shader'].includes(def.type) &&
     typeof val !== 'string'
   ) {
     throwError(keyPath, `${def.type} (string)`);


### PR DESCRIPTION
- **Update `packages/core/src/schema.ts`**: Added `model`, `json`, `shader` to `PropType` union and updated `validateValue` logic.
- **Update `packages/core/src/schema.test.ts`**: Added unit tests for new asset types.
- **Documentation**: Updated `docs/status/CORE.md`, `docs/PROGRESS-CORE.md`, and `/.sys/llmdocs/context-core.md`.
- **Version**: Incremented CORE version to 2.14.0.

---
*PR created automatically by Jules for task [9109749819271504205](https://jules.google.com/task/9109749819271504205) started by @BintzGavin*