### PR TITLE
Sync Renderer Core Dependency to 3.6.0

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -62,6 +62,8 @@ The `RendererOptions` interface controls the render pipeline:
 - `audioCodec`: `'aac'` (default), `'libvorbis'`, etc.
 - `audioFilePath`: Path to external audio file to mix in.
 - `audioTracks`: List of audio tracks (files or `AudioTrackConfig` objects with `path`, `loop`, `volume`, `offset`).
+- `intermediateImageFormat`: `'png'` (default) or `'jpeg'` for DOM mode capture.
+- `intermediateImageQuality`: JPEG quality (0-100) if format is jpeg.
 - `stabilityTimeout`: Timeout for frame stability (default 30000ms).
 - `inputProps`: Object injected into the page as `window.__HELIOS_PROPS__`.
 

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.53.2
+- ✅ Completed: Sync Core Dependency - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.6.0` (matching the workspace), fixing dependency resolution issues and ensuring compatibility with the latest core features.
+
 ## RENDERER v1.53.1
 - ✅ Completed: Fix Workspace Version Mismatch - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.4.0` (matching the workspace), enabling strict version synchronization and preventing lockfile drift.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.53.1
+**Version**: 1.53.2
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.53.2] ✅ Completed: Sync Core Dependency - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.6.0` (matching the workspace), fixing dependency resolution issues and ensuring compatibility with the latest core features.
 - [1.53.1] ✅ Completed: Fix Workspace Version Mismatch - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.4.0` (matching the workspace), enabling strict version synchronization and preventing lockfile drift.
 - [1.53.0] ✅ Completed: Enhance Diagnostics - Updated `CanvasStrategy.diagnose()` to perform comprehensive checks of supported WebCodecs (H.264, VP8, VP9, AV1) in the browser environment, returning a detailed `codecs` report for better debuggability.
 - [1.52.1] ✅ Completed: Fix GSAP Timeline Synchronization - Updated `SeekTimeDriver` to wait for `window.__helios_gsap_timeline__` initialization (handling ES module async loading) and explicitly seek the GSAP timeline in `setTime`, resolving the black screen issue in the promo video example.

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "3.4.0",
+    "@helios-project/core": "3.6.0",
     "playwright": "^1.42.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.6.0` (matching the workspace), fixing dependency resolution issues.
Verified with `npm test -w packages/renderer` (specifically verifying transparency and critical sync tests).
Updated `docs/status/RENDERER.md`, `docs/PROGRESS-RENDERER.md`, and `/.sys/llmdocs/context-renderer.md`.
Excluded `package-lock.json` to avoid boundary violations.

---
*PR created automatically by Jules for task [14742703310495105679](https://jules.google.com/task/14742703310495105679) started by @BintzGavin*