### PR TITLE
📋 CORE: Expose VERSION and Harden Init

### DIFF
--- a/.sys/plans/2026-06-11-CORE-expose-version.md
+++ b/.sys/plans/2026-06-11-CORE-expose-version.md
@@ -1,0 +1,31 @@
+# Context & Goal
+- **Objective**: Expose the package version as a runtime constant and verify robust initialization of `bindToDocumentTimeline` with pre-existing virtual time.
+- **Trigger**: Backlog item "Fix GSAP Timeline Synchronization" implies potential race conditions during initialization where `window.__HELIOS_VIRTUAL_TIME__` might be set before `Helios` is instantiated. Additionally, `package.json` version (3.6.0) has drifted from documentation (3.8.0).
+- **Impact**: Enables runtime version compatibility checks (hardening protocol boundaries) and ensures `Helios` correctly syncs with the environment even if the driver script executes before the application logic.
+
+# File Inventory
+- **Modify**: `packages/core/src/index.ts` (Export `VERSION`)
+- **Modify**: `packages/core/src/index.test.ts` (Add test case for pre-existing virtual time)
+- **Modify**: `packages/core/package.json` (Bump version to 3.8.1)
+
+# Implementation Spec
+- **Architecture**:
+  - Add a named export `VERSION` to `packages/core/src/index.ts` matching the `package.json` version.
+  - In `index.test.ts`, verify that `bindToDocumentTimeline` correctly picks up `window.__HELIOS_VIRTUAL_TIME__` if it was assigned *before* the method was called.
+- **Pseudo-Code**:
+  - `packages/core/src/index.ts`: `export const VERSION = '3.8.1';`
+  - `packages/core/package.json`: Update `"version": "3.8.1"`.
+  - `packages/core/src/index.test.ts`: Add `it('should sync with pre-existing __HELIOS_VIRTUAL_TIME__ on bind')` that sets `window.__HELIOS_VIRTUAL_TIME__` before `bindToDocumentTimeline()` and asserts `currentFrame` matches immediately.
+- **Public API Changes**:
+  - New export: `VERSION` (string).
+- **Dependencies**: None.
+
+# Test Plan
+- **Verification**: `npm test -w packages/core`
+- **Success Criteria**:
+  - `packages/core` tests pass (specifically the new test case).
+  - `import { VERSION } from '@helios-project/core'` returns `'3.8.1'`.
+  - `package.json` version is `'3.8.1'`.
+- **Edge Cases**:
+  - Pre-existing virtual time is `0` (should work).
+  - Pre-existing virtual time is `NaN` (should be ignored by setter logic, verified by existing logic but good to keep in mind).


### PR DESCRIPTION
Created a specification file for:
1. Exposing `VERSION` constant in `packages/core`.
2. Adding verification test for `bindToDocumentTimeline` with pre-existing `__HELIOS_VIRTUAL_TIME__`.
3. Bumping `package.json` version to 3.8.1.

This bridges a small gap in version introspection and ensures initialization robustness as identified in the Backlog.

---
*PR created automatically by Jules for task [13736552613367013734](https://jules.google.com/task/13736552613367013734) started by @BintzGavin*