### PR TITLE
✨ RENDERER: Enable Audio Looping

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -4,7 +4,7 @@
 The Renderer operates on a "Dual-Path" architecture to support different use cases:
 1. **DOM Strategy (`DomStrategy`)**: Used for HTML/CSS-heavy compositions. It uses Playwright to capture screenshots of the page at each frame.
    - **Drivers**: Uses `SeekTimeDriver` to manipulate `document.timeline` and sync media/CSS animations (supports Shadow DOM, enforces deterministic Jan 1 2024 epoch).
-   - **Discovery**: Uses `dom-scanner` to recursively discover media elements (including Shadow DOM) and implements recursive `<img>` tag and CSS background image discovery for preloading.
+   - **Discovery**: Uses `dom-scanner` to recursively discover media elements (including Shadow DOM) and implements recursive `<img>` tag and CSS background image discovery for preloading. Supports automatic audio looping for `<audio loop>` elements.
    - **Output**: Best for sharp text and vector graphics.
 2. **Canvas Strategy (`CanvasStrategy`)**: Used for WebGL/Canvas-heavy compositions (e.g., Three.js, PixiJS). It captures the `<canvas>` context directly.
    - **Drivers**: Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise virtual time control (supports Shadow DOM media sync, enforces deterministic Jan 2024 epoch, ensures sync-before-render order, waits for budget expiration, enforces stability timeout via `Runtime.terminateExecution`).
@@ -59,6 +59,7 @@ The `RendererOptions` interface controls the render pipeline:
 - `videoCodec`: `'libx264'` (default), `'copy'`, or others.
 - `audioCodec`: `'aac'` (default), `'libvorbis'`, etc.
 - `audioFilePath`: Path to external audio file to mix in.
+- `audioTracks`: List of audio tracks (files or `AudioTrackConfig` objects with `path`, `loop`, `volume`, `offset`).
 - `stabilityTimeout`: Timeout for frame stability (default 30000ms).
 - `inputProps`: Object injected into the page as `window.__HELIOS_PROPS__`.
 

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.52.0
+- ✅ Completed: Enable Audio Looping - Updated `DomScanner` and `FFmpegBuilder` to support the `loop` attribute on `<audio>` and `<video>` elements by injecting `-stream_loop -1` into FFmpeg input args.
+
 ## RENDERER v1.51.0
 - ✅ Completed: Enable Recursive Shadow DOM Image Preloading - Updated `DomStrategy` to recursively discover and preload `<img>` tags within Shadow DOMs using `TreeWalker`, ensuring images in Web Components are fully loaded before rendering.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.51.0
+**Version**: 1.52.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.52.0] ✅ Completed: Enable Audio Looping - Updated `DomScanner` and `FFmpegBuilder` to support the `loop` attribute on `<audio>` and `<video>` elements by injecting `-stream_loop -1` into FFmpeg input args.
 - [1.51.0] ✅ Completed: Enable Recursive Shadow DOM Image Preloading - Updated `DomStrategy` to recursively discover and preload `<img>` tags within Shadow DOMs using `TreeWalker`, ensuring images in Web Components are fully loaded before rendering.
 - [1.50.0] ✅ Completed: Enable Blob Audio - Implemented `blob-extractor` to bridge browser `blob:` URLs to FFmpeg by extracting content to temporary files, enabling support for dynamic client-side audio (e.g., text-to-speech).
 - [1.49.0] ✅ Completed: Precision Frame Control - Added `frameCount` to `RendererOptions`, enabling exact frame-count rendering for distributed rendering workflows, overriding floating-point duration calculations.

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -33,6 +33,12 @@ export interface AudioTrackConfig {
    * Defaults to 0 (no fade out).
    */
   fadeOutDuration?: number;
+
+  /**
+   * Whether to loop the audio track indefinitely.
+   * Defaults to false.
+   */
+  loop?: boolean;
 }
 
 export interface BrowserConfig {

--- a/packages/renderer/src/utils/FFmpegBuilder.ts
+++ b/packages/renderer/src/utils/FFmpegBuilder.ts
@@ -17,6 +17,7 @@ export class FFmpegBuilder {
             seek: track.seek ?? 0,
             fadeInDuration: track.fadeInDuration ?? 0,
             fadeOutDuration: track.fadeOutDuration ?? 0,
+            loop: track.loop,
           });
         }
       });
