### PR TITLE
✨ CORE: Add Decoder Diagnostics

### DIFF
--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v3.3.0
+- ✅ Completed: Decoder Diagnostics - Added `videoDecoders` (h264, vp8, vp9, av1) and `audioDecoders` (aac, opus) checks to `Helios.diagnose()` and `DiagnosticReport` using WebCodecs API.
+
 ## CORE v3.2.0
 - ✅ Completed: Implement AI System Prompt Generator - Added `createSystemPrompt` and `HELIOS_BASE_PROMPT` to programmatically generate context-aware system prompts for AI agents.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 3.2.0
+**Version**: 3.3.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
-- **Last Updated**: 2026-05-29
+- **Last Updated**: 2026-05-31
 
+[v3.3.0] ✅ Completed: Decoder Diagnostics - Added `videoDecoders` (h264, vp8, vp9, av1) and `audioDecoders` (aac, opus) checks to `Helios.diagnose()` and `DiagnosticReport` using WebCodecs API.
 [v3.2.0] ✅ Completed: Implement AI System Prompt Generator - Added `createSystemPrompt` and `HELIOS_BASE_PROMPT` to programmatically generate context-aware system prompts for AI agents.
 [v3.1.0] ✅ Completed: Synchronize Version - Synced package.json version to 3.1.0 to match documentation and updated player/renderer dependencies.
 [v3.1.0] ✅ Completed: Enhance Schema UI Constraints - Added `pattern`, `accept`, and `group` to `PropDefinition` and implemented validation logic for regex and file extensions.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -120,6 +120,14 @@ describe('Helios Core', () => {
       expect(report).toHaveProperty('audioCodecs');
       expect(report.audioCodecs).toHaveProperty('aac');
       expect(report.audioCodecs).toHaveProperty('opus');
+      expect(report).toHaveProperty('videoDecoders');
+      expect(report.videoDecoders).toHaveProperty('h264');
+      expect(report.videoDecoders).toHaveProperty('vp8');
+      expect(report.videoDecoders).toHaveProperty('vp9');
+      expect(report.videoDecoders).toHaveProperty('av1');
+      expect(report).toHaveProperty('audioDecoders');
+      expect(report.audioDecoders).toHaveProperty('aac');
+      expect(report.audioDecoders).toHaveProperty('opus');
       expect(report).toHaveProperty('userAgent');
     });
 
@@ -185,6 +193,46 @@ describe('Helios Core', () => {
       const report = await Helios.diagnose();
       expect(report.audioCodecs.aac).toBe(true);
       expect(report.audioCodecs.opus).toBe(true);
+      expect(mockIsConfigSupported).toHaveBeenCalledTimes(2);
+      vi.unstubAllGlobals();
+    });
+
+    it('should handle missing VideoDecoder gracefully', async () => {
+      vi.stubGlobal('VideoDecoder', undefined);
+      const report = await Helios.diagnose();
+      expect(report.videoDecoders.h264).toBe(false);
+      vi.unstubAllGlobals();
+    });
+
+    it('should detect video decoders if VideoDecoder is supported', async () => {
+      const mockIsConfigSupported = vi.fn().mockResolvedValue({ supported: true });
+      vi.stubGlobal('VideoDecoder', {
+        isConfigSupported: mockIsConfigSupported
+      });
+
+      const report = await Helios.diagnose();
+      expect(report.videoDecoders.h264).toBe(true);
+      expect(mockIsConfigSupported).toHaveBeenCalledTimes(4);
+      vi.unstubAllGlobals();
+    });
+
+    it('should handle missing AudioDecoder gracefully', async () => {
+      vi.stubGlobal('AudioDecoder', undefined);
+      const report = await Helios.diagnose();
+      expect(report.audioDecoders.aac).toBe(false);
+      expect(report.audioDecoders.opus).toBe(false);
+      vi.unstubAllGlobals();
+    });
+
+    it('should detect audio decoders if AudioDecoder is supported', async () => {
+      const mockIsConfigSupported = vi.fn().mockResolvedValue({ supported: true });
+      vi.stubGlobal('AudioDecoder', {
+        isConfigSupported: mockIsConfigSupported
+      });
+
+      const report = await Helios.diagnose();
+      expect(report.audioDecoders.aac).toBe(true);
+      expect(report.audioDecoders.opus).toBe(true);
       expect(mockIsConfigSupported).toHaveBeenCalledTimes(2);
       vi.unstubAllGlobals();
     });


### PR DESCRIPTION
💡 **What**: Added `videoDecoders` and `audioDecoders` capabilities detection to `Helios.diagnose()`.
🎯 **Why**: To enable `HeliosPlayer` and `ClientSideExporter` to verify if source assets can be decoded and played on the client, preventing runtime errors.
📊 **Impact**: Improved reliability of client-side playback and export by allowing early detection of incompatible media formats.
🔬 **Verification**: Run `npm test -w packages/core` to verify the new diagnostics tests.

---
*PR created automatically by Jules for task [13898435774923807354](https://jules.google.com/task/13898435774923807354) started by @BintzGavin*