### PR TITLE
feat(core): Add generic type support for inputProps in Helios class

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -544,6 +544,29 @@ describe('Helios Core', () => {
       const helios = new Helios({ duration: 10, fps: 30 });
       expect(helios.getState().inputProps).toEqual({});
     });
+
+    it('should support generic typed inputProps', () => {
+      interface MyProps {
+        title: string;
+        count: number;
+      }
+      const initial: MyProps = { title: 'Test', count: 1 };
+
+      // Instantiate with generic type
+      const helios = new Helios<MyProps>({
+        duration: 10,
+        fps: 30,
+        inputProps: initial
+      });
+
+      // Type inference should work (runtime verification)
+      expect(helios.getState().inputProps.title).toBe('Test');
+      expect(helios.inputProps.peek().count).toBe(1);
+
+      // Update with typed props
+      helios.setInputProps({ title: 'Updated', count: 2 });
+      expect(helios.getState().inputProps).toEqual({ title: 'Updated', count: 2 });
+    });
   });
 
   describe('Playback Rate', () => {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -141,13 +141,13 @@ export function validateSchema(schema: HeliosSchema | undefined, parentKey = '')
   }
 }
 
-export function validateProps(props: Record<string, any>, schema?: HeliosSchema): Record<string, any> {
+export function validateProps<T = Record<string, any>>(props: T, schema?: HeliosSchema): T {
   if (!schema) return props;
 
   const validProps: Record<string, any> = {};
 
   for (const [key, def] of Object.entries(schema)) {
-    const val = props[key];
+    const val = (props as any)[key];
 
     // Check requirement
     if (val === undefined) {
@@ -166,13 +166,13 @@ export function validateProps(props: Record<string, any>, schema?: HeliosSchema)
   }
 
   // Preserve extra props that are not in schema
-  for (const key of Object.keys(props)) {
+  for (const key of Object.keys(props as any)) {
     if (!(key in schema)) {
-      validProps[key] = props[key];
+      validProps[key] = (props as any)[key];
     }
   }
 
-  return validProps;
+  return validProps as T;
 }
 
 function validateValue(val: any, def: PropDefinition, keyPath: string): any {


### PR DESCRIPTION
Enabled strict type checking for input props by making the Helios class generic. Updated HeliosState, HeliosOptions, and validateProps to propagate the generic type TInputProps. Added a test case to verify runtime behavior with typed props.

---
*PR created automatically by Jules for task [5025898845803587590](https://jules.google.com/task/5025898845803587590) started by @BintzGavin*