### PR TITLE
✨ CORE: Expose duration and fps as signals

### DIFF
--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -124,10 +124,8 @@ class Helios {
   public get playbackRange(): ReadonlySignal<[number, number] | null>;
   public get width(): ReadonlySignal<number>;
   public get height(): ReadonlySignal<number>;
-
-  // Getters
-  public get duration(): number;
-  public get fps(): number;
+  public get duration(): ReadonlySignal<number>;
+  public get fps(): ReadonlySignal<number>;
 
   // Static
   static diagnose(): Promise<DiagnosticReport>;

--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v3.0.0
+- ✅ Completed: Expose Duration/FPS Signals - Changed `duration` and `fps` to return `ReadonlySignal<number>` for reactive updates (Breaking Change).
+
 ## CORE v2.20.0
 - ✅ Completed: Audio Diagnostics - Added audioCodecs (aac, opus) detection to Helios.diagnose() and DiagnosticReport.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 2.20.0
+**Version**: 3.0.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
-- **Last Updated**: 2026-05-25
+- **Last Updated**: 2026-05-26
 
+[v3.0.0] ✅ Completed: Expose Duration/FPS Signals - Changed `duration` and `fps` to return `ReadonlySignal<number>` for reactive updates (Breaking Change).
 [v2.20.0] ✅ Completed: Audio Diagnostics - Added audioCodecs (aac, opus) detection to Helios.diagnose() and DiagnosticReport.
 [v2.19.1] ✅ Completed: Update Documentation - Added usage examples for `stagger` and `shift` to README.
 [v2.19.0] ✅ Completed: Implement Sequencing Helpers - Added `stagger` and `shift` utilities to `packages/core` to simplify animation timing.

--- a/packages/core/src/index-signals.test.ts
+++ b/packages/core/src/index-signals.test.ts
@@ -69,4 +69,38 @@ describe('Helios Signals API', () => {
     expect(currentProps).toEqual(props);
     expect(helios.inputProps.value).toEqual(props);
   });
+
+  it('should expose duration and fps as signals', () => {
+    const helios = new Helios({ duration: 10, fps: 30 });
+    expect(helios.duration.value).toBe(10);
+    expect(helios.fps.value).toBe(30);
+  });
+
+  it('should update duration signal on setDuration', () => {
+    const helios = new Helios({ duration: 10, fps: 30 });
+    let durationValue = -1;
+    effect(() => {
+      durationValue = helios.duration.value;
+    });
+
+    expect(durationValue).toBe(10);
+
+    helios.setDuration(20);
+    expect(durationValue).toBe(20);
+    expect(helios.duration.value).toBe(20);
+  });
+
+  it('should update fps signal on setFps', () => {
+    const helios = new Helios({ duration: 10, fps: 30 });
+    let fpsValue = -1;
+    effect(() => {
+      fpsValue = helios.fps.value;
+    });
+
+    expect(fpsValue).toBe(30);
+
+    helios.setFps(60);
+    expect(fpsValue).toBe(60);
+    expect(helios.fps.value).toBe(60);
+  });
 });

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -850,7 +850,7 @@ Updated`;
     it('should update duration via setDuration', () => {
       const helios = new Helios({ duration: 10, fps: 30 });
       helios.setDuration(20);
-      expect(helios.duration).toBe(20);
+      expect(helios.duration.value).toBe(20);
       expect(helios.getState().duration).toBe(20);
     });
 
@@ -882,7 +882,7 @@ Updated`;
     it('should update fps via setFps', () => {
       const helios = new Helios({ duration: 10, fps: 30 });
       helios.setFps(60);
-      expect(helios.fps).toBe(60);
+      expect(helios.fps.value).toBe(60);
       expect(helios.getState().fps).toBe(60);
     });
 

--- a/packages/core/src/node-runtime.test.ts
+++ b/packages/core/src/node-runtime.test.ts
@@ -12,7 +12,7 @@ describe('Helios - Node Runtime Support', () => {
     });
 
     expect(helios).toBeDefined();
-    expect(helios.fps).toBe(30);
+    expect(helios.fps.value).toBe(30);
   });
 
   it('should play using TimeoutTicker in Node environment', async () => {


### PR DESCRIPTION
💡 What: Refactored Helios.duration and Helios.fps getters to return ReadonlySignal<number> instead of primitive numbers. Updated internal logic to access .value and updated tests.
🎯 Why: To unify the API surface and allow consumers to subscribe to reactive updates for duration and frame rate changes (e.g. via setDuration), supporting the "Headless State Machine" vision.
📊 Impact: Breaking change for consumers accessing helios.duration/fps directly as numbers. Enables fine-grained reactivity.
🔬 Verification: npm test -w packages/core (346 tests passed).

---
*PR created automatically by Jules for task [17711503556525168951](https://jules.google.com/task/17711503556525168951) started by @BintzGavin*