### PR TITLE
✨ RENDERER: CdpTimeDriver Budget - Wait for virtual time budget expiration

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -7,7 +7,7 @@ The Renderer operates on a "Dual-Path" architecture to support different use cas
    - **Discovery**: Uses `dom-scanner` to recursively discover media elements (including Shadow DOM).
    - **Output**: Best for sharp text and vector graphics.
 2. **Canvas Strategy (`CanvasStrategy`)**: Used for WebGL/Canvas-heavy compositions (e.g., Three.js, PixiJS). It captures the `<canvas>` context directly.
-   - **Drivers**: Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise virtual time control (supports Shadow DOM media sync, enforces deterministic Jan 1 2024 epoch, ensures sync-before-render order).
+   - **Drivers**: Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise virtual time control (supports Shadow DOM media sync, enforces deterministic Jan 1 2024 epoch, ensures sync-before-render order, waits for budget expiration).
    - **Output**: Best for high-performance 2D/3D graphics.
 
 Both strategies pipe frame data directly to an FFmpeg process via stdin ("Zero Disk I/O"), ensuring high performance and low latency.
@@ -39,6 +39,7 @@ packages/renderer/
     ├── verify-shadow-dom-audio.ts # Shadow DOM audio test
     ├── verify-shadow-dom-sync.ts  # Shadow DOM sync test (DOM Mode)
     ├── verify-cdp-shadow-dom-sync.ts # Shadow DOM media sync test (Canvas Mode)
+    ├── verify-cdp-driver.ts    # CdpDriver budget test
     └── ...                     # Other verification scripts
 ```
 

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.47.2
+- ✅ Completed: CdpTimeDriver Budget - Updated `CdpTimeDriver` to wait for `virtualTimeBudgetExpired` event, ensuring the browser fully processes the time budget before capturing the frame.
+
 ## RENDERER v1.47.1
 - ✅ Completed: CdpTimeDriver Media Sync Timing - Updated `CdpTimeDriver` to synchronize media elements before advancing virtual time, ensuring correct frame capture.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.47.1
+**Version**: 1.47.2
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.47.2] ✅ Completed: CdpTimeDriver Budget - Updated `CdpTimeDriver` to wait for `virtualTimeBudgetExpired` event, ensuring the browser fully processes the time budget before capturing the frame.
 - [1.47.1] ✅ Completed: CdpTimeDriver Media Sync Timing - Updated `CdpTimeDriver` to synchronize media elements before advancing virtual time, ensuring correct frame capture.
 - [1.47.0] ✅ Completed: SeekTimeDriver Determinism - Updated `SeekTimeDriver` to enforce deterministic `Date.now()` by setting a fixed epoch (Jan 1, 2024), aligning DOM-based rendering determinism with Canvas-based rendering.
 - [1.46.0] ✅ Completed: CdpTimeDriver Determinism - Updated `CdpTimeDriver` to enforce deterministic `Date.now()` by setting `initialVirtualTime` to Jan 1, 2024 (UTC), ensuring frame consistency across runs.

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -91,9 +91,16 @@ export class CdpTimeDriver implements TimeDriver {
 
     // 2. Advance virtual time
     // This triggers the browser event loop and requestAnimationFrame
-    await this.client.send('Emulation.setVirtualTimePolicy', {
-      policy: 'advance',
-      budget: budget
+    await new Promise<void>((resolve, reject) => {
+      if (!this.client) return resolve();
+
+      // Use 'once' to avoid leaking listeners
+      this.client.once('Emulation.virtualTimeBudgetExpired', () => resolve());
+
+      this.client.send('Emulation.setVirtualTimePolicy', {
+        policy: 'advance',
+        budget: budget
+      }).catch(reject);
     });
 
     this.currentTime = timeInSeconds;


### PR DESCRIPTION
💡 What: Updated CdpTimeDriver to wrap Emulation.setVirtualTimePolicy in a Promise that waits for the Emulation.virtualTimeBudgetExpired event.
🎯 Why: The previous implementation would return immediately after sending the command, potentially leading to race conditions where the frame was captured before the browser had fully processed the time advancement.
📊 Impact: Improves deterministic rendering reliability for heavy animations in Canvas mode by ensuring the browser event loop has fully processed the budget.
🔬 Verification: Verified with packages/renderer/tests/verify-cdp-driver.ts which confirms correct time advancement.

---
*PR created automatically by Jules for task [16064805908140462170](https://jules.google.com/task/16064805908140462170) started by @BintzGavin*