### PR TITLE
Fix workspace version mismatch in renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 # Allow promo video output
 !examples/promo-video/output/
 !examples/promo-video/output/helios-promo.mp4
+test-results/

--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -46,6 +46,7 @@ packages/renderer/
     ├── verify-cdp-driver.ts    # CdpDriver budget test
     ├── verify-cdp-driver-timeout.ts # CdpDriver stability timeout test
     ├── verify-diagnose.ts      # Codec diagnostics test
+    ├── verify-transparency.ts  # Transparency support test
     └── ...                     # Other verification scripts
 ```
 

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.53.1
+- ✅ Completed: Fix Workspace Version Mismatch - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.4.0` (matching the workspace), enabling strict version synchronization and preventing lockfile drift.
+
 ## RENDERER v1.53.0
 - ✅ Completed: Enhance Diagnostics - Updated `CanvasStrategy.diagnose()` to perform comprehensive checks of supported WebCodecs (H.264, VP8, VP9, AV1) in the browser environment, returning a detailed `codecs` report for better debuggability.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.53.0
+**Version**: 1.53.1
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.53.1] ✅ Completed: Fix Workspace Version Mismatch - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.4.0` (matching the workspace), enabling strict version synchronization and preventing lockfile drift.
 - [1.53.0] ✅ Completed: Enhance Diagnostics - Updated `CanvasStrategy.diagnose()` to perform comprehensive checks of supported WebCodecs (H.264, VP8, VP9, AV1) in the browser environment, returning a detailed `codecs` report for better debuggability.
 - [1.52.1] ✅ Completed: Fix GSAP Timeline Synchronization - Updated `SeekTimeDriver` to wait for `window.__helios_gsap_timeline__` initialization (handling ES module async loading) and explicitly seek the GSAP timeline in `setTime`, resolving the black screen issue in the promo video example.
 - [1.52.0] ✅ Completed: Enable Audio Looping - Updated `DomScanner` and `FFmpegBuilder` to support the `loop` attribute on `<audio>` and `<video>` elements by injecting `-stream_loop -1` into FFmpeg input args.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8413,7 +8413,7 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/core": "^3.3.0",
+        "@helios-project/core": "3.4.0",
         "playwright": "^1.42.1"
       },
       "devDependencies": {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "^3.3.0",
+    "@helios-project/core": "3.4.0",
     "playwright": "^1.42.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates `packages/renderer/package.json` to use `@helios-project/core` version `3.4.0` to match the workspace version, resolving a backlog maintenance task.
Adds `test-results/` to `.gitignore` to prevent committing binary artifacts from verification tests.
Verified by running `npm install` and verification tests (including `verify-transparency.ts`).
Updated `docs/status/RENDERER.md` and `docs/PROGRESS-RENDERER.md`.

---
*PR created automatically by Jules for task [140500985082393459](https://jules.google.com/task/140500985082393459) started by @BintzGavin*