### PR TITLE
✨ CORE: Implement Typed Arrays

### DIFF
--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -111,7 +111,16 @@ export type PropType =
   | 'font'
   | 'model'
   | 'json'
-  | 'shader';
+  | 'shader'
+  | 'int8array'
+  | 'uint8array'
+  | 'uint8clampedarray'
+  | 'int16array'
+  | 'uint16array'
+  | 'int32array'
+  | 'uint32array'
+  | 'float32array'
+  | 'float64array';
 
 export interface PropDefinition {
   type: PropType;

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -104,3 +104,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 - Group multiple completions under the same version section if they're part of the same release
 ## STUDIO v0.53.0
 - ✅ Completed: Recursive Schema Support - Implemented ObjectInput and ArrayInput for recursive UI generation in Props Editor.
+
+## CORE v2.17.0
+- ✅ Completed: Implement Typed Arrays - Added support for Typed Arrays (Float32Array, etc.) in HeliosSchema and validateProps.

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 2.16.0
+**Version**: 2.17.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
 - **Last Updated**: 2026-04-26
 
+[v2.17.0] ✅ Completed: Implement Typed Arrays - Added support for Typed Arrays (Float32Array, etc.) in HeliosSchema and validateProps.
 [v2.16.0] ✅ Completed: Time-Based Control - Added `currentTime` signal and `seekToTime()` method to `Helios` class for direct time manipulation.
 [v2.15.0] ✅ Completed: Enhance Diagnose - Expanded `Helios.diagnose()` to include WebGL, WebAudio, Color Gamut, and Video Codec support.
 [v2.14.0] ✅ Completed: Implement Missing Asset Types - Added `model`, `json`, and `shader` to supported `PropType` values and validation logic.

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -357,4 +357,41 @@ describe('validateProps', () => {
 
       expect(() => validateProps({ level1: { level2: [{ val: -1 }] } }, schema)).toThrow(/Prop 'level1.level2\[0\].val' must be >= 0/);
   });
+
+  it('should validate Typed Arrays', () => {
+    const schema = {
+      i8: { type: 'int8array' as const, optional: true },
+      u8: { type: 'uint8array' as const, optional: true },
+      u8c: { type: 'uint8clampedarray' as const, optional: true },
+      i16: { type: 'int16array' as const, optional: true },
+      u16: { type: 'uint16array' as const, optional: true },
+      i32: { type: 'int32array' as const, optional: true },
+      u32: { type: 'uint32array' as const, optional: true },
+      f32: { type: 'float32array' as const, optional: true },
+      f64: { type: 'float64array' as const, optional: true },
+    };
+
+    const valid = {
+      i8: new Int8Array([1]),
+      u8: new Uint8Array([1]),
+      u8c: new Uint8ClampedArray([1]),
+      i16: new Int16Array([1]),
+      u16: new Uint16Array([1]),
+      i32: new Int32Array([1]),
+      u32: new Uint32Array([1]),
+      f32: new Float32Array([1.0]),
+      f64: new Float64Array([1.0]),
+    };
+    expect(validateProps(valid, schema)).toEqual(valid);
+
+    // Invalid types (plain arrays)
+    expect(() => validateProps({ i8: [] }, schema)).toThrow(HeliosError);
+
+    // Mismatched Typed Arrays
+    expect(() => validateProps({ f32: new Float64Array([1.0]) }, schema)).toThrow(HeliosError);
+    expect(() => validateProps({ f32: new Float64Array([1.0]) }, schema)).toThrow(/Expected Float32Array/);
+
+    expect(() => validateProps({ u8: new Int8Array([1]) }, schema)).toThrow(HeliosError);
+    expect(() => validateProps({ u8: new Int8Array([1]) }, schema)).toThrow(/Expected Uint8Array/);
+  });
 });

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -14,7 +14,16 @@ export type PropType =
   | 'font'
   | 'model'
   | 'json'
-  | 'shader';
+  | 'shader'
+  | 'int8array'
+  | 'uint8array'
+  | 'uint8clampedarray'
+  | 'int16array'
+  | 'uint16array'
+  | 'int32array'
+  | 'uint32array'
+  | 'float32array'
+  | 'float64array';
 
 export interface PropDefinition {
   type: PropType;
@@ -108,6 +117,17 @@ function validateValue(val: any, def: PropDefinition, keyPath: string): any {
   if (def.type === 'boolean' && typeof val !== 'boolean') throwError(keyPath, 'boolean');
   if (def.type === 'array' && !Array.isArray(val)) throwError(keyPath, 'array');
   if (def.type === 'object' && (typeof val !== 'object' || Array.isArray(val) || val === null)) throwError(keyPath, 'object');
+
+  // Typed Arrays
+  if (def.type === 'int8array' && !(val instanceof Int8Array)) throwError(keyPath, 'Int8Array');
+  if (def.type === 'uint8array' && !(val instanceof Uint8Array)) throwError(keyPath, 'Uint8Array');
+  if (def.type === 'uint8clampedarray' && !(val instanceof Uint8ClampedArray)) throwError(keyPath, 'Uint8ClampedArray');
+  if (def.type === 'int16array' && !(val instanceof Int16Array)) throwError(keyPath, 'Int16Array');
+  if (def.type === 'uint16array' && !(val instanceof Uint16Array)) throwError(keyPath, 'Uint16Array');
+  if (def.type === 'int32array' && !(val instanceof Int32Array)) throwError(keyPath, 'Int32Array');
+  if (def.type === 'uint32array' && !(val instanceof Uint32Array)) throwError(keyPath, 'Uint32Array');
+  if (def.type === 'float32array' && !(val instanceof Float32Array)) throwError(keyPath, 'Float32Array');
+  if (def.type === 'float64array' && !(val instanceof Float64Array)) throwError(keyPath, 'Float64Array');
 
   // Color and Assets are treated as strings for runtime check
   if (


### PR DESCRIPTION
Added Typed Array support to HeliosSchema.

Changes:
- Updated `PropType` in `packages/core/src/schema.ts` to include typed array types.
- Updated `validateValue` in `packages/core/src/schema.ts` to validate typed arrays using `instanceof`.
- Added tests in `packages/core/src/schema.test.ts`.

Verification:
- Ran `npm test -w packages/core` and all tests passed (after installing dependencies).

---
*PR created automatically by Jules for task [17963722804098976760](https://jules.google.com/task/17963722804098976760) started by @BintzGavin*