### PR TITLE
feat(studio): Refactor CLI to use Hybrid Vite Server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8395,7 +8395,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.49.2",
+      "version": "0.49.3",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^3.3.0",
@@ -8422,6 +8422,12 @@
         "tsx": "^4.21.0",
         "typescript": "^5.0.0"
       }
+    },
+    "packages/renderer/node_modules/@helios-project/core": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@helios-project/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-Co7lS4GCj1WnKV0O+Yt4mtdyrHSJiEQ6evVgWwJyRFhpv5r2FV3wPGiZ4c2cdLoqfSXpMBBz4+3YdRQdiuX7zg==",
+      "license": "ELv2"
     },
     "packages/renderer/node_modules/@types/node": {
       "version": "20.19.10",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -26,7 +26,8 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build:cli": "vite build -c vite.config.cli.ts",
+    "build": "tsc && vite build && npm run build:cli",
     "lint": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest",

--- a/packages/studio/vite.config.cli.ts
+++ b/packages/studio/vite.config.cli.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, 'src/server/plugin.ts'),
+      formats: ['es'],
+      fileName: 'index'
+    },
+    outDir: 'dist/cli',
+    ssr: true, // Target Node.js environment
+    rollupOptions: {
+      external: [
+        'vite',
+        'fs',
+        'path',
+        'child_process',
+        'net',
+        'url',
+        'http',
+        'os',
+        'events',
+        'stream',
+        'util',
+        '@modelcontextprotocol/sdk',
+        /@modelcontextprotocol\/sdk\/.*/
+      ]
+    },
+    // Minify false to make debugging easier if needed
+    minify: false
+  }
+});

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 import vue from '@vitejs/plugin-vue'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import solidPlugin from 'vite-plugin-solid'
-import { studioApiPlugin } from './vite-plugin-studio-api'
+import { studioApiPlugin } from './src/server/plugin'
 import path from 'path'
 
 const projectRoot = process.env.HELIOS_PROJECT_ROOT


### PR DESCRIPTION
Refactors the Studio CLI to use the Vite JavaScript API instead of spawning a child process. This enables HMR for user projects by rooting the server in the user's project directory while serving the Studio UI as a static overlay via a custom middleware. This change addresses the vision gap for "Hot Reloading" and aligns with the journal's architectural guidance.

---
*PR created automatically by Jules for task [14421977108621156080](https://jules.google.com/task/14421977108621156080) started by @BintzGavin*