### PR TITLE
feat(studio): Add interactive Timecode Display

### DIFF
--- a/packages/studio/src/components/Controls/TimecodeDisplay.css
+++ b/packages/studio/src/components/Controls/TimecodeDisplay.css
@@ -1,0 +1,31 @@
+.timecode-display {
+  cursor: text;
+  padding: 0 4px;
+  border-radius: 2px;
+  display: inline-block;
+  min-width: 80px;
+  text-align: center;
+}
+
+.timecode-display:hover {
+  background: #333;
+}
+
+.timecode-input {
+  font-family: monospace;
+  font-size: 11px;
+  color: #fff;
+  background: #111;
+  border: 1px solid #007bff;
+  padding: 0 4px;
+  width: 80px;
+  outline: none;
+  border-radius: 2px;
+  text-align: center;
+}
+
+/* Ensure placeholder and selection color */
+.timecode-input::selection {
+  background: #007bff;
+  color: white;
+}

--- a/packages/studio/src/components/Controls/TimecodeDisplay.test.tsx
+++ b/packages/studio/src/components/Controls/TimecodeDisplay.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { TimecodeDisplay } from './TimecodeDisplay';
+
+describe('TimecodeDisplay', () => {
+  const mockOnChange = vi.fn();
+  const fps = 30;
+  const totalFrames = 300; // 10s
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  it('renders timecode correctly', () => {
+    // Frame 30 = 1s
+    render(<TimecodeDisplay frame={30} fps={fps} totalFrames={totalFrames} onChange={mockOnChange} />);
+    expect(screen.getByText('00:00:01:00')).toBeInTheDocument();
+  });
+
+  it('switches to input on click', () => {
+    render(<TimecodeDisplay frame={30} fps={fps} totalFrames={totalFrames} onChange={mockOnChange} />);
+    const display = screen.getByText('00:00:01:00');
+    fireEvent.click(display);
+
+    const input = screen.getByDisplayValue('00:00:01:00');
+    expect(input).toBeInTheDocument();
+    expect(input.tagName).toBe('INPUT');
+  });
+
+  it('commits frame number change on enter', () => {
+    render(<TimecodeDisplay frame={30} fps={fps} totalFrames={totalFrames} onChange={mockOnChange} />);
+    const display = screen.getByText('00:00:01:00');
+    fireEvent.click(display);
+
+    const input = screen.getByDisplayValue('00:00:01:00');
+    // Change to "60" (frame number)
+    fireEvent.change(input, { target: { value: '60' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    expect(mockOnChange).toHaveBeenCalledWith(60);
+    // Should revert to span
+    expect(screen.queryByDisplayValue('60')).not.toBeInTheDocument();
+  });
+
+  it('commits timecode change on enter', () => {
+    render(<TimecodeDisplay frame={30} fps={fps} totalFrames={totalFrames} onChange={mockOnChange} />);
+    const display = screen.getByText('00:00:01:00');
+    fireEvent.click(display);
+
+    const input = screen.getByDisplayValue('00:00:01:00');
+    // Change to "00:00:02:00" (Frame 60)
+    fireEvent.change(input, { target: { value: '00:00:02:00' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    expect(mockOnChange).toHaveBeenCalledWith(60);
+  });
+
+  it('clamps value to totalFrames', () => {
+    render(<TimecodeDisplay frame={30} fps={fps} totalFrames={totalFrames} onChange={mockOnChange} />);
+    fireEvent.click(screen.getByText('00:00:01:00'));
+    const input = screen.getByDisplayValue('00:00:01:00');
+
+    fireEvent.change(input, { target: { value: '1000' } });
+    fireEvent.blur(input);
+
+    expect(mockOnChange).toHaveBeenCalledWith(300); // totalFrames
+  });
+
+  it('reverts on invalid input', () => {
+    render(<TimecodeDisplay frame={30} fps={fps} totalFrames={totalFrames} onChange={mockOnChange} />);
+    fireEvent.click(screen.getByText('00:00:01:00'));
+    const input = screen.getByDisplayValue('00:00:01:00');
+
+    fireEvent.change(input, { target: { value: 'invalid' } });
+    fireEvent.blur(input);
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+    // Should revert to original display
+    expect(screen.getByText('00:00:01:00')).toBeInTheDocument();
+  });
+});

--- a/packages/studio/src/components/Controls/TimecodeDisplay.tsx
+++ b/packages/studio/src/components/Controls/TimecodeDisplay.tsx
@@ -1,0 +1,104 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { framesToTimecode, timecodeToFrames } from '@helios-project/core';
+import './TimecodeDisplay.css';
+
+interface TimecodeDisplayProps {
+  frame: number;
+  fps: number;
+  totalFrames: number;
+  onChange: (frame: number) => void;
+}
+
+export const TimecodeDisplay: React.FC<TimecodeDisplayProps> = ({ frame, fps, totalFrames, onChange }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Format the display timecode
+  const displayTimecode = React.useMemo(() => {
+    if (!fps || fps <= 0) return "00:00:00:00";
+    try {
+      return framesToTimecode(frame, fps);
+    } catch (e) {
+      return "00:00:00:00";
+    }
+  }, [frame, fps]);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const handleStartEdit = () => {
+    setInputValue(displayTimecode);
+    setIsEditing(true);
+  };
+
+  const commit = () => {
+    if (!inputValue.trim()) {
+      setIsEditing(false);
+      return;
+    }
+
+    let targetFrame = frame;
+
+    try {
+      if (inputValue.includes(':')) {
+        // Parse as timecode
+        targetFrame = timecodeToFrames(inputValue, fps);
+      } else {
+        // Parse as frame number
+        const parsed = parseInt(inputValue, 10);
+        if (!isNaN(parsed)) {
+          targetFrame = parsed;
+        }
+      }
+    } catch (e) {
+      console.warn('Invalid timecode input:', inputValue);
+      // Revert on error
+      setIsEditing(false);
+      return;
+    }
+
+    // Clamp
+    targetFrame = Math.max(0, Math.min(targetFrame, totalFrames));
+
+    if (targetFrame !== frame) {
+      onChange(targetFrame);
+    }
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      commit();
+    } else if (e.key === 'Escape') {
+      setIsEditing(false);
+    }
+  };
+
+  if (isEditing) {
+    return (
+      <input
+        ref={inputRef}
+        className="timecode-input"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onBlur={commit}
+        onKeyDown={handleKeyDown}
+      />
+    );
+  }
+
+  return (
+    <span
+      className="timecode-display"
+      onClick={handleStartEdit}
+      title="Click to edit (Timecode or Frame #)"
+    >
+      {displayTimecode}
+    </span>
+  );
+};

--- a/packages/studio/src/components/Timeline.tsx
+++ b/packages/studio/src/components/Timeline.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { useStudio } from '../context/StudioContext';
 import { framesToTimecode } from '@helios-project/core';
+import { TimecodeDisplay } from './Controls/TimecodeDisplay';
 import './Timeline.css';
 
 interface Tick {
@@ -226,7 +227,14 @@ export const Timeline: React.FC = () => {
     <div className="timeline-container">
       <div className="timeline-header">
         <div className="timeline-header-left">
-          <span>{formatTime(currentFrame, fps)} / {formatTime(totalFrames, fps)}</span>
+          <TimecodeDisplay
+            frame={currentFrame}
+            fps={fps}
+            totalFrames={totalFrames}
+            onChange={(f) => controller?.seek(f)}
+          />
+          <span style={{ margin: '0 4px', color: '#666' }}>/</span>
+          <span>{formatTime(totalFrames, fps)}</span>
           <div className="timeline-zoom-control">
             <span className="timeline-zoom-label">Fit</span>
             <input

--- a/verification/verify_timecode.py
+++ b/verification/verify_timecode.py
@@ -1,0 +1,52 @@
+from playwright.sync_api import Page, expect, sync_playwright
+import time
+
+def test_timecode_edit(page: Page):
+    page.goto("http://localhost:5173")
+    page.wait_for_timeout(2000)
+
+    play_btn = page.locator("button[title='Play / Pause (Space)']")
+
+    # Force toggle to ensure we have control
+    print("Clicking Play...")
+    play_btn.click()
+    page.wait_for_timeout(1000)
+
+    print("Clicking Pause...")
+    play_btn.click()
+    page.wait_for_timeout(1000)
+
+    # Check if timecode is stable
+    display = page.locator(".timecode-display")
+    initial_text = display.text_content()
+    print(f"Timecode after pause: {initial_text}")
+
+    page.wait_for_timeout(1000)
+    final_text = display.text_content()
+    print(f"Timecode 1s later: {final_text}")
+
+    if initial_text != final_text:
+        print("WARNING: Timecode is still moving!")
+
+    # Now try to edit
+    display.click()
+    input_el = page.locator(".timecode-input")
+    input_el.fill("10")
+    input_el.press("Enter")
+
+    expect(display).to_contain_text(":10")
+
+    page.screenshot(path="/home/jules/verification/timecode_edit.png")
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        try:
+            test_timecode_edit(page)
+            print("Verification successful!")
+        except Exception as e:
+            print(f"Verification failed: {e}")
+            page.screenshot(path="/home/jules/verification/failure.png")
+        finally:
+            browser.close()


### PR DESCRIPTION
Implemented an interactive Timecode Display in the Studio Timeline. Users can now click the timecode to edit it, accepting either a frame number or SMPTE timecode (HH:MM:SS:FF) to seek the composition. This improves navigation precision and developer experience.

---
*PR created automatically by Jules for task [9396851138207917900](https://jules.google.com/task/9396851138207917900) started by @BintzGavin*