### PR TITLE
✨ RENDERER: Canvas Selector Support

### DIFF
--- a/packages/renderer/src/strategies/CanvasStrategy.ts
+++ b/packages/renderer/src/strategies/CanvasStrategy.ts
@@ -70,6 +70,17 @@ export class CanvasStrategy implements RenderStrategy {
     // Ensure fonts are loaded before capture starts
     await page.evaluate(function() { return document.fonts.ready; });
 
+    // Validate that the canvas element exists
+    const selector = this.options.canvasSelector || 'canvas';
+    const canvasExists = await page.evaluate((sel) => {
+      const el = document.querySelector(sel);
+      return el instanceof HTMLCanvasElement;
+    }, selector);
+
+    if (!canvasExists) {
+      throw new Error(`Canvas not found matching selector: ${selector}`);
+    }
+
     // Scan for audio tracks using the shared utility
     const initialTracks = await scanForAudioTracks(page);
 


### PR DESCRIPTION
This change implements the `canvasSelector` option in `CanvasStrategy` (defaulting to `'canvas'`). It adds a validation step in the `prepare` method to check if the target element exists and is an `HTMLCanvasElement`, throwing a descriptive error if not. This robustness improvement prevents downstream errors during frame capture. Validated with a new multi-canvas test fixture.


---
*PR created automatically by Jules for task [10337057548987833954](https://jules.google.com/task/10337057548987833954) started by @BintzGavin*