### PR TITLE
✨ STUDIO: Rename Composition

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -96,7 +96,7 @@ npx @helios-project/studio
     -   **Switcher**: Cmd+K to switch active composition.
     -   **Create**: Create new compositions from templates.
     -   **Duplicate**: Clone existing compositions.
-    -   **Settings**: Edit metadata (resolution, FPS, duration).
+    -   **Settings**: Edit metadata (resolution, FPS, duration) and Rename composition.
 
 ## E. Integration
 

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.69.0
+- ✅ Completed: Rename Composition - Implemented ability to rename compositions from the Settings modal, including backend directory moving and ID updates.
+
 ## STUDIO v0.68.1
 - ✅ Verified: Persistent Render Jobs - Verified implementation and updated documentation to reflect persistence behavior.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.68.1
+**Version**: 0.69.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.69.0] ✅ Completed: Rename Composition - Implemented ability to rename compositions from the Settings modal, including backend directory moving and ID updates.
 - [v0.68.1] ✅ Verified: Persistent Render Jobs - Verified implementation and updated documentation to reflect persistence behavior.
 - [v0.68.0] ✅ Completed: Duplicate Composition - Implemented "Duplicate Composition" feature with UI modal, API endpoint, and file copy logic.
 - [v0.67.0] ✅ Completed: Schema Constraints UI - Implemented UI support for schema constraints (`minLength`, `maxLength`, `pattern`, `minItems`, `maxItems`, `accept`) in the Props Editor, enabling validation feedback and asset filtering.

--- a/packages/studio/src/components/CompositionSettingsModal.tsx
+++ b/packages/studio/src/components/CompositionSettingsModal.tsx
@@ -4,6 +4,7 @@ import './CompositionSettingsModal.css';
 
 export const CompositionSettingsModal: React.FC = () => {
   const { isSettingsOpen, setSettingsOpen, updateCompositionMetadata, activeComposition, setDuplicateOpen } = useStudio();
+  const [name, setName] = useState('');
   const [width, setWidth] = useState(1920);
   const [height, setHeight] = useState(1080);
   const [fps, setFps] = useState(30);
@@ -14,6 +15,7 @@ export const CompositionSettingsModal: React.FC = () => {
 
   useEffect(() => {
     if (isSettingsOpen && activeComposition) {
+      setName(activeComposition.name);
       if (activeComposition.metadata) {
         setWidth(activeComposition.metadata.width);
         setHeight(activeComposition.metadata.height);
@@ -33,7 +35,7 @@ export const CompositionSettingsModal: React.FC = () => {
     setError(null);
 
     try {
-      await updateCompositionMetadata(activeComposition.id, { width, height, fps, duration });
+      await updateCompositionMetadata(activeComposition.id, { width, height, fps, duration }, name);
       setSettingsOpen(false);
     } catch (err: any) {
       setError(err.message || 'Failed to update settings');
@@ -49,6 +51,19 @@ export const CompositionSettingsModal: React.FC = () => {
         <div className="settings-modal-header">Composition Settings</div>
 
         <form onSubmit={handleSubmit}>
+          <div className="settings-modal-row">
+            <div className="settings-modal-input-group" style={{ flex: 1 }}>
+              <label>Name</label>
+              <input
+                type="text"
+                className="settings-modal-input"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                disabled={loading}
+              />
+            </div>
+          </div>
+
           <div className="settings-modal-row">
             <div className="settings-modal-input-group">
               <label>Width</label>

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -96,7 +96,7 @@ interface StudioContextType {
   setSettingsOpen: (isOpen: boolean) => void;
   createComposition: (name: string, template?: string, options?: CompositionMetadata) => Promise<void>;
   duplicateComposition: (sourceId: string, newName: string) => Promise<void>;
-  updateCompositionMetadata: (id: string, metadata: CompositionMetadata) => Promise<void>;
+  updateCompositionMetadata: (id: string, metadata: CompositionMetadata, name?: string) => Promise<void>;
   deleteComposition: (id: string) => Promise<void>;
 
   // Assets
@@ -295,12 +295,15 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }
   };
 
-  const updateCompositionMetadata = async (id: string, metadata: CompositionMetadata) => {
+  const updateCompositionMetadata = async (id: string, metadata: CompositionMetadata, name?: string) => {
     try {
+      const body: any = { id, ...metadata };
+      if (name) body.name = name;
+
       const res = await fetch('/api/compositions', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id, ...metadata })
+        body: JSON.stringify(body)
       });
 
       if (!res.ok) {


### PR DESCRIPTION
💡 **What**: Implemented "Rename Composition" functionality allowing users to rename compositions from the Settings Modal.
🎯 **Why**: To complete the composition lifecycle management (Create, Duplicate, Rename, Delete) and improve workflow efficiency.
📊 **Impact**: Users can now reorganize their projects without leaving the Studio interface.
🔬 **Verification**: Added unit tests in packages/studio/src/server/discovery.test.ts covering rename success, conflict handling, and missing source.

---
*PR created automatically by Jules for task [515130721197232236](https://jules.google.com/task/515130721197232236) started by @BintzGavin*