### PR TITLE
✨ CORE: Expose Version and Verify Init Sync

### DIFF
--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v3.9.1
+- ✅ Completed: Expose Version and Verify Init Sync - Exported `VERSION` constant and verified robust `bindToDocumentTimeline` initialization with pre-existing virtual time.
+
 ## CORE v3.9.0
 - ✅ Completed: Fix Signal Glitches and Runtime Safety - Optimized `EffectImpl` to avoid redundant executions (diamond problem) and guarded `Helios.bindToDocumentTimeline` for Node.js compatibility.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 3.9.0
+**Version**: 3.9.1
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
-- **Last Updated**: 2026-06-10
+- **Last Updated**: 2026-06-11
 
+[v3.9.1] ✅ Completed: Expose Version and Verify Init Sync - Exported `VERSION` constant and verified robust `bindToDocumentTimeline` initialization with pre-existing virtual time.
 [v3.9.0] ✅ Completed: Fix Signal Glitches and Runtime Safety - Optimized `EffectImpl` to avoid redundant executions (diamond problem) and guarded `Helios.bindToDocumentTimeline` for Node.js compatibility.
 [v3.8.0] ✅ Completed: Implement Audio Track Discovery - Implemented `availableAudioTracks` signal in `Helios` and updated `DomDriver` to discover elements with `data-helios-track-id`.
 [v3.7.0] ✅ Completed: Implement DomDriver Audio Looping - Updated `DomDriver` to respect the `loop` attribute on media elements, wrapping time calculations to support infinite loops.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/core",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "type": "module",
   "description": "Core library for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -413,6 +413,20 @@ describe('Helios Core', () => {
 
         delete (window as any).__HELIOS_VIRTUAL_TIME__;
     });
+
+    it('should sync with pre-existing __HELIOS_VIRTUAL_TIME__ on bind', async () => {
+        // Set virtual time BEFORE creating Helios or binding
+        (window as any).__HELIOS_VIRTUAL_TIME__ = 5000;
+
+        const helios = new Helios({ duration: 10, fps: 30 });
+        helios.bindToDocumentTimeline();
+
+        // Should sync immediately without waiting for poll
+        expect(helios.getState().currentFrame).toBe(150); // 5000ms * 30fps / 1000 = 150
+
+        delete (window as any).__HELIOS_VIRTUAL_TIME__;
+        helios.unbindFromDocumentTimeline();
+    });
   });
 
   describe('WAAPI Synchronization', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,3 +14,5 @@ export * from './transitions.js';
 export * from './ai.js';
 export * from './Helios.js';
 export * from './render-session.js';
+
+export const VERSION = '3.9.1';


### PR DESCRIPTION
Exposed `VERSION` constant in `packages/core` and added a unit test to verify `bindToDocumentTimeline` correctly synchronizes with pre-existing `window.__HELIOS_VIRTUAL_TIME__`. This ensures robust initialization when the timing driver loads before the Helios instance.

---
*PR created automatically by Jules for task [14282526115047040327](https://jules.google.com/task/14282526115047040327) started by @BintzGavin*