### PR TITLE
✨ STUDIO: Render Preview

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -57,10 +57,11 @@ packages/studio
 - **Timeline**: Track-based timeline with scrubbing, zooming, markers, and timecode display.
 - **Props Editor**: Auto-generated inputs based on composition schema (supports recursive objects and arrays, copy/reset tools, step constraints, specialized formats like date/color, and diverse asset types like model/json/shader).
 - **Assets Panel**: Drag-and-drop asset management with search and type filtering.
-- **Renders Panel**: Manage render jobs, view error details for failed jobs, and download outputs.
+- **Renders Panel**: Manage render jobs, view error details for failed jobs, preview outputs in a modal, and download outputs.
 - **Captions Panel**: Edit and export captions (SRT).
 - **Diagnostics Panel**: View system capabilities (FFmpeg, GPU).
 - **Composition Settings Modal**: Edit width, height, FPS, and duration of the active composition.
+- **Render Preview Modal**: Instant playback of rendered video files.
 - **Create Composition Modal**: Create new compositions using templates (Vanilla JS, React, Vue, Svelte, Three.js).
 - **Global Shortcuts**: Configure keyboard shortcuts for actions.
 

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.60.0
+- ✅ Completed: Render Preview - Implemented a modal to preview rendered videos directly within the Studio UI.
+
 ## STUDIO v0.59.0
 - ✅ Completed: Show Render Errors - Implemented error display in Renders Panel, enabling users to debug failed render jobs.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.59.0
+**Version**: 0.60.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.60.0] ✅ Completed: Render Preview - Implemented a modal to preview rendered videos directly within the Studio UI.
 - [v0.59.0] ✅ Completed: Show Render Errors - Implemented error display in Renders Panel, enabling users to debug failed render jobs.
 - [v0.58.0] ✅ Completed: Three.js Template - Implemented a "Three.js" template for the Composition Creator, enabling users to quickly bootstrap 3D compositions.
 - [v0.57.0] ✅ Completed: Asset Filtering - Implemented search bar and type filter in Assets Panel to improve asset management.

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -12,6 +12,7 @@ import { CompositionSettingsModal } from './components/CompositionSettingsModal'
 import { KeyboardShortcutsModal } from './components/KeyboardShortcutsModal'
 import { DiagnosticsModal } from './components/DiagnosticsModal'
 import { SystemPromptModal } from './components/SystemPromptModal'
+import { RenderPreviewModal } from './components/RenderPreviewModal'
 import { GlobalShortcuts } from './components/GlobalShortcuts'
 import { Stage } from './components/Stage/Stage'
 import { Sidebar } from './components/Sidebar/Sidebar'
@@ -117,6 +118,7 @@ function AppContent() {
       <KeyboardShortcutsModal />
       <DiagnosticsModal />
       <SystemPromptModal />
+      <RenderPreviewModal />
       <GlobalShortcuts />
     </>
   )

--- a/packages/studio/src/components/RenderPreviewModal.css
+++ b/packages/studio/src/components/RenderPreviewModal.css
@@ -1,0 +1,68 @@
+.preview-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+  backdrop-filter: blur(2px);
+}
+
+.preview-modal {
+  background: #1e1e1e;
+  border: 1px solid #333;
+  border-radius: 8px;
+  width: auto;
+  max-width: 90vw;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid #333;
+  background: #252525;
+}
+
+.preview-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #fff;
+}
+
+.preview-close-button {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 4px;
+  line-height: 1;
+}
+
+.preview-close-button:hover {
+  color: #fff;
+}
+
+.preview-content {
+  background: #000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.preview-video {
+  max-width: 100%;
+  max-height: calc(90vh - 60px); /* Subtract header height */
+  outline: none;
+}

--- a/packages/studio/src/components/RenderPreviewModal.tsx
+++ b/packages/studio/src/components/RenderPreviewModal.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useStudio } from '../context/StudioContext';
+import './RenderPreviewModal.css';
+
+export const RenderPreviewModal: React.FC = () => {
+  const { previewUrl, setPreviewUrl } = useStudio();
+
+  if (!previewUrl) return null;
+
+  return (
+    <div className="preview-modal-overlay" onClick={() => setPreviewUrl(null)}>
+      <div className="preview-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="preview-header">
+          <h2>Render Preview</h2>
+          <button className="preview-close-button" onClick={() => setPreviewUrl(null)}>
+            ×
+          </button>
+        </div>
+        <div className="preview-content">
+          <video controls autoPlay src={previewUrl} className="preview-video" />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/studio/src/components/RendersPanel/RendersPanel.tsx
+++ b/packages/studio/src/components/RendersPanel/RendersPanel.tsx
@@ -17,7 +17,8 @@ export const RendersPanel: React.FC = () => {
     isExporting,
     exportProgress,
     exportVideo,
-    cancelExport
+    cancelExport,
+    setPreviewUrl
   } = useStudio();
 
   const [exportFormat, setExportFormat] = useState<'mp4' | 'webm'>('mp4');
@@ -147,25 +148,43 @@ export const RendersPanel: React.FC = () => {
           {job.status === 'completed' && (
              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: '4px' }}>
                 <div style={{ fontSize: '10px', color: '#4caf50' }}>Done</div>
-                {job.outputUrl && (
-                    <a
-                        href={job.outputUrl}
-                        download
-                        target="_blank"
-                        rel="noreferrer"
-                        style={{
-                            fontSize: '10px',
-                            color: '#66b2ff',
-                            textDecoration: 'none',
-                            border: '1px solid #66b2ff',
-                            padding: '2px 6px',
-                            borderRadius: '4px',
-                            background: 'rgba(0, 123, 255, 0.1)'
-                        }}
+                <div style={{ display: 'flex', gap: '8px' }}>
+                  {job.outputUrl && (
+                    <button
+                      onClick={() => setPreviewUrl(job.outputUrl!)}
+                      style={{
+                        fontSize: '10px',
+                        color: '#fff',
+                        border: 'none',
+                        padding: '3px 8px',
+                        borderRadius: '4px',
+                        background: '#2196f3',
+                        cursor: 'pointer'
+                      }}
                     >
-                        Download
-                    </a>
-                )}
+                      Preview
+                    </button>
+                  )}
+                  {job.outputUrl && (
+                      <a
+                          href={job.outputUrl}
+                          download
+                          target="_blank"
+                          rel="noreferrer"
+                          style={{
+                              fontSize: '10px',
+                              color: '#66b2ff',
+                              textDecoration: 'none',
+                              border: '1px solid #66b2ff',
+                              padding: '2px 6px',
+                              borderRadius: '4px',
+                              background: 'rgba(0, 123, 255, 0.1)'
+                          }}
+                      >
+                          Download
+                      </a>
+                  )}
+                </div>
              </div>
           )}
           {job.status === 'cancelled' && (

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -133,6 +133,10 @@ interface StudioContextType {
   // Snapshot
   takeSnapshot: () => Promise<void>;
 
+  // Render Preview
+  previewUrl: string | null;
+  setPreviewUrl: (url: string | null) => void;
+
   // Client-Side Export
   isExporting: boolean;
   exportProgress: number;
@@ -154,6 +158,7 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [isSettingsOpen, setSettingsOpen] = useState(false);
   const [canvasSize, setCanvasSize] = useState({ width: 1920, height: 1080 });
   const [renderConfig, setRenderConfig] = useState<RenderConfig>({ mode: 'canvas' });
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   const [renderJobs, setRenderJobs] = useState<RenderJob[]>([]);
 
@@ -541,6 +546,8 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         renderConfig,
         setRenderConfig,
         takeSnapshot,
+        previewUrl,
+        setPreviewUrl,
         isExporting,
         exportProgress,
         exportVideo,


### PR DESCRIPTION
💡 **What**: Implemented a "Render Preview" modal in Studio that plays back server-side rendered videos. Added a "Preview" button to the Renders Panel for completed jobs.
🎯 **Why**: Previously, users had to download rendered files to view them, which slowed down the iteration loop. This closes the gap in the "Browser-based development environment" vision.
📊 **Impact**: Faster feedback loop for server-side renders.
🔬 **Verification**:
1. Start Studio: `npx helios studio`
2. Run a render job.
3. Upon completion, click "Preview" in the Renders panel.
4. Verify the modal opens and plays the video.
(Verified with Playwright script `verify_render_preview.py` and visual inspection of screenshot).

---
*PR created automatically by Jules for task [9712091773452240181](https://jules.google.com/task/9712091773452240181) started by @BintzGavin*