### PR TITLE
✨ PLAYER: Synchronize version to 0.56.1

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.56.1
+- ✅ Verified: Synced package.json version with status file.
+
 ## PLAYER v0.56.0
 - ✅ Completed: Expose Diagnostics - Implemented `diagnose()` method in `HeliosController` (Direct and Bridge) to expose environment capabilities (WebCodecs, etc.) to the host.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.56.0
+**Version**: v0.56.1
 
 # Status: PLAYER
 
@@ -51,6 +51,7 @@
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.56.1] ✅ Verified: Synced package.json version with status file.
 [v0.56.0] ✅ Completed: Expose Diagnostics - Implemented `diagnose()` method in `HeliosController` (Direct and Bridge) to expose environment capabilities (WebCodecs, etc.) to the host.
 [v0.55.0] ✅ Completed: Shadow DOM Export - Implemented `cloneWithShadow` and recursive asset inlining to support capturing content inside Shadow DOM (Web Components) during client-side export.
 [v0.54.0] ✅ Completed: Audio Fades - Implemented audio fade-in and fade-out support in client-side exporter via `data-helios-fade-in` and `data-helios-fade-out` attributes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10392,7 +10392,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.51.0",
+      "version": "0.56.1",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^4.1.0",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.51.0",
+  "version": "0.56.1",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",


### PR DESCRIPTION
This change synchronizes the `packages/player` version in `package.json` (previously 0.51.0) with the actual feature set and status file (0.56.1). This ensures that build artifacts correctly reflect the included features (Shadow DOM export, Diagnostics, etc.). No functional code changes were made.

Verified by running `npm run build` and `npm test` in `packages/player`.

---
*PR created automatically by Jules for task [12624688238438077200](https://jules.google.com/task/12624688238438077200) started by @BintzGavin*