### PR TITLE
Implement Picture-in-Picture Support for Helios Player

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -11,7 +11,8 @@ The `<helios-player>` component uses a Shadow DOM to encapsulate its styles and 
 - `<iframe>`: Hosts the Helios composition (sandboxed).
 - `.click-layer`: Captures clicks for play/pause and double-clicks for fullscreen.
 - `.captions-container`: Displays active captions.
-- `.controls` (role="toolbar"): Contains playback controls (Play/Pause, Volume, Captions, Export, Speed, Scrubber Wrapper, Time Display, Fullscreen).
+- `.pip-video`: Hidden video element used for Picture-in-Picture proxy.
+- `.controls` (role="toolbar"): Contains playback controls (Play/Pause, Volume, Captions, Export, Speed, Scrubber Wrapper, Time Display, Fullscreen, PiP).
   - `.scrubber-wrapper`: Container for the scrubber range input and markers.
     - `.scrubber-tooltip`: Displays timestamp on hover.
     - `.markers-container`: Overlays visual markers on the timeline track.
@@ -34,6 +35,8 @@ The component dispatches standard HTMLMediaElement events:
 - `loadeddata`: Initial data is loaded.
 - `canplay`: The player can start playing.
 - `canplaythrough`: The player can play through without buffering.
+- `enterpictureinpicture`: The player has entered Picture-in-Picture mode.
+- `leavepictureinpicture`: The player has left Picture-in-Picture mode.
 - `error`: An error occurred.
 
 ## C. Attributes
@@ -96,6 +99,7 @@ Properties and methods available on the `HeliosPlayer` element instance:
 - `defaultMuted`: Get/Set default muted state.
 - `defaultPlaybackRate`: Get/Set default playback speed.
 - `canPlayType(type)`: Returns string indicating support (always empty for video MIME types).
+- `requestPictureInPicture()`: Request Picture-in-Picture mode (returns Promise<PictureInPictureWindow>).
 
 ## G. Interaction
 - **Keyboard Shortcuts**:

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.49.0
+- ✅ Completed: Picture-in-Picture - Implemented `requestPictureInPicture` API and UI toggle button for the player, supported in Direct/Same-Origin mode.
+
 ## PLAYER v0.48.4
 - ✅ Completed: Optimize Caption Rendering - Implemented state diffing to prevent unnecessary DOM updates during caption rendering, improving performance.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.48.4
+**Version**: v0.49.0
 
 # Status: PLAYER
 
