### PR TITLE
✨ PLAYER: Smart Controls

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -58,6 +58,7 @@ The component observes the following attributes:
 - `controlslist`: Space-separated tokens to customize UI (`nodownload`, `nofullscreen`).
 - `crossorigin`: CORS setting for the element (`anonymous`, `use-credentials`).
 - `sandbox`: Space-separated tokens for iframe security flags (default: `allow-scripts allow-same-origin`).
+- `disablepictureinpicture`: Boolean attribute to hide the Picture-in-Picture button.
 
 ## D. Child Elements
 - `<track>`: Standard HTMLTrackElement for importing captions (kind="captions"). Requires `src` (SRT or WebVTT file). Automatically populates the `textTracks` list.
@@ -101,6 +102,7 @@ Properties and methods available on the `HeliosPlayer` element instance:
 - `defaultPlaybackRate`: Get/Set default playback speed.
 - `canPlayType(type)`: Returns string indicating support (always empty for video MIME types).
 - `requestPictureInPicture()`: Request Picture-in-Picture mode (returns Promise<PictureInPictureWindow>).
+- `disablePictureInPicture`: Get/Set disable state for Picture-in-Picture button.
 
 **HeliosController Interface:**
 The controller returned by `getController()` provides advanced methods:

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.53.0
+- ✅ Completed: Smart Controls - Implemented 'disablepictureinpicture' attribute and auto-hiding CC button/auto-enabling default tracks.
+
 ## PLAYER v0.52.0
 - ✅ Completed: WebVTT Support - Implemented `caption-parser` to support standard WebVTT captions alongside SRT, enabling broader compatibility with caption file formats.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.52.0
+**Version**: v0.53.0
 
 # Status: PLAYER
 
@@ -42,10 +42,13 @@
 - Visualizes markers on the timeline, allowing users to identify and seek to specific points of interest.
 - Migrated client-side export to use `mediabunny`, replacing deprecated `mp4-muxer` and `webm-muxer`.
 - Implemented persistence for `volume`, `playbackRate`, and `muted` properties, ensuring values set before connection are applied upon initialization.
