### PR TITLE
📋 RENDERER: Fix CDP Hang on Resource Loading

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.54.0
+**Version**: 1.55.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.55.0] ✅ Completed: Enhance Dom Preloading - Updated `DomStrategy` to detect and preload `<video>` posters, SVG `<image>` elements, and CSS masks (`mask-image`), ensuring zero-artifact rendering for these asset types.
 - [1.54.0] ✅ Completed: Implement Canvas Selector - Added `canvasSelector` to `RendererOptions` and updated `CanvasStrategy` to target specific canvas elements (e.g., `#my-canvas`), enabling support for multi-canvas compositions and layered architectures.
 - [1.53.2] ✅ Completed: Sync Core Dependency - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.6.0` (matching the workspace), fixing dependency resolution issues and ensuring compatibility with the latest core features.
 - [1.53.1] ✅ Completed: Fix Workspace Version Mismatch - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.4.0` (matching the workspace), enabling strict version synchronization and preventing lockfile drift.
@@ -218,3 +219,7 @@
 ## [2026-06-12] - Incomplete DomStrategy Preloading
 **Learning:** In addition to the previously identified background image gap, `DomStrategy` also misses `<video poster>`, SVG `<image>`, and CSS `mask-image` properties, potentially causing FOUC in complex compositions.
 **Action:** Created plan `2026-06-12-RENDERER-Enhance-Dom-Preloading.md` to implement comprehensive asset discovery for these types.
+
+## [2026-06-15] - CDP Deadlock on Resource Loading
+**Learning:** `CdpTimeDriver` pauses the virtual clock in `prepare()`, which freezes the browser's event loop (timers, media events). If `strategy.prepare()` (which scans for resources using `setTimeout` fallbacks or `canplaythrough` events) runs *after* `timeDriver.prepare()`, it causes a deadlock where resource discovery hangs indefinitely.
+**Action:** Always initialize strategies (resource discovery) *before* activating `TimeDriver` clock control (especially CDP pause policies). This ensures resources are loaded using the robust wall-clock environment before deterministic rendering begins.

--- a/.sys/plans/2026-06-15-RENDERER-Fix-CDP-Hang.md
+++ b/.sys/plans/2026-06-15-RENDERER-Fix-CDP-Hang.md
@@ -1,0 +1,36 @@
+# Context & Goal
+- **Objective**: Prevent `CanvasStrategy` from hanging indefinitely during initialization when audio resources are present.
+- **Trigger**: Architectural flaw identified where `CdpTimeDriver` pauses the virtual clock before `DomScanner` (in `CanvasStrategy`) can discover and load resources, causing `setTimeout` and media events to deadlock.
+- **Impact**: Enables robust rendering of compositions with audio/video assets in "Canvas Mode" (Production), ensuring the "Production Rendering" vision (CDP-based) is viable.
+
+# File Inventory
+- **Create**: `packages/renderer/tests/verify-cdp-hang.ts` (Reproduction script)
+- **Modify**: `packages/renderer/src/index.ts` (Reorder initialization)
+- **Modify**: `packages/renderer/tests/verify-canvas-implicit-audio.ts` (Fix broken mock to support new Canvas existence check)
+- **Read-Only**: `packages/renderer/src/strategies/CanvasStrategy.ts`, `packages/renderer/src/drivers/CdpTimeDriver.ts`
+
+# Implementation Spec
+- **Architecture**:
+  - Change the `Renderer` initialization lifecycle to perform resource discovery (`strategy.prepare`) *before* seizing control of the browser clock (`timeDriver.prepare`).
+  - This ensures that resource loading (which relies on the browser's event loop and wall-clock timers) completes using the standard environment before `CdpTimeDriver` applies the `pause` policy for deterministic frame rendering.
+- **Pseudo-Code**:
+  - In `packages/renderer/src/index.ts` -> `render()` method:
+    - LOCATE `await this.timeDriver.prepare(page);`
+    - LOCATE `await this.strategy.prepare(page);`
+    - SWAP the order so `strategy.prepare` runs first.
+  - In `packages/renderer/tests/verify-canvas-implicit-audio.ts`:
+    - LOCATE `evaluate` mock function.
+    - ADD check for `fnOrString.toString().includes('HTMLCanvasElement')` -> return `true`.
+- **Public API Changes**: None.
+- **Dependencies**: None.
+
+# Test Plan
+- **Verification**:
+  1. Create reproduction script `packages/renderer/tests/verify-cdp-hang.ts` that serves HTML with `<audio preload="none">` and asserts successful render.
+  2. Run `npx tsx packages/renderer/tests/verify-cdp-hang.ts`.
+  3. Run `npx tsx packages/renderer/tests/verify-canvas-implicit-audio.ts` to ensure no regression in happy path.
+- **Success Criteria**:
+  - `verify-cdp-hang.ts` completes without timeout.
+  - `verify-canvas-implicit-audio.ts` passes.
+- **Edge Cases**:
+  - Audio files that fail to load (handled by existing 10s timeout in `DomScanner` - now effective because clock is running).


### PR DESCRIPTION
Plan to fix deadlock in CanvasStrategy where resource discovery hangs due to CDP pausing the virtual clock prematurely.

---
*PR created automatically by Jules for task [14148539586692998538](https://jules.google.com/task/14148539586692998538) started by @BintzGavin*