### PR TITLE
✨ DEMO: Fix Promo Video Rendering

### DIFF
--- a/docs/PROGRESS-DEMO.md
+++ b/docs/PROGRESS-DEMO.md
@@ -1,3 +1,6 @@
+## DEMO v1.85.1
+- ✅ Completed: Fix Promo Video Rendering - Updated workspace dependencies to resolve build failures and confirmed successful rendering of `examples/promo-video`.
+
 ## DEMO v1.85.0
 - ✅ Completed: Vanilla Captions Animation - Created `examples/vanilla-captions-animation` demonstrating Helios captions (SRT) support in Vanilla TypeScript, replacing the legacy `examples/captions-animation`.
 

--- a/docs/status/DEMO.md
+++ b/docs/status/DEMO.md
@@ -1,6 +1,6 @@
 # Status: DEMO Domain
 
-**Version**: 1.85.0
+**Version**: 1.85.1
 
 ## Vision
 The DEMO domain is responsible for:
@@ -15,6 +15,7 @@ The DEMO domain is responsible for:
 - None
 
 ## Completed Tasks
+- [v1.85.1] ✅ Completed: Fix Promo Video Rendering - Updated workspace dependencies to resolve build failures and confirmed successful rendering of `examples/promo-video`.
 - [v1.85.0] ✅ Completed: Vanilla Captions Animation - Created `examples/vanilla-captions-animation` demonstrating Helios captions (SRT) support in Vanilla TypeScript, replacing the legacy `examples/captions-animation`.
 - [v1.84.0] ✅ Completed: Solid Captions Animation - Created `examples/solid-captions-animation` demonstrating Helios captions (SRT) support in SolidJS.
 - [v1.83.0] ✅ Completed: Solid Three.js Canvas Animation - Created `examples/solid-threejs-canvas-animation` demonstrating Three.js integration with SolidJS and Helios.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10383,7 +10383,7 @@
     },
     "packages/core": {
       "name": "@helios-project/core",
-      "version": "5.0.1",
+      "version": "5.1.0",
       "license": "ELv2",
       "devDependencies": {
         "typescript": "^5.0.0",
@@ -10395,7 +10395,7 @@
       "version": "0.56.1",
       "license": "ELv2",
       "dependencies": {
-        "@helios-project/core": "^5.0.1",
+        "@helios-project/core": "^5.1.0",
         "mediabunny": "^1.31.0"
       },
       "devDependencies": {
@@ -10410,7 +10410,7 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/core": "5.0.1",
+        "@helios-project/core": "5.1.0",
         "playwright": "^1.42.1"
       },
       "devDependencies": {
@@ -10442,8 +10442,8 @@
       "version": "0.72.1",
       "license": "ELv2",
       "dependencies": {
-        "@helios-project/core": "5.0.1",
-        "@helios-project/player": "^0.48.3",
+        "@helios-project/core": "^5.1.0",
+        "@helios-project/player": "^0.56.1",
         "@helios-project/renderer": "^0.0.2",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "react": "^19.2.3",
@@ -10483,16 +10483,6 @@
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
-      }
-    },
-    "packages/studio/node_modules/@helios-project/player": {
-      "version": "0.48.3",
-      "resolved": "https://registry.npmjs.org/@helios-project/player/-/player-0.48.3.tgz",
-      "integrity": "sha512-YqG7dMlBNq9TDbNaUelSgcNITaTjwJU9EwooyYSYv2JFNiC9SyubR22wiR03AOpLlkdDWA1LTggDak/k+cfCDQ==",
-      "license": "ELv2",
-      "dependencies": {
-        "@helios-project/core": "^3.3.0",
-        "mediabunny": "^1.31.0"
       }
     },
     "packages/studio/node_modules/cssstyle": {

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -46,7 +46,7 @@
     "helios"
   ],
   "dependencies": {
-    "@helios-project/core": "^5.0.1",
+    "@helios-project/core": "^5.1.0",
     "mediabunny": "^1.31.0"
   },
   "devDependencies": {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "5.0.1",
+    "@helios-project/core": "5.1.0",
     "playwright": "^1.42.1"
   },
   "devDependencies": {

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -44,8 +44,8 @@
     "helios"
   ],
   "dependencies": {
-    "@helios-project/core": "^4.1.0",
-    "@helios-project/player": "^0.48.3",
+    "@helios-project/core": "^5.1.0",
+    "@helios-project/player": "^0.56.1",
     "@helios-project/renderer": "^0.0.2",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "react": "^19.2.3",


### PR DESCRIPTION
Fixed dependency mismatches in workspace packages (`renderer`, `player`, `studio`) that were causing build failures and preventing the Promo Video example from rendering correctly. Verified the fix by running E2E tests for the Promo Video example.

---
*PR created automatically by Jules for task [5562785198809085581](https://jules.google.com/task/5562785198809085581) started by @BintzGavin*