### PR TITLE
✨ RENDERER: Fix CDP Hang

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -1,7 +1,7 @@
 # Renderer Agent Context
 
 ## A. Strategy
-The Renderer operates on a "Dual-Path" architecture to support different use cases:
+The Renderer operates on a "Dual-Path" architecture to support different use cases. The pipeline strictly enforces `strategy.prepare` (resource discovery/loading) before `timeDriver.prepare` (time freezing) to prevent deadlocks in CDP mode:
 1. **DOM Strategy (`DomStrategy`)**: Used for HTML/CSS-heavy compositions. It uses Playwright to capture screenshots of the page at each frame.
    - **Drivers**: Uses `SeekTimeDriver` to manipulate `document.timeline` and sync media/CSS animations (supports Shadow DOM, enforces deterministic Jan 1 2024 epoch, handles GSAP timeline sync).
    - **Discovery**: Uses `dom-scanner` to recursively discover media elements (including Shadow DOM) and implements recursive preloading for `<img>` tags, `<video>` posters, SVG images, and CSS background/mask images. Supports automatic audio looping for `<audio loop>` elements.
@@ -44,6 +44,7 @@ packages/renderer/
     ├── verify-cdp-shadow-dom-sync.ts # Shadow DOM media sync test (Canvas Mode)
     ├── verify-shadow-dom-images.ts # Shadow DOM image discovery test
     ├── verify-enhanced-dom-preload.ts # Enhanced DOM preloading test
+    ├── verify-cdp-hang.ts      # CDP initialization order/deadlock test
     ├── verify-cdp-driver.ts    # CdpDriver budget test
     ├── verify-cdp-driver-timeout.ts # CdpDriver stability timeout test
     ├── verify-diagnose.ts      # Codec diagnostics test

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.56.0
+- ✅ Completed: Fix CDP Hang - Swapped initialization order in `Renderer` to call `strategy.prepare` before `timeDriver.prepare`, ensuring `DomScanner` can discover and load media assets before the CDP `TimeDriver` freezes the virtual clock.
+
 ## RENDERER v1.55.0
 - ✅ Completed: Enhance Dom Preloading - Updated `DomStrategy` to detect and preload `<video>` posters, SVG `<image>` elements, and CSS masks (`mask-image`), ensuring zero-artifact rendering for these asset types.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.55.0
