### PR TITLE
📋 RENDERER: Canvas Selector Plan

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -201,3 +201,7 @@
 ## [2026-06-08] - Incomplete Declarative Audio Fades
 **Learning:** `DomScanner` misses `data-helios-fade-in` and `data-helios-fade-out` attributes, limiting the "Use What You Know" vision for audio elements. Users can specify fades in JSON config but not in HTML.
 **Action:** Created plan to parse these attributes in `scanForAudioTracks` and map them to the existing `AudioTrackConfig` fields.
+
+## 2026-06-09 - Orphaned Plans
+**Learning:** Found an existing plan (`2026-02-18-RENDERER-Canvas-Selector.md`) that was never implemented (test file missing). This indicates a potential disconnect between Planning and Execution phases.
+**Action:** When identifying gaps, check `.sys/plans` for existing but unexecuted plans before creating new ones. If found, "revive" them by updating the date/content or referencing them.

--- a/.sys/plans/2026-06-09-RENDERER-Canvas-Selector.md
+++ b/.sys/plans/2026-06-09-RENDERER-Canvas-Selector.md
@@ -1,0 +1,48 @@
+# Context & Goal
+- **Objective**: Implement `canvasSelector` option in `Renderer` to allow targeting a specific `<canvas>` element during rendering.
+- **Trigger**: Vision Gap - `CanvasStrategy` currently naively selects the first `<canvas>` element, causing failure in multi-canvas environments (e.g., stacked layers).
+- **Impact**: Enables rendering of complex multi-canvas compositions (e.g., separate background/foreground layers) by allowing the user to specify the target canvas.
+
+# File Inventory
+- **Create**:
+  - `packages/renderer/tests/verify-canvas-selector.ts`: Verification script using a multi-canvas Data URL composition.
+- **Modify**:
+  - `packages/renderer/src/types.ts`: Add `canvasSelector` to `RendererOptions`.
+  - `packages/renderer/src/strategies/CanvasStrategy.ts`: Update capture methods to use the selector.
+  - `packages/renderer/tests/run-all.ts`: Add `tests/verify-canvas-selector.ts` to the test suite.
+- **Read-Only**:
+  - `packages/renderer/src/Renderer.ts`: To verify option passing.
+
+# Implementation Spec
+- **Architecture**:
+  - Update `CanvasStrategy` to accept `canvasSelector` (defaulting to `'canvas'`).
+  - Pass this selector into `page.evaluate` contexts during `captureWebCodecs`, `captureCanvas`, and `prepare`.
+  - Use `document.querySelector(selector)` instead of hardcoded `document.querySelector('canvas')`.
+  - Ensure clear error messaging if the selected canvas is not found.
+- **Pseudo-Code**:
+  - IN `CanvasStrategy.prepare`:
+    - GET selector from `options.canvasSelector` OR default to `'canvas'`.
+    - IN `page.evaluate`:
+      - FIND element using selector.
+      - IF not found OR not canvas: THROW error "Canvas not found matching selector: [selector]".
+  - IN `CanvasStrategy.captureWebCodecs`:
+    - PASS selector to evaluate.
+    - FIND canvas using selector.
+    - CAPTURE frame.
+  - IN `CanvasStrategy.captureCanvas`:
+    - PASS selector to evaluate.
+    - FIND canvas using selector.
+    - CALL `toDataURL`.
+- **Public API Changes**:
+  - `RendererOptions` interface gains `canvasSelector?: string`.
+- **Dependencies**: None.
+
+# Test Plan
+- **Verification**: `npx tsx packages/renderer/tests/verify-canvas-selector.ts`
+- **Success Criteria**:
+  - Render 1: Target `#canvas-a` (Red) -> Output file created, size > 0.
+  - Render 2: Target `#canvas-b` (Blue) -> Output file created, size > 0.
+  - Render 3: Target `#canvas-z` (Missing) -> Fails with specific "Canvas not found" error.
+- **Edge Cases**:
+  - Selector matches multiple elements -> `querySelector` picks first (standard DOM behavior).
+  - Selector matches non-canvas element -> `CanvasStrategy` should check `instanceof HTMLCanvasElement` or throw.


### PR DESCRIPTION
Created `/.sys/plans/2026-06-09-RENDERER-Canvas-Selector.md` to guide the implementation of a configurable canvas selector for the Renderer. This addresses the gap where only the first canvas element could be targeted.

Includes:
- Spec for `RendererOptions` update.
- Spec for `CanvasStrategy` update.
- Test plan for `verify-canvas-selector.ts`.

---
*PR created automatically by Jules for task [6904996179945650826](https://jules.google.com/task/6904996179945650826) started by @BintzGavin*