### PR TITLE
✨ RENDERER: Implement CdpTimeDriver Stability Timeout

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -7,7 +7,7 @@ The Renderer operates on a "Dual-Path" architecture to support different use cas
    - **Discovery**: Uses `dom-scanner` to recursively discover media elements (including Shadow DOM).
    - **Output**: Best for sharp text and vector graphics.
 2. **Canvas Strategy (`CanvasStrategy`)**: Used for WebGL/Canvas-heavy compositions (e.g., Three.js, PixiJS). It captures the `<canvas>` context directly.
-   - **Drivers**: Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise virtual time control (supports Shadow DOM media sync, enforces deterministic Jan 2024 epoch, ensures sync-before-render order, waits for budget expiration).
+   - **Drivers**: Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise virtual time control (supports Shadow DOM media sync, enforces deterministic Jan 2024 epoch, ensures sync-before-render order, waits for budget expiration, enforces stability timeout via `Runtime.terminateExecution`).
    - **Optimization**: Prioritizes H.264 (AVC) intermediate codec for hardware acceleration, falling back to VP8.
    - **Output**: Best for high-performance 2D/3D graphics.
 
@@ -42,6 +42,7 @@ packages/renderer/
     ├── verify-shadow-dom-sync.ts  # Shadow DOM sync test (DOM Mode)
     ├── verify-cdp-shadow-dom-sync.ts # Shadow DOM media sync test (Canvas Mode)
     ├── verify-cdp-driver.ts    # CdpDriver budget test
+    ├── verify-cdp-driver-timeout.ts # CdpDriver stability timeout test
     └── ...                     # Other verification scripts
 ```
 
@@ -55,6 +56,7 @@ The `RendererOptions` interface controls the render pipeline:
 - `videoCodec`: `'libx264'` (default), `'copy'`, or others.
 - `audioCodec`: `'aac'` (default), `'libvorbis'`, etc.
 - `audioFilePath`: Path to external audio file to mix in.
+- `stabilityTimeout`: Timeout for frame stability (default 30000ms).
 - `inputProps`: Object injected into the page as `window.__HELIOS_PROPS__`.
 
 ## D. FFmpeg Interface

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,9 @@
+## RENDERER v1.48.2
+- ✅ Completed: CdpTimeDriver Timeout - Implemented configurable stability timeout in `CdpTimeDriver` using Node.js-based race condition and CDP `Runtime.terminateExecution` to handle hanging user checks when virtual time is paused.
+
+## RENDERER v1.48.1
+- ✅ Completed: Enable Comprehensive Verification Suite - Updated `run-all.ts` to include 8 previously ignored verification scripts (CDP determinism, Shadow DOM sync, WAAPI sync), ensuring full test coverage. Also fixed `verify-canvas-strategy.ts` to align with the H.264 default.
+
 ## RENDERER v1.48.0
 - ✅ Completed: Prioritize H.264 - Updated `CanvasStrategy` to prioritize H.264 (AVC) intermediate codec over VP8 by default, enabling hardware acceleration and better performance on supported systems.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.48.1
+**Version**: 1.48.2
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.48.2] ✅ Completed: CdpTimeDriver Timeout - Implemented configurable stability timeout in `CdpTimeDriver` using Node.js-based race condition and CDP `Runtime.terminateExecution` to handle hanging user checks when virtual time is paused.
 - [1.48.1] ✅ Completed: Enable Comprehensive Verification Suite - Updated `run-all.ts` to include 8 previously ignored verification scripts (CDP determinism, Shadow DOM sync, WAAPI sync), ensuring full test coverage. Also fixed `verify-canvas-strategy.ts` to align with the H.264 default.
 - [1.48.0] ✅ Completed: Prioritize H.264 - Updated `CanvasStrategy` to prioritize H.264 (AVC) intermediate codec over VP8 by default, enabling hardware acceleration and better performance on supported systems.
 - [1.47.4] ✅ Completed: Validate Codec Compatibility - Updated `DomStrategy` and `CanvasStrategy` to throw clear errors when `videoCodec: 'copy'` is used with image sequence fallback, preventing FFmpeg crashes. Also fixed regression tests to provide valid options to `DomStrategy`.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -34,7 +34,7 @@ export class Renderer {
       this.timeDriver = new SeekTimeDriver(this.options.stabilityTimeout);
     } else {
       this.strategy = new CanvasStrategy(this.options);
-      this.timeDriver = new CdpTimeDriver();
+      this.timeDriver = new CdpTimeDriver(this.options.stabilityTimeout);
     }
   }
 

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -11,6 +11,7 @@ const tests = [
   'tests/verify-cdp-determinism.ts',
   'tests/verify-cdp-driver.ts',
   'tests/verify-cdp-driver-stability.ts',
+  'tests/verify-cdp-driver-timeout.ts',
   'tests/verify-cdp-media-offsets.ts',
   'tests/verify-cdp-media-sync-timing.ts',
   'tests/verify-cdp-shadow-dom-sync.ts',

--- a/packages/renderer/tests/verify-cdp-driver-timeout.ts
+++ b/packages/renderer/tests/verify-cdp-driver-timeout.ts
@@ -1,0 +1,51 @@
+import { chromium } from 'playwright';
+import { CdpTimeDriver } from '../src/drivers/CdpTimeDriver.js';
+
+async function test() {
+  console.log('Starting CdpTimeDriver Timeout test...');
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Initialize with a short timeout (e.g. 500ms)
+  const TIMEOUT_MS = 500;
+  const driver = new CdpTimeDriver(TIMEOUT_MS);
+  await driver.prepare(page);
+
+  console.log(`Driver prepared with ${TIMEOUT_MS}ms timeout.`);
+
+  // Inject mock helios object with a HANGING waitUntilStable
+  // Use string evaluation to avoid esbuild artifacts (__name)
+  await page.evaluate(`
+    window.helios = {
+      waitUntilStable: () => {
+        console.log('Helper called, hanging indefinitely...');
+        return new Promise(() => {}); // Never resolves
+      }
+    };
+  `);
+
+  console.log('Advancing time to 1.0s...');
+  const startTime = Date.now();
+  await driver.setTime(page, 1.0);
+  const endTime = Date.now();
+  const duration = endTime - startTime;
+
+  console.log(`setTime completed in ${duration}ms`);
+
+  // Allow some margin for execution overhead.
+  // In a slow environment, it might take longer, but it shouldn't hang indefinitely.
+  if (duration >= TIMEOUT_MS) {
+    console.log(`✅ Stability check timed out as expected (>= ${TIMEOUT_MS}ms).`);
+  } else {
+     console.error(`❌ returned too early (${duration}ms). It should have waited at least ${TIMEOUT_MS}ms.`);
+     process.exit(1);
+  }
+
+  await browser.close();
+}
+
+test().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
💡 **What**: Implemented a configurable timeout for `CdpTimeDriver` stability checks using a Node.js-based race condition and CDP `Runtime.terminateExecution`.
🎯 **Why**: To prevent the renderer from hanging indefinitely if a user's `window.helios.waitUntilStable()` hook fails to resolve (e.g. infinite promise).
📊 **Impact**: Increases renderer robustness by failing fast or continuing execution after a timeout (default 30s) instead of blocking the pipeline forever.
🔬 **Verification**: Added `tests/verify-cdp-driver-timeout.ts` which injects a hanging stability hook and asserts that `setTime` completes within the timeout period. Verified full suite with `npm test`.

---
*PR created automatically by Jules for task [239178068675351704](https://jules.google.com/task/239178068675351704) started by @BintzGavin*