### PR TITLE
DEMO: Dynamic Player Export Verification Plan

### DIFF
--- a/.jules/DEMO.md
+++ b/.jules/DEMO.md
@@ -27,3 +27,7 @@
 ## [1.70.0] - Player E2E ESM Strategy
 **Learning:** Testing `<helios-player>` interaction requires a browser environment. Using an Import Map to alias `@helios-project/core` allows testing the ESM bundle directly in a static HTML fixture, avoiding complex test-bundling steps.
 **Action:** Use static server + Import Maps for lightweight Web Component E2E fixtures.
+
+## [1.72.1] - Client-Side Verification Parity
+**Learning:** The "Primary Export Path" (Client-Side WebCodecs) was only verified by a single static example, while the "Secondary" path (Server-Side) was verified dynamically against all examples. This created a coverage gap where we claimed "Primary" status without comprehensive verification.
+**Action:** When a feature is designated as "Primary", ensure its verification pipeline is at least as robust as the secondary/legacy path (e.g., dynamic discovery of all test cases).

--- a/.sys/plans/2026-02-05-DEMO-VerifyPlayerExport.md
+++ b/.sys/plans/2026-02-05-DEMO-VerifyPlayerExport.md
@@ -1,0 +1,78 @@
+# Plan: Dynamic Player Export Verification
+
+## 1. Context & Goal
+- **Objective**: Create a new E2E test `tests/e2e/verify-player-export.ts` that iterates through all examples, loads them into `<helios-player>`, and verifies that the client-side export (WebCodecs) triggers a file download.
+- **Trigger**: The vision states "Client-Side WebCodecs as Primary Export", but currently we only verify this path for a single API example. We need broad coverage to ensure the "Primary" path is robust across all composition types (DOM, Canvas, etc.).
+- **Impact**: Increases confidence in the client-side export feature, ensuring it works for React, Vue, Svelte, and Vanilla examples.
+
+## 2. File Inventory
+- **Create**: `tests/e2e/verify-player-export.ts`
+- **Modify**: `tests/e2e/verify-all.ts`
+- **Read-Only**: `tests/e2e/verify-render.ts`, `tests/e2e/fixtures/player.html`, `vite.build-example.config.js`
+
+## 3. Implementation Spec
+- **Architecture**:
+    - Use Playwright with a local Node.js static server (serving project root).
+    - Reuse `tests/e2e/fixtures/player.html` as the harness.
+    - Logic:
+        1. Discover all examples (checking for `composition.html` in `examples/`).
+        2. Launch Browser & Server.
+        3. For each example:
+            a. Verify build artifact exists (`output/example-build/examples/${name}/composition.html`).
+            b. Navigate to `http://localhost:${PORT}/tests/e2e/fixtures/player.html`.
+            c. Set `<helios-player src="...">`.
+            d. Click "Export" button in Shadow DOM (`.export-btn`).
+            e. Wait for `download` event.
+            f. Verify download completes (stream is readable).
+- **Pseudo-Code**:
+    ```typescript
+    // verify-player-export.ts
+    import { chromium } from '@playwright/test';
+    import * as http from 'http';
+    import * as fs from 'fs';
+    import * as path from 'path';
+
+    // Copy discoverCases logic from verify-render.ts
+    // Copy static server logic from verify-player.ts
+
+    async function main() {
+       const cases = await discoverCases();
+       const server = startServer(ROOT_DIR, 4176);
+       const browser = await chromium.launch();
+
+       for (const testCase of cases) {
+           const page = await browser.newPage();
+           await page.goto('http://localhost:4176/tests/e2e/fixtures/player.html');
+
+           // Update src
+           const compositionUrl = `/output/example-build/${testCase.relativePath}`;
+           await page.evaluate((src) => {
+               document.querySelector('helios-player').setAttribute('src', src);
+           }, compositionUrl);
+
+           // Wait for load
+           await page.waitForTimeout(1000); // Give it a moment to load metadata
+
+           // Click Export
+           // Selector verified in packages/player/src/index.ts: class="export-btn"
+           const [download] = await Promise.all([
+               page.waitForEvent('download'),
+               page.locator('helios-player >> .export-btn').click()
+           ]);
+
+           // Success if download starts
+           await download.path();
+           console.log(`✅ ${testCase.name} Exported successfully!`);
+       }
+    }
+    ```
+- **Dependencies**: Depends on `npm run build:examples` (which is already run in `verify-all.ts`).
+- **Public API Changes**: None.
+
+## 4. Test Plan
+- **Verification**: `npm run verify:e2e` (which will run the new script via `verify-all.ts`).
+- **Success Criteria**: The script iterates all examples and prints "✅ [Example Name] Exported successfully!" for each.
+- **Edge Cases**:
+    - Export failure (timeout or error dialog in player).
+    - Browser support (Playwright uses headless Chromium, which should support WebCodecs).
+    - Filter argument (`process.argv[2]`) should be supported to run single test.


### PR DESCRIPTION
Identified a gap in the verification strategy: while the "Client-Side WebCodecs" export is designated as the primary export path in the vision, it was only verified by a single static example. This plan outlines the creation of `tests/e2e/verify-player-export.ts` to dynamically discover and test all examples against the `<helios-player>` export feature.

---
*PR created automatically by Jules for task [3929001413615531674](https://jules.google.com/task/3929001413615531674) started by @BintzGavin*