### PR TITLE
✨ GAVIN: Update Dependencies and Scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,19 @@ build/
 *.tsbuildinfo
 output/
 
+# Test outputs
+**/output-*/
+**/temp/
+**/tests/*.mp4
+**/tests/*.wav
+**/tests/*.webm
+**/scripts/*.mp4
+**/scripts/*.wav
+**/scripts/*.webm
+packages/renderer/output/
+packages/renderer/output-*/
+packages/renderer/temp/
+
 # Logs
 logs
 *.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -7332,6 +7332,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7349,6 +7350,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7366,6 +7368,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7383,6 +7386,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7400,6 +7404,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7417,6 +7422,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7434,6 +7440,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7451,6 +7458,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7468,6 +7476,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7485,6 +7494,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7502,6 +7512,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7519,6 +7530,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7536,6 +7548,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7553,6 +7566,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7570,6 +7584,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7587,6 +7602,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7604,6 +7620,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7621,6 +7638,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7638,6 +7656,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7655,6 +7674,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7672,6 +7692,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7689,6 +7710,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7706,6 +7728,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7723,6 +7746,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7740,6 +7764,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7757,6 +7782,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8474,10 +8500,10 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.48.1",
+      "version": "0.48.3",
       "license": "ELv2",
       "dependencies": {
-        "@helios-project/core": "3.3.0",
+        "@helios-project/core": "^3.3.0",
         "mediabunny": "^1.31.0"
       },
       "devDependencies": {
@@ -8492,7 +8518,7 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/core": "3.3.0",
+        "@helios-project/core": "^3.3.0",
         "playwright": "^1.42.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "packages/*"
   ],
   "scripts": {
+    "build": "npm run build -w packages/core && npm run build -w packages/player && npm run build -w packages/cli && npm run build -w packages/renderer",
+    "test": "npm run test -w packages/core & npm run test -w packages/player & npm run test -w packages/renderer & wait",
+    "test:core": "npm run test -w packages/core",
+    "test:player": "npm run test -w packages/player",
+    "test:renderer": "npm run test -w packages/renderer",
     "dev": "npx vite ./examples/simple-canvas-animation",
     "dev:react": "vite serve examples/react-canvas-animation",
     "dev:react-dom": "vite serve examples/react-dom-animation",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,8 +25,17 @@
   ],
   "scripts": {
     "build": "tsc",
-    "dev": "tsc -w"
+    "dev": "tsc -w",
+    "prepublishOnly": "npm run build"
   },
+  "keywords": [
+    "video",
+    "animation",
+    "programmatic-video",
+    "cli",
+    "video-rendering",
+    "helios"
+  ],
   "dependencies": {
     "commander": "^13.1.0",
     "chalk": "^5.4.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,8 +27,20 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "vitest"
+    "test": "vitest",
+    "prepublishOnly": "npm run build"
   },
+  "keywords": [
+    "video",
+    "animation",
+    "programmatic-video",
+    "video-engine",
+    "web-animations",
+    "css-animations",
+    "waapi",
+    "canvas",
+    "webgl"
+  ],
   "devDependencies": {
     "typescript": "^5.0.0",
     "vitest": "^4.0.17"

--- a/packages/player/dist/bridge.js
+++ b/packages/player/dist/bridge.js
@@ -3,6 +3,8 @@ import { getAudioAssets } from "./features/audio-utils";
 export function connectToParent(helios) {
     // 1. Listen for messages from parent
     window.addEventListener('message', async (event) => {
+        if (event.source !== window.parent)
+            return;
         const { type, frame } = event.data;
         switch (type) {
             case 'HELIOS_GET_AUDIO_TRACKS':

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -33,10 +33,20 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "tsc -w",
-    "test": "vitest"
+    "test": "vitest",
+    "prepublishOnly": "npm run build"
   },
+  "keywords": [
+    "video",
+    "animation",
+    "programmatic-video",
+    "video-player",
+    "web-component",
+    "custom-element",
+    "helios"
+  ],
   "dependencies": {
-    "@helios-project/core": "3.1.0",
+    "@helios-project/core": "^3.3.0",
     "mediabunny": "^1.31.0"
   },
   "devDependencies": {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -27,11 +27,22 @@
     "build": "tsc",
     "dev": "tsc -w",
     "verify:error": "tsx scripts/verify-error-handling.ts",
-    "test": "npx tsx tests/run-all.ts"
+    "test": "npx tsx tests/run-all.ts",
+    "prepublishOnly": "npm run build"
   },
+  "keywords": [
+    "video",
+    "animation",
+    "programmatic-video",
+    "video-rendering",
+    "ffmpeg",
+    "playwright",
+    "headless-browser",
+    "helios"
+  ],
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "3.1.0",
+    "@helios-project/core": "^3.3.0",
     "playwright": "^1.42.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- Added `prepublishOnly` script to build packages before publishing in `cli`, `core`, `player`, and `renderer`.
- Updated package versions for `player` and `renderer` to use `^3.3.0`.
- Enhanced `.gitignore` to exclude additional test and output files.
- Improved build and test scripts in `package.json` for better workflow management.