### PR TITLE
Fix Excalidraw animation rendering by copying assets and configuring paths

### DIFF
--- a/examples/excalidraw-animation/composition.html
+++ b/examples/excalidraw-animation/composition.html
@@ -24,6 +24,11 @@
   <script>
     // Define process.env for Excalidraw if needed
     window.process = { env: { NODE_ENV: 'development' } };
+    // Set asset path for local rendering (file protocol)
+    if (window.location.protocol === 'file:') {
+      // Excalidraw requires an absolute URL for the asset path
+      window.EXCALIDRAW_ASSET_PATH = new URL('../../excalidraw-assets/', window.location.href).href;
+    }
   </script>
   <script type="module" src="./src/main.jsx"></script>
 </body>

--- a/vite.build-example.config.js
+++ b/vite.build-example.config.js
@@ -6,6 +6,22 @@ import vue from "@vitejs/plugin-vue";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import solidPlugin from "vite-plugin-solid";
 
+const copyExcalidrawAssetsPlugin = () => {
+  return {
+    name: 'copy-excalidraw-assets',
+    closeBundle: async () => {
+      const src = resolve(__dirname, 'node_modules/@excalidraw/excalidraw/dist/prod/fonts');
+      const dest = resolve(__dirname, 'output/example-build/excalidraw-assets');
+      if (fs.existsSync(src)) {
+        await fs.promises.cp(src, dest, { recursive: true });
+        console.log('Copied Excalidraw fonts to output/example-build/excalidraw-assets');
+      } else {
+        console.warn('Excalidraw fonts source not found at:', src);
+      }
+    }
+  }
+}
+
 function discoverExamples() {
   const examplesDir = resolve(__dirname, "examples");
   const inputs = {};
@@ -56,7 +72,8 @@ export default defineConfig({
     svelte(),
     solidPlugin({
       include: /examples\/solid-(canvas|dom|threejs-canvas)-animation|examples\/solid-transitions|examples\/solid-animation-helpers/,
-    })
+    }),
+    copyExcalidrawAssetsPlugin()
   ],
   // Root of the project
   root: ".",


### PR DESCRIPTION
Fixes an issue where the Excalidraw animation example rendered as unstyled HTML/blank diagram in the final video output due to missing font assets and incorrect asset path configuration in the offline `file://` rendering environment.

Changes:
1.  Modified `vite.build-example.config.js` to include a custom plugin that copies Excalidraw fonts from `node_modules` to the build output directory (`output/example-build/excalidraw-assets`).
2.  Updated `examples/excalidraw-animation/composition.html` to detect the `file:` protocol and set `window.EXCALIDRAW_ASSET_PATH` to an absolute URL pointing to the copied assets. This allows Excalidraw to successfully load fonts when running in the renderer's headless browser.

Verified by running `npx tsx tests/e2e/verify-render.ts "Excalidraw Animation"`, which confirmed successful rendering and content presence.

---
*PR created automatically by Jules for task [6377955999367516784](https://jules.google.com/task/6377955999367516784) started by @BintzGavin*