### PR TITLE
✨ PLAYER: Expose Diagnostics

### DIFF
--- a/packages/player/src/bridge.ts
+++ b/packages/player/src/bridge.ts
@@ -82,6 +82,10 @@ export function connectToParent(helios: Helios) {
       case 'HELIOS_GET_SCHEMA':
         window.parent.postMessage({ type: 'HELIOS_SCHEMA', schema: helios.schema }, '*');
         break;
+      case 'HELIOS_DIAGNOSE':
+        const report = await Helios.diagnose();
+        window.parent.postMessage({ type: 'HELIOS_DIAGNOSE_RESULT', report }, '*');
+        break;
       case 'HELIOS_CAPTURE_FRAME':
         handleCaptureFrame(helios, event.data);
         break;


### PR DESCRIPTION
This PR exposes the `Helios.diagnose()` capabilities through the `HeliosController` interface in the player package. This allows consumers of the player (such as the Studio or Agents) to programmatically check the environment's capabilities (WebCodecs, WebGL, etc.) even when the player is running inside an iframe.

The implementation includes:
- Interface update for `HeliosController`.
- `DirectController` implementation calling `Helios.diagnose()`.
- `BridgeController` implementation using postMessage protocol.
- Bridge handling for `HELIOS_DIAGNOSE`.
- Unit tests covering both controllers.

---
*PR created automatically by Jules for task [2895635406583970201](https://jules.google.com/task/2895635406583970201) started by @BintzGavin*