### PR TITLE
✨ PLAYER: Import SRT Captions

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -5,6 +5,7 @@ The `<helios-player>` component uses a Shadow DOM to encapsulate its styles and 
 
 **Shadow Root:**
 - `<style>`: Encapsulated CSS.
+- `<slot>`: (Hidden) Accepts light DOM children like `<track>` elements.
 - `.status-overlay`: Displays loading, connecting, and error states.
 - `.poster-container`: Displays the poster image and "Big Play Button".
 - `<iframe>`: Hosts the Helios composition (sandboxed).
@@ -49,7 +50,10 @@ The component observes the following attributes:
 - `controlslist`: Space-separated tokens to customize UI (`nodownload`, `nofullscreen`).
 - `crossorigin`: CORS setting for the element (`anonymous`, `use-credentials`).
 
-## D. Styling
+## D. Child Elements
+- `<track>`: Standard HTMLTrackElement for importing captions (kind="captions"). Requires `src` (SRT file) and `default` attribute to be active.
+
+## E. Styling
 The component exposes the following CSS variables for theming:
 
 - `--helios-controls-bg`: Background color of the controls bar.

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -182,3 +182,6 @@
 
 ## [2026-01-20] PLAYER
 - ✅ Completed: Refactor Player Control Logic - Verified `<helios-player>` uses `window.helios` and supports client-side export.
+
+## PLAYER v0.42.0
+- ✅ Completed: Import SRT Captions - Implemented support for <track> elements to import SRT captions via the setCaptions API.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.41.0
+**Version**: v0.42.0
 
 # Status: PLAYER
 
@@ -33,10 +33,12 @@
 - Implements `controlslist` attribute support (`nodownload`, `nofullscreen`) to customize UI visibility.
 - Implements CSS Variables (custom properties) for theming the player UI (`--helios-controls-bg`, `--helios-accent-color`, etc.).
 - Supports Native Loop via `setLoop` in Controller/Bridge, removing client-side loop hacks.
+- Supports importing SRT captions via standard `<track kind="captions">` child elements.
 
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.42.0] ✅ Completed: Import SRT Captions - Implemented support for `<track>` elements to import SRT captions via the setCaptions API.
 [v0.41.0] ✅ Completed: Standard Media API Gap Fill - Implemented `canPlayType`, `defaultMuted`, `defaultPlaybackRate`, `preservesPitch`, `srcObject`, and `crossOrigin` for fuller `HTMLMediaElement` parity.
 [v0.40.0] ✅ Completed: Range-Based Export - Client-side export now respects the active 'playbackRange' (loop region), exporting only the selected portion of the timeline.
 [v0.39.0] ✅ Completed: Native Loop Support - Refactored `HeliosController` and `bridge` to use `helios.setLoop()` natively, removing manual client-side looping logic.
@@ -111,3 +113,4 @@
 - [x] Enable Canvas Inlining for DOM Export.
 - [x] Enable Video Inlining for DOM Export.
 - [x] Implement Bridge Error Propagation.
+- [x] Implement `<track>` support for SRT captions.

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -236,7 +236,7 @@ describe('HeliosPlayer API Parity', () => {
         cb({ message: "Test Error" });
         return vi.fn();
       }),
-      setInputProps: vi.fn(),
+      setInputProps: vi.fn(), setCaptions: vi.fn(),
       setAudioMuted: vi.fn(),
     };
     (player as any).setController(mockController);

--- a/packages/player/src/bridge.ts
+++ b/packages/player/src/bridge.ts
@@ -62,6 +62,11 @@ export function connectToParent(helios: Helios) {
             helios.setInputProps(event.data.props);
         }
         break;
+      case 'HELIOS_SET_CAPTIONS':
+        if (event.data.captions !== undefined) {
+            helios.setCaptions(event.data.captions);
+        }
+        break;
       case 'HELIOS_GET_SCHEMA':
         window.parent.postMessage({ type: 'HELIOS_SCHEMA', schema: helios.schema }, '*');
         break;

