### PR TITLE
✨ STUDIO: Missing Asset Types Support

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -47,7 +47,7 @@ packages/studio
 ## UI Components
 - **Stage**: Visual preview with zoom, pan, safe area guides, and transparency toggle.
 - **Timeline**: Track-based timeline with scrubbing, zooming, markers, and timecode display.
-- **Props Editor**: Auto-generated inputs based on composition schema (supports recursive objects and arrays, copy/reset tools, step constraints, and specialized formats like date/color).
+- **Props Editor**: Auto-generated inputs based on composition schema (supports recursive objects and arrays, copy/reset tools, step constraints, specialized formats like date/color, and diverse asset types like model/json/shader).
 - **Assets Panel**: Drag-and-drop asset management.
 - **Renders Panel**: Manage render jobs and download outputs.
 - **Captions Panel**: Edit and export captions (SRT).

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.56.0
+- ✅ Completed: Missing Asset Types - Implemented support for `model`, `json`, and `shader` types in Studio schema inputs, enabling asset discovery and usage.
+
 ## STUDIO v0.55.0
 - ✅ Completed: Props Step Format - Implemented support for `step` (number) and `format` (string) properties in the Props Editor, enabling specialized inputs like date, color, and stepped sliders.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.55.0
+**Version**: 0.56.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.56.0] ✅ Completed: Missing Asset Types - Implemented support for `model`, `json`, and `shader` types in Studio schema inputs, enabling asset discovery and usage.
 - [v0.55.0] ✅ Completed: Props Step Format - Implemented support for `step` (number) and `format` (string) properties in the Props Editor, enabling specialized inputs like date, color, and stepped sliders.
 - [v0.54.0] ✅ Completed: Props Editor Polish - Implemented Props Toolbar with "Copy JSON" and "Reset" buttons, and ensured `inputProps` persist across Hot Module Reloading (HMR).
 - [v0.53.0] ✅ Completed: Recursive Schema Support - Implemented `ObjectInput` and `ArrayInput` in Props Editor to support nested object and array schemas with recursive UI generation.

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/studio",
-  "version": "0.51.0",
+  "version": "0.56.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/studio/src/components/SchemaInputs.tsx
+++ b/packages/studio/src/components/SchemaInputs.tsx
@@ -3,6 +3,9 @@ import type { PropDefinition, PropType } from '@helios-project/core';
 import { useStudio } from '../context/StudioContext';
 import './PropsEditor.css'; // Re-use styles
 
+// Extended PropType to support future types not yet in Core
+type ExtendedPropType = PropType | 'model' | 'json' | 'shader';
+
 interface SchemaInputProps {
   definition: PropDefinition;
   value: any;
@@ -14,7 +17,10 @@ export const SchemaInput: React.FC<SchemaInputProps> = ({ definition, value, onC
     return <EnumInput options={definition.enum} value={value} onChange={onChange} />;
   }
 
-  switch (definition.type) {
+  // Cast to ExtendedPropType to allow handling new types
+  const type = definition.type as ExtendedPropType;
+
+  switch (type) {
     case 'string':
       return <StringInput value={value} onChange={onChange} format={definition.format} />;
     case 'number':
@@ -27,7 +33,10 @@ export const SchemaInput: React.FC<SchemaInputProps> = ({ definition, value, onC
     case 'video':
     case 'audio':
     case 'font':
-      return <AssetInput type={definition.type} value={value} onChange={onChange} />;
+    case 'model':
+    case 'json':
+    case 'shader':
+      return <AssetInput type={type} value={value} onChange={onChange} />;
     case 'object':
         if (definition.properties) {
             return <ObjectInput definition={definition} value={value} onChange={onChange} />;
@@ -45,7 +54,9 @@ export const SchemaInput: React.FC<SchemaInputProps> = ({ definition, value, onC
 
 // Helper to get safe default values
 export const getDefaultValueForType = (type: PropType): any => {
-    switch (type) {
+    // Cast to allow extended types
+    const extendedType = type as ExtendedPropType;
+    switch (extendedType) {
         case 'string': return '';
         case 'number': return 0;
         case 'boolean': return false;
@@ -56,6 +67,9 @@ export const getDefaultValueForType = (type: PropType): any => {
         case 'video':
         case 'audio':
         case 'font':
+        case 'model':
+        case 'json':
+        case 'shader':
             return '';
         default: return undefined;
     }
@@ -142,7 +156,7 @@ const ArrayInput: React.FC<{ definition: PropDefinition; value: any; onChange: (
     );
 };
 
-const AssetInput: React.FC<{ type: PropType; value: string; onChange: (val: string) => void }> = ({
+const AssetInput: React.FC<{ type: ExtendedPropType; value: string; onChange: (val: string) => void }> = ({
   type,
   value,
   onChange


### PR DESCRIPTION
Implemented support for `model`, `json`, and `shader` asset types in the Studio's `SchemaInputs.tsx` and `AssetInput` to align with Core's upcoming `PropType` updates. This change enables asset discovery and usage for these new types in compositions. Verified by running `npm run build -w packages/studio` and confirming no TypeScript errors. Also updated documentation and bumped version to `0.56.0`.

---
*PR created automatically by Jules for task [14501587017053198701](https://jules.google.com/task/14501587017053198701) started by @BintzGavin*