### PR TITLE
✨ STUDIO: Verify and Document Persistent Render Jobs

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -12,7 +12,7 @@ Helios Studio is a browser-based development environment for video composition. 
     - `npx helios studio` - Via main CLI (starts Vite dev server)
     - `npx @helios-project/studio` or `helios-studio` - Standalone CLI (serves built dist via vite preview)
 -   **Bin Script**: `bin/helios-studio.js` - Executable script that serves the built Studio UI
--   **Server**: A Vite plugin (`vite-plugin-studio-api.ts`) provides API endpoints for filesystem access (assets, compositions) and render management.
+-   **Server**: A Vite plugin (`vite-plugin-studio-api.ts`) provides API endpoints for filesystem access (assets, compositions) and render management. It uses `RenderManager` to handle render jobs, persisting job history to `renders/jobs.json`.
 -   **UI**: A React application (`packages/studio/src`) that consumes the API and controls the Player.
 -   **Communication**: The UI communicates with the Player via the `HeliosController` bridge (postMessage) and with the Server via HTTP API.
 -   **Publishing**: Studio is a publishable npm package (`publishConfig.access: "public"`) with `bin` field for CLI installation.
@@ -111,7 +111,7 @@ npx @helios-project/studio
 **With Renderer:**
 -   Studio triggers renders via POST `/api/render`.
 -   The backend spawns a Renderer process (using `RenderManager`) to generate MP4/WebM files.
--   Render progress is polled via GET `/api/render`.
+-   Render progress and history are managed via `/api/jobs` and persisted to disk.
 
 ## F. Publishing
 

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.68.1
+- ✅ Verified: Persistent Render Jobs - Verified implementation and updated documentation to reflect persistence behavior.
+
 ## STUDIO v0.68.0
 - ✅ Completed: Duplicate Composition - Implemented "Duplicate Composition" feature with UI modal, API endpoint, and file copy logic.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.68.0
+**Version**: 0.68.1
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.68.1] ✅ Verified: Persistent Render Jobs - Verified implementation and updated documentation to reflect persistence behavior.
 - [v0.68.0] ✅ Completed: Duplicate Composition - Implemented "Duplicate Composition" feature with UI modal, API endpoint, and file copy logic.
 - [v0.67.0] ✅ Completed: Schema Constraints UI - Implemented UI support for schema constraints (`minLength`, `maxLength`, `pattern`, `minItems`, `maxItems`, `accept`) in the Props Editor, enabling validation feedback and asset filtering.
 - [v0.66.0] ✅ Completed: TypedArray Support - Implemented support for TypedArray props (e.g., `float32array`, `int8array`) in the Props Editor using JSON serialization and added missing tests. Fixed a critical React Hook violation in PropsEditor.


### PR DESCRIPTION
Verified the implementation of Persistent Render Jobs in `packages/studio`.
Updated `/.sys/llmdocs/context-studio.md` to document that render jobs are persisted to `renders/jobs.json`.
Updated `docs/status/STUDIO.md` to version 0.68.1.
Updated `docs/PROGRESS-STUDIO.md` with the verification entry.
Verified that tests in `packages/studio/src/server/render-manager.test.ts` pass.

---
*PR created automatically by Jules for task [7762001237823305348](https://jules.google.com/task/7762001237823305348) started by @BintzGavin*