### PR TITLE
✨ RENDERER: Prioritize H.264 Codec

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -7,7 +7,8 @@ The Renderer operates on a "Dual-Path" architecture to support different use cas
    - **Discovery**: Uses `dom-scanner` to recursively discover media elements (including Shadow DOM).
    - **Output**: Best for sharp text and vector graphics.
 2. **Canvas Strategy (`CanvasStrategy`)**: Used for WebGL/Canvas-heavy compositions (e.g., Three.js, PixiJS). It captures the `<canvas>` context directly.
-   - **Drivers**: Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise virtual time control (supports Shadow DOM media sync, enforces deterministic Jan 1 2024 epoch, ensures sync-before-render order, waits for budget expiration).
+   - **Drivers**: Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise virtual time control (supports Shadow DOM media sync, enforces deterministic Jan 2024 epoch, ensures sync-before-render order, waits for budget expiration).
+   - **Optimization**: Prioritizes H.264 (AVC) intermediate codec for hardware acceleration, falling back to VP8.
    - **Output**: Best for high-performance 2D/3D graphics.
 
 Both strategies pipe frame data directly to an FFmpeg process via stdin ("Zero Disk I/O"), ensuring high performance and low latency.

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.48.0
+- ✅ Completed: Prioritize H.264 - Updated `CanvasStrategy` to prioritize H.264 (AVC) intermediate codec over VP8 by default, enabling hardware acceleration and better performance on supported systems.
+
 ## RENDERER v1.47.4
 - ✅ Completed: Validate Codec Compatibility - Updated `DomStrategy` and `CanvasStrategy` to throw clear errors when `videoCodec: 'copy'` is used with image sequence fallback, preventing FFmpeg crashes. Also fixed regression tests to provide valid options to `DomStrategy`.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.47.4
+**Version**: 1.48.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.48.0] ✅ Completed: Prioritize H.264 - Updated `CanvasStrategy` to prioritize H.264 (AVC) intermediate codec over VP8 by default, enabling hardware acceleration and better performance on supported systems.
 - [1.47.4] ✅ Completed: Validate Codec Compatibility - Updated `DomStrategy` and `CanvasStrategy` to throw clear errors when `videoCodec: 'copy'` is used with image sequence fallback, preventing FFmpeg crashes. Also fixed regression tests to provide valid options to `DomStrategy`.
 - [1.47.3] ✅ Completed: Shadow DOM Background Preload - Verified and enhanced `DomStrategy` to recursively find and preload CSS background images inside nested Shadow DOMs, ensuring zero-artifact rendering for Web Components.
 - [1.47.2] ✅ Completed: CdpTimeDriver Budget - Updated `CdpTimeDriver` to wait for `virtualTimeBudgetExpired` event, ensuring the browser fully processes the time budget before capturing the frame.

--- a/packages/renderer/src/strategies/CanvasStrategy.ts
+++ b/packages/renderer/src/strategies/CanvasStrategy.ts
@@ -109,6 +109,8 @@ export class CanvasStrategy implements RenderStrategy {
         addCandidate('vp8');
     } else {
         // Default behavior
+        // Prioritize H.264 (Hardware) -> VP8 (Software Fallback)
+        addCandidate('avc1.4d002a');
         addCandidate('vp8');
     }
 

--- a/packages/renderer/tests/verify-smart-codec-selection.ts
+++ b/packages/renderer/tests/verify-smart-codec-selection.ts
@@ -67,7 +67,7 @@ async function runTest() {
         console.log('✅ Copy mode checks passed');
     }
 
-     // Test 2: Default Mode -> Candidates should be VP8
+     // Test 2: Default Mode -> Candidates should prioritize H.264
     {
         console.log('Test 2: Default Mode');
         const options: RendererOptions = {
@@ -82,7 +82,8 @@ async function runTest() {
 
         const mockPage = createMockPage((args) => {
             capturedArgs = args;
-            return { supported: true, codec: 'vp8', isH264: false };
+            // Simulate H264 supported
+            return { supported: true, codec: 'avc1.4d002a', isH264: true };
         });
 
         await strategy.prepare(mockPage);
@@ -92,11 +93,12 @@ async function runTest() {
 
         console.log('Candidates:', codecs);
 
-        assert.strictEqual(codecs[0], 'vp8', 'VP8 should be first candidate');
+        assert.strictEqual(codecs[0], 'avc1.4d002a', 'H.264 should be first candidate');
+        assert.strictEqual(codecs[1], 'vp8', 'VP8 should be second candidate');
 
         const ffmpegArgs = strategy.getFFmpegArgs(options, 'out.mp4');
         const fIndex = ffmpegArgs.indexOf('-f');
-        assert.strictEqual(ffmpegArgs[fIndex + 1], 'ivf', 'Should use ivf format');
+        assert.strictEqual(ffmpegArgs[fIndex + 1], 'h264', 'Should use h264 format');
 
         console.log('✅ Default mode checks passed');
     }


### PR DESCRIPTION
Updated `CanvasStrategy` to prioritize H.264 (AVC) intermediate codec over VP8 by default in CanvasStrategy to enable hardware acceleration. Verified with `packages/renderer/tests/verify-smart-codec-selection.ts`.

---
*PR created automatically by Jules for task [11612244688524959034](https://jules.google.com/task/11612244688524959034) started by @BintzGavin*