### PR TITLE
Plan: Configurable Export Quality for Helios Player

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -29,3 +29,7 @@
 ## [v0.57.0] - Dependency Deadlock
 **Learning:** Encountered a situation where root-level `npm install` failed due to version mismatches in *other* workspaces, blocking `npm run build` for the current workspace despite correct local dependencies.
 **Action:** When verification is blocked by external environment issues, proceed with implementation and manual code verification, but clearly document the limitation. Ensure unit tests are added to aid future validation once the environment is stabilized.
+
+## [v0.58.0] - Export Bitrate Configuration
+**Learning:** `mediabunny` exposes `bitrate` in its `VideoEncodingConfig`, which maps directly to WebCodecs `VideoEncoder` configuration, allowing for precise quality control.
+**Action:** When adding export configuration, pass parameters directly through to the `VideoEncodingConfig` object in `ClientSideExporter`.

--- a/.sys/plans/2026-02-02-PLAYER-Configurable-Export-Quality.md
+++ b/.sys/plans/2026-02-02-PLAYER-Configurable-Export-Quality.md
@@ -1,0 +1,41 @@
+# Plan: Configurable Export Quality for Helios Player
+
+## 1. Context & Goal
+- **Objective**: Implement configurable video export quality via `export-quality` (preset) and `export-bitrate` (explicit) attributes on `<helios-player>`.
+- **Trigger**: The current export implementation hardcodes the bitrate to 5Mbps, which causes artifacts in 4K exports and wasted bandwidth for small previews.
+- **Impact**: Unlocks professional-grade high-resolution exports and efficient low-bandwidth previews.
+
+## 2. File Inventory
+- **Modify**: `packages/player/src/index.ts` (Add `export-quality`, `export-bitrate` attributes and pass to exporter)
+- **Modify**: `packages/player/src/features/exporter.ts` (Implement bitrate calculation logic)
+- **Modify**: `packages/player/src/features/exporter.test.ts` (Add unit tests for bitrate calculation and new options)
+
+## 3. Implementation Spec
+- **Architecture**:
+  - Update `HeliosPlayer` to observe `export-quality` and `export-bitrate`.
+  - Update `ClientSideExporter.export()` interface to accept `bitrate` (number).
+  - In `exporter.ts`, calculate target bitrate if not explicitly provided:
+    - Formula: `bitrate = width * height * fps * bpp`
+    - BPP (Bits Per Pixel) Mapping:
+      - `low`: 0.05
+      - `medium`: 0.1 (default)
+      - `high`: 0.2
+      - `extreme`: 0.3
+- **Public API Changes**:
+  - `<helios-player>` attributes:
+    - `export-quality`: "low" | "medium" | "high" | "extreme" (default: "medium")
+    - `export-bitrate`: number (bits per second, overrides quality)
+  - `HeliosPlayer` properties:
+    - `exportQuality`: string
+    - `exportBitrate`: number
+- **Dependencies**: None.
+
+## 4. Test Plan
+- **Verification**: Run `npm test` in `packages/player`.
+- **Success Criteria**:
+  - `exporter.test.ts` verifies that `VideoSampleSource` receives the correct bitrate for different quality settings.
+  - `exporter.test.ts` verifies that `export-bitrate` overrides `export-quality`.
+  - Existing tests pass.
+- **Edge Cases**:
+  - Invalid `export-quality` string (fallback to medium).
+  - `export-bitrate` set to 0 or negative (fallback to default calculation).


### PR DESCRIPTION
This plan details the implementation of configurable export quality for the `<helios-player>` component. It introduces `export-quality` (preset) and `export-bitrate` (explicit) attributes to control the `VideoEncoder` bitrate via `mediabunny`.

---
*PR created automatically by Jules for task [10955671356261548403](https://jules.google.com/task/10955671356261548403) started by @BintzGavin*