### PR TITLE
✨ STUDIO: Persistent Preferences

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -52,6 +52,7 @@ packages/studio/
 │   ├── context/         # React Context (StudioContext)
 │   ├── data/            # Static Data (AI Context)
 │   ├── hooks/           # Custom Hooks
+│   │   └── usePersistentState.ts # localStorage Persistence Hook
 │   ├── server/          # Backend Logic
 │   │   ├── discovery.ts      # Composition & Asset Discovery
 │   │   ├── documentation.ts  # Documentation Search & Resolution
@@ -103,8 +104,9 @@ npx @helios-project/studio
 
 ## D. UI Components
 
--   **Stage**: Wraps `<helios-player>` and provides canvas controls (Zoom, Pan, Safe Areas).
--   **Timeline**: Visualizes playback progress, markers, and captions. Supports seeking and scrubbing.
+-   **Persistence**: Uses `usePersistentState` to remember UI settings (Sidebar Tab, Stage Zoom/Pan, Timeline Zoom, Active Composition) across reloads.
+-   **Stage**: Wraps `<helios-player>` and provides canvas controls (Zoom, Pan, Safe Areas). Settings are persisted.
+-   **Timeline**: Visualizes playback progress, markers, and captions. Supports seeking and scrubbing. Zoom level is persisted.
 -   **Props Editor**: auto-generated form based on the composition's `HeliosSchema`.
     -   Supports primitives (string, number, boolean) with constraints (min/max/step, minLength/maxLength/pattern).
     -   Supports assets (image, video, audio) with type and extension filtering.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.78.0
+- ✅ Completed: Persistent Preferences - Implemented persistence for Sidebar tab, Stage settings (Zoom/Pan/Transparency/Guides), Timeline Zoom, and Active Composition using `localStorage`.
+
 ## STUDIO v0.77.0
 - ✅ Completed: Omnibar Command Palette - Replaced Composition Switcher with a unified Omnibar (Cmd+K) for searching commands, compositions, and assets.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.77.0
+**Version**: 0.78.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.78.0] ✅ Completed: Persistent Preferences - Implemented persistence for Sidebar tab, Stage settings (Zoom/Pan/Transparency/Guides), Timeline Zoom, and Active Composition using `localStorage`.
 - [v0.77.0] ✅ Completed: Omnibar Command Palette - Replaced Composition Switcher with a unified Omnibar (Cmd+K) for searching commands, compositions, and assets.
 - [v0.76.0] ✅ Completed: Audio Mixer Panel - Implemented "Audio" panel in Sidebar with volume and mute controls for individual audio tracks, backed by `HeliosController`.
 - [v0.75.0] ✅ Completed: Compositions Panel - Implemented persistent "Compositions" panel in Sidebar with creation, duplication, and deletion workflows.

--- a/packages/studio/src/components/Sidebar/Sidebar.tsx
+++ b/packages/studio/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useStudio } from '../../context/StudioContext';
+import { usePersistentState } from '../../hooks/usePersistentState';
 import './Sidebar.css';
 import { AssetsPanel } from '../AssetsPanel/AssetsPanel';
 import { RendersPanel } from '../RendersPanel/RendersPanel';
