### PR TITLE
📋 RENDERER: CdpTimeDriver Timeout Plan

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -112,3 +112,7 @@
 ## [2026-04-22] - CdpTimeDriver Determinism
 **Learning:** `CdpTimeDriver` initializes virtual time policy without a fixed epoch (`initialVirtualTime`), causing `Date.now()` to return inconsistent values across runs (based on wall clock). This violates the "Deterministic Rendering" vision.
 **Action:** Created a plan to set `initialVirtualTime` to a fixed epoch (e.g. Jan 1 2024) in `CdpTimeDriver.prepare`, ensuring bit-identical outputs for time-dependent animations.
+
+## [2026-05-26] - CdpTimeDriver Stability Gap
+**Learning:** `CdpTimeDriver` (Canvas mode) awaits `window.helios.waitUntilStable()` indefinitely, unlike `SeekTimeDriver` which respects a timeout. This creates a risk of infinite hanging if user scripts fail to resolve.
+**Action:** Created plan to implement `stabilityTimeout` in `CdpTimeDriver` using `Promise.race`.

--- a/.sys/plans/2026-05-26-RENDERER-CdpTimeDriver-Timeout.md
+++ b/.sys/plans/2026-05-26-RENDERER-CdpTimeDriver-Timeout.md
@@ -1,0 +1,39 @@
+# Context & Goal
+- **Objective**: Implement a configurable timeout for `CdpTimeDriver`'s stability check to prevent infinite hanging when user hooks fail to resolve.
+- **Trigger**: `SeekTimeDriver` supports `stabilityTimeout`, but `CdpTimeDriver` (used in the default Canvas mode) awaits `window.helios.waitUntilStable()` indefinitely.
+- **Impact**: Improves renderer robustness by ensuring the process recovers (continues rendering) even if a user's stability check hangs.
+
+# File Inventory
+- **Modify**: `packages/renderer/src/drivers/CdpTimeDriver.ts` (Add timeout logic to `setTime` script)
+- **Modify**: `packages/renderer/src/index.ts` (Pass `stabilityTimeout` to `CdpTimeDriver` constructor)
+- **Create**: `packages/renderer/tests/verify-cdp-driver-timeout.ts` (Verify timeout behavior)
+- **Read-Only**: `packages/renderer/src/drivers/SeekTimeDriver.ts` (Reference implementation)
+
+# Implementation Spec
+- **Architecture**: Update `CdpTimeDriver` to accept a `timeout` in its constructor (defaulting to 30000ms). In `setTime`, inject a script that uses `Promise.race` between `window.helios.waitUntilStable()` and a `setTimeout` based on the configured value.
+- **Pseudo-Code**:
+  - `CdpTimeDriver` class:
+    - Add property `private timeout: number`
+    - Update `constructor(timeout: number = 30000)` to set `this.timeout`.
+  - `setTime(page, time)`:
+    - Update `stabilityScript` template string:
+      - Accept `timeoutMs` as argument (along with `t` or separate).
+      - Check if `window.helios.waitUntilStable` exists.
+      - If exists:
+        - Create `waitPromise = window.helios.waitUntilStable()`
+        - Create `timeoutPromise = new Promise(resolve => setTimeout(resolve, timeoutMs))`
+        - `await Promise.race([waitPromise, timeoutPromise])`
+    - Pass `this.timeout` to the `page.evaluate` call.
+- **Public API Changes**: None (internal driver change).
+- **Dependencies**: None.
+
+# Test Plan
+- **Verification**:
+  - Run `npx ts-node packages/renderer/tests/verify-cdp-driver-timeout.ts` (New test)
+  - Run `npx ts-node packages/renderer/tests/verify-cdp-driver-stability.ts` (Regression test)
+- **Success Criteria**:
+  - The new test `verify-cdp-driver-timeout.ts` should inject a hanging `waitUntilStable` hook (e.g. `new Promise(() => {})`), call `driver.setTime`, and verify that it returns after the specified timeout (e.g. 1000ms).
+  - The existing test `verify-cdp-driver-stability.ts` should pass without modification, confirming `waitUntilStable` is still awaited when it resolves quickly.
+- **Edge Cases**:
+  - Timeout is 0: `setTimeout(..., 0)` generally runs on next tick. It should return almost immediately.
+  - `waitUntilStable` is missing: Script should skip awaiting and return immediately.


### PR DESCRIPTION
Created a detailed specification for implementing a configurable timeout for the `CdpTimeDriver` stability check. This addresses a reliability gap where the renderer could hang indefinitely if a user's `waitUntilStable` hook fails to resolve.

The plan involves:
1.  Adding a `timeout` property to `CdpTimeDriver`.
2.  Updating `setTime` to use `Promise.race` in the injected script.
3.  Updating `Renderer` to pass the `stabilityTimeout` option.
4.  Adding a specific regression test.

---
*PR created automatically by Jules for task [5250307492045288490](https://jules.google.com/task/5250307492045288490) started by @BintzGavin*