### PR TITLE
📋 PLAYER: Audio Track Control Plan

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -5,3 +5,7 @@
 ## [v0.46.1] - Planner Role Violation
 **Learning:** I mistakenly implemented the feature code instead of just creating the plan file, violating the Planner Protocol.
 **Action:** Always stop after creating the `.md` plan file. Do not write feature code, do not run build/test verification for the feature code (only for the plan feasibility if needed).
+
+## [v0.49.3] - Audio Track Control Gap
+**Learning:** Discovered that `HeliosController` interface blocked Studio from controlling individual audio tracks, despite Core support.
+**Action:** When defining cross-domain interfaces (Player <-> Studio), verify all necessary Core capabilities are exposed, not just the ones needed for the immediate UI.

--- a/.sys/plans/2026-02-01-PLAYER-audio-tracks.md
+++ b/.sys/plans/2026-02-01-PLAYER-audio-tracks.md
@@ -1,0 +1,38 @@
+# 2026-02-01-PLAYER-audio-tracks.md
+
+#### 1. Context & Goal
+- **Objective**: Implement `setAudioTrackVolume` and `setAudioTrackMuted` in the `HeliosController` interface and bridge protocol.
+- **Trigger**: The Studio domain requires granular control over individual audio tracks, but the current Player API only supports global volume/mute.
+- **Impact**: Unlocks track-level audio mixing in Helios Studio.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**:
+  - `packages/player/src/controllers.ts`: Update `HeliosController` interface and `DirectController`/`BridgeController` implementations.
+  - `packages/player/src/bridge.ts`: Handle `HELIOS_SET_TRACK_VOLUME` and `HELIOS_SET_TRACK_MUTED` messages.
+  - `packages/player/src/controllers.test.ts`: Add unit tests for new methods.
+- **Read-Only**: `packages/core/src/index.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Extend the existing Bridge/Controller pattern. `DirectController` calls core methods directly; `BridgeController` uses `postMessage` to trigger core methods inside the iframe.
+- **Pseudo-Code**:
+  - **Interface Update**: Add methods for setting track volume and mute status to `HeliosController` interface.
+  - **DirectController**: Implement new methods to proxy calls directly to the underlying `Helios` instance.
+  - **BridgeController**: Implement new methods to serialize arguments into `HELIOS_SET_TRACK_VOLUME` and `HELIOS_SET_TRACK_MUTED` messages and post them to the iframe.
+  - **Bridge Handler**:
+    - Listen for `HELIOS_SET_TRACK_VOLUME`. Validate `trackId` (string) and `volume` (number). Call `helios.setAudioTrackVolume`.
+    - Listen for `HELIOS_SET_TRACK_MUTED`. Validate `trackId` (string) and `muted` (boolean). Call `helios.setAudioTrackMuted`.
+- **Public API Changes**:
+  - `HeliosController` interface gains:
+    - `setAudioTrackVolume(trackId: string, volume: number): void`
+    - `setAudioTrackMuted(trackId: string, muted: boolean): void`
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm test -w packages/player`
+- **Success Criteria**:
+  - Unit tests pass for `DirectController` delegating to `Helios` instance.
+  - Unit tests pass for `BridgeController` sending correct `postMessage` payloads.
+- **Edge Cases**:
+  - Invalid types in bridge messages (should be ignored).
+  - Missing track IDs (handled by Core, but Player should pass them through).


### PR DESCRIPTION
Plan to enable track-level audio control in Helios Player, unblocking Studio audio mixing features.
Includes:
- Spec for updating HeliosController interface.
- Spec for Bridge protocol updates.
- Test plan.

---
*PR created automatically by Jules for task [17908696804201268633](https://jules.google.com/task/17908696804201268633) started by @BintzGavin*