--- a/packages/player/src/captions.test.ts
+++ b/packages/player/src/captions.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { HeliosPlayer } from './index';
+import type { HeliosController } from './controllers';
+
+describe('HeliosPlayer Captions', () => {
+  let player: HeliosPlayer;
+  let mockController: HeliosController;
+
+  beforeEach(() => {
+    // Mock ResizeObserver
+    global.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as any;
+
+    // Mock Fetch
+    global.fetch = vi.fn();
+
+    // Mock Controller
+    mockController = {
+      play: vi.fn(),
+      pause: vi.fn(),
+      seek: vi.fn(),
+      setAudioVolume: vi.fn(),
+      setAudioMuted: vi.fn(),
+      setLoop: vi.fn(),
+      setPlaybackRate: vi.fn(),
+      setPlaybackRange: vi.fn(),
+      clearPlaybackRange: vi.fn(),
+      setInputProps: vi.fn(),
+      setCaptions: vi.fn(),
+      subscribe: vi.fn(() => () => {}),
+      onError: vi.fn(() => () => {}),
+      getState: vi.fn(() => ({ fps: 30, duration: 10, currentFrame: 0, isPlaying: false })),
+      dispose: vi.fn(),
+      captureFrame: vi.fn(),
+      getAudioTracks: vi.fn(),
+      getSchema: vi.fn()
+    };
+
+    // Create Player
+    // Ensure custom element is defined (it might be defined by import side effect)
+    if (!customElements.get('helios-player')) {
+        customElements.define('helios-player', HeliosPlayer);
+    }
+    player = document.createElement('helios-player') as HeliosPlayer;
+    document.body.appendChild(player);
+
+    // Manually trigger controller connection (since we are not using iframe/bridge in this unit test)
+    // We access the private method via 'any' casting.
+    (player as any).setController(mockController);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(player);
+    vi.restoreAllMocks();
+  });
+
+  it('should load captions from a default track element', async () => {
+    const srtContent = "1\n00:00:01,000 --> 00:00:02,000\nHello World";
+    (global.fetch as any).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(srtContent)
+    });
+
+    const track = document.createElement('track');
+    track.setAttribute('kind', 'captions');
+    track.setAttribute('src', 'subs.srt');
+    track.setAttribute('default', '');
+
+    player.appendChild(track);
+
+    // Wait for slotchange and fetch
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringMatching(/subs.srt$/));
+    expect(mockController.setCaptions).toHaveBeenCalledWith(srtContent);
+  });
+
+  it('should clear captions if no default track is found', async () => {
+    const track = document.createElement('track');
+    track.setAttribute('kind', 'captions');
+    track.setAttribute('src', 'subs.srt');
+    // default is missing
+
+    player.appendChild(track);
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    // It should be called with empty array because logic says "if no default track, clear captions"
+    expect(mockController.setCaptions).toHaveBeenCalledWith([]);
+  });
+
+  it('should clear captions when track is removed', async () => {
+    // 1. Add track
+    const srtContent = "1\n00:00:01,000 --> 00:00:02,000\nHello World";
+    (global.fetch as any).mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(srtContent)
+    });
+    const track = document.createElement('track');
+    track.setAttribute('kind', 'captions');
+    track.setAttribute('src', 'subs.srt');
+    track.setAttribute('default', '');
+    player.appendChild(track);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mockController.setCaptions).toHaveBeenCalledWith(srtContent);
+
+    // 2. Remove track
+    player.removeChild(track);
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(mockController.setCaptions).toHaveBeenCalledWith([]);
+  });
+
+  it('should handle fetch errors gracefully', async () => {
+     // Clear initialization call from setController
+     (mockController.setCaptions as any).mockClear();
+
+     (global.fetch as any).mockResolvedValue({
+        ok: false,
+        status: 404
+    });
+
+    const track = document.createElement('track');
+    track.setAttribute('kind', 'captions');
+    track.setAttribute('src', 'missing.srt');
+    track.setAttribute('default', '');
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    player.appendChild(track);
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringMatching(/missing.srt$/));
+    expect(mockController.setCaptions).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith("HeliosPlayer: Failed to load captions", expect.anything());
+  });
+});

