### PR TITLE
📋 CORE: Update Skill Docs

### DIFF
--- a/.jules/CORE.md
+++ b/.jules/CORE.md
@@ -1,3 +1,7 @@
 ## [3.3.0] - Protocol Boundaries
 **Learning:** I attempted to fix a workspace dependency issue by modifying `packages/player/package.json` and `packages/renderer/package.json`, which violated the protocol of exclusive ownership.
 **Action:** In the future, if a change in Core requires updates in other packages, I must document it as a dependency or blocker, or coordinate, but never directly modify files outside my domain.
+
+## [3.3.0] - Documentation Drift
+**Learning:** Documentation for AI agents (`SKILL.md`) is a critical part of the "Agent Experience First" vision and can silently drift from the codebase, causing hallucinated usage.
+**Action:** Always verify `SKILL.md` examples against source code (`src/`) during the "Gap Identification" phase, treating documentation bugs as high-priority vision gaps.

--- a/.sys/plans/2026-06-03-CORE-Update-Skill-Docs.md
+++ b/.sys/plans/2026-06-03-CORE-Update-Skill-Docs.md
@@ -1,0 +1,37 @@
+#### 1. Context & Goal
+- **Objective**: Update `.agents/skills/helios/core/SKILL.md` to accurately reflect the v3.3.0 Core API surface.
+- **Trigger**: Vision analysis revealed outdated function signatures (`createSystemPrompt`), incomplete types (`DiagnosticReport`), and missing features (`stagger`, `shift`) in the agent documentation, creating a gap in "Agent Experience First".
+- **Impact**: Prevents AI agents (including future planner/executor agents) from hallucinating incorrect API usage, ensuring generated code works with the current codebase.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**: `.agents/skills/helios/core/SKILL.md` (Update API Reference sections)
+- **Read-Only**:
+  - `packages/core/src/index.ts`
+  - `packages/core/src/ai.ts`
+  - `packages/core/src/sequencing.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Documentation sync. Update the Markdown skill file to match the TypeScript source of truth.
+- **Pseudo-Code**:
+  1. **Update `createSystemPrompt`**:
+     - Change example from `createSystemPrompt(helios, "prompt")` to `createSystemPrompt(helios)`.
+     - Update description to reflect that it generates a base prompt + context, without accepting a user prompt argument.
+  2. **Update `DiagnosticReport`**:
+     - Add fields: `webgl`, `webgl2`, `webAudio` (boolean).
+     - Add field: `colorGamut` ('srgb' | 'p3' | 'rec2020' | null).
+     - Add fields: `videoCodecs`, `audioCodecs`, `videoDecoders`, `audioDecoders` (record of booleans).
+  3. **Add Sequencing Helpers**:
+     - Under "Animation Helpers" or a new "Sequencing" section, add documentation for `stagger` and `shift`.
+     - Example for `stagger`: `stagger(items, 5)` -> item[i].from = i * 5.
+     - Example for `shift`: `shift(items, 30)` -> item.from += 30.
+- **Public API Changes**: None (Documentation only).
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: Run `cat .agents/skills/helios/core/SKILL.md` to display the file content.
+- **Success Criteria**:
+  - `createSystemPrompt` usage shows exactly 1 argument.
+  - `DiagnosticReport` interface lists `videoDecoders` and `audioDecoders`.
+  - `stagger` and `shift` are documented with code examples.
+- **Edge Cases**: Verify that the JSON structure in `DiagnosticReport` examples matches the nested object structure defined in `index.ts`.


### PR DESCRIPTION
Identified a gap in "Agent Experience First" vision where `SKILL.md` was outdated.
Created a plan to update `createSystemPrompt` signature, `DiagnosticReport` fields, and add sequencing helpers (`stagger`, `shift`) to the documentation.

---
*PR created automatically by Jules for task [7672701237047753842](https://jules.google.com/task/7672701237047753842) started by @BintzGavin*