### PR TITLE
docs: block DEMO verification due to CORE build failure

### DIFF
--- a/docs/status/DEMO.md
+++ b/docs/status/DEMO.md
@@ -9,7 +9,7 @@ The DEMO domain is responsible for:
 3.  **Build Config:** Maintaining the root `vite.config.js` and build scripts to support the examples.
 
 ## Blocked Items
-- None
+- Verification blocked by build failure in `packages/core`. `npm run build` fails with `error TS2741` in `src/index.test.ts` (missing `availableAudioTracks` in test state).
 
 ## Active Tasks
 - None


### PR DESCRIPTION
Updates `docs/status/DEMO.md` to log a 'Blocked' item regarding the build failure in `packages/core`. The build fails due to a missing property `availableAudioTracks` in a test case in `src/index.test.ts`. This blocks the DEMO agent from verifying examples.

---
*PR created automatically by Jules for task [14496721394830923296](https://jules.google.com/task/14496721394830923296) started by @BintzGavin*