### PR TITLE
Sync Player Version for Expose Audio Track IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8396,7 +8396,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^3.3.0",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",


### PR DESCRIPTION
Synced `packages/player/package.json` version to `0.51.0` to match `docs/status/PLAYER.md` and the existing implementation of `Expose Audio Track IDs`.

Verified that:
- `getAudioAssets` in `src/features/audio-utils.ts` correctly extracts IDs from `data-helios-track-id`.
- `AudioAsset` interface includes `id`.
- Unit tests in `src/features/audio-utils.test.ts` cover the ID extraction logic.
- The package builds and passes tests.

Note: The feature code was already present in the codebase; this commit ensures the package version reflects the feature addition.

---
*PR created automatically by Jules for task [7813448382494556849](https://jules.google.com/task/7813448382494556849) started by @BintzGavin*