@@ -44,6 +44,7 @@
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.49.0] ✅ Completed: Picture-in-Picture - Implemented `requestPictureInPicture` API and UI toggle button for the player, supported in Direct/Same-Origin mode.
 [v0.48.4] ✅ Completed: Optimize Caption Rendering - Implemented state diffing to prevent unnecessary DOM updates during caption rendering, improving performance.
 [v0.48.3] ✅ Completed: Verify Player - Validated interactive playback (play/pause) via E2E test.
 [v0.48.2] ✅ Completed: Enforce Bridge Connection Security - Added missing `event.source` check in `connectToParent` (bridge.ts) to verify messages originate from the parent window, completing the bridge security hardening.

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -14,6 +14,7 @@ interface MediaError {
 }
 export declare class HeliosPlayer extends HTMLElement implements TrackHost {
     private iframe;
+    private pipVideo;
     private _textTracks;
     private _domTracks;
     private playPauseBtn;
@@ -31,6 +32,7 @@ export declare class HeliosPlayer extends HTMLElement implements TrackHost {
     private retryAction;
     private speedSelector;
     private fullscreenBtn;
+    private pipBtn;
     private captionsContainer;
     private ccBtn;
     private showCaptions;
@@ -117,6 +119,10 @@ export declare class HeliosPlayer extends HTMLElement implements TrackHost {
     set preload(val: string);
     get sandbox(): string;
     set sandbox(val: string);
+    requestPictureInPicture(): Promise<PictureInPictureWindow>;
+    private togglePip;
+    private onEnterPip;
+    private onLeavePip;
     play(): Promise<void>;
     load(): void;
     pause(): void;

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.48.3",
+  "version": "0.49.0",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/player/src/features/pip.test.ts
+++ b/packages/player/src/features/pip.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { HeliosPlayer } from '../index';
+
+describe('HeliosPlayer Picture-in-Picture', () => {
+  let player: HeliosPlayer;
+  let mockVideo: HTMLVideoElement;
+  let mockCanvas: HTMLCanvasElement;
+  let mockStream: MediaStream;
+  let mockPipWindow: PictureInPictureWindow;
+
+  beforeEach(() => {
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Mock ResizeObserver
+    global.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as any;
+
+    // Mock document.pictureInPictureEnabled
+    Object.defineProperty(document, 'pictureInPictureEnabled', {
+      value: true,
+      writable: true
+    });
+
+    // Mock requestPictureInPicture on HTMLVideoElement prototype
+    mockPipWindow = {} as PictureInPictureWindow;
+    HTMLVideoElement.prototype.requestPictureInPicture = vi.fn().mockResolvedValue(mockPipWindow);
+    HTMLVideoElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+
+    // Mock captureStream on HTMLCanvasElement prototype
+    mockStream = {} as MediaStream;
+    HTMLCanvasElement.prototype.captureStream = vi.fn().mockReturnValue(mockStream);
+
+    // Create player instance
+    player = new HeliosPlayer();
+    document.body.appendChild(player);
+
+    // Mock iframe content access (Same Origin)
+    const iframe = player.shadowRoot?.querySelector('iframe');
+    if (iframe) {
+        mockCanvas = document.createElement('canvas');
+        // We need to mock the contentWindow/contentDocument access
+        // Since jsdom iframes are tricky, we'll spy on the method if possible,
+        // or ensure the logic in HeliosPlayer handles the test environment.
+        // For this test, we might need to manually inject the canvas or mock the query selector
+        // But the player logic will try to access iframe.contentDocument.
+
+        // In jsdom, accessing contentDocument of a cross-origin iframe (default) might block.
+        // But here we are in same origin.
+
+        // Let's mock the iframe's contentDocument getter if possible, or just rely on jsdom behavior
+        // jsdom iframes don't load external content by default.
+
+        // We can define a getter for contentDocument on the iframe element itself for testing
+        Object.defineProperty(iframe, 'contentDocument', {
+            get: () => {
+                const doc = document.implementation.createHTMLDocument();
+                doc.body.appendChild(mockCanvas);
+                return doc;
+            },
+            configurable: true
+        });
+    }
+  });
+
+  afterEach(() => {
+    if (player && player.parentNode) {
+      document.body.removeChild(player);
+    }
+  });
+
+  it('should be defined', () => {
+    expect(player).toBeInstanceOf(HeliosPlayer);
+  });
+
+  it('should expose requestPictureInPicture method', () => {
+    expect(typeof player.requestPictureInPicture).toBe('function');
+  });
+
+  it('should throw error if Picture-in-Picture is not enabled in document', async () => {
+    Object.defineProperty(document, 'pictureInPictureEnabled', { value: false });
+    await expect(player.requestPictureInPicture()).rejects.toThrow('Picture-in-Picture not supported');
+  });
+
+  it('should throw error if canvas cannot be found (e.g. Cross-Origin)', async () => {
+    // Mock iframe to return null for contentDocument (simulating cross-origin or access denied)
+    const iframe = player.shadowRoot?.querySelector('iframe');
+    if (iframe) {
+        Object.defineProperty(iframe, 'contentDocument', {
+            get: () => null
+        });
+        // Also mock contentWindow document access failing
+        Object.defineProperty(iframe, 'contentWindow', {
+            get: () => ({ document: undefined }) // Simplified mock
+        });
+    }
+
+    await expect(player.requestPictureInPicture()).rejects.toThrow();
+    // We accept any error message related to access or missing canvas
+  });
+
+  it('should successfully request Picture-in-Picture when canvas is available', async () => {
+    const result = await player.requestPictureInPicture();
+
+    expect(HTMLCanvasElement.prototype.captureStream).toHaveBeenCalled();
+    expect(HTMLVideoElement.prototype.requestPictureInPicture).toHaveBeenCalled();
+    expect(result).toBe(mockPipWindow);
+  });
+});


### PR DESCRIPTION
Added `requestPictureInPicture` API and UI toggle button. Uses `canvas.captureStream()` to feed a hidden video element. Verified with unit tests and frontend verification.

---
*PR created automatically by Jules for task [1702797115706871494](https://jules.google.com/task/1702797115706871494) started by @BintzGavin*