### PR TITLE
Enable bundled build for Player

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8462,7 +8462,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "3.1.0",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -16,6 +16,8 @@
     "access": "public"
   },
   "main": "dist/index.js",
+  "module": "dist/index.js",
+  "unpkg": "dist/helios-player.global.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
@@ -24,10 +26,12 @@
     ".": "./dist/index.js",
     "./bridge": "./dist/bridge.js",
     "./controllers": "./dist/controllers.js",
-    "./features/exporter": "./dist/features/exporter.js"
+    "./features/exporter": "./dist/features/exporter.js",
+    "./bundle": "./dist/helios-player.bundle.mjs",
+    "./global": "./dist/helios-player.global.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && vite build",
     "dev": "tsc -w",
     "test": "vitest"
   },

--- a/packages/player/vite.config.ts
+++ b/packages/player/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'HeliosPlayer',
+      fileName: (format) => `helios-player.${format === 'es' ? 'bundle.mjs' : 'global.js'}`,
+      formats: ['es', 'umd']
+    },
+    rollupOptions: {
+      // Externalize @helios-project/core as it is primarily a type dependency
+      // or provided by the environment/iframe.
+      // We bundle mediabunny so it works drop-in.
+      external: ['@helios-project/core'],
+      output: {
+        globals: {
+          '@helios-project/core': 'HeliosCore'
+        }
+      }
+    },
+    emptyOutDir: false, // Preserve tsc output
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
Added Vite configuration to package @helios-project/player as a self-contained bundle (UMD and ESM), including dependencies like 'mediabunny' but externalizing '@helios-project/core'. This enables the player to be used as a drop-in script in vanilla HTML environments.

---
*PR created automatically by Jules for task [9685600064487434837](https://jules.google.com/task/9685600064487434837) started by @BintzGavin*