--- a/packages/player/src/controllers.ts
+++ b/packages/player/src/controllers.ts
@@ -12,6 +12,7 @@ export interface HeliosController {
   setPlaybackRate(rate: number): void;
   setPlaybackRange(startFrame: number, endFrame: number): void;
   clearPlaybackRange(): void;
+  setCaptions(captions: string | CaptionCue[]): void;
   setInputProps(props: Record<string, any>): void;
   subscribe(callback: (state: any) => void): () => void;
   onError(callback: (err: any) => void): () => void;
@@ -33,6 +34,7 @@ export class DirectController implements HeliosController {
   setPlaybackRate(rate: number) { this.instance.setPlaybackRate(rate); }
   setPlaybackRange(start: number, end: number) { this.instance.setPlaybackRange(start, end); }
   clearPlaybackRange() { this.instance.clearPlaybackRange(); }
+  setCaptions(captions: string | CaptionCue[]) { this.instance.setCaptions(captions); }
   setInputProps(props: Record<string, any>) { this.instance.setInputProps(props); }
   subscribe(callback: (state: any) => void) { return this.instance.subscribe(callback); }
   getState() { return this.instance.getState(); }
@@ -153,6 +155,7 @@ export class BridgeController implements HeliosController {
   setPlaybackRate(rate: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_PLAYBACK_RATE', rate }, '*'); }
   setPlaybackRange(start: number, end: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_PLAYBACK_RANGE', start, end }, '*'); }
   clearPlaybackRange() { this.iframeWindow.postMessage({ type: 'HELIOS_CLEAR_PLAYBACK_RANGE' }, '*'); }
+  setCaptions(captions: string | CaptionCue[]) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_CAPTIONS', captions }, '*'); }
   setInputProps(props: Record<string, any>) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_PROPS', props }, '*'); }
 
   subscribe(callback: (state: any) => void) {

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -96,7 +96,7 @@ describe('HeliosPlayer', () => {
         seek: vi.fn(),
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
+        dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn()
     };
 
@@ -180,7 +180,7 @@ describe('HeliosPlayer', () => {
         seek: vi.fn(),
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
+        dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn()
     };
     (player as any).setController(mockController);
@@ -253,7 +253,7 @@ describe('HeliosPlayer', () => {
       seek: vi.fn(),
       subscribe: vi.fn().mockReturnValue(() => {}),
       onError: vi.fn().mockReturnValue(() => {}),
-      dispose: vi.fn(),
+      dispose: vi.fn(), setCaptions: vi.fn(),
       setPlaybackRate: vi.fn()
     };
     (player as any).setController(mockController);
@@ -300,7 +300,7 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn()
         };
         (player as any).setController(mockController);
@@ -417,7 +417,7 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn()
@@ -505,7 +505,7 @@ describe('HeliosPlayer', () => {
         seek: vi.fn(),
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
+        dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn()
       };
       (player as any).setController(mockController);
@@ -533,7 +533,7 @@ describe('HeliosPlayer', () => {
         seek: vi.fn(),
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(),
+        dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn()
       };
       (player as any).setController(mockController);
@@ -562,7 +562,7 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn()
         };
         (player as any).setController(mockController);
@@ -600,7 +600,7 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn()
         };
         (player as any).setController(mockController);
@@ -635,7 +635,7 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setAudioVolume: vi.fn(),
             setAudioMuted: vi.fn(),
@@ -732,7 +732,7 @@ describe('HeliosPlayer', () => {
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
             getAudioTracks: vi.fn()
@@ -914,7 +914,7 @@ describe('HeliosPlayer', () => {
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
             getAudioTracks: vi.fn()
@@ -979,7 +979,7 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn()
         };
@@ -1097,7 +1097,7 @@ describe('HeliosPlayer', () => {
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
             getAudioTracks: vi.fn()
@@ -1141,7 +1141,7 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn()
@@ -1283,7 +1283,7 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(),
+            dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn()


### PR DESCRIPTION
💡 **What**: Implemented support for `<track>` elements in `<helios-player>` to import SRT captions.
🎯 **Why**: To enable declarative loading of captions via standard HTML semantics.
📊 **Impact**: Users can now use `<track kind="captions" src="subs.srt" default>` to load captions into the Helios player.
🔬 **Verification**: Added `packages/player/src/captions.test.ts` and verified with `npm test -w packages/player`.

---
*PR created automatically by Jules for task [10758705953050523762](https://jules.google.com/task/10758705953050523762) started by @BintzGavin*