+**Version**: 1.56.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.56.0] ✅ Completed: Fix CDP Hang - Swapped initialization order in `Renderer` to call `strategy.prepare` before `timeDriver.prepare`, ensuring `DomScanner` can discover and load media assets before the CDP `TimeDriver` freezes the virtual clock.
 - [1.55.0] ✅ Completed: Enhance Dom Preloading - Updated `DomStrategy` to detect and preload `<video>` posters, SVG `<image>` elements, and CSS masks (`mask-image`), ensuring zero-artifact rendering for these asset types.
 - [1.54.0] ✅ Completed: Implement Canvas Selector - Added `canvasSelector` to `RendererOptions` and updated `CanvasStrategy` to target specific canvas elements (e.g., `#my-canvas`), enabling support for multi-canvas compositions and layered architectures.
 - [1.53.2] ✅ Completed: Sync Core Dependency - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.6.0` (matching the workspace), fixing dependency resolution issues and ensuring compatibility with the latest core features.

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -122,8 +122,8 @@ export class Renderer {
       console.log('[Helios Diagnostics]', JSON.stringify(diagnostics, null, 2));
 
       console.log('Preparing render strategy...');
-      await this.timeDriver.prepare(page);
       await this.strategy.prepare(page);
+      await this.timeDriver.prepare(page);
       console.log('Strategy prepared.');
 
       const ffmpegPath = this.options.ffmpegPath || ffmpeg.path;

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -15,6 +15,7 @@ const tests = [
   'tests/verify-cdp-driver.ts',
   'tests/verify-cdp-driver-stability.ts',
   'tests/verify-cdp-driver-timeout.ts',
+  'tests/verify-cdp-hang.ts',
   'tests/verify-cdp-media-offsets.ts',
   'tests/verify-cdp-media-sync-timing.ts',
   'tests/verify-cdp-shadow-dom-sync.ts',

--- a/packages/renderer/tests/verify-canvas-implicit-audio.ts
+++ b/packages/renderer/tests/verify-canvas-implicit-audio.ts
@@ -40,6 +40,11 @@ async function runTests() {
             return true;
         }
 
+        // Handle Canvas existence check
+        if (typeof fnOrString === 'function' && fnOrString.toString().includes('HTMLCanvasElement')) {
+            return true;
+        }
+
         // Handle WebCodecs detection (CanvasStrategy.prepare)
         // Return not supported to fallback to standard behavior for simplicity
         if (typeof fnOrString === 'string' && fnOrString.includes('VideoEncoder')) {

--- a/packages/renderer/tests/verify-cdp-hang.ts
+++ b/packages/renderer/tests/verify-cdp-hang.ts
@@ -1,0 +1,88 @@
+import { Renderer } from '../src/index.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+async function runTest() {
+  console.log('Running CDP Hang Verification...');
+
+  const tempHtmlPath = path.join(os.tmpdir(), 'cdp-hang-test.html');
+  const outputVideoPath = path.join(os.tmpdir(), 'cdp-hang-output.mp4');
+
+  // Minimal valid WAV file
+  const wavHeader = Buffer.alloc(44);
+  wavHeader.write('RIFF', 0);
+  wavHeader.writeUInt32LE(36 + 4000, 4);
+  wavHeader.write('WAVE', 8);
+  wavHeader.write('fmt ', 12);
+  wavHeader.writeUInt32LE(16, 16);
+  wavHeader.writeUInt16LE(1, 20);
+  wavHeader.writeUInt16LE(1, 22);
+  wavHeader.writeUInt32LE(8000, 24);
+  wavHeader.writeUInt32LE(8000, 28);
+  wavHeader.writeUInt16LE(1, 32);
+  wavHeader.writeUInt16LE(8, 34);
+  wavHeader.write('data', 36);
+  wavHeader.writeUInt32LE(4000, 40);
+  const pcmData = Buffer.alloc(4000, 128);
+  const wavFile = Buffer.concat([wavHeader, pcmData]);
+  const wavBase64 = wavFile.toString('base64');
+  const dataUri = `data:audio/wav;base64,${wavBase64}`;
+
+  const htmlContent = `
+    <!DOCTYPE html>
+    <html>
+    <body>
+      <canvas id="canvas" width="640" height="360"></canvas>
+      <!-- We use preload="none" to ensure it doesn't load until we interact with it -->
+      <!-- But DomScanner interacts with it. -->
+      <audio id="audio" src="${dataUri}" preload="none"></audio>
+      <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = 'blue';
+        ctx.fillRect(0, 0, 640, 360);
+      </script>
+    </body>
+    </html>
+  `;
+
+  fs.writeFileSync(tempHtmlPath, htmlContent);
+
+  const renderer = new Renderer({
+    width: 640,
+    height: 360,
+    fps: 30,
+    durationInSeconds: 1,
+    mode: 'canvas',
+    stabilityTimeout: 5000, // Short timeout for test
+  });
+
+  try {
+    console.log('Starting render (should hang/timeout if bug exists)...');
+
+    // We expect this to potentially hang or timeout if the bug exists.
+    const renderPromise = renderer.render('file://' + tempHtmlPath, outputVideoPath);
+
+    // Create a timeout that rejects
+    const timeoutPromise = new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('Test Timeout')), 10000);
+    });
+
+    await Promise.race([renderPromise, timeoutPromise]);
+
+    console.log('✅ Render completed successfully.');
+  } catch (e: any) {
+    if (e.message === 'Test Timeout') {
+        console.error('❌ Test timed out! CDP Hang reproduced.');
+        process.exit(1);
+    }
+    console.error('❌ Test failed with error:', e);
+    process.exit(1);
+  } finally {
+    if (fs.existsSync(tempHtmlPath)) fs.unlinkSync(tempHtmlPath);
+    if (fs.existsSync(outputVideoPath)) fs.unlinkSync(outputVideoPath);
+  }
+}
+
+runTest();


### PR DESCRIPTION
Fixes a deadlock issue in the Renderer initialization where `CdpTimeDriver` froze the browser clock before `DomScanner` could complete resource discovery, causing renders with audio to hang. Swapping the initialization order ensures resources are loaded before time is frozen.

---
*PR created automatically by Jules for task [11258979411041709832](https://jules.google.com/task/11258979411041709832) started by @BintzGavin*