### PR TITLE
✨ RENDERER: Precision Frame Control

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -50,7 +50,8 @@ packages/renderer/
 The `RendererOptions` interface controls the render pipeline:
 - `width`, `height`: Output resolution.
 - `fps`: Target frame rate.
-- `durationInSeconds`: Total length of the video.
+- `durationInSeconds`: Total length of the video (fallback if `frameCount` is not set).
+- `frameCount`: Exact number of frames to render (overrides `durationInSeconds`).
 - `mode`: `'dom'` or `'canvas'`.
 - `browserConfig`: Object to customize Playwright browser launch (`headless`, `args`, `executablePath`).
 - `videoCodec`: `'libx264'` (default), `'copy'`, or others.

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.49.0
+- ✅ Completed: Precision Frame Control - Added `frameCount` to `RendererOptions`, enabling exact frame-count rendering for distributed rendering workflows, overriding floating-point duration calculations.
+
 ## RENDERER v1.48.2
 - ✅ Completed: CdpTimeDriver Timeout - Implemented configurable stability timeout in `CdpTimeDriver` using Node.js-based race condition and CDP `Runtime.terminateExecution` to handle hanging user checks when virtual time is paused.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.48.2
+**Version**: 1.49.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.49.0] ✅ Completed: Precision Frame Control - Added `frameCount` to `RendererOptions`, enabling exact frame-count rendering for distributed rendering workflows, overriding floating-point duration calculations.
 - [1.48.2] ✅ Completed: CdpTimeDriver Timeout - Implemented configurable stability timeout in `CdpTimeDriver` using Node.js-based race condition and CDP `Runtime.terminateExecution` to handle hanging user checks when virtual time is paused.
 - [1.48.1] ✅ Completed: Enable Comprehensive Verification Suite - Updated `run-all.ts` to include 8 previously ignored verification scripts (CDP determinism, Shadow DOM sync, WAAPI sync), ensuring full test coverage. Also fixed `verify-canvas-strategy.ts` to align with the H.264 default.
 - [1.48.0] ✅ Completed: Prioritize H.264 - Updated `CanvasStrategy` to prioritize H.264 (AVC) intermediate codec over VP8 by default, enabling hardware acceleration and better performance on supported systems.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -127,7 +127,9 @@ export class Renderer {
       console.log('Strategy prepared.');
 
       const ffmpegPath = this.options.ffmpegPath || ffmpeg.path;
-      const totalFrames = this.options.durationInSeconds * this.options.fps;
+      const totalFrames = this.options.frameCount
+        ? this.options.frameCount
+        : this.options.durationInSeconds * this.options.fps;
       const fps = this.options.fps;
       const startFrame = this.options.startFrame || 0;
 

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -67,6 +67,13 @@ export interface RendererOptions {
   startFrame?: number;
 
   /**
+   * The exact number of frames to render.
+   * If provided, this overrides `durationInSeconds` for calculating loop limits.
+   * Useful for precise distributed rendering to avoid floating point errors.
+   */
+  frameCount?: number;
+
+  /**
    * Path to an audio file to include in the output video.
    * If provided, the audio will be mixed with the video.
    */

--- a/packages/renderer/src/utils/FFmpegBuilder.ts
+++ b/packages/renderer/src/utils/FFmpegBuilder.ts
@@ -172,7 +172,11 @@ export class FFmpegBuilder {
         }
       }
 
-      finalArgs.push('-c:a', audioCodec, '-t', options.durationInSeconds.toString());
+      const duration = options.frameCount
+        ? options.frameCount / options.fps
+        : options.durationInSeconds;
+
+      finalArgs.push('-c:a', audioCodec, '-t', duration.toString());
 
       if (options.audioBitrate) {
         finalArgs.push('-b:a', options.audioBitrate);

--- a/packages/renderer/tests/verify-frame-count.ts
+++ b/packages/renderer/tests/verify-frame-count.ts
@@ -1,0 +1,145 @@
+import { Renderer } from '../src/index';
+import { RendererOptions } from '../src/types';
+import { CanvasStrategy } from '../src/strategies/CanvasStrategy';
+import { FFmpegBuilder } from '../src/utils/FFmpegBuilder';
+import path from 'path';
+import fs from 'fs';
+
+async function verifyFrameCount() {
+  console.log('Verifying frameCount support...');
+
+  const outputPath = path.resolve('test-frame-count.mp4');
+
+  // Clean up previous run
+  if (fs.existsSync(outputPath)) {
+    fs.unlinkSync(outputPath);
+  }
+
+  // Options: 100 frames requested, but duration says 10 seconds (at 30fps = 300 frames).
+  // We expect frameCount (100) to win.
+  const options: RendererOptions = {
+    width: 100,
+    height: 100,
+    fps: 30,
+    durationInSeconds: 10, // Intentionally conflicting
+    frameCount: 100,       // This should take precedence
+    mode: 'canvas',
+    videoCodec: 'libx264',
+    headless: true,
+    // Use 'cat' as ffmpeg so it just consumes stdin and exits when closed
+    // actually, we will use a custom node script to ensure it behaves nicely
+    ffmpegPath: process.execPath
+  };
+
+  const renderer = new Renderer(options);
+
+  // Mock the strategy
+  const strategy = (renderer as any).strategy as CanvasStrategy;
+
+  let capturedFrames = 0;
+
+  strategy.prepare = async (page) => {
+    console.log('Mock strategy.prepare called');
+  };
+
+  strategy.diagnose = async (page) => {
+    return {};
+  };
+
+  strategy.capture = async (page, time) => {
+    capturedFrames++;
+    return Buffer.from('dummy-frame-data');
+  };
+
+  strategy.finish = async (page) => {
+    return Buffer.alloc(0);
+  };
+
+  const realGetArgs = strategy.getFFmpegArgs.bind(strategy);
+  let generatedArgs: string[] = [];
+
+  // Mock getFFmpegArgs to return args for our dummy script
+  strategy.getFFmpegArgs = (opts, outPath) => {
+    // Generate real args to verify them later
+    generatedArgs = FFmpegBuilder.getArgs(opts, outPath, []);
+
+    // Return args for "node -e 'process.stdin.resume(); process.stdin.on(`end`, ()=>process.exit(0));'"
+    // We can use -e for inline script
+    return [
+        '-e',
+        'process.stdin.resume(); process.stdin.on("end", () => process.exit(0));'
+    ];
+  };
+
+  try {
+    // Run render
+    // Use about:blank to minimize browser overhead
+    await renderer.render('about:blank', outputPath);
+
+    console.log(`Captured ${capturedFrames} frames.`);
+
+    if (capturedFrames !== 100) {
+      console.error(`❌ Failed: Expected 100 frames, got ${capturedFrames}`);
+      process.exit(1);
+    } else {
+        console.log(`✅ Frame count verified: ${capturedFrames}`);
+    }
+
+    // Verify FFmpeg Args
+    const tIndex = generatedArgs.indexOf('-t');
+    if (tIndex === -1) {
+         console.log('⚠️ Audio track not present, skipping -t verification in FFmpeg args.');
+    } else {
+        const tValue = parseFloat(generatedArgs[tIndex + 1]);
+        const expectedDuration = 100 / 30;
+        if (Math.abs(tValue - expectedDuration) < 0.001) {
+             console.log(`✅ FFmpeg duration verified: ${tValue}`);
+        } else {
+             console.error(`❌ FFmpeg duration mismatch: Expected ~${expectedDuration}, got ${tValue}`);
+        }
+    }
+
+  } catch (error) {
+    console.error('Test failed with error:', error);
+    process.exit(1);
+  }
+}
+
+async function verifyAudioDuration() {
+    console.log('\nVerifying Audio Duration Logic...');
+
+    const options: RendererOptions = {
+        width: 100,
+        height: 100,
+        fps: 30,
+        durationInSeconds: 10,
+        frameCount: 100,
+        mode: 'canvas',
+        audioFilePath: 'dummy.mp3'
+    };
+
+    const args = FFmpegBuilder.getArgs(options, 'out.mp4', []);
+    const tIndex = args.indexOf('-t');
+
+    if (tIndex === -1) {
+        console.error('❌ Failed: -t argument missing when audio is present');
+        process.exit(1);
+    }
+
+    const tValue = parseFloat(args[tIndex + 1]);
+    const expectedDuration = 100 / 30;
+
+    if (Math.abs(tValue - expectedDuration) < 0.001) {
+        console.log(`✅ Audio duration verified: ${tValue} (Expected: ~${expectedDuration})`);
+    } else {
+        console.error(`❌ Audio duration mismatch: Expected ~${expectedDuration}, got ${tValue}`);
+        process.exit(1);
+    }
+}
+
+async function run() {
+    await verifyFrameCount();
+    await verifyAudioDuration();
+}
+
+run();


### PR DESCRIPTION
Implemented `frameCount` option in `RendererOptions`. Updated `Renderer.ts` to use `frameCount` for `totalFrames` calculation if present. Updated `FFmpegBuilder.ts` to use `frameCount` for audio duration calculation if present. Added verification script `packages/renderer/tests/verify-frame-count.ts`. Updated documentation.

---
*PR created automatically by Jules for task [18267237433063031484](https://jules.google.com/task/18267237433063031484) started by @BintzGavin*