### PR TITLE
Persist Media Properties in Helios Player

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,5 +1,8 @@
 # PLAYER Progress Log
 
+## PLAYER v0.49.1
+- ✅ Completed: Persist Media Properties - Implemented persistence for `volume`, `playbackRate`, and `muted` properties so values set before the player loads are applied when the controller connects.
+
 ## PLAYER v0.49.0
 - ✅ Completed: Picture-in-Picture - Implemented `requestPictureInPicture` API and UI toggle button for the player, supported in Direct/Same-Origin mode.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.49.0
+**Version**: v0.49.1
 
 # Status: PLAYER
 
@@ -40,10 +40,12 @@
 - Implemented robust `load()` behavior that supports reloading the current `src` to facilitate programmatic retries.
 - Visualizes markers on the timeline, allowing users to identify and seek to specific points of interest.
 - Migrated client-side export to use `mediabunny`, replacing deprecated `mp4-muxer` and `webm-muxer`.
+- Implemented persistence for `volume`, `playbackRate`, and `muted` properties, ensuring values set before connection are applied upon initialization.
 
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.49.1] ✅ Completed: Persist Media Properties - Implemented persistence for `volume`, `playbackRate`, and `muted` properties so values set before the player loads are applied when the controller connects.
 [v0.49.0] ✅ Completed: Picture-in-Picture - Implemented `requestPictureInPicture` API and UI toggle button for the player, supported in Direct/Same-Origin mode.
 [v0.48.4] ✅ Completed: Optimize Caption Rendering - Implemented state diffing to prevent unnecessary DOM updates during caption rendering, improving performance.
 [v0.48.3] ✅ Completed: Verify Player - Validated interactive playback (play/pause) via E2E test.

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -97,7 +97,13 @@ describe('HeliosPlayer', () => {
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
         dispose: vi.fn(), setCaptions: vi.fn(),
-        setPlaybackRate: vi.fn()
+        setPlaybackRate: vi.fn(),
+        setAudioVolume: vi.fn(),
+        setAudioMuted: vi.fn(),
+        setInputProps: vi.fn(),
+        setLoop: vi.fn(),
+        setPlaybackRange: vi.fn(),
+        clearPlaybackRange: vi.fn()
     };
 
     // Inject controller (using private access workaround)
@@ -183,7 +189,11 @@ describe('HeliosPlayer', () => {
         dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn()
+        clearPlaybackRange: vi.fn(),
+        setAudioVolume: vi.fn(),
+        setAudioMuted: vi.fn(),
+        setInputProps: vi.fn(),
+        setLoop: vi.fn()
     };
     (player as any).setController(mockController);
 
@@ -249,7 +259,13 @@ describe('HeliosPlayer', () => {
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
         dispose: vi.fn(), setCaptions: vi.fn(),
-        setPlaybackRate: vi.fn()
+        setPlaybackRate: vi.fn(),
+        setAudioVolume: vi.fn(),
+        setAudioMuted: vi.fn(),
+        setInputProps: vi.fn(),
+        setLoop: vi.fn(),
+        setPlaybackRange: vi.fn(),
+        clearPlaybackRange: vi.fn()
     };
     (player as any).setController(mockController);
 
@@ -322,7 +338,13 @@ describe('HeliosPlayer', () => {
       subscribe: vi.fn().mockReturnValue(() => {}),
       onError: vi.fn().mockReturnValue(() => {}),
       dispose: vi.fn(), setCaptions: vi.fn(),
-      setPlaybackRate: vi.fn()
+      setPlaybackRate: vi.fn(),
+      setAudioVolume: vi.fn(),
+      setAudioMuted: vi.fn(),
+      setInputProps: vi.fn(),
+      setLoop: vi.fn(),
+      setPlaybackRange: vi.fn(),
+      clearPlaybackRange: vi.fn()
     };
     (player as any).setController(mockController);
 
@@ -369,7 +391,13 @@ describe('HeliosPlayer', () => {
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
             dispose: vi.fn(), setCaptions: vi.fn(),
-            setPlaybackRate: vi.fn()
+            setPlaybackRate: vi.fn(),
+            setAudioVolume: vi.fn(),
+            setAudioMuted: vi.fn(),
+            setInputProps: vi.fn(),
+            setLoop: vi.fn(),
+            setPlaybackRange: vi.fn(),
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -488,7 +516,11 @@ describe('HeliosPlayer', () => {
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
-            setAudioMuted: vi.fn()
+        setAudioMuted: vi.fn(),
+        setAudioVolume: vi.fn(),
+        setLoop: vi.fn(),
+        setPlaybackRange: vi.fn(),
+        clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -574,7 +606,13 @@ describe('HeliosPlayer', () => {
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
         dispose: vi.fn(), setCaptions: vi.fn(),
-        setPlaybackRate: vi.fn()
+        setPlaybackRate: vi.fn(),
+        setAudioVolume: vi.fn(),
+        setAudioMuted: vi.fn(),
+        setInputProps: vi.fn(),
+        setLoop: vi.fn(),
+        setPlaybackRange: vi.fn(),
+        clearPlaybackRange: vi.fn()
       };
       (player as any).setController(mockController);
 
@@ -602,7 +640,13 @@ describe('HeliosPlayer', () => {
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
         dispose: vi.fn(), setCaptions: vi.fn(),
-        setPlaybackRate: vi.fn()
+        setPlaybackRate: vi.fn(),
+        setAudioVolume: vi.fn(),
+        setAudioMuted: vi.fn(),
+        setInputProps: vi.fn(),
+        setLoop: vi.fn(),
+        setPlaybackRange: vi.fn(),
+        clearPlaybackRange: vi.fn()
       };
       (player as any).setController(mockController);
 
@@ -631,7 +675,13 @@ describe('HeliosPlayer', () => {
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
             dispose: vi.fn(), setCaptions: vi.fn(),
-            setPlaybackRate: vi.fn()
+            setPlaybackRate: vi.fn(),
+            setAudioVolume: vi.fn(),
+            setAudioMuted: vi.fn(),
+            setInputProps: vi.fn(),
+            setLoop: vi.fn(),
+            setPlaybackRange: vi.fn(),
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
 
@@ -669,7 +719,13 @@ describe('HeliosPlayer', () => {
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
             dispose: vi.fn(), setCaptions: vi.fn(),
-            setPlaybackRate: vi.fn()
+            setPlaybackRate: vi.fn(),
+            setAudioVolume: vi.fn(),
+            setAudioMuted: vi.fn(),
+            setInputProps: vi.fn(),
+            setLoop: vi.fn(),
+            setPlaybackRange: vi.fn(),
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
 
@@ -1049,7 +1105,12 @@ describe('HeliosPlayer', () => {
             onError: vi.fn().mockReturnValue(() => {}),
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setInputProps: vi.fn()
+        setInputProps: vi.fn(),
+        setAudioVolume: vi.fn(),
+        setAudioMuted: vi.fn(),
+        setLoop: vi.fn(),
+        setPlaybackRange: vi.fn(),
+        clearPlaybackRange: vi.fn()
         };
     });
 
@@ -1212,7 +1273,11 @@ describe('HeliosPlayer', () => {
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
-            setAudioMuted: vi.fn()
+            setAudioMuted: vi.fn(),
+            setAudioVolume: vi.fn(),
+            setLoop: vi.fn(),
+            setPlaybackRange: vi.fn(),
+            clearPlaybackRange: vi.fn()
         };
     });
 
@@ -1354,7 +1419,11 @@ describe('HeliosPlayer', () => {
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
-            setAudioMuted: vi.fn()
+            setAudioMuted: vi.fn(),
+            setAudioVolume: vi.fn(),
+            setLoop: vi.fn(),
+            setPlaybackRange: vi.fn(),
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -1428,7 +1497,11 @@ describe('HeliosPlayer', () => {
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
-            setAudioMuted: vi.fn()
+            setAudioMuted: vi.fn(),
+            setAudioVolume: vi.fn(),
+            setLoop: vi.fn(),
+            setPlaybackRange: vi.fn(),
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -1531,6 +1604,62 @@ describe('HeliosPlayer', () => {
         expect(markerEls.length).toBe(1);
         const m = markerEls[0] as HTMLDivElement;
         expect(m.title).toBe('Valid');
+    });
+  });
+
+  describe('Persistence of Media Properties', () => {
+    let mockController: any;
+
+    beforeEach(() => {
+        mockController = {
+            getState: vi.fn().mockReturnValue({ currentFrame: 0, duration: 10, fps: 30, isPlaying: false }),
+            play: vi.fn(),
+            pause: vi.fn(),
+            seek: vi.fn(),
+            subscribe: vi.fn().mockReturnValue(() => {}),
+            onError: vi.fn().mockReturnValue(() => {}),
+            dispose: vi.fn(), setCaptions: vi.fn(),
+            setPlaybackRate: vi.fn(),
+            setInputProps: vi.fn(),
+            setAudioMuted: vi.fn(),
+            setAudioVolume: vi.fn()
+        };
+    });
+
+    it('should persist volume set before controller connection', () => {
+        // Set volume before connect
+        player.volume = 0.5;
+        expect(player.volume).toBe(0.5);
+
+        // Connect
+        (player as any).setController(mockController);
+
+        // Should have applied to controller
+        expect(mockController.setAudioVolume).toHaveBeenCalledWith(0.5);
+    });
+
+    it('should persist playbackRate set before controller connection', () => {
+        // Set rate before connect
+        player.playbackRate = 2.0;
+        expect(player.playbackRate).toBe(2.0);
+
+        // Connect
+        (player as any).setController(mockController);
+
+        // Should have applied to controller
+        expect(mockController.setPlaybackRate).toHaveBeenCalledWith(2.0);
+    });
+
+    it('should persist muted state set before controller connection', () => {
+        // Set muted before connect
+        player.muted = true;
+        expect(player.muted).toBe(true);
+
+        // Connect
+        (player as any).setController(mockController);
+
+        // Should have applied to controller
+        expect(mockController.setAudioMuted).toHaveBeenCalledWith(true);
     });
   });
 });


### PR DESCRIPTION
Implemented persistence for `volume`, `playbackRate`, and `muted` properties in `<helios-player>`. Values set before the internal controller is initialized are now stored and applied automatically upon connection. This fixes a race condition where programmatic property assignments would be lost if performed before the composition loaded.

Updated unit tests to verify persistence and corrected mock controller definitions across the test suite to support the new initialization logic.

**Impact**: Ensures `<helios-player>` behaves more like a standard `HTMLMediaElement` by respecting properties set at any time.

---
*PR created automatically by Jules for task [15287965288906804917](https://jules.google.com/task/15287965288906804917) started by @BintzGavin*