### PR TITLE
✨ PLAYER: Audio Track Control

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -76,6 +76,7 @@ The component exposes the following CSS variables for theming:
 ## F. Public API Members
 Properties and methods available on the `HeliosPlayer` element instance:
 
+- `getController()`: Returns the underlying `HeliosController` instance (if connected).
 - `textTracks`: Returns a `HeliosTextTrackList` object containing `HeliosTextTrack` instances.
 - `addTextTrack(kind, label, language)`: Creates and returns a new `HeliosTextTrack`.
 - `play()`: Starts playback.
@@ -100,6 +101,14 @@ Properties and methods available on the `HeliosPlayer` element instance:
 - `defaultPlaybackRate`: Get/Set default playback speed.
 - `canPlayType(type)`: Returns string indicating support (always empty for video MIME types).
 - `requestPictureInPicture()`: Request Picture-in-Picture mode (returns Promise<PictureInPictureWindow>).
+
+**HeliosController Interface:**
+The controller returned by `getController()` provides advanced methods:
+- `setAudioTrackVolume(trackId: string, volume: number): void`
+- `setAudioTrackMuted(trackId: string, muted: boolean): void`
+- `setInputProps(props: Record<string, any>): void`
+- `setPlaybackRange(startFrame: number, endFrame: number): void`
+- `clearPlaybackRange(): void`
 
 ## G. Interaction
 - **Keyboard Shortcuts**:

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.49.3
+**Version**: v0.50.0
 
 # Status: PLAYER
 
@@ -21,6 +21,7 @@
 - Supports Interactive Playback Range via keyboard shortcuts (`I`, `O`, `X`).
 - Displays actionable error messages with "Dismiss" option for failed client-side exports.
 - Supports Volume and Mute controls via UI and Bridge.
+- Supports Audio Track Volume and Mute controls via Controller API and Bridge.
 - Supports caption rendering overlay with toggleable "CC" button.
 - Supports WebM (VP9/Opus) client-side export via `export-format` attribute.
 - Implements Standard Media API (play, pause, currentTime, events) for better interoperability.
@@ -45,6 +46,7 @@
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.50.0] ✅ Completed: Audio Track Control - Added `setAudioTrackVolume` and `setAudioTrackMuted` to `HeliosController` and the Bridge protocol, enabling granular audio control.
 [v0.49.3] ✅ Completed: Verify and Harden Persist Media Properties - Added comprehensive unit tests for volume clamping and muted property precedence to verify robustness of persisted media properties.
 [v0.49.3] ✅ Verified: Synced package.json version with status file and verified all tests pass.
 [v0.49.2] ✅ Completed: Fix API Parity Tests - Updated `api_parity.test.ts` mock controller to match the `HeliosController` interface, ensuring tests pass with the new media persistence logic.

--- a/packages/player/src/bridge.ts
+++ b/packages/player/src/bridge.ts
@@ -54,6 +54,16 @@ export function connectToParent(helios: Helios) {
             helios.setAudioMuted(event.data.muted);
         }
         break;
