### PR TITLE
Fix Excalidraw animation rendering and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,3 @@ Thumbs.db
 !examples/promo-video/output/
 !examples/promo-video/output/helios-promo.mp4
 test-results/
-!examples/excalidraw-animation/output/

--- a/examples/excalidraw-animation/src/App.jsx
+++ b/examples/excalidraw-animation/src/App.jsx
@@ -20,9 +20,17 @@ export default function App() {
     const frame = useVideoFrame(helios);
     const [excalidrawAPI, setExcalidrawAPI] = useState(null);
     const [centered, setCentered] = useState(false);
+    const [fontsLoaded, setFontsLoaded] = useState(false);
 
     useEffect(() => {
-        if (excalidrawAPI) {
+        // Preload Excalidraw font to ensure no unstyled text
+        document.fonts.load("20px Virgil").then(() => {
+            setFontsLoaded(true);
+        });
+    }, []);
+
+    useEffect(() => {
+        if (excalidrawAPI && fontsLoaded) {
             const elements = getArchitectureElements(frame);
             excalidrawAPI.updateScene({
                 elements
@@ -35,6 +43,10 @@ export default function App() {
             }
         }
     }, [frame, excalidrawAPI, centered]);
+
+    if (!fontsLoaded) {
+        return null;
+    }
 
     return (
         <div style={{ height: "100vh", width: "100vw" }}>


### PR DESCRIPTION
Ensures Excalidraw animation renders correctly by waiting for the custom font to load before mounting the component. This prevents unstyled text in the generated video. Also updates .gitignore to exclude build artifacts from the example output directory.

---
*PR created automatically by Jules for task [5635744169574104104](https://jules.google.com/task/5635744169574104104) started by @BintzGavin*