### PR TITLE
✨ CORE: Implement Helios.bindTo() for timeline synchronization

### DIFF
--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -184,6 +184,8 @@ class Helios {
   seek(frame: number): void;
 
   // Timeline Binding
+  bindTo(master: Helios): void;
+  unbind(): void;
   bindToDocumentTimeline(): void;
   unbindFromDocumentTimeline(): void;
 }

--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v3.5.0
+- ✅ Completed: Implement Timeline Sync - Added `Helios.bindTo(master)` and `Helios.unbind()` for synchronizing multiple Helios instances.
+
 ## CORE v3.4.0
 - ✅ Completed: Implement Audio Tracks - Added support for audio tracks allowing independent volume/mute control for groups of elements using `data-helios-track-id`.
 - ✅ Completed: Update Skills and Version - Synced package.json version to 3.4.0 and updated SKILL.md with Audio Track API and TypedArray schema types.

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 3.4.0
+**Version**: 3.5.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
-- **Last Updated**: 2026-06-03
+- **Last Updated**: 2026-06-08
 
+[v3.5.0] ✅ Completed: Implement Timeline Sync - Added `Helios.bindTo(master)` and `Helios.unbind()` for synchronizing multiple Helios instances.
 [v3.4.0] ✅ Completed: Implement Audio Tracks - Added track-based volume/mute control via data-helios-track-id and helios.setAudioTrackVolume/Muted.
 [v3.3.1] ✅ Completed: Update Skill Docs - Updated .agents/skills/helios/core/SKILL.md to match v3.3.0 API (DiagnosticReport, Sequencing Helpers).
 [v3.3.0] ✅ Completed: Enable Testing & Sync Version - Added vitest to devDependencies, verified tests pass, and updated dependent packages (renderer, player) to use core version 3.3.0.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1215,4 +1215,70 @@ Updated`;
         expect(helios.getState().isPlaying).toBe(false);
     });
   });
+
+  describe('Helios Synchronization', () => {
+    it('should sync with master', () => {
+      const h1 = new Helios({ duration: 10, fps: 30 });
+      const h2 = new Helios({ duration: 10, fps: 30 });
+
+      h2.bindTo(h1);
+      h1.seek(30); // 1 second
+
+      expect(h2.currentFrame.peek()).toBe(30);
+      expect(h2.currentTime.peek()).toBe(1);
+    });
+
+    it('should sync playback state', () => {
+      const h1 = new Helios({ duration: 10, fps: 30 });
+      const h2 = new Helios({ duration: 10, fps: 30 });
+
+      h2.bindTo(h1);
+
+      h1.play();
+      expect(h2.isPlaying.peek()).toBe(true);
+
+      h1.pause();
+      expect(h2.isPlaying.peek()).toBe(false);
+
+      h1.setPlaybackRate(2);
+      expect(h2.playbackRate.peek()).toBe(2);
+    });
+
+    it('should stop syncing when unbound', () => {
+      const h1 = new Helios({ duration: 10, fps: 30 });
+      const h2 = new Helios({ duration: 10, fps: 30 });
+
+      h2.bindTo(h1);
+      h1.seek(30);
+      expect(h2.currentFrame.peek()).toBe(30);
+
+      h2.unbind();
+      h1.seek(60);
+      expect(h2.currentFrame.peek()).toBe(30); // Should stay at old frame
+    });
+
+    it('should sync with different FPS', () => {
+      const h1 = new Helios({ duration: 10, fps: 30 });
+      const h2 = new Helios({ duration: 10, fps: 60 }); // Double FPS
+
+      h2.bindTo(h1);
+      h1.seek(30); // 1 second
+
+      // h2 should be at 1 second * 60 fps = 60 frames
+      expect(h2.currentFrame.peek()).toBe(60);
+      expect(h2.currentTime.peek()).toBe(1);
+    });
+
+    it('should sync with different FPS (fractional)', () => {
+      const h1 = new Helios({ duration: 10, fps: 30 });
+      const h2 = new Helios({ duration: 10, fps: 24 });
+
+      h2.bindTo(h1);
+      h1.seek(15); // 0.5 seconds
+
+      // h2 should be at 0.5 * 24 = 12 frames
+      expect(h2.currentFrame.peek()).toBe(12);
+      expect(h2.currentTime.peek()).toBe(0.5);
+    });
+  });
 });


### PR DESCRIPTION
Implemented `Helios.bindTo(master)` to synchronize one Helios instance with another.
- Added `bindTo` and `unbind` methods.
- Added `private _syncDispose` for cleanup.
- Updated `dispose()` to ensure proper unbinding.
- Added unit tests for synchronization (frame sync, playback state, rate, multi-FPS).

---
*PR created automatically by Jules for task [10770349593334564751](https://jules.google.com/task/10770349593334564751) started by @BintzGavin*