### PR TITLE
✨ STUDIO: Show render errors

### DIFF
--- a/packages/studio/src/components/RendersPanel/RendersPanel.css
+++ b/packages/studio/src/components/RendersPanel/RendersPanel.css
@@ -64,3 +64,34 @@
 .start-render-btn:hover {
   background-color: #005f9e;
 }
+
+.error-details {
+  margin-top: 4px;
+  font-size: 10px;
+  color: #f44336;
+}
+
+.error-details summary {
+  cursor: pointer;
+  outline: none;
+  font-weight: bold;
+  opacity: 0.8;
+}
+
+.error-details summary:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+.error-details pre {
+  margin: 4px 0 0 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: rgba(244, 67, 54, 0.1);
+  padding: 4px;
+  border-radius: 2px;
+  color: #ffcdd2;
+  max-height: 100px;
+  overflow-y: auto;
+  font-family: monospace;
+}

--- a/packages/studio/src/components/RendersPanel/RendersPanel.tsx
+++ b/packages/studio/src/components/RendersPanel/RendersPanel.tsx
@@ -172,7 +172,15 @@ export const RendersPanel: React.FC = () => {
              <div style={{ fontSize: '10px', color: '#ff9800' }}>Cancelled</div>
           )}
           {job.status === 'failed' && (
-             <div style={{ fontSize: '10px', color: '#f44336' }}>Failed</div>
+             <div className="render-job-failed">
+               <div style={{ fontSize: '10px', color: '#f44336' }}>Failed</div>
+               {job.error && (
+                 <details className="error-details">
+                   <summary>Show Error</summary>
+                   <pre>{job.error}</pre>
+                 </details>
+               )}
+             </div>
           )}
         </div>
       ))}


### PR DESCRIPTION
Implemented error message display in the Renders Panel. When a render job fails, the error details (from `job.error`) are now shown in a collapsible `<details>` element, allowing users to diagnose issues like missing files or FFmpeg errors. Verified by mocking a failed job and inspecting the UI.

---
*PR created automatically by Jules for task [14883113629650542742](https://jules.google.com/task/14883113629650542742) started by @BintzGavin*