### PR TITLE
Sync Core Dependency in Renderer

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -49,6 +49,7 @@ packages/renderer/
     ├── verify-cdp-driver-timeout.ts # CdpDriver stability timeout test
     ├── verify-diagnose.ts      # Codec diagnostics test
     ├── verify-transparency.ts  # Transparency support test
+    ├── verify-canvas-strategy.ts # Canvas WebCodecs strategy test
     └── ...                     # Other verification scripts
 ```
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -41,7 +41,7 @@
 
 ### 8. Maintenance
 - [x] Synchronize package versions (Fix CORE 2.7.1 dependency mismatch in PLAYER/RENDERER).
-- [ ] Fix workspace version mismatch between packages/renderer and packages/core (Core 2.11.0 vs Renderer req 2.10.0).
+- [x] Fix workspace version mismatch between packages/renderer and packages/core (Core 2.11.0 vs Renderer req 2.10.0).
 - [x] **Fix GSAP Timeline Synchronization in SeekTimeDriver**
   - **Problem**: Promo video (`examples/promo-video/composition.html`) renders a black video with only the background visible. All scenes (Logo Reveal, Tagline, Code to Video, Frameworks, CTA, End Card) are missing because GSAP timeline animations aren't being seeked during rendering.
   - **Last Working State**: Commit `9558e19` (Jan 29, 2026) - "✨ PROMO: Add Promo Video Example and Render Script"

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.56.1
+- ✅ Completed: Sync Core Dependency - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.9.2` (matching the workspace), ensuring compatibility. Also fixed `tests/verify-canvas-strategy.ts` to correctly inject a canvas element.
+
 ## RENDERER v1.56.0
 - ✅ Completed: Fix CDP Hang - Swapped initialization order in `Renderer` to call `strategy.prepare` before `timeDriver.prepare`, ensuring `DomScanner` can discover and load media assets before the CDP `TimeDriver` freezes the virtual clock.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.56.0
+**Version**: 1.56.1
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.56.1] ✅ Completed: Sync Core Dependency - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `3.9.2` (matching the workspace), ensuring compatibility. Also fixed `tests/verify-canvas-strategy.ts` to correctly inject a canvas element.
 - [1.56.0] ✅ Completed: Fix CDP Hang - Swapped initialization order in `Renderer` to call `strategy.prepare` before `timeDriver.prepare`, ensuring `DomScanner` can discover and load media assets before the CDP `TimeDriver` freezes the virtual clock.
 - [1.55.0] ✅ Completed: Enhance Dom Preloading - Updated `DomStrategy` to detect and preload `<video>` posters, SVG `<image>` elements, and CSS masks (`mask-image`), ensuring zero-artifact rendering for these asset types.
 - [1.54.0] ✅ Completed: Implement Canvas Selector - Added `canvasSelector` to `RendererOptions` and updated `CanvasStrategy` to target specific canvas elements (e.g., `#my-canvas`), enabling support for multi-canvas compositions and layered architectures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10383,7 +10383,7 @@
     },
     "packages/core": {
       "name": "@helios-project/core",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "license": "ELv2",
       "devDependencies": {
         "typescript": "^5.0.0",
@@ -10410,7 +10410,7 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/core": "3.9.1",
+        "@helios-project/core": "3.9.2",
         "playwright": "^1.42.1"
       },
       "devDependencies": {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "3.9.1",
+    "@helios-project/core": "3.9.2",
     "playwright": "^1.42.1"
   },
   "devDependencies": {

--- a/packages/renderer/tests/verify-canvas-strategy.ts
+++ b/packages/renderer/tests/verify-canvas-strategy.ts
@@ -10,6 +10,7 @@ async function testCodec(codecOption: string | undefined, expectedFourCC: string
 
   // Mock VideoEncoder to ensure tests run even if the environment doesn't strictly support the codec.
   // We are testing the logic of Header Generation and Config Passing, not the browser's implementation.
+  await page.setContent('<canvas id="canvas" width="1920" height="1080"></canvas>');
   await page.evaluate(() => {
     (window as any).VideoEncoder = class {
       static isConfigSupported(config: any) {


### PR DESCRIPTION
💡 **What**: Updated `@helios-project/core` dependency to `3.9.2` in `packages/renderer`.
🎯 **Why**: To resolve workspace version mismatch with `packages/core`.
📊 **Impact**: Ensures compatibility and prevents potential build/runtime issues.
🔬 **Verification**: Ran `npm test` and specifically `verify-canvas-strategy.ts` (which was fixed to inject a canvas element).

---
*PR created automatically by Jules for task [13497617138568602816](https://jules.google.com/task/13497617138568602816) started by @BintzGavin*