### PR TITLE
✨ RENDERER: Validate Codec Compatibility

### DIFF
--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.47.4
+- ✅ Completed: Validate Codec Compatibility - Updated `DomStrategy` and `CanvasStrategy` to throw clear errors when `videoCodec: 'copy'` is used with image sequence fallback, preventing FFmpeg crashes. Also fixed regression tests to provide valid options to `DomStrategy`.
+
 ## RENDERER v1.47.3
 - ✅ Completed: Shadow DOM Background Preload - Verified and enhanced `DomStrategy` to recursively find and preload CSS background images inside nested Shadow DOMs, ensuring zero-artifact rendering for Web Components.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.47.3
+**Version**: 1.47.4
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.47.4] ✅ Completed: Validate Codec Compatibility - Updated `DomStrategy` and `CanvasStrategy` to throw clear errors when `videoCodec: 'copy'` is used with image sequence fallback, preventing FFmpeg crashes. Also fixed regression tests to provide valid options to `DomStrategy`.
 - [1.47.3] ✅ Completed: Shadow DOM Background Preload - Verified and enhanced `DomStrategy` to recursively find and preload CSS background images inside nested Shadow DOMs, ensuring zero-artifact rendering for Web Components.
 - [1.47.2] ✅ Completed: CdpTimeDriver Budget - Updated `CdpTimeDriver` to wait for `virtualTimeBudgetExpired` event, ensuring the browser fully processes the time budget before capturing the frame.
 - [1.47.1] ✅ Completed: CdpTimeDriver Media Sync Timing - Updated `CdpTimeDriver` to synchronize media elements before advancing virtual time, ensuring correct frame capture.

