### PR TITLE
📋 STUDIO: Audio Timeline Visualization Plan

### DIFF
--- a/.jules/STUDIO.md
+++ b/.jules/STUDIO.md
@@ -21,3 +21,7 @@
 ## [0.77.0] - Command Palette Pattern
 **Learning:** Expanding the "Composition Switcher" into a full "Command Palette" (Omnibar) is a high-value pattern for Developer Tools. It allows unified access to commands, navigation, and assets, reducing UI clutter and improving "Agent Experience" by making capabilities discoverable via text search.
 **Action:** When designing complex IDE-like interfaces, prioritize centralized command access over scattered buttons.
+
+## [0.79.0] - Type Sharing Constraints
+**Learning:** `packages/player` does not export `AudioAsset`, forcing duplication or manual type definition in Studio. Since planners cannot modify other packages, we must accept this duplication in `packages/studio/src/types.ts` as a necessary compromise.
+**Action:** When integrating with internal packages that lack public exports, prefer creating a local `types.ts` to contain the duplicated types rather than using brittle import paths.

--- a/.sys/plans/2026-02-18-STUDIO-audio-timeline.md
+++ b/.sys/plans/2026-02-18-STUDIO-audio-timeline.md
@@ -1,0 +1,86 @@
+# Spec: Studio Audio Timeline Visualization
+
+## 1. Context & Goal
+- **Objective**: Visualize audio tracks on the Studio Timeline and centralize audio track state management.
+- **Trigger**: The Vision ("Visual timeline") vs. Reality (Hidden audio tracks). Users can hear audio but cannot see its placement relative to the video frames.
+- **Impact**: Enables precise timing adjustments for audio-visual synchronization. Centralizes audio state for better consistency between Mixer and Timeline.
+
+## 2. File Inventory
+- **Create**:
+    - `packages/studio/src/types.ts`: Shared types definition (AudioTrack, etc.).
+- **Modify**:
+    - `packages/studio/src/context/StudioContext.tsx`: Add `audioTracks` to state, implement fetching/decoding/caching logic, and expose update methods.
+    - `packages/studio/src/components/Timeline.tsx`: Render audio tracks visually.
+    - `packages/studio/src/components/Timeline.css`: Styles for audio tracks.
+    - `packages/studio/src/components/Timeline.test.tsx`: Verify rendering.
+    - `packages/studio/src/components/AudioMixerPanel/AudioMixerPanel.tsx`: Refactor to use centralized state.
+- **Read-Only**:
+    - `packages/player/src/features/audio-utils.ts` (Reference for AudioAsset structure)
+
+## 3. Implementation Spec
+
+### Architecture
+- **State Management**: Move `audioTracks` (and their metadata like duration/volume) from `AudioMixerPanel` local state to `StudioContext` global state.
+- **Data Flow**:
+    1. `StudioContext` fetches raw assets via `controller.getAudioTracks()`.
+    2. `StudioContext` calculates duration (decoding buffer if needed) and caches it.
+    3. `StudioContext` exposes `playerState.audioTracks` (read-only for UI) and `updateAudioTrack...` methods.
+    4. `Timeline` and `AudioMixerPanel` consume this state.
+
+### Types (packages/studio/src/types.ts)
+```typescript
+export interface AudioTrack {
+  id: string;
+  buffer?: ArrayBuffer;
+  mimeType: string | null;
+  volume: number;
+  muted: boolean;
+  loop: boolean;
+  startTime: number; // ms
+  duration: number; // ms (calculated)
+  fadeInDuration: number;
+  fadeOutDuration: number;
+}
+```
+
+### StudioContext Updates
+- Add `audioTracks` to `PlayerState`.
+- Implement `refreshAudioTracks()`:
+    - Calls `controller.getAudioTracks()`.
+    - Merges with existing state (preserving calculated durations to avoid re-decoding).
+    - If new buffer, decode using `AudioContext` to get duration.
+    - Cache decoded durations in a `useRef` map to persist across re-renders.
+- Implement `setAudioTrackVolume(id, vol)`: Calls controller & updates local state.
+- Implement `setAudioTrackMuted(id, muted)`: Calls controller & updates local state.
+- Trigger `refreshAudioTracks` on:
+    - Controller connection.
+    - `inputProps` change (debounced or explicit check).
+
+### Timeline Updates
+- Add a new "track row" container below the ruler.
+- Render `<div className="timeline-audio-track">` for each track.
+- Position using `left: (startTime / totalDuration)%` and `width: (duration / totalDuration)%`.
+- Style to look distinct (e.g., green/blue bars).
+
+### AudioMixerPanel Updates
+- Remove local `fetchTracks`, `tracks` state.
+- Use `playerState.audioTracks`.
+- Use `context.setAudioTrackVolume` / `Muted`.
+
+### Timeline.test.tsx Updates
+- Update the mock context `defaultPlayerState` to include `audioTracks: []`.
+- Add a new test case: "renders audio tracks from playerState.audioTracks".
+    - Mock a player state with `audioTracks: [{ id: 'a1', startTime: 0, duration: 2000, ... }]`.
+    - Verify that a `.timeline-audio-track` element is rendered with correct positioning and attributes.
+
+## 4. Test Plan
+- **Verification**:
+    - `npm test -w packages/studio` (Focus on `Timeline.test.tsx`).
+    - `npx helios studio` -> Load a composition with audio.
+    - Check if audio bars appear on timeline.
+    - Check if Audio Mixer still works (syncs volume/mute).
+- **Edge Cases**:
+    - No audio tracks.
+    - Audio track with 0 duration.
+    - Audio track starting negative or beyond duration.
+    - Large audio files (decoding performance).


### PR DESCRIPTION
I have created a detailed specification for visualizing audio tracks on the Helios Studio timeline.

**Plan Highlights:**
- **Centralized State:** Moving audio track state management to `StudioContext`.
- **Visualization:** Adding a visual track row to `Timeline.tsx` to show audio clips.
- **Constraints Handling:** Working around the lack of `AudioAsset` export in `player` by defining local types.
- **Verification:** Detailed test plan included.

I also documented the architectural constraint regarding type sharing in `.jules/STUDIO.md`.

---
*PR created automatically by Jules for task [13314636342023659315](https://jules.google.com/task/13314636342023659315) started by @BintzGavin*