@@ -52,6 +53,9 @@ export class FFmpegBuilder {
 
       // Add input arguments
       // Note: -ss before -i for fast seeking
+      if (track.loop) {
+        audioInputArgs.push('-stream_loop', '-1');
+      }
       audioInputArgs.push('-ss', inputSeek.toString(), '-i', track.path);
 
       // Build filter chain for this input

--- a/packages/renderer/src/utils/dom-scanner.ts
+++ b/packages/renderer/src/utils/dom-scanner.ts
@@ -78,7 +78,8 @@ export async function scanForAudioTracks(page: Page): Promise<AudioTrackConfig[]
               path: src,
               volume: volume,
               offset: isNaN(offset) ? 0 : offset,
-              seek: isNaN(seek) ? 0 : seek
+              seek: isNaN(seek) ? 0 : seek,
+              loop: el.loop
             });
           }
         });
@@ -103,6 +104,7 @@ export async function scanForAudioTracks(page: Page): Promise<AudioTrackConfig[]
       volume: track.volume,
       offset: track.offset,
       seek: track.seek,
+      loop: track.loop,
     }));
 
   if (validTracks.length > 0) {

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 const tests = [
   'tests/verify-audio-codecs.ts',
   'tests/verify-audio-fades.ts',
+  'tests/verify-audio-loop.ts',
   'tests/verify-bitrate.ts',
   'tests/verify-browser-config.ts',
   'tests/verify-canvas-implicit-audio.ts',

--- a/packages/renderer/tests/verify-audio-loop.ts
+++ b/packages/renderer/tests/verify-audio-loop.ts
@@ -1,0 +1,173 @@
+import { chromium } from 'playwright';
+import { DomStrategy } from '../src/strategies/DomStrategy.js';
+import { RendererOptions } from '../src/types.js';
+import path from 'path';
+
+async function run() {
+  console.log('Starting Audio Loop Verification...');
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  // Mock audio files to prevent network errors
+  await page.route('**/*.mp3', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'audio/mpeg',
+      body: Buffer.from('mock audio data')
+    });
+  });
+
+  const htmlContent = `
+    <!DOCTYPE html>
+    <html>
+    <body>
+      <!-- Track 1: Looped -->
+      <audio src="loop.mp3" loop></audio>
+
+      <!-- Track 2: Play once -->
+      <audio src="once.mp3"></audio>
+
+      <!-- Track 3: Looped Video (should also work) -->
+      <video src="loop-video.mp4" loop muted></video>
+    </body>
+    </html>
+  `;
+
+  await page.setContent(htmlContent);
+
+  // Initialize Strategy
+  const options: RendererOptions = {
+    width: 1920,
+    height: 1080,
+    fps: 30,
+    durationInSeconds: 10,
+    mode: 'dom',
+    videoCodec: 'libx264', // Required for DomStrategy
+    audioCodec: 'aac'
+  };
+
+  const strategy = new DomStrategy(options);
+
+  console.log('Preparing strategy...');
+  await strategy.prepare(page);
+
+  console.log('Generating FFmpeg arguments...');
+  const args = strategy.getFFmpegArgs(options, 'output.mp4');
+
+  // Verify args
+  console.log('FFmpeg Args:', args);
+
+  // We expect 3 inputs (audio, audio, video-audio).
+  // Note: DomStrategy discovers tracks.
+
+  // Helper to find index of input file
+  const findInputIndex = (filename: string) => args.indexOf(filename);
+
+  const loopMp3Index = findInputIndex('loop.mp3'); // May be absolute path if scanner resolves it, but page.setContent uses relative.
+  // Actually scanner returns 'currentSrc' which is usually absolute.
+  // Playwright's page.setContent might result in about:blank relative URLs or localhost?
+  // Let's check what scanner returns.
+
+  // To make it robust, let's verify if -stream_loop -1 appears before the input.
+
+  let failure = false;
+
+  // Check loop.mp3
+  // Find the index of loop.mp3 (checking for suffix)
+  const loopMp3ArgIndex = args.findIndex(arg => arg.endsWith('loop.mp3'));
+  if (loopMp3ArgIndex === -1) {
+    console.error('❌ loop.mp3 not found in args');
+    failure = true;
+  } else {
+    // Check if -stream_loop -1 is before it (and before -ss, -i)
+    // The sequence in FFmpegBuilder is: [-stream_loop, -1, -ss, ..., -i, path]
+    // So loopMp3ArgIndex is path.
+    // -i is at loopMp3ArgIndex - 1
+    // -ss value is at loopMp3ArgIndex - 3
+    // -ss is at loopMp3ArgIndex - 4
+    // -1 is at loopMp3ArgIndex - 5
+    // -stream_loop is at loopMp3ArgIndex - 6
+
+    // Let's just search backwards from the input index for -stream_loop
+    const streamLoopIndex = args.lastIndexOf('-stream_loop', loopMp3ArgIndex);
+    const loopValueIndex = args.lastIndexOf('-1', loopMp3ArgIndex);
+
+    // It should be close.
+    if (streamLoopIndex !== -1 && loopValueIndex === streamLoopIndex + 1 && streamLoopIndex > loopMp3ArgIndex - 10) {
+      console.log('✅ loop.mp3 has -stream_loop -1');
+    } else {
+      console.error('❌ loop.mp3 missing -stream_loop -1');
+      failure = true;
+    }
+  }
+
+  // Check once.mp3
+  const onceMp3ArgIndex = args.findIndex(arg => arg.endsWith('once.mp3'));
+  if (onceMp3ArgIndex === -1) {
+    console.error('❌ once.mp3 not found in args');
+    failure = true;
+  } else {
+    // Should NOT have stream_loop before it (closest one should be for another file or -1)
+    const streamLoopIndex = args.lastIndexOf('-stream_loop', onceMp3ArgIndex);
+
+    // If we found one, make sure it's not associated with this input.
+    // In our case, loop.mp3 is first in DOM, so it comes first in args.
+    // once.mp3 is second.
+    // If loop.mp3 has stream_loop, streamLoopIndex will point to that.
+    // We need to ensure there isn't one *immediately* before once.mp3.
+
+    // The previous input (loop.mp3) args end at loopMp3ArgIndex.
+    // So we check between loopMp3ArgIndex and onceMp3ArgIndex.
+
+    let hasLoop = false;
+    for (let i = streamLoopIndex; i > -1 && i < onceMp3ArgIndex; i++) {
+        if (args[i] === '-stream_loop' && i > loopMp3ArgIndex) {
+            hasLoop = true;
+            break;
+        }
+    }
+
+    if (hasLoop) {
+      console.error('❌ once.mp3 INCORRECTLY has -stream_loop -1');
+      failure = true;
+    } else {
+      console.log('✅ once.mp3 correctly does not have -stream_loop');
+    }
+  }
+
+  // Check loop-video.mp4 (video elements scanning)
+  const loopVideoArgIndex = args.findIndex(arg => arg.endsWith('loop-video.mp4'));
+  if (loopVideoArgIndex !== -1) {
+      const streamLoopIndex = args.lastIndexOf('-stream_loop', loopVideoArgIndex);
+      const loopValueIndex = args.lastIndexOf('-1', loopVideoArgIndex);
+
+      if (streamLoopIndex !== -1 && loopValueIndex === streamLoopIndex + 1 && streamLoopIndex > onceMp3ArgIndex) {
+          console.log('✅ loop-video.mp4 has -stream_loop -1');
+      } else {
+          console.error('❌ loop-video.mp4 missing -stream_loop -1');
+          failure = true;
+      }
+  } else {
+      // It might be skipped if dom scanner treats video tags differently for audio extraction?
+      // dom-scanner.ts: if (tagName === 'AUDIO' || tagName === 'VIDEO') ...
+      // So it should be there.
+      console.error('❌ loop-video.mp4 not found in args');
+      failure = true;
+  }
+
+  await browser.close();
+
+  if (failure) {
+    console.error('FAILED');
+    process.exit(1);
+  } else {
+    console.log('PASSED');
+    process.exit(0);
+  }
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
💡 **What**: Enabled support for the `loop` attribute on `<audio>` and `<video>` elements to allow seamless background media looping.
🎯 **Why**: To align with the "Use What You Know" principle and allow users to create infinite background loops simply by adding the `loop` attribute to their media tags.
📊 **Impact**: Users no longer need to manually configure audio tracks or edit audio files for looping background music.
🔬 **Verification**: Run `npx tsx packages/renderer/tests/verify-audio-loop.ts` to verify that the `-stream_loop -1` flag is correctly injected into the FFmpeg command.

---
*PR created automatically by Jules for task [4370262547783561904](https://jules.google.com/task/4370262547783561904) started by @BintzGavin*