@@ -9,7 +10,7 @@ import { AudioMixerPanel } from '../AudioMixerPanel/AudioMixerPanel';
 
 export const Sidebar: React.FC = () => {
   const { setHelpOpen, setDiagnosticsOpen, setAssistantOpen } = useStudio();
-  const [activeTab, setActiveTab] = useState<'compositions' | 'assets' | 'renders' | 'captions' | 'audio'>('compositions');
+  const [activeTab, setActiveTab] = usePersistentState<'compositions' | 'assets' | 'renders' | 'captions' | 'audio'>('sidebar-active-tab', 'compositions');
 
   return (
     <div className="studio-sidebar">

--- a/packages/studio/src/components/Stage/Stage.tsx
+++ b/packages/studio/src/components/Stage/Stage.tsx
@@ -4,6 +4,7 @@ import { useStudio } from '../../context/StudioContext';
 import { EmptyState } from './EmptyState';
 import { StageToolbar } from './StageToolbar';
 import { useKeyboardShortcut } from '../../hooks/useKeyboardShortcut';
+import { usePersistentState } from '../../hooks/usePersistentState';
 import './Stage.css';
 
 interface StageProps {
@@ -19,10 +20,10 @@ export const Stage: React.FC<StageProps> = ({ src }) => {
   const playerRef = useRef<HeliosPlayerElement>(null);
 
   // State
-  const [zoom, setZoom] = useState(1);
-  const [pan, setPan] = useState({ x: 0, y: 0 });
-  const [isTransparent, setIsTransparent] = useState(true);
-  const [showGuides, setShowGuides] = useState(false);
+  const [zoom, setZoom] = usePersistentState('stage-zoom', 1);
+  const [pan, setPan] = usePersistentState('stage-pan', { x: 0, y: 0 });
+  const [isTransparent, setIsTransparent] = usePersistentState('stage-transparent', true);
+  const [showGuides, setShowGuides] = usePersistentState('stage-guides', false);
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
 

--- a/packages/studio/src/components/Timeline.tsx
+++ b/packages/studio/src/components/Timeline.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { useStudio } from '../context/StudioContext';
+import { usePersistentState } from '../hooks/usePersistentState';
 import { framesToTimecode } from '@helios-project/core';
 import { TimecodeDisplay } from './Controls/TimecodeDisplay';
 import './Timeline.css';
@@ -30,7 +31,7 @@ export const Timeline: React.FC = () => {
   const contentRef = useRef<HTMLDivElement>(null);
 
   const [isDragging, setIsDragging] = useState<'playhead' | 'in' | 'out' | null>(null);
-  const [zoom, setZoom] = useState(0);
+  const [zoom, setZoom] = usePersistentState('timeline-zoom', 0);
   const [hoverFrame, setHoverFrame] = useState<number | null>(null);
   const [contentWidth, setContentWidth] = useState(0);
 

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -449,8 +449,26 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       .then(res => res.json())
       .then((data: Composition[]) => {
         setCompositions(data);
-        if (data.length > 0 && !activeComposition) {
-          setActiveComposition(data[0]);
+
+        let targetComp = null;
+
+        // Try to restore from localStorage
+        try {
+           const savedId = localStorage.getItem('helios-studio:active-composition-id');
+           if (savedId) {
+             const parsedId = JSON.parse(savedId);
+             targetComp = data.find((c: Composition) => c.id === parsedId);
+           }
+        } catch (e) {}
+
+        // Fallback to first if not found
+        if (!targetComp && data.length > 0) {
+           targetComp = data[0];
+        }
+
+        // Only set if we found something and no active composition is set yet
+        if (targetComp && !activeComposition) {
+           setActiveComposition(targetComp);
         }
       })
       .catch(err => {
@@ -459,6 +477,13 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
     fetchAssets();
   }, []);
+
+  // Persist active composition ID
+  useEffect(() => {
+    if (activeComposition) {
+      localStorage.setItem('helios-studio:active-composition-id', JSON.stringify(activeComposition.id));
+    }
+  }, [activeComposition]);
 
   // Reset range when composition changes
   useEffect(() => {

--- a/packages/studio/src/hooks/usePersistentState.ts
+++ b/packages/studio/src/hooks/usePersistentState.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+export function usePersistentState<T>(key: string, initialValue: T): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const prefixedKey = `helios-studio:${key}`;
+
+  // Initialize state function
+  const [state, setState] = useState<T>(() => {
+    try {
+      const item = localStorage.getItem(prefixedKey);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (e) {
+      console.warn(`Failed to load state for ${key}`, e);
+      return initialValue;
+    }
+  });
+
+  // Update storage effect
+  useEffect(() => {
+    try {
+      localStorage.setItem(prefixedKey, JSON.stringify(state));
+    } catch (e) {
+      console.warn(`Failed to save state for ${key}`, e);
+    }
+  }, [prefixedKey, state]);
+
+  return [state, setState];
+}


### PR DESCRIPTION
Implemented `usePersistentState` hook and applied it to Sidebar, Stage, Timeline, and StudioContext to persist UI preferences and active composition ID across reloads. Updated documentation to reflect changes.

---
*PR created automatically by Jules for task [17471738452004565966](https://jules.google.com/task/17471738452004565966) started by @BintzGavin*