--- a/packages/renderer/scripts/verify-advanced-audio.ts
+++ b/packages/renderer/scripts/verify-advanced-audio.ts
@@ -11,7 +11,7 @@ const runTest = () => {
   console.log('Verifying Advanced Audio Arguments Generation...');
 
   const outputPath = 'output.mp4';
-  const domStrategy = new DomStrategy();
+  const domStrategy = new DomStrategy({ width: 1920, height: 1080, fps: 30, durationInSeconds: 1 });
 
   // Test Case 1: Volume Control
   // Track 1: Volume 0.5

--- a/packages/renderer/scripts/verify-audio-args.ts
+++ b/packages/renderer/scripts/verify-audio-args.ts
@@ -29,7 +29,7 @@ const runTest = () => {
   const outputPath = 'output.mp4';
 
   // Test DomStrategy
-  const domStrategy = new DomStrategy();
+  const domStrategy = new DomStrategy({ width: 1920, height: 1080, fps: 30, durationInSeconds: 1 });
 
   // Case 1: DomStrategy with Audio
   const argsDomWithAudio = domStrategy.getFFmpegArgs(optionsWithAudio, outputPath);

--- a/packages/renderer/src/strategies/CanvasStrategy.ts
+++ b/packages/renderer/src/strategies/CanvasStrategy.ts
@@ -255,6 +255,10 @@ export class CanvasStrategy implements RenderStrategy {
     } else {
       this.useWebCodecs = false;
       console.log(`CanvasStrategy: WebCodecs not available (${result.reason}). Falling back to toDataURL.`);
+
+      if (this.options.videoCodec === 'copy') {
+        throw new Error("CanvasStrategy failed to initialize WebCodecs and fell back to image capture, which cannot be used with 'copy' codec. Ensure VideoEncoder is supported or use a transcoding codec.");
+      }
     }
   }
 

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -7,7 +7,11 @@ import { scanForAudioTracks } from '../utils/dom-scanner.js';
 export class DomStrategy implements RenderStrategy {
   private discoveredAudioTracks: AudioTrackConfig[] = [];
 
-  constructor(private options: RendererOptions) {}
+  constructor(private options: RendererOptions) {
+    if (this.options.videoCodec === 'copy') {
+      throw new Error("DomStrategy produces image sequences and cannot be used with 'copy' codec. Please use a transcoding codec like 'libx264' (default).");
+    }
+  }
 
   async diagnose(page: Page): Promise<any> {
     return await page.evaluate(() => {

--- a/packages/renderer/tests/verify-codec-validation.ts
+++ b/packages/renderer/tests/verify-codec-validation.ts
@@ -1,0 +1,82 @@
+import { DomStrategy } from '../src/strategies/DomStrategy';
+import { CanvasStrategy } from '../src/strategies/CanvasStrategy';
+import { RendererOptions } from '../src/types';
+import { Page } from 'playwright';
+
+async function main() {
+  console.log('Starting Codec Validation Verification...');
+  let errors = 0;
+
+  // 1. Verify DomStrategy Validation
+  try {
+    console.log('[Test 1] Testing DomStrategy with videoCodec="copy"...');
+    const options: RendererOptions = {
+      width: 1920,
+      height: 1080,
+      fps: 30,
+      durationInSeconds: 1,
+      mode: 'dom',
+      videoCodec: 'copy', // Invalid
+    };
+
+    new DomStrategy(options);
+    console.error('❌ FAIL: DomStrategy should have thrown an error but did not.');
+    errors++;
+  } catch (e: any) {
+    if (e.message.includes('DomStrategy produces image sequences and cannot be used with \'copy\' codec')) {
+      console.log('✅ PASS: DomStrategy threw expected error.');
+    } else {
+      console.error(`❌ FAIL: DomStrategy threw unexpected error: ${e.message}`);
+      errors++;
+    }
+  }
+
+  // 2. Verify CanvasStrategy Validation (Mocking prepare)
+  try {
+    console.log('[Test 2] Testing CanvasStrategy (Fallback) with videoCodec="copy"...');
+    const options: RendererOptions = {
+        width: 1920,
+        height: 1080,
+        fps: 30,
+        durationInSeconds: 1,
+        mode: 'canvas',
+        videoCodec: 'copy', // Invalid if WebCodecs fails
+    };
+
+    const strategy = new CanvasStrategy(options);
+
+    // Mock page to simulate WebCodecs NOT supported
+    const mockPage = {
+        evaluate: async (fn: any, args: any) => {
+            // Return structure that satisfies WebCodecs check (supported: false)
+            return { supported: false, reason: 'Mocked unsupported' };
+        },
+        viewportSize: () => ({ width: 1920, height: 1080 }),
+        frames: () => [],
+    } as unknown as Page;
+
+    await strategy.prepare(mockPage);
+
+    console.error('❌ FAIL: CanvasStrategy should have thrown an error but did not.');
+    errors++;
+  } catch (e: any) {
+    if (e.message.includes('CanvasStrategy failed to initialize WebCodecs and fell back to image capture')) {
+        console.log('✅ PASS: CanvasStrategy threw expected error.');
+    } else {
+        console.error(`❌ FAIL: CanvasStrategy threw unexpected error: ${e.message}`);
+        errors++;
+    }
+  }
+
+  if (errors > 0) {
+    console.error(`\nValidation failed with ${errors} errors.`);
+    process.exit(1);
+  } else {
+    console.log('\nAll validation tests passed!');
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/renderer/tests/verify-implicit-audio.ts
+++ b/packages/renderer/tests/verify-implicit-audio.ts
@@ -23,7 +23,7 @@ async function verify() {
     </html>
   `);
 
-  const strategy = new DomStrategy();
+  const strategy = new DomStrategy({ width: 1280, height: 720, fps: 30, durationInSeconds: 5, mode: 'dom' });
 
   console.log('Running strategy.prepare()...');
   await strategy.prepare(page);


### PR DESCRIPTION
Implements fail-fast validation in `DomStrategy` and `CanvasStrategy` to prevent invalid `videoCodec: 'copy'` configuration when the renderer is operating in image sequence mode (e.g. `mode: 'dom'` or `mode: 'canvas'` without WebCodecs). This prevents cryptic FFmpeg failures and provides clear feedback to the user.

Also fixes regression tests where `DomStrategy` was instantiated without options, which now causes a runtime error due to the new validation logic accessing `options`.

---
*PR created automatically by Jules for task [14151873821294549430](https://jules.google.com/task/14151873821294549430) started by @BintzGavin*