### PR TITLE
Fix Excalidraw animation example and renderer dependency

### DIFF
--- a/examples/excalidraw-animation/src/App.jsx
+++ b/examples/excalidraw-animation/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Excalidraw } from "@excalidraw/excalidraw";
+import "@excalidraw/excalidraw/index.css";
 import { Helios } from '../../../packages/core/src/index.ts';
 import { useVideoFrame } from './hooks/useVideoFrame';
 import { getArchitectureElements } from './diagram';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10383,7 +10383,7 @@
     },
     "packages/core": {
       "name": "@helios-project/core",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "license": "ELv2",
       "devDependencies": {
         "typescript": "^5.0.0",
@@ -10410,7 +10410,7 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/core": "3.9.1",
+        "@helios-project/core": "3.9.2",
         "playwright": "^1.42.1"
       },
       "devDependencies": {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "3.9.1",
+    "@helios-project/core": "3.9.2",
     "playwright": "^1.42.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR fixes a rendering issue in `examples/excalidraw-animation` where the Excalidraw diagram was not appearing because its CSS was not imported. It also includes a fix for `packages/renderer` dependency on `core` to resolve a version mismatch preventing installation in the monorepo.

---
*PR created automatically by Jules for task [17151720243489461850](https://jules.google.com/task/17151720243489461850) started by @BintzGavin*