+- Implements Smart Controls: 'CC' button is hidden when no tracks are present, and 'Picture-in-Picture' button can be hidden via `disablepictureinpicture`.
+- Supports auto-enabling of captions if a track is marked as `default`.
 
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.53.0] ✅ Completed: Smart Controls - Implemented 'disablepictureinpicture' attribute and auto-hiding CC button/auto-enabling default tracks.
 [v0.52.0] ✅ Completed: WebVTT Support - Implemented `caption-parser` to support standard WebVTT captions alongside SRT, enabling broader compatibility with caption file formats.
 [v0.51.0] ✅ Completed: Expose Audio Track IDs - Updated `getAudioAssets` to populate `id` from `data-helios-track-id`, standard `id`, or fallback index, enabling robust track identification.
 [v0.50.0] ✅ Completed: Audio Track Control - Added `setAudioTrackVolume` and `setAudioTrackMuted` to `HeliosController` and the Bridge protocol, enabling granular audio control.

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -122,6 +122,8 @@ export declare class HeliosPlayer extends HTMLElement implements TrackHost {
     set preload(val: string);
     get sandbox(): string;
     set sandbox(val: string);
+    get disablePictureInPicture(): boolean;
+    set disablePictureInPicture(val: boolean);
     requestPictureInPicture(): Promise<PictureInPictureWindow>;
     private togglePip;
     private onEnterPip;

--- a/packages/player/src/features/smart-controls.test.ts
+++ b/packages/player/src/features/smart-controls.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { HeliosPlayer } from '../index';
+import { HeliosTextTrack, HeliosTextTrackList } from './text-tracks';
+
+// Mock ClientSideExporter
+vi.mock('./exporter', () => {
+  return {
+    ClientSideExporter: vi.fn().mockImplementation(() => {
+      return {
+        export: vi.fn()
+      };
+    })
+  };
+});
+
+// Mock ResizeObserver
+global.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as any;
+
+describe('HeliosPlayer Smart Controls', () => {
+  let player: HeliosPlayer;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    // Use constructor directly to ensure instance is created correctly in test env
+    player = new HeliosPlayer();
+    document.body.appendChild(player);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('disablePictureInPicture', () => {
+    it('should default to enabled (visible)', () => {
+        expect(player.disablePictureInPicture).toBe(false);
+        const pipBtn = player.shadowRoot!.querySelector('.pip-btn') as HTMLButtonElement;
+        expect(pipBtn.style.display).not.toBe('none');
+    });
+
+    it('should hide pip button when attribute is set', () => {
+        player.setAttribute('disablepictureinpicture', '');
+        expect(player.disablePictureInPicture).toBe(true);
+        const pipBtn = player.shadowRoot!.querySelector('.pip-btn') as HTMLButtonElement;
+        expect(pipBtn.style.display).toBe('none');
+    });
+
+    it('should hide pip button when property is set', () => {
+        player.disablePictureInPicture = true;
+        expect(player.hasAttribute('disablepictureinpicture')).toBe(true);
+        const pipBtn = player.shadowRoot!.querySelector('.pip-btn') as HTMLButtonElement;
+        expect(pipBtn.style.display).toBe('none');
+    });
+
+    it('should show pip button when attribute is removed', () => {
+        player.setAttribute('disablepictureinpicture', '');
+        expect(player.disablePictureInPicture).toBe(true);
+
+        player.removeAttribute('disablepictureinpicture');
+        expect(player.disablePictureInPicture).toBe(false);
+        const pipBtn = player.shadowRoot!.querySelector('.pip-btn') as HTMLButtonElement;
+        expect(pipBtn.style.display).not.toBe('none');
+    });
+  });
+
+  describe('Smart CC Button', () => {
+    it('should hide CC button initially (no tracks)', () => {
+        const ccBtn = player.shadowRoot!.querySelector('.cc-btn') as HTMLButtonElement;
+        // In JSDOM, computed style might not be fully calculated, but we check inline style
+        // Our logic sets inline style.display = 'none' if empty
+        // However, handleSlotChange is called on connect.
+        expect(ccBtn.style.display).toBe('none');
+    });
+
+    it('should show CC button when tracks are added', () => {
+        const track = document.createElement('track');
+        track.setAttribute('kind', 'captions');
+        track.setAttribute('label', 'English');
+        track.setAttribute('srclang', 'en');
+
+        player.appendChild(track);
+
+        // slotchange is async in some envs or we might need to manually trigger handleSlotChange in unit test environment if slot logic isn't fully emulated
+        // But let's check if we can trigger it.
+        // In JSDOM, slotchange might not fire automatically or correctly for web components without full browser layout.
+        // We can manually call handleSlotChange if needed, but let's see if our existing logic covers it.
+        // We attached slotchange listener in connectedCallback.
+
+        // Simulating slotchange
+        (player as any).handleSlotChange();
+
+        const ccBtn = player.shadowRoot!.querySelector('.cc-btn') as HTMLButtonElement;
+        expect(ccBtn.style.display).not.toBe('none');
+    });
+
+    it('should hide CC button when all tracks are removed', () => {
+        // Add track
+        const track = document.createElement('track');
+        player.appendChild(track);
+        (player as any).handleSlotChange();
+
+        const ccBtn = player.shadowRoot!.querySelector('.cc-btn') as HTMLButtonElement;
+        expect(ccBtn.style.display).not.toBe('none');
+
+        // Remove track
+        player.removeChild(track);
+        (player as any).handleSlotChange();
+
+        expect(ccBtn.style.display).toBe('none');
+    });
+
+    it('should show CC button when track is added via JS API', () => {
+        const ccBtn = player.shadowRoot!.querySelector('.cc-btn') as HTMLButtonElement;
+        expect(ccBtn.style.display).toBe('none');
+
+        player.addTextTrack('captions', 'JS Track', 'en');
+
+        expect(ccBtn.style.display).not.toBe('none');
+    });
+
+    it('should auto-enable captions if default track is present', () => {
+        const track = document.createElement('track');
+        track.setAttribute('kind', 'captions');
+        track.setAttribute('default', '');
+
+        player.appendChild(track);
+        (player as any).handleSlotChange();
+
+        // Check showCaptions state
+        expect((player as any).showCaptions).toBe(true);
+
+        // Check UI state
+        const ccBtn = player.shadowRoot!.querySelector('.cc-btn') as HTMLButtonElement;
+        expect(ccBtn.classList.contains('active')).toBe(true);
+    });
+
+    it('should NOT auto-enable captions if no default track is present', () => {
+        const track = document.createElement('track');
+        track.setAttribute('kind', 'captions');
+
+        player.appendChild(track);
+        (player as any).handleSlotChange();
+
+        // Check showCaptions state
+        expect((player as any).showCaptions).toBe(false);
+
+        // Check UI state
+        const ccBtn = player.shadowRoot!.querySelector('.cc-btn') as HTMLButtonElement;
+        expect(ccBtn.classList.contains('active')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Implemented Smart Controls for `<helios-player>`:
- **`disablepictureinpicture`**: Added support for standard attribute/property to hide the Picture-in-Picture button.
- **Smart CC Button**: Automatically hides the Closed Captions button if no tracks are present, and shows it when tracks are added (via DOM or JS API).
- **Default Captions**: Automatically enables captions if a track is marked as `default` during initialization.
- **Reactive UI**: Refactored visibility logic to listen to `addtrack`/`removetrack` events for robustness.
- **Documentation**: Updated status, progress, and context files.
- **Verification**: Added `src/features/smart-controls.test.ts` covering all new scenarios.

---
*PR created automatically by Jules for task [17286954880496693389](https://jules.google.com/task/17286954880496693389) started by @BintzGavin*