### PR TITLE
📋 CORE: Fix Leaky Signal Subscriptions

### DIFF
--- a/.jules/CORE.md
+++ b/.jules/CORE.md
@@ -25,3 +25,7 @@
 ## [2.16.0] - Planner Role Clarity
 **Learning:** The Planner Agent's `set_plan` steps must be "Create the spec file" and "Verify the spec file", NOT "Implement the code". The plan content goes *inside* the spec file.
 **Action:** Ensure `set_plan` steps focus on the *meta-task* of planning (creating documentation), not the execution of the plan itself.
+
+## [2.17.0] - Leaky Signal Subscriptions
+**Learning:** The implementation of `Signal.subscribe` using `effect` caused a leaky abstraction where the subscription implicitly tracked dependencies accessed within the callback.
+**Action:** When implementing reactive primitives, ensure that explicit subscriptions (like `subscribe`) execute their callbacks in an untracked context to prevent accidental dependency collection.

--- a/.sys/plans/2026-05-23-CORE-Fix-Leaky-Signal-Subscriptions.md
+++ b/.sys/plans/2026-05-23-CORE-Fix-Leaky-Signal-Subscriptions.md
@@ -1,0 +1,41 @@
+# CORE Spec: Fix Leaky Signal Subscriptions
+
+## 1. Context & Goal
+- **Objective**: Fix the "leaky abstraction" in `Signal.subscribe` where accessing other signals inside the subscription callback causes unwanted dependency tracking.
+- **Trigger**: The current implementation of `subscribe` uses `effect` internally, which tracks all signals accessed within the callback. This violates the expected behavior where a subscription should only trigger on updates to the subscribed signal.
+- **Impact**: Ensures predictable state management and prevents infinite loops or redundant callback firings when users access other signals inside a subscription.
+
+## 2. File Inventory
+- **Modify**: `packages/core/src/signals.ts` (Implement `untracked` and update `subscribe` methods)
+- **Modify**: `packages/core/src/signals.test.ts` (Add regression test for leaky subscriptions)
+
+## 3. Implementation Spec
+- **Architecture**: Introduce `untracked` helper to temporarily disable dependency tracking. Re-implement `subscribe` to use manual `Subscriber` management instead of `effect`, wrapping the callback execution in `untracked`.
+- **Pseudo-Code**:
+```typescript
+export function untracked<T>(fn: () => T): T {
+  const prev = activeSubscriber;
+  activeSubscriber = null;
+  try { return fn(); } finally { activeSubscriber = prev; }
+}
+
+class SignalImpl<T> {
+   subscribe(fn: (v: T) => void) {
+     const sub = {
+       notify: () => untracked(() => fn(this.peek())),
+       addDependency: () => {}
+     };
+     this.addSubscriber(sub);
+     untracked(() => fn(this.peek()));
+     return () => this.removeSubscriber(sub);
+   }
+}
+// Apply similar logic to ComputedImpl
+```
+- **Public API Changes**: Export `untracked` function. Change behavior of `subscribe` to be non-tracking for the callback.
+- **Dependencies**: None.
+
+## 4. Test Plan
+- **Verification**: Run `npm test -w packages/core`
+- **Success Criteria**: New test case "should not track dependencies in subscribe callback" passes, and all existing tests pass.
+- **Edge Cases**: Nested subscriptions, subscriptions inside effects (should be fine as `untracked` restores `activeSubscriber`).


### PR DESCRIPTION
Added spec file .sys/plans/2026-05-23-CORE-Fix-Leaky-Signal-Subscriptions.md detailing the fix for leaky abstractions in Signal.subscribe.

---
*PR created automatically by Jules for task [7694718000516142704](https://jules.google.com/task/7694718000516142704) started by @BintzGavin*