### PR TITLE
✨ STUDIO: Array Reordering

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -110,7 +110,7 @@ npx @helios-project/studio
 -   **Props Editor**: auto-generated form based on the composition's `HeliosSchema`.
     -   Supports primitives (string, number, boolean) with constraints (min/max/step, minLength/maxLength/pattern).
     -   Supports assets (image, video, audio) with type and extension filtering.
-    -   Supports complex types (object, array, typed arrays) with size constraints (minItems/maxItems).
+    -   Supports complex types (object, array, typed arrays) with size constraints (minItems/maxItems) and item reordering.
     -   Supports collapsible groups via `group` property.
 -   **Compositions Panel**: Persistent sidebar panel for managing compositions (Browse, Create, Duplicate, Delete).
 -   **Assets Panel**: Discovers and allows drag-and-drop of assets from the project. Supports uploading, deleting, and renaming assets.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.79.0
+- ✅ Completed: Array Reordering - Implemented ability to reorder array items (up/down) in the Props Editor.
+
 ## STUDIO v0.78.0
 - ✅ Completed: Persistent Preferences - Implemented persistence for Sidebar tab, Stage settings (Zoom/Pan/Transparency/Guides), Timeline Zoom, and Active Composition using `localStorage`.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.78.0
+**Version**: 0.79.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.79.0] ✅ Completed: Array Reordering - Implemented ability to reorder array items (up/down) in the Props Editor, improving list management.
 - [v0.78.0] ✅ Completed: Persistent Preferences - Implemented persistence for Sidebar tab, Stage settings (Zoom/Pan/Transparency/Guides), Timeline Zoom, and Active Composition using `localStorage`.
 - [v0.77.0] ✅ Completed: Omnibar Command Palette - Replaced Composition Switcher with a unified Omnibar (Cmd+K) for searching commands, compositions, and assets.
 - [v0.76.0] ✅ Completed: Audio Mixer Panel - Implemented "Audio" panel in Sidebar with volume and mute controls for individual audio tracks, backed by `HeliosController`.

--- a/packages/studio/src/components/PropsEditor.css
+++ b/packages/studio/src/components/PropsEditor.css
@@ -150,6 +150,35 @@
   flex: 1;
 }
 
+.prop-array-controls {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+}
+
+.prop-array-control-btn {
+  padding: 4px 8px;
+  background-color: #f5f5f5;
+  color: #333;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+}
+
+.prop-array-control-btn:hover {
+  background-color: #e0e0e0;
+}
+
+.prop-array-control-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .prop-array-remove {
   padding: 4px 8px;
   background-color: #ffebee;
@@ -158,10 +187,16 @@
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.8em;
+  white-space: nowrap;
 }
 
 .prop-array-remove:hover {
   background-color: #ffcdd2;
+}
+
+.prop-array-remove:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .prop-array-add {

--- a/packages/studio/src/components/PropsEditor.test.tsx
+++ b/packages/studio/src/components/PropsEditor.test.tsx
@@ -488,4 +488,55 @@ describe('PropsEditor', () => {
     expect(optionValues).toContain('/assets/image.png');
     expect(optionValues).not.toContain('/assets/image.jpg');
   });
+
+  it('reorders array items', () => {
+    const schema: HeliosSchema = {
+      listProp: {
+        type: 'array',
+        items: { type: 'string' }
+      }
+    };
+
+    (StudioContext.useStudio as any).mockReturnValue({
+      ...defaultContext,
+      playerState: {
+        inputProps: {
+          listProp: ['A', 'B', 'C']
+        },
+        schema
+      }
+    });
+
+    render(<PropsEditor />);
+
+    // Check initial order
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs[0]).toHaveValue('A');
+    expect(inputs[1]).toHaveValue('B');
+    expect(inputs[2]).toHaveValue('C');
+
+    // Find "Move Down" button for first item ('A')
+    const downButtons = screen.getAllByTitle('Move Down');
+    const upButtons = screen.getAllByTitle('Move Up');
+
+    // First item 'A' (index 0)
+    // Up should be disabled
+    expect(upButtons[0]).toBeDisabled();
+    // Down should be enabled
+    expect(downButtons[0]).not.toBeDisabled();
+
+    // Click Down on 'A' -> should become ['B', 'A', 'C']
+    fireEvent.click(downButtons[0]);
+    expect(mockSetInputProps).toHaveBeenCalledWith({ listProp: ['B', 'A', 'C'] });
+
+    // Last item 'C' (index 2)
+    // Down should be disabled
+    expect(downButtons[2]).toBeDisabled();
+    // Up should be enabled
+    expect(upButtons[2]).not.toBeDisabled();
+
+    // Click Up on 'C' -> should become ['A', 'C', 'B'] (assuming starting from original ['A', 'B', 'C'])
+    fireEvent.click(upButtons[2]);
+    expect(mockSetInputProps).toHaveBeenCalledWith({ listProp: ['A', 'C', 'B'] });
+  });
 });

--- a/packages/studio/src/components/SchemaInputs.tsx
+++ b/packages/studio/src/components/SchemaInputs.tsx
@@ -170,6 +170,24 @@ const ArrayInput: React.FC<{
         onChange(copy);
     };
 
+    const handleMoveUp = (index: number) => {
+        if (index <= 0) return;
+        const copy = [...safeValue];
+        const temp = copy[index];
+        copy[index] = copy[index - 1];
+        copy[index - 1] = temp;
+        onChange(copy);
+    };
+
+    const handleMoveDown = (index: number) => {
+        if (index >= safeValue.length - 1) return;
+        const copy = [...safeValue];
+        const temp = copy[index];
+        copy[index] = copy[index + 1];
+        copy[index + 1] = temp;
+        onChange(copy);
+    };
+
     return (
         <div className="prop-array-container">
             {safeValue.map((item: any, index: number) => (
@@ -183,14 +201,32 @@ const ArrayInput: React.FC<{
                             />
                         )}
                      </div>
-                     <button
-                        className="prop-array-remove"
-                        onClick={() => handleRemove(index)}
-                        title="Remove Item"
-                        disabled={minItems !== undefined && safeValue.length <= minItems}
-                     >
-                        Remove
-                     </button>
+                     <div className="prop-array-controls">
+                        <button
+                            className="prop-array-control-btn"
+                            onClick={() => handleMoveUp(index)}
+                            title="Move Up"
+                            disabled={index === 0}
+                        >
+                            ↑
+                        </button>
+                        <button
+                            className="prop-array-control-btn"
+                            onClick={() => handleMoveDown(index)}
+                            title="Move Down"
+                            disabled={index === safeValue.length - 1}
+                        >
+                            ↓
+                        </button>
+                        <button
+                            className="prop-array-remove"
+                            onClick={() => handleRemove(index)}
+                            title="Remove Item"
+                            disabled={minItems !== undefined && safeValue.length <= minItems}
+                        >
+                            Remove
+                        </button>
+                     </div>
                 </div>
             ))}
             {canAdd && (


### PR DESCRIPTION
Implemented reordering functionality for array inputs in the Helios Studio Props Editor. Users can now move items up and down within an array, improving the management of ordered lists.

Key changes:
- Updated `SchemaInputs.tsx` to include `handleMoveUp` and `handleMoveDown` logic in `ArrayInput`.
- Added Up/Down buttons to the array item controls.
- Updated `PropsEditor.css` to style the new control buttons.
- Added comprehensive unit tests in `PropsEditor.test.tsx` to verify reordering logic and UI state.
- Updated documentation to reflect the new capability.

---
*PR created automatically by Jules for task [13397576372257514542](https://jules.google.com/task/13397576372257514542) started by @BintzGavin*