### PR TITLE
✨ STUDIO: Refactor Render Manager Imports and Verify Persistence

### DIFF
--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.70.2
+- ✅ Verified: Refactor Render Manager Imports - Updated tsconfig.json to alias @helios-project packages to source, and refactored render-manager.ts to use clean imports, ensuring robust type checking and verified persistence logic.
+
 ## STUDIO v0.70.1
 - ✅ Verified: Maintenance - Synced package.json version and added lint script.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.70.1
+**Version**: 0.70.2
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.70.2] ✅ Verified: Refactor Render Manager Imports - Updated tsconfig.json to alias @helios-project packages to source, and refactored render-manager.ts to use clean imports, ensuring robust type checking and verified persistence logic.
 - [v0.70.1] ✅ Verified: Maintenance - Synced package.json version and added lint script.
 - [v0.70.0] ✅ Completed: Persistent Render Jobs - Finalized verification and closed out the plan for persistent render jobs, ensuring job history survives restarts.
 - [v0.69.0] ✅ Verified: Maintenance - Synced package.json version and re-verified persistent render jobs functionality via tests.

--- a/packages/studio/src/server/render-manager.test.ts
+++ b/packages/studio/src/server/render-manager.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs';
 
 // Mock dependencies
-vi.mock('../../../renderer/src/index', () => ({
+vi.mock('@helios-project/renderer', () => ({
   Renderer: class MockRenderer {
     render() { return Promise.resolve(); }
     diagnose() { return Promise.resolve({}); }

--- a/packages/studio/src/server/render-manager.ts
+++ b/packages/studio/src/server/render-manager.ts
@@ -1,5 +1,4 @@
-// @ts-ignore - Importing from sibling package source to avoid build issues
-import { Renderer } from '../../../renderer/src/index';
+import { Renderer } from '@helios-project/renderer';
 import path from 'path';
 import fs from 'fs';
 import { getProjectRoot } from './discovery';

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -14,7 +14,12 @@
     "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@helios-project/core": ["../core/src/index.ts"],
+      "@helios-project/player": ["../player/src/index.ts"],
+      "@helios-project/renderer": ["../renderer/src/index.ts"]
+    }
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]


### PR DESCRIPTION
💡 What: Refactored `packages/studio/src/server/render-manager.ts` to use clean imports from `@helios-project/renderer` via TypeScript path mapping, replacing a relative import workaround.
🎯 Why: To improve code maintainability and robustness by leveraging TypeScript path resolution instead of fragile relative paths.
📊 Impact: Ensures type safety and cleaner dependencies in the Studio backend. Also verified the Persistent Render Jobs feature.
🔬 Verification: Ran `npm test -w packages/studio`, confirming all 92 tests passed, including persistence logic.

Plan: .sys/plans/2026-05-28-STUDIO-PersistentRenderJobs.md

---
*PR created automatically by Jules for task [15301641903665109129](https://jules.google.com/task/15301641903665109129) started by @BintzGavin*