### PR TITLE
✨ CORE: Decouple TimeDriver from DOM and Sync Version

### DIFF
--- a/.jules/CORE.md
+++ b/.jules/CORE.md
@@ -25,3 +25,7 @@
 ## [4.1.0] - JSDOM Computed Styles
 **Learning:** In JSDOM (vitest), `window.getComputedStyle(el)` returns empty values unless the element is attached to the document body.
 **Action:** In tests involving computed styles, always use `document.body.appendChild(el)` in `beforeEach` and remove it in `afterEach`.
+
+## [5.0.1] - Mock Duck Typing
+**Learning:** Strict type checks (`instanceof HTMLElement`) in `DomDriver` broke existing tests that used mock objects.
+**Action:** When enforcing runtime type safety for DOM APIs, allow "duck typing" (checking for presence of methods like `querySelectorAll` or `getAnimations`) to support test mocks and alternative environments.

--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -47,6 +47,7 @@ packages/core/src/
 ├── signals.ts
 ├── subscription-timing.test.ts
 ├── time-control.ts
+├── worker-runtime.test.ts
 ├── timecode.ts
 └── transitions.ts
 ```
@@ -101,7 +102,7 @@ export interface HeliosOptions<TInputProps = Record<string, any>> {
   loop?: boolean;
   playbackRange?: [number, number];
   autoSyncAnimations?: boolean;
-  animationScope?: HTMLElement;
+  animationScope?: unknown;
   inputProps?: TInputProps;
   schema?: HeliosSchema;
   playbackRate?: number;

--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v5.0.1
+- ✅ Completed: Decouple TimeDriver from DOM - Updated `TimeDriver` and `Helios` to accept `unknown` scope, enabling Web Worker support, and synchronized version.
+
 ## CORE v5.0.0
 - ✅ Completed: Implement Audio Track Metadata - Updated `availableAudioTracks` signal to return `AudioTrackMetadata[]` instead of `string[]` (Breaking Change), including `startTime` and `duration` discovery.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 5.0.0
+**Version**: 5.0.1
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
-- **Last Updated**: 2026-06-26
+- **Last Updated**: 2026-07-27
 
+[v5.0.1] ✅ Completed: Decouple TimeDriver from DOM - Updated `TimeDriver` and `Helios` to accept `unknown` scope, enabling Web Worker support, and synchronized version.
 [v5.0.0] ✅ Completed: Implement Audio Track Metadata - Updated `availableAudioTracks` signal to return `AudioTrackMetadata[]` instead of `string[]` (Breaking Change), including `startTime` and `duration` discovery.
 [v4.1.0] ✅ Completed: Implement Marker Metadata - Updated `Marker` interface to include optional `metadata` and make `label` optional.
 [v4.0.0] ✅ Completed: Remove WaapiDriver - Removed deprecated `WaapiDriver` and bumped version to 4.0.0 (Breaking Change). Also fixed TypeScript build errors in tests ensuring compatibility with `Helios<T>` generics.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/core",
-  "version": "4.1.0",
+  "version": "5.0.1",
   "type": "module",
   "description": "Core library for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",

--- a/packages/core/src/Helios.ts
+++ b/packages/core/src/Helios.ts
@@ -44,7 +44,7 @@ export interface HeliosOptions<TInputProps = Record<string, any>> {
   loop?: boolean;
   playbackRange?: [number, number];
   autoSyncAnimations?: boolean;
-  animationScope?: HTMLElement;
+  animationScope?: unknown;
   inputProps?: TInputProps;
   schema?: HeliosSchema;
   playbackRate?: number;
@@ -234,7 +234,7 @@ export class Helios<TInputProps = Record<string, any>> {
   // Other internals
   private syncWithDocumentTimeline = false;
   private autoSyncAnimations = false;
-  private animationScope: HTMLElement | Document = typeof document !== 'undefined' ? document : ({} as Document);
+  private animationScope?: unknown = typeof document !== 'undefined' ? document : undefined;
   private driver: TimeDriver;
   private ticker: Ticker;
   private subscriberMap = new Map<HeliosSubscriber<TInputProps>, () => void>();

--- a/packages/core/src/drivers/NoopDriver.ts
+++ b/packages/core/src/drivers/NoopDriver.ts
@@ -1,7 +1,7 @@
 import { TimeDriver } from './TimeDriver.js';
 
 export class NoopDriver implements TimeDriver {
-  init(scope: HTMLElement | Document) {
+  init(scope: unknown) {
     // No-op
   }
 

--- a/packages/core/src/drivers/TimeDriver.ts
+++ b/packages/core/src/drivers/TimeDriver.ts
@@ -9,7 +9,7 @@ export interface DriverMetadata {
 }
 
 export interface TimeDriver {
-  init(scope: HTMLElement | Document): void;
+  init(scope: unknown): void;
   update(timeInMs: number, options?: {
     isPlaying: boolean;
     playbackRate: number;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,4 +15,4 @@ export * from './ai.js';
 export * from './Helios.js';
 export * from './render-session.js';
 
-export const VERSION = '4.1.0';
+export const VERSION = '5.0.1';

--- a/packages/core/src/worker-runtime.test.ts
+++ b/packages/core/src/worker-runtime.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { Helios } from './Helios.js';
+
+describe('Helios Worker Runtime', () => {
+  it('should initialize without DOM access', () => {
+    // Ensure document is undefined (Vitest default is node, but let's be sure)
+    expect(typeof document).toBe('undefined');
+
+    const helios = new Helios({
+      fps: 30,
+      duration: 10,
+      width: 1920,
+      height: 1080
+    });
+
+    expect(helios).toBeDefined();
+    expect(helios.duration.value).toBe(10);
+    expect(helios.fps.value).toBe(30);
+  });
+
+  it('should support seek operations without DOM', () => {
+    const helios = new Helios({
+      fps: 30,
+      duration: 10
+    });
+
+    helios.seek(15); // Frame 15 (0.5s)
+    expect(helios.currentFrame.value).toBe(15);
+    expect(helios.currentTime.value).toBe(0.5);
+  });
+
+  it('should diagnose environment correctly', async () => {
+    const diagnosis = await Helios.diagnose();
+    // Vitest (Node) environment might set navigator.userAgent
+    expect(diagnosis.userAgent).toMatch(/Node/);
+    expect(diagnosis.waapi).toBe(false);
+  });
+});


### PR DESCRIPTION
Decoupled TimeDriver from strict DOM types to support Web Workers and Node.js environments, enabling headless usage. Updated DomDriver to support mock objects in tests.

---
*PR created automatically by Jules for task [17902058049109818832](https://jules.google.com/task/17902058049109818832) started by @BintzGavin*