### PR TITLE
✨ CORE: Implement Marker Metadata

### DIFF
--- a/.agents/skills/helios/core/SKILL.md
+++ b/.agents/skills/helios/core/SKILL.md
@@ -147,6 +147,7 @@ interface Marker {
   time: number; // Time in seconds
   label?: string;
   color?: string;
+  metadata?: Record<string, any>;
 }
 
 helios.setMarkers(markers: Marker[])

--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -104,6 +104,14 @@ export interface HeliosOptions<TInputProps = Record<string, any>> {
   ticker?: Ticker;
 }
 
+export interface Marker {
+  id: string;
+  time: number; // in seconds
+  label?: string;
+  color?: string; // hex code
+  metadata?: Record<string, any>;
+}
+
 export interface DiagnosticReport {
   waapi: boolean;
   webCodecs: boolean;

--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v4.1.0
+- ✅ Completed: Implement Marker Metadata - Updated `Marker` interface to include optional `metadata` and make `label` optional.
+
 ## CORE v4.0.0
 - ✅ Completed: Remove WaapiDriver - Removed deprecated `WaapiDriver` and bumped version to 4.0.0 (Breaking Change). Also fixed TypeScript build errors in tests ensuring compatibility with `Helios<T>` generics.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 4.0.0
+**Version**: 4.1.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
-- **Last Updated**: 2026-06-12
+- **Last Updated**: 2026-06-26
 
+[v4.1.0] ✅ Completed: Implement Marker Metadata - Updated `Marker` interface to include optional `metadata` and make `label` optional.
 [v4.0.0] ✅ Completed: Remove WaapiDriver - Removed deprecated `WaapiDriver` and bumped version to 4.0.0 (Breaking Change). Also fixed TypeScript build errors in tests ensuring compatibility with `Helios<T>` generics.
 [v3.9.2] ✅ Completed: Verify Subscription Timing - Added `packages/core/src/subscription-timing.test.ts` to verify that `helios.subscribe` fires synchronously after `seek()` and virtual time updates, confirming CORE behavior is correct for RENDERER synchronization.
 [v3.9.2] ✅ Completed: Synchronize Version - Updated `package.json` and `index.ts` to 3.9.2 to match status file and fix workspace version mismatch.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/core",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "type": "module",
   "description": "Core library for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,4 +15,4 @@ export * from './ai.js';
 export * from './Helios.js';
 export * from './render-session.js';
 
-export const VERSION = '4.0.0';
+export const VERSION = '4.1.0';

--- a/packages/core/src/markers.test.ts
+++ b/packages/core/src/markers.test.ts
@@ -9,6 +9,20 @@ describe('markers', () => {
       expect(validateMarker(marker)).toEqual(marker);
     });
 
+    it('should pass for a marker without label', () => {
+      const marker: Marker = { id: 'm1', time: 10 };
+      expect(validateMarker(marker)).toEqual(marker);
+    });
+
+    it('should pass for a marker with metadata', () => {
+      const marker: Marker = {
+        id: 'm1',
+        time: 10,
+        metadata: { type: 'scene', tags: ['intro', 'dark'] }
+      };
+      expect(validateMarker(marker)).toEqual(marker);
+    });
+
     it('should throw if id is empty', () => {
       const marker: Marker = { id: '', time: 10, label: 'Intro' };
       expect(() => validateMarker(marker)).toThrow(/Marker ID cannot be empty/);

--- a/packages/core/src/markers.ts
+++ b/packages/core/src/markers.ts
@@ -3,8 +3,9 @@ import { HeliosError, HeliosErrorCode } from './errors.js';
 export interface Marker {
   id: string;
   time: number; // in seconds
-  label: string;
+  label?: string;
   color?: string; // hex code
+  metadata?: Record<string, any>;
 }
 
 export function validateMarker(marker: Marker): Marker {


### PR DESCRIPTION
Implemented Marker Metadata support in @helios-project/core.

💡 **What**: Updated the `Marker` interface to support an optional `metadata` property (`Record<string, any>`) and made the `label` property optional.
🎯 **Why**: To allow agents and Studio users to attach semantic data (e.g., "scene-type") to markers and support markers without explicit display labels, aligning with the "Agent Experience First" vision.
📊 **Impact**: Enables richer timeline descriptions and "tagging" of video sections.
🔬 **Verification**: Run `npm test -w packages/core`. Verified that `validateMarker` accepts markers with metadata and markers without labels.

---
*PR created automatically by Jules for task [10413933934226899846](https://jules.google.com/task/10413933934226899846) started by @BintzGavin*