+      case 'HELIOS_SET_AUDIO_TRACK_VOLUME':
+        if (typeof event.data.trackId === 'string' && typeof event.data.volume === 'number') {
+            helios.setAudioTrackVolume(event.data.trackId, event.data.volume);
+        }
+        break;
+      case 'HELIOS_SET_AUDIO_TRACK_MUTED':
+        if (typeof event.data.trackId === 'string' && typeof event.data.muted === 'boolean') {
+            helios.setAudioTrackMuted(event.data.trackId, event.data.muted);
+        }
+        break;
       case 'HELIOS_SET_LOOP':
         if (typeof event.data.loop === 'boolean') {
             helios.setLoop(event.data.loop);

--- a/packages/player/src/controllers.test.ts
+++ b/packages/player/src/controllers.test.ts
@@ -42,6 +42,8 @@ describe('DirectController', () => {
             seek: vi.fn(),
             setAudioVolume: vi.fn(),
             setAudioMuted: vi.fn(),
+            setAudioTrackVolume: vi.fn(),
+            setAudioTrackMuted: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRate: vi.fn(),
             setPlaybackRange: vi.fn(),
@@ -111,6 +113,14 @@ describe('DirectController', () => {
 
         controller.setAudioMuted(true);
         expect(mockHeliosInstance.setAudioMuted).toHaveBeenCalledWith(true);
+    });
+
+    it('should set audio track volume and muted', () => {
+        controller.setAudioTrackVolume('track-1', 0.8);
+        expect(mockHeliosInstance.setAudioTrackVolume).toHaveBeenCalledWith('track-1', 0.8);
+
+        controller.setAudioTrackMuted('track-1', true);
+        expect(mockHeliosInstance.setAudioTrackMuted).toHaveBeenCalledWith('track-1', true);
     });
 
     it('should set loop', () => {
@@ -245,6 +255,14 @@ describe('BridgeController', () => {
 
         controller.setAudioMuted(true);
         expect(mockWindow.postMessage).toHaveBeenCalledWith({ type: 'HELIOS_SET_MUTED', muted: true }, '*');
+    });
+
+    it('should post messages for audio track controls', () => {
+        controller.setAudioTrackVolume('track-1', 0.8);
+        expect(mockWindow.postMessage).toHaveBeenCalledWith({ type: 'HELIOS_SET_AUDIO_TRACK_VOLUME', trackId: 'track-1', volume: 0.8 }, '*');
+
+        controller.setAudioTrackMuted('track-1', true);
+        expect(mockWindow.postMessage).toHaveBeenCalledWith({ type: 'HELIOS_SET_AUDIO_TRACK_MUTED', trackId: 'track-1', muted: true }, '*');
     });
 
     it('should post messages for loop', () => {

--- a/packages/player/src/controllers.ts
+++ b/packages/player/src/controllers.ts
@@ -8,6 +8,8 @@ export interface HeliosController {
   seek(frame: number): void;
   setAudioVolume(volume: number): void;
   setAudioMuted(muted: boolean): void;
+  setAudioTrackVolume(trackId: string, volume: number): void;
+  setAudioTrackMuted(trackId: string, muted: boolean): void;
   setLoop(loop: boolean): void;
   setPlaybackRate(rate: number): void;
   setPlaybackRange(startFrame: number, endFrame: number): void;
@@ -30,6 +32,8 @@ export class DirectController implements HeliosController {
   seek(frame: number) { this.instance.seek(frame); }
   setAudioVolume(volume: number) { this.instance.setAudioVolume(volume); }
   setAudioMuted(muted: boolean) { this.instance.setAudioMuted(muted); }
+  setAudioTrackVolume(trackId: string, volume: number) { this.instance.setAudioTrackVolume(trackId, volume); }
+  setAudioTrackMuted(trackId: string, muted: boolean) { this.instance.setAudioTrackMuted(trackId, muted); }
   setLoop(loop: boolean) { this.instance.setLoop(loop); }
   setPlaybackRate(rate: number) { this.instance.setPlaybackRate(rate); }
   setPlaybackRange(start: number, end: number) { this.instance.setPlaybackRange(start, end); }
@@ -152,6 +156,8 @@ export class BridgeController implements HeliosController {
   seek(frame: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SEEK', frame }, '*'); }
   setAudioVolume(volume: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_VOLUME', volume }, '*'); }
   setAudioMuted(muted: boolean) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_MUTED', muted }, '*'); }
+  setAudioTrackVolume(trackId: string, volume: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_AUDIO_TRACK_VOLUME', trackId, volume }, '*'); }
+  setAudioTrackMuted(trackId: string, muted: boolean) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_AUDIO_TRACK_MUTED', trackId, muted }, '*'); }
   setLoop(loop: boolean) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_LOOP', loop }, '*'); }
   setPlaybackRate(rate: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_PLAYBACK_RATE', rate }, '*'); }
   setPlaybackRange(start: number, end: number) { this.iframeWindow.postMessage({ type: 'HELIOS_SET_PLAYBACK_RANGE', start, end }, '*'); }


### PR DESCRIPTION
💡 **What**: Added `setAudioTrackVolume` and `setAudioTrackMuted` methods to `HeliosController`, `DirectController`, and `BridgeController`, and updated the bridge protocol to support these commands.
🎯 **Why**: To enable granular audio mixing in Studio and other consumers by allowing control over individual audio tracks via the player bridge.
📊 **Impact**: Consumers can now adjust volume and mute state for specific audio tracks identified by their ID.
🔬 **Verification**: Run `npm test -w packages/player` to verify unit tests for controllers and bridge.

---
*PR created automatically by Jules for task [9443600756140947881](https://jules.google.com/task/9443600756140947881) started by @BintzGavin*