### PR TITLE
✨ STUDIO: Props Grouping

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -59,7 +59,7 @@ packages/studio
 ## UI Components
 - **Stage**: Visual preview with zoom, pan, safe area guides, and transparency toggle.
 - **Timeline**: Track-based timeline with scrubbing, zooming, markers, and timecode display.
-- **Props Editor**: Auto-generated inputs based on composition schema (supports recursive objects and arrays, copy/reset tools, step constraints, specialized formats like date/color, and diverse asset types like model/json/shader).
+- **Props Editor**: Auto-generated inputs based on composition schema (supports recursive objects and arrays, collapsible groups, copy/reset tools, step constraints, specialized formats like date/color, and diverse asset types like model/json/shader).
 - **Assets Panel**: Drag-and-drop asset management with search and type filtering. Prioritizes the `public` directory for asset discovery and generates relative URLs.
 - **Renders Panel**: Manage render jobs, view error details for failed jobs, preview outputs in a modal, and download outputs.
 - **Captions Panel**: Edit and export captions (SRT).

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.64.0
+- ✅ Completed: Props Grouping - Implemented collapsible groups in Props Editor based on schema `group` property.
+
 ## STUDIO v0.63.1
 - ✅ Verified: Maintenance - Synced package.json version and verified Studio UI with Playwright.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.63.1
+**Version**: 0.64.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.64.0] ✅ Completed: Props Grouping - Implemented collapsible groups in Props Editor based on schema `group` property.
 - [v0.63.1] ✅ Verified: Maintenance - Synced package.json version and verified Studio UI with Playwright.
 - [v0.63.0] ✅ Completed: Refine Assets Panel - Updated asset discovery to prioritize `public` directory and use relative paths/URLs, aligning with vision.
 - [v0.62.0] ✅ Completed: MCP Server Integration - Implemented Model Context Protocol server allowing AI agents to inspect, create, and render compositions.

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -35,6 +35,13 @@ function AppContent() {
   useEffect(() => {
     if (!controller) return;
 
+    // Fetch schema separately since it's not in the high-frequency state stream
+    controller.getSchema().then((schema) => {
+      if (schema) {
+        setPlayerState((prev) => ({ ...prev, schema }));
+      }
+    });
+
     // Subscribe to state updates
     const unsubscribe = controller.subscribe((state: any) => {
       setPlayerState(state);

--- a/packages/studio/src/components/PropsEditor.css
+++ b/packages/studio/src/components/PropsEditor.css
@@ -212,3 +212,47 @@
 .props-toolbar-btn.danger:hover {
   background-color: #ffcdd2;
 }
+
+/* Prop Groups */
+.prop-group {
+  border: 1px solid #eee;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.prop-group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px;
+  background-color: #f5f5f5;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.9em;
+  font-weight: bold;
+  color: #333;
+}
+
+.prop-group-header:hover {
+  background-color: #eeeeee;
+}
+
+.prop-group-arrow {
+  display: inline-block;
+  font-size: 0.8em;
+  transition: transform 0.2s ease;
+  transform: rotate(0deg);
+}
+
+.prop-group-arrow.collapsed {
+  transform: rotate(-90deg);
+}
+
+.prop-group-content {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background-color: #fff;
+  border-top: 1px solid #eee;
+}


### PR DESCRIPTION
💡 **What**: Implemented collapsible groups in the Studio Props Editor based on the `group` property in the `HeliosSchema`. Updated `PropsEditor` to organize props into `PropGroup` components and `App.tsx` to fetch the schema from the controller.
🎯 **Why**: To improve the user experience when editing complex compositions with many properties by categorizing them logically, as defined in the vision.
📊 **Impact**: Users can now define groups in their schema (e.g., `group: "Circle Settings"`) and see them reflected in the UI, reducing clutter and improving navigability.
🔬 **Verification**: Added unit tests in `PropsEditor.test.tsx` and verified visually with a Playwright script that demonstrated grouping, collapsing, and expanding behavior.

---
*PR created automatically by Jules for task [16452470080219282308](https://jules.google.com/task/16452470080219282308) started by @BintzGavin*