### PR TITLE
✨ PLAYER: Visualize Markers

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -11,7 +11,10 @@ The `<helios-player>` component uses a Shadow DOM to encapsulate its styles and 
 - `<iframe>`: Hosts the Helios composition (sandboxed).
 - `.click-layer`: Captures clicks for play/pause and double-clicks for fullscreen.
 - `.captions-container`: Displays active captions.
-- `.controls` (role="toolbar"): Contains playback controls (Play/Pause, Volume, Captions, Export, Speed, Scrubber, Time Display, Fullscreen).
+- `.controls` (role="toolbar"): Contains playback controls (Play/Pause, Volume, Captions, Export, Speed, Scrubber Wrapper, Time Display, Fullscreen).
+  - `.scrubber-wrapper`: Container for the scrubber range input and markers.
+    - `.markers-container`: Overlays visual markers on the timeline track.
+    - `.scrubber`: The seek range input.
 
 ## B. Events
 The component dispatches standard HTMLMediaElement events:

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -45,6 +45,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - If this is a new version, create the section at the top of the file (after any existing content)
 - Group multiple completions under the same version section if they're part of the same release
 
+### PLAYER v0.46.0
+- ✅ Completed: Visualize Markers - Implemented visual rendering of timeline markers on the scrubber, including clickable interaction to seek to the marker's timestamp.
+
 ### PLAYER v0.45.0
 - ✅ Completed: Interactive Playback Range - Implemented `I` (In), `O` (Out), and `X` (Clear) keyboard shortcuts to set the playback loop range interactively.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.45.0
+**Version**: v0.46.0
 
 # Status: PLAYER
 
@@ -37,10 +37,12 @@
 - Supports importing SRT captions via standard `<track kind="captions">` child elements and exposes standard `textTracks` / `addTextTrack` API.
 - Supports `sandbox` attribute to customize iframe security flags (default: `allow-scripts allow-same-origin`).
 - Implemented robust `load()` behavior that supports reloading the current `src` to facilitate programmatic retries.
+- Visualizes markers on the timeline, allowing users to identify and seek to specific points of interest.
 
 ## Critical Task
 - **None**: Recent task completed.
 
+[v0.46.0] ✅ Completed: Visualize Markers - Implemented visual rendering of timeline markers on the scrubber, including clickable interaction to seek to the marker's timestamp.
 [v0.45.0] ✅ Completed: Interactive Playback Range - Implemented `I` (In), `O` (Out), and `X` (Clear) keyboard shortcuts to set the playback loop range interactively.
 [v0.44.2] ✅ Completed: Fix load() Behavior - Updated `load()` to reload the current source if no pending source exists, and refactored `retryConnection` to use this standard method.
 [v0.44.1] ✅ Completed: Documentation Update - Synced package.json version and documented missing features (sandbox, controlslist, textTracks, CSS vars).

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -20,6 +20,7 @@ export declare class HeliosPlayer extends HTMLElement implements TrackHost {
     private volumeBtn;
     private volumeSlider;
     private scrubber;
+    private markersContainer;
     private timeDisplay;
     private exportBtn;
     private overlay;

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.44.1",
+  "version": "0.46.0",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",


### PR DESCRIPTION
Implemented marker visualization on the `<helios-player>` timeline.
- Wrapped the scrubber in a `.scrubber-wrapper` to allow layering of markers.
- Added `.markers-container` and `.marker` styles.
- Updated `updateUI` to render markers from `HeliosState`.
- Added interactivity: clicking a marker seeks to its time.
- Optimized `updateUI` to only rebuild markers when they change.
- Added comprehensive unit tests.

---
*PR created automatically by Jules for task [15697405577189473765](https://jules.google.com/task/15697405577189473765) started by @BintzGavin*