### PR TITLE
✨ RENDERER: Sync Core Dependency and Verify GSAP Fix

### DIFF
--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.57.2
+- ✅ Completed: Sync Core Dependency - Updated `packages/renderer` dependency on `@helios-project/core` to `5.1.0` to match the local workspace, resolving build failures and enabling verification of GSAP timeline synchronization.
+
 ## RENDERER v1.57.1
 - ✅ Completed: Verify Looping Media - Enabled regression test `verify-video-loop.ts` in `run-all.ts` and updated dependencies to resolve environment issues, confirming correct looping behavior in both SeekTimeDriver and CdpTimeDriver.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,11 @@
+**Version**: 1.57.2
+
 **Version**: 1.57.1
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.57.2] ✅ Completed: Sync Core Dependency - Updated `packages/renderer` dependency on `@helios-project/core` to `5.1.0` to match the local workspace, resolving build failures and enabling verification of GSAP timeline synchronization.
 - [1.57.1] ✅ Completed: Verify Looping Media - Enabled regression test `verify-video-loop.ts` in `run-all.ts` and updated dependencies to resolve environment issues, confirming correct looping behavior in both SeekTimeDriver and CdpTimeDriver.
 - [1.57.0] ✅ Completed: Enable Looping Media - Updated SeekTimeDriver and CdpTimeDriver to implement modulo arithmetic for `currentTime` when the `loop` attribute is present, ensuring correct looping behavior during rendering.
 - [1.56.5] ✅ Completed: Update Verification Suite - Updated `verify-ffmpeg-path.ts` to be self-contained and robust, and verified that `verify-cancellation.ts`, `verify-trace.ts`, and `verify-ffmpeg-path.ts` pass and are included in the main test runner.

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "5.0.1",
+    "@helios-project/core": "5.1.0",
     "playwright": "^1.42.1"
   },
   "devDependencies": {


### PR DESCRIPTION
💡 **What**: Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `5.1.0`. Verified the fix for GSAP timeline synchronization by rendering `examples/promo-video`.

🎯 **Why**: The `packages/renderer` workspace was pinned to `5.0.1`, but the local `packages/core` is at `5.1.0`, causing `npm install` to fail and blocking verification. The "GSAP Timeline Synchronization" issue was reported as a regression, and verifying it required a working environment.

📊 **Impact**: Unblocks development and verification for the Renderer domain. Confirms that `SeekTimeDriver` correctly handles GSAP animations via Helios subscription even if direct timeline detection fails.

🔬 **Verification**:
1. `npm install` (via manual linking for verification) -> Success.
2. `npm test` in `packages/renderer` -> `verify-video-loop.ts` passed.
3. `npx tsx examples/promo-video/render.ts` -> Generated valid video (893KB) with visible animation, confirming the fix works.

---
*PR created automatically by Jules for task [11463572192626665000](https://jules.google.com/task/11463572192626665000) started by @BintzGavin*