### PR TITLE
✨ RENDERER: Enforce deterministic Date.now() in SeekTimeDriver

### DIFF
--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -9,8 +9,8 @@ export class SeekTimeDriver implements TimeDriver {
       // Initialize virtual time
       (window as any).__HELIOS_VIRTUAL_TIME__ = 0;
 
-      // Capture initial wall clock to anchor Date.now()
-      const initialDate = Date.now();
+      // Use a fixed epoch to ensure deterministic Date.now() across runs
+      const initialDate = 1704067200000; // 2024-01-01T00:00:00.000Z
 
       // Override performance.now()
       // We don't need to keep the original because we want full control


### PR DESCRIPTION
Fixed Date.now() epoch to Jan 1, 2024 (1704067200000) in SeekTimeDriver to ensure bit-identical rendering across different runs. Updated verification script to assert absolute timestamp consistency.

---
*PR created automatically by Jules for task [9075635974550692341](https://jules.google.com/task/9075635974550692341) started by @BintzGavin*