### PR TITLE
✨ RENDERER: Verify Looping Media

### DIFF
--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.57.1
+- ✅ Completed: Verify Looping Media - Enabled regression test `verify-video-loop.ts` in `run-all.ts` and updated dependencies to resolve environment issues, confirming correct looping behavior in both SeekTimeDriver and CdpTimeDriver.
+
 ## RENDERER v1.57.0
 - ✅ Completed: Enable Looping Media - Updated SeekTimeDriver and CdpTimeDriver to implement modulo arithmetic for `currentTime` when the `loop` attribute is present, ensuring correct looping behavior during rendering.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.57.0
+**Version**: 1.57.1
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.57.1] ✅ Completed: Verify Looping Media - Enabled regression test `verify-video-loop.ts` in `run-all.ts` and updated dependencies to resolve environment issues, confirming correct looping behavior in both SeekTimeDriver and CdpTimeDriver.
 - [1.57.0] ✅ Completed: Enable Looping Media - Updated SeekTimeDriver and CdpTimeDriver to implement modulo arithmetic for `currentTime` when the `loop` attribute is present, ensuring correct looping behavior during rendering.
 - [1.56.5] ✅ Completed: Update Verification Suite - Updated `verify-ffmpeg-path.ts` to be self-contained and robust, and verified that `verify-cancellation.ts`, `verify-trace.ts`, and `verify-ffmpeg-path.ts` pass and are included in the main test runner.
 - [1.56.4] ✅ Completed: Restore Environment - Restored missing node_modules and verified full test suite passes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10383,7 +10383,7 @@
     },
     "packages/core": {
       "name": "@helios-project/core",
-      "version": "4.1.0",
+      "version": "5.0.1",
       "license": "ELv2",
       "devDependencies": {
         "typescript": "^5.0.0",
@@ -10395,7 +10395,7 @@
       "version": "0.56.1",
       "license": "ELv2",
       "dependencies": {
-        "@helios-project/core": "^4.1.0",
+        "@helios-project/core": "^5.0.1",
         "mediabunny": "^1.31.0"
       },
       "devDependencies": {
@@ -10410,7 +10410,7 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/core": "4.1.0",
+        "@helios-project/core": "5.0.1",
         "playwright": "^1.42.1"
       },
       "devDependencies": {
@@ -10442,7 +10442,7 @@
       "version": "0.72.1",
       "license": "ELv2",
       "dependencies": {
-        "@helios-project/core": "^4.1.0",
+        "@helios-project/core": "5.0.1",
         "@helios-project/player": "^0.48.3",
         "@helios-project/renderer": "^0.0.2",
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "4.1.0",
+    "@helios-project/core": "5.0.1",
     "playwright": "^1.42.1"
   },
   "devDependencies": {

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -45,6 +45,7 @@ const tests = [
   'tests/verify-shadow-dom-sync.ts',
   'tests/verify-smart-codec-selection.ts',
   'tests/verify-stream-copy.ts',
+  'tests/verify-video-loop.ts',
   'tests/verify-waapi-sync.ts',
   'scripts/verify-advanced-audio.ts',
   'scripts/verify-audio-args.ts',


### PR DESCRIPTION
💡 What: Enabled the `verify-video-loop.ts` regression test in `run-all.ts` and updated `packages/renderer` dependencies to match the workspace version of `@helios-project/core` (5.0.1).
🎯 Why: To ensure the previously implemented looping media logic in `SeekTimeDriver` and `CdpTimeDriver` is rigorously tested and to fix the broken verification environment caused by dependency mismatch.
📊 Impact: Confirms correct looping behavior for video/audio elements in both DOM and Canvas rendering strategies, preventing regressions where looped media might freeze or play linearly.
🔬 Verification: Run `npm test` in `packages/renderer` or `npx tsx packages/renderer/tests/verify-video-loop.ts`. The test verifies modulo arithmetic for looped media timestamps.

---
*PR created automatically by Jules for task [9150850122773964134](https://jules.google.com/task/9150850122773964134) started by @BintzGavin*