### PR TITLE
✨ CORE: Verify Subscription Timing

### DIFF
--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -43,6 +43,7 @@ packages/core/src/
 ├── schema.ts
 ├── sequencing.ts
 ├── signals.ts
+├── subscription-timing.test.ts
 ├── time-control.ts
 ├── timecode.ts
 └── transitions.ts

--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v3.9.2
+- ✅ Completed: Verify Subscription Timing - Added `packages/core/src/subscription-timing.test.ts` to verify that `helios.subscribe` fires synchronously after `seek()` and virtual time updates, confirming CORE behavior is correct for RENDERER synchronization.
+
 ## CORE v3.9.1
 - ✅ Completed: Expose Version and Verify Init Sync - Exported `VERSION` constant and verified robust `bindToDocumentTimeline` initialization with pre-existing virtual time.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 3.9.1
+**Version**: 3.9.2
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
 - **Last Updated**: 2026-06-11
 
+[v3.9.2] ✅ Completed: Verify Subscription Timing - Added `packages/core/src/subscription-timing.test.ts` to verify that `helios.subscribe` fires synchronously after `seek()` and virtual time updates, confirming CORE behavior is correct for RENDERER synchronization.
 [v3.9.1] ✅ Completed: Expose Version and Verify Init Sync - Exported `VERSION` constant and verified robust `bindToDocumentTimeline` initialization with pre-existing virtual time.
 [v3.9.0] ✅ Completed: Fix Signal Glitches and Runtime Safety - Optimized `EffectImpl` to avoid redundant executions (diamond problem) and guarded `Helios.bindToDocumentTimeline` for Node.js compatibility.
 [v3.8.0] ✅ Completed: Implement Audio Track Discovery - Implemented `availableAudioTracks` signal in `Helios` and updated `DomDriver` to discover elements with `data-helios-track-id`.

--- a/packages/core/src/subscription-timing.test.ts
+++ b/packages/core/src/subscription-timing.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+import { Helios } from './Helios';
+
+describe('Helios Subscription Timing', () => {
+  let originalWindow: any;
+  let originalDocument: any;
+
+  beforeAll(() => {
+    // Save original globals
+    originalWindow = (global as any).window;
+    originalDocument = (global as any).document;
+
+    // Mock window if not available (Node environment)
+    if (typeof window === 'undefined') {
+      (global as any).window = {};
+    }
+
+    // Mock document if not available
+    if (typeof document === 'undefined') {
+        (global as any).document = {};
+    }
+
+    // Mock document.timeline
+    if (typeof document !== 'undefined' && !document.timeline) {
+        Object.defineProperty(document, 'timeline', {
+            value: { currentTime: 0 },
+            writable: true,
+            configurable: true
+        });
+    }
+  });
+
+  afterAll(() => {
+    // Restore globals
+    if (originalWindow === undefined) {
+        delete (global as any).window;
+    } else {
+        (global as any).window = originalWindow;
+    }
+
+    if (originalDocument === undefined) {
+        delete (global as any).document;
+    } else {
+        (global as any).document = originalDocument;
+    }
+  });
+
+  afterEach(() => {
+    // Cleanup window properties
+    if (typeof window !== 'undefined') {
+      delete (window as any).__HELIOS_VIRTUAL_TIME__;
+    }
+  });
+
+  it('should fire subscribe callback synchronously after seek()', () => {
+    const helios = new Helios({
+      fps: 30,
+      duration: 10
+    });
+
+    let lastFrame = -1;
+    const spy = vi.fn((state) => {
+      lastFrame = state.currentFrame;
+    });
+
+    helios.subscribe(spy);
+
+    expect(spy).toHaveBeenCalledTimes(1); // Initial call
+    expect(lastFrame).toBe(0);
+
+    helios.seek(30); // 1 second
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(lastFrame).toBe(30);
+  });
+
+  it('should fire subscribe callback synchronously after virtual time update', () => {
+    const helios = new Helios({
+      fps: 30,
+      duration: 10
+    });
+
+    helios.bindToDocumentTimeline();
+
+    let lastFrame = -1;
+    const spy = vi.fn((state) => {
+      lastFrame = state.currentFrame;
+    });
+
+    helios.subscribe(spy);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(lastFrame).toBe(0);
+
+    // Simulate virtual time update
+    const timeInMs = 1000;
+    (window as any).__HELIOS_VIRTUAL_TIME__ = timeInMs;
+
+    // The setter in bindToDocumentTimeline should trigger update immediately
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(lastFrame).toBe(30); // 1000ms * 30fps / 1000 = 30 frames
+  });
+});


### PR DESCRIPTION
💡 What: Added `packages/core/src/subscription-timing.test.ts` to verify that `helios.subscribe` fires synchronously after `seek()` and virtual time updates.
🎯 Why: To investigate a potential race condition reported in RENDERER (GSAP synchronization issue).
📊 Impact: Confirms that CORE timing behavior is correct (synchronous), suggesting the issue lies in downstream usage or environment (e.g., GSAP timeline availability).
🔬 Verification: Run `npm test -w packages/core`

---
*PR created automatically by Jules for task [11490118862203987983](https://jules.google.com/task/11490118862203987983) started by @BintzGavin*