### PR TITLE
✨ RENDERER: Enable looping media in TimeDrivers

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -3,11 +3,11 @@
 ## A. Strategy
 The Renderer operates on a "Dual-Path" architecture to support different use cases. The pipeline strictly enforces `strategy.prepare` (resource discovery/loading) before `timeDriver.prepare` (time freezing) to prevent deadlocks in CDP mode:
 1. **DOM Strategy (`DomStrategy`)**: Used for HTML/CSS-heavy compositions. It uses Playwright to capture screenshots of the page at each frame.
-   - **Drivers**: Uses `SeekTimeDriver` to manipulate `document.timeline` and sync media/CSS animations (supports Shadow DOM, enforces deterministic Jan 1 2024 epoch, handles GSAP timeline sync).
-   - **Discovery**: Uses `dom-scanner` to recursively discover media elements (including Shadow DOM) and implements recursive preloading for `<img>` tags, `<video>` posters, SVG images, and CSS background/mask images. Supports automatic audio looping for `<audio loop>` elements.
+   - **Drivers**: Uses `SeekTimeDriver` to manipulate `document.timeline` and sync media/CSS animations (supports Shadow DOM, enforces deterministic Jan 1 2024 epoch, handles GSAP timeline sync, supports media looping).
+   - **Discovery**: Uses `dom-scanner` to recursively discover media elements (including Shadow DOM) and implements recursive preloading for `<img>` tags, `<video>` posters, SVG images, and CSS background/mask images. Supports automatic audio looping for `<audio loop>` elements via FFmpeg concat.
    - **Output**: Best for sharp text and vector graphics.
 2. **Canvas Strategy (`CanvasStrategy`)**: Used for WebGL/Canvas-heavy compositions (e.g., Three.js, PixiJS). It captures the `<canvas>` context directly.
-   - **Drivers**: Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise virtual time control (supports Shadow DOM media sync, enforces deterministic Jan 2024 epoch, ensures sync-before-render order, waits for budget expiration, enforces stability timeout via `Runtime.terminateExecution`).
+   - **Drivers**: Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise virtual time control (supports Shadow DOM media sync, enforces deterministic Jan 2024 epoch, ensures sync-before-render order, waits for budget expiration, enforces stability timeout via `Runtime.terminateExecution`, supports media looping).
    - **Optimization**: Prioritizes H.264 (AVC) intermediate codec for hardware acceleration, falling back to VP8. Exposes `diagnose()` API to verify supported WebCodecs.
    - **Output**: Best for high-performance 2D/3D graphics.
 
@@ -58,6 +58,7 @@ packages/renderer/
     ├── verify-diagnose.ts      # Codec diagnostics test
     ├── verify-transparency.ts  # Transparency support test
     ├── verify-canvas-strategy.ts # Canvas WebCodecs strategy test
+    ├── verify-video-loop.ts    # Video looping logic verification
     └── ...                     # Other verification scripts
 ```
 

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.57.0
+- ✅ Completed: Enable Looping Media - Updated SeekTimeDriver and CdpTimeDriver to implement modulo arithmetic for `currentTime` when the `loop` attribute is present, ensuring correct looping behavior during rendering.
+
 ## RENDERER v1.56.5
 - ✅ Completed: Update Verification Suite - Updated `verify-ffmpeg-path.ts` to be self-contained and robust, and verified that `verify-cancellation.ts`, `verify-trace.ts`, and `verify-ffmpeg-path.ts` pass and are included in the main test runner.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.56.5
+**Version**: 1.57.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.57.0] ✅ Completed: Enable Looping Media - Updated SeekTimeDriver and CdpTimeDriver to implement modulo arithmetic for `currentTime` when the `loop` attribute is present, ensuring correct looping behavior during rendering.
 - [1.56.5] ✅ Completed: Update Verification Suite - Updated `verify-ffmpeg-path.ts` to be self-contained and robust, and verified that `verify-cancellation.ts`, `verify-trace.ts`, and `verify-ffmpeg-path.ts` pass and are included in the main test runner.
 - [1.56.4] ✅ Completed: Restore Environment - Restored missing node_modules and verified full test suite passes.
 - [1.56.3] ✅ Completed: Update Verification Suite - Refactored `verify-cancellation.ts` and `verify-trace.ts` to be self-contained and added them (along with `verify-ffmpeg-path.ts`) to `run-all.ts`, ensuring continuous regression testing for these features.

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -83,7 +83,12 @@ export class CdpTimeDriver implements TimeDriver {
 
           // Calculate target time
           // Formula: GlobalTime - Offset + InPoint
-          const targetTime = Math.max(0, t - offset + seek);
+          let targetTime = Math.max(0, t - offset + seek);
+
+          // Handle Looping
+          if (el.loop && el.duration > 0 && targetTime > el.duration) {
+            targetTime = targetTime % el.duration;
+          }
 
           el.currentTime = targetTime;
           // Note: We intentionally do NOT await 'seeked' here because CDP virtual time is paused.

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -156,7 +156,12 @@ export class SeekTimeDriver implements TimeDriver {
 
           // Calculate target time
           // Formula: GlobalTime - Offset + InPoint
-          const targetTime = Math.max(0, t - offset + seek);
+          let targetTime = Math.max(0, t - offset + seek);
+
+          // Handle Looping
+          if (el.loop && el.duration > 0 && targetTime > el.duration) {
+            targetTime = targetTime % el.duration;
+          }
 
           el.currentTime = targetTime;
 

--- a/packages/renderer/tests/verify-video-loop.ts
+++ b/packages/renderer/tests/verify-video-loop.ts
@@ -1,0 +1,140 @@
+import { chromium, Page } from 'playwright';
+import { SeekTimeDriver } from '../src/drivers/SeekTimeDriver.js';
+import { CdpTimeDriver } from '../src/drivers/CdpTimeDriver.js';
+import { TimeDriver } from '../src/drivers/TimeDriver.js';
+
+async function verifyDriver(name: string, driver: TimeDriver, page: Page) {
+  console.log(`\nVerifying ${name}...`);
+
+  // Reset page content
+  await page.setContent(`
+    <!DOCTYPE html>
+    <html>
+    <body>
+      <video id="loopVideo" loop></video>
+      <video id="onceVideo"></video>
+      <video id="offsetVideo" loop data-helios-offset="2"></video>
+      <script>
+        // Mock duration for all video elements
+        Object.defineProperty(HTMLMediaElement.prototype, 'duration', { get: () => 10 });
+
+        // Mock pause/play to avoid errors
+        HTMLMediaElement.prototype.pause = () => {};
+        HTMLMediaElement.prototype.play = async () => {};
+      </script>
+    </body>
+    </html>
+  `);
+
+  await driver.prepare(page);
+
+  // Case 1: Time < Duration (No loop needed)
+  await driver.setTime(page, 5);
+  let times = await page.evaluate(() => {
+    return {
+      loop: (document.getElementById('loopVideo') as HTMLVideoElement).currentTime,
+      once: (document.getElementById('onceVideo') as HTMLVideoElement).currentTime
+    };
+  });
+
+  if (Math.abs(times.loop - 5) > 0.1) console.error(`❌ [${name}] Normal playback failed: expected 5, got ${times.loop}`);
+  else console.log(`✅ [${name}] Normal playback ok`);
+
+  // Case 2: Time > Duration (Looping)
+  // Time = 15. Duration = 10. Expected = 5.
+  await driver.setTime(page, 15);
+  times = await page.evaluate(() => {
+    return {
+      loop: (document.getElementById('loopVideo') as HTMLVideoElement).currentTime,
+      once: (document.getElementById('onceVideo') as HTMLVideoElement).currentTime
+    };
+  });
+
+  let failure = false;
+  if (Math.abs(times.loop - 5) > 0.1) {
+    console.error(`❌ [${name}] Loop failed: expected 5, got ${times.loop}`);
+    failure = true;
+  } else {
+    console.log(`✅ [${name}] Loop behavior ok`);
+  }
+
+  // Non-looped video should not loop (it might be clamped or linear depending on browser,
+  // but our driver logic sets it linearly if not looped)
+  // Wait, if not looped, we set `currentTime = targetTime`.
+  // If targetTime > duration, browser usually clamps it to duration.
+  // But since we mocked duration but didn't actually load media, the browser might allow setting currentTime > duration?
+  // Let's check what it is.
+  // Actually, standard HTML5 video clamps currentTime to duration.
+  // But if we mocked duration via prototype, does the internal clamping logic use that?
+  // Probably not. The internal logic uses the real media engine state.
+  // However, our driver sets `el.currentTime = targetTime`.
+  // If we set `currentTime = 15`, and the browser thinks duration is NaN (empty), it might work?
+  // Or if we didn't load anything, `currentTime` might stay 0.
+  //
+  // To make this robust without real media, we can check if the driver *tried* to set it.
+  // But we can't easily spy on the element inside the page from here without more complex injection.
+  //
+  // Actually, for the purpose of this test (verifying our injected logic), we can verify what `currentTime` IS after setting.
+  // If our logic worked, we sent `5` to the `loopVideo`.
+  // If we sent `15` to `onceVideo`, and the browser clamps it (or not), that's fine.
+  // The important part is that `loopVideo` got `5`.
+
+  // Case 3: Offset + Loop
+  // Offset = 2. Time = 15.
+  // Raw = 15 - 2 = 13.
+  // Duration = 10.
+  // Expected = 13 % 10 = 3.
+  times = await page.evaluate(() => {
+    return {
+      offset: (document.getElementById('offsetVideo') as HTMLVideoElement).currentTime
+    };
+  });
+
+  if (Math.abs(times.offset - 3) > 0.1) {
+    console.error(`❌ [${name}] Offset Loop failed: expected 3, got ${times.offset}`);
+    failure = true;
+  } else {
+    console.log(`✅ [${name}] Offset Loop behavior ok`);
+  }
+
+  return !failure;
+}
+
+async function run() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  // Polyfill generic window stuff if needed
+  await page.addInitScript(() => {
+    (window as any).helios = {};
+  });
+
+  let success = true;
+
+  // Verify SeekTimeDriver
+  const seekDriver = new SeekTimeDriver();
+  await seekDriver.init(page);
+  if (!await verifyDriver('SeekTimeDriver', seekDriver, page)) success = false;
+
+  // Verify CdpTimeDriver
+  // Note: CdpTimeDriver needs a new context/session usually, but let's try reusing.
+  // Actually CdpTimeDriver uses `page.context().newCDPSession(page)`.
+  const cdpDriver = new CdpTimeDriver();
+  await cdpDriver.init(page);
+  if (!await verifyDriver('CdpTimeDriver', cdpDriver, page)) success = false;
+
+  await browser.close();
+
+  if (success) {
+    console.log('\nALL TESTS PASSED');
+    process.exit(0);
+  } else {
+    console.error('\nTESTS FAILED');
+    process.exit(1);
+  }
+}
+
+run().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
This PR updates `SeekTimeDriver` and `CdpTimeDriver` in `packages/renderer` to correctly handle HTMLMediaElements with the `loop` attribute. Previously, `currentTime` would be set linearly beyond the duration, causing looped media to freeze at the last frame. The fix applies modulo arithmetic (`currentTime % duration`) when appropriate.

Impact:
- Loops in background videos or ambient audio now render correctly in both DOM and Canvas modes.

Verification:
- Run `npx tsx packages/renderer/tests/verify-video-loop.ts`.

---
*PR created automatically by Jules for task [12082405406458365201](https://jules.google.com/task/12082405406458365201) started by @BintzGavin*