### PR TITLE
✨ STUDIO: Persistent Render Jobs

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -3,7 +3,7 @@
 ## Architecture
 The Studio is a browser-based development environment for Helios compositions. It runs on Vite and communicates with the backend via API endpoints provided by `vite-plugin-studio-api.ts`.
 - **CLI**: `npx helios studio` (via `packages/cli` or similar) starts the Vite server.
-- **Backend**: `vite-plugin-studio-api.ts` handles file system operations (discovery, creation, update, deletion of compositions and assets), render job management, and hosts a **Model Context Protocol (MCP)** server for AI agent integration.
+- **Backend**: `vite-plugin-studio-api.ts` handles file system operations (discovery, creation, update, deletion of compositions and assets), render job management (persisted to disk), and hosts a **Model Context Protocol (MCP)** server for AI agent integration.
 - **Frontend**: A React application located in `packages/studio/src`.
   - `StudioContext`: Centralized state management.
   - `Stage`: The main preview area using `<helios-player>`.
@@ -29,8 +29,10 @@ packages/studio
 │   ├── hooks
 │   ├── main.tsx
 │   ├── server
+│   │   ├── discovery.test.ts
 │   │   ├── discovery.ts
 │   │   ├── mcp.ts
+│   │   ├── render-manager.test.ts
 │   │   ├── render-manager.ts
 │   │   ├── templates
 │   │   │   ├── index.ts
@@ -61,7 +63,7 @@ packages/studio
 - **Timeline**: Track-based timeline with scrubbing, zooming, markers, and timecode display.
 - **Props Editor**: Auto-generated inputs based on composition schema (supports recursive objects and arrays, collapsible groups, copy/reset tools, step constraints, specialized formats like date/color, and diverse asset types like model/json/shader).
 - **Assets Panel**: Drag-and-drop asset management with search and type filtering. Prioritizes the `public` directory for asset discovery and generates relative URLs.
-- **Renders Panel**: Manage render jobs, view error details for failed jobs, preview outputs in a modal, and download outputs.
+- **Renders Panel**: Manage render jobs (persistent across restarts), view error details for failed jobs, preview outputs in a modal, and download outputs.
 - **Captions Panel**: Edit and export captions (SRT).
 - **Diagnostics Panel**: View system capabilities (FFmpeg, GPU).
 - **Composition Settings Modal**: Edit width, height, FPS, and duration of the active composition.
@@ -72,5 +74,5 @@ packages/studio
 ## Integration
 - **Core**: Uses `Helios` engine for rendering and schema definitions.
 - **Player**: Uses `<helios-player>` for preview.
-- **Renderer**: Communicates with `@helios-project/renderer` via backend API for exporting videos.
+- **Renderer**: Communicates with `@helios-project/renderer` via backend API for exporting videos. Render jobs are persisted to `renders/jobs.json`.
 - **MCP**: Exposes Studio capabilities to AI agents via `helios://compositions` resource and `render_composition`/`create_composition` tools (SSE/JSON-RPC).

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.65.0
+- ✅ Completed: Persistent Render Jobs - Implemented persistence of render jobs to `jobs.json` in the `renders` directory, ensuring history survives server restarts.
+
 ## STUDIO v0.64.0
 - ✅ Completed: Props Grouping - Implemented collapsible groups in Props Editor based on schema `group` property.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.64.0
+**Version**: 0.65.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.65.0] ✅ Completed: Persistent Render Jobs - Implemented persistence of render jobs to `jobs.json` in the `renders` directory, ensuring history survives server restarts.
 - [v0.64.0] ✅ Completed: Props Grouping - Implemented collapsible groups in Props Editor based on schema `group` property.
 - [v0.63.1] ✅ Verified: Maintenance - Synced package.json version and verified Studio UI with Playwright.
 - [v0.63.0] ✅ Completed: Refine Assets Panel - Updated asset discovery to prioritize `public` directory and use relative paths/URLs, aligning with vision.

--- a/packages/studio/src/server/render-manager.test.ts
+++ b/packages/studio/src/server/render-manager.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+
+// Mock dependencies
+vi.mock('../../../renderer/src/index', () => ({
+  Renderer: class MockRenderer {
+    render() { return Promise.resolve(); }
+    diagnose() { return Promise.resolve({}); }
+  }
+}));
+
+const tempDir = path.join(__dirname, 'temp-test-persistence');
+
+// Mock discovery to redirect project root
+vi.mock('./discovery', () => ({
+  getProjectRoot: () => tempDir
+}));
+
+describe('RenderManager Persistence', () => {
+  const rendersDir = path.join(tempDir, 'renders');
+  const jobsFile = path.join(rendersDir, 'jobs.json');
+
+  beforeEach(() => {
+    // Clean up
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    fs.mkdirSync(rendersDir, { recursive: true });
+    vi.resetModules(); // Ensure clean import for each test
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should load existing jobs and mark interrupted ones as failed', async () => {
+    // Setup existing jobs
+    const existingJob = {
+      id: 'existing-1',
+      status: 'rendering',
+      progress: 0.5,
+      compositionId: 'comp-1',
+      createdAt: Date.now()
+    };
+    fs.writeFileSync(jobsFile, JSON.stringify([existingJob], null, 2));
+
+    // Import to trigger loadJobs
+    const { getJobs } = await import('./render-manager');
+
+    const jobs = getJobs();
+    const job = jobs.find(j => j.id === 'existing-1');
+    expect(job).toBeDefined();
+    expect(job?.status).toBe('failed');
+    expect(job?.error).toContain('Server restarted');
+  });
+
+  it('should save new jobs to disk', async () => {
+    const { startRender, getJobs } = await import('./render-manager');
+
+    // Wait for startRender to complete (it's async but returns jobId immediately)
+    // Actually startRender returns Promise<string>
+    const jobId = await startRender({ compositionUrl: '/test' }, 3000);
+
+    // Wait a tick for async file write if any (it is sync in our impl but wrapped in async function)
+    await new Promise(r => setTimeout(r, 100));
+
+    const jobs = getJobs();
+    expect(jobs.length).toBeGreaterThan(0);
+    const job = jobs.find(j => j.id === jobId);
+
+    // Check disk
+    const content = JSON.parse(fs.readFileSync(jobsFile, 'utf-8'));
+    const savedJob = content.find((j: any) => j.id === jobId);
+    expect(savedJob).toBeDefined();
+    // Since MockRenderer resolves immediately, it should be 'completed'
+    expect(savedJob.status).toBe('completed');
+  });
+
+  it('should remove job from disk on delete', async () => {
+    const { startRender, deleteJob } = await import('./render-manager');
+    const jobId = await startRender({ compositionUrl: '/test' }, 3000);
+
+    // Wait for completion
+    await new Promise(r => setTimeout(r, 100));
+
+    // Ensure it's there
+    expect(fs.readFileSync(jobsFile, 'utf-8')).toContain(jobId);
+
+    deleteJob(jobId);
+
+    // Ensure it's gone
+    const content = JSON.parse(fs.readFileSync(jobsFile, 'utf-8'));
+    expect(content.find((j: any) => j.id === jobId)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implemented persistence for render jobs in Studio using a JSON file (`renders/jobs.json`) in the project root. This ensures that job history is preserved across server restarts. Jobs that were running or queued during a restart are automatically marked as 'failed' upon next load to maintain state consistency. Added a new test file to verify persistence logic.

---
*PR created automatically by Jules for task [5136289988703480638](https://jules.google.com/task/5136289988703480638) started by @BintzGavin*