### PR TITLE
✨ STUDIO: Implement Timeline Audio Visualization

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -6,7 +6,7 @@ Studio acts as a host environment for the Helios Player.
 
 - **Frontend**: React-based UI that wraps the `<helios-player>` component.
 - **Backend**: Vite plugin (`vite-plugin-studio-api`) that provides API endpoints for file discovery, asset management, and render job orchestration.
-- **Context**: `StudioContext` manages the global state (active composition, player state, assets).
+- **Context**: `StudioContext` manages the global state (active composition, player state including audio tracks metadata, assets).
 
 ## B. File Tree
 
@@ -42,7 +42,7 @@ packages/studio/
 
 ## D. UI Components
 
-- **Timeline**: Visual timeline with scrubbing, playhead, and markers.
+- **Timeline**: Visual timeline with scrubbing, playhead, markers, and audio track visualization.
 - **Props Editor**: Schema-aware input forms for composition properties.
 - **Assets Panel**: Drag-and-drop asset management.
 - **Renders Panel**: Render job tracking and history.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.81.0
+- ✅ Completed: Timeline Audio Visualization - Implemented visualization of audio tracks on the timeline using `availableAudioTracks` metadata, separating it from runtime state.
+
 ## STUDIO v0.80.2
 - ✅ Completed: Test Coverage - Added unit tests for Toast notification system (ToastItem, ToastContext, ToastContainer) and verified with mocked environment.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.80.2
+**Version**: 0.81.0
 
 # Studio Domain Status
 
@@ -7,6 +7,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.81.0] ✅ Completed: Timeline Audio Visualization - Implemented visualization of audio tracks on the timeline using `availableAudioTracks` metadata, separating it from runtime state.
 - [v0.80.2] ✅ Completed: Test Coverage - Added unit tests for Toast notification system (ToastItem, ToastContext, ToastContainer) and verified with mocked environment.
 - [v0.80.1] ✅ Completed: Maintenance - Updated dependencies to align with Core v5 and Player v0.57.1, resolving workspace conflicts.
 - [v0.80.0] ✅ Completed: Toast Notifications - Implemented centralized toast notification system for success/error feedback.

--- a/packages/studio/src/components/AssetsPanel/AssetItem.test.tsx
+++ b/packages/studio/src/components/AssetsPanel/AssetItem.test.tsx
@@ -4,6 +4,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AssetItem } from './AssetItem';
 import { Asset } from '../../context/StudioContext';
 
+// Mock useToast
+vi.mock('../../context/ToastContext', () => ({
+  useToast: () => ({ addToast: vi.fn() })
+}));
+
 // Mock useStudio
 const mockDeleteAsset = vi.fn();
 const mockRenameAsset = vi.fn(() => Promise.resolve());

--- a/packages/studio/src/components/Timeline.test.tsx
+++ b/packages/studio/src/components/Timeline.test.tsx
@@ -21,6 +21,8 @@ describe('Timeline', () => {
     playbackRate: 1,
     isPlaying: false,
     inputProps: {},
+    availableAudioTracks: [],
+    audioTracks: {},
   };
 
   const defaultContext = {
@@ -153,5 +155,31 @@ describe('Timeline', () => {
 
     expect(event.stopPropagation).toHaveBeenCalled();
     expect(mockSeek).toHaveBeenCalledWith(150); // 5s * 30fps = 150
+  });
+
+  it('renders audio tracks from playerState.availableAudioTracks', () => {
+    const availableAudioTracks = [
+      { id: 'track1', startTime: 2, duration: 4 }, // Start 2s, End 6s
+      { id: 'track2', startTime: 8, duration: 1 }  // Start 8s, End 9s
+    ];
+
+    (StudioContext.useStudio as any).mockReturnValue({
+      ...defaultContext,
+      playerState: { ...defaultPlayerState, availableAudioTracks }
+    });
+
+    const { container } = render(<Timeline />);
+    const tracks = container.querySelectorAll('.timeline-audio-track');
+
+    expect(tracks).toHaveLength(2);
+    expect(tracks[0]).toHaveAttribute('title', 'Audio: track1');
+    expect(tracks[1]).toHaveAttribute('title', 'Audio: track2');
+
+    // Verify positioning (roughly)
+    // Total frames = 300 (10s)
+    // Track 1: Start 2s (60f) -> 20%. Duration 4s (120f) -> 40%.
+    const style1 = tracks[0].getAttribute('style');
+    expect(style1).toContain('left: 20%');
+    expect(style1).toContain('width: 40%');
   });
 });

--- a/packages/studio/src/components/Timeline.tsx
+++ b/packages/studio/src/components/Timeline.tsx
@@ -26,7 +26,7 @@ export const Timeline: React.FC = () => {
   const totalFrames = duration * fps || 100;
   const captions = playerState.captions || [];
   const markers = playerState.markers || [];
-  const audioTracks = playerState.audioTracks || [];
+  const audioTracks = playerState.availableAudioTracks || [];
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);

--- a/packages/studio/src/context/StudioContext.test.tsx
+++ b/packages/studio/src/context/StudioContext.test.tsx
@@ -3,6 +3,12 @@ import { render, act, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { StudioProvider, useStudio } from './StudioContext';
 
+// Mock ToastContext
+vi.mock('./ToastContext', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+  ToastProvider: ({ children }: any) => <div>{children}</div>
+}));
+
 // Mock Component to consume context and trigger snapshot
 const TestComponent = ({ onReady }: { onReady: (context: any) => void }) => {
   const context = useStudio();

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useRef } from 'react';
 import { type HeliosController, ClientSideExporter } from '@helios-project/player';
-import type { HeliosSchema, CaptionCue, Marker } from '@helios-project/core';
+import type { HeliosSchema, CaptionCue, Marker, AudioTrackMetadata } from '@helios-project/core';
 import { useToast } from './ToastContext';
 
 export interface CompositionMetadata {
@@ -46,12 +46,6 @@ export interface RenderJob {
   outPoint?: number;
 }
 
-export interface AudioTrackMetadata {
-  id: string;
-  startTime: number;
-  duration: number;
-}
-
 export interface PlayerState {
   currentFrame: number;
   duration: number;
@@ -64,7 +58,8 @@ export interface PlayerState {
   schema?: HeliosSchema;
   captions: CaptionCue[];
   markers: Marker[];
-  audioTracks: AudioTrackMetadata[];
+  audioTracks: Record<string, { volume: number; muted: boolean }>;
+  availableAudioTracks: AudioTrackMetadata[];
 }
 
 const DEFAULT_PLAYER_STATE: PlayerState = {
@@ -79,7 +74,8 @@ const DEFAULT_PLAYER_STATE: PlayerState = {
   schema: undefined,
   captions: [],
   markers: [],
-  audioTracks: []
+  audioTracks: {},
+  availableAudioTracks: []
 };
 
 interface StudioContextType {


### PR DESCRIPTION
Implemented visualization of audio tracks on the Studio Timeline.

💡 **What**:
- Refactored `PlayerState` in `StudioContext` to separate `audioTracks` (runtime state: volume/mute) and `availableAudioTracks` (metadata: id/start/duration).
- Updated `Timeline.tsx` to visualize audio blocks using `availableAudioTracks` metadata.
- Updated `Timeline.test.tsx` to verify correct rendering of audio tracks.
- Fixed test regressions in `AssetItem` and `StudioContext` by mocking `useToast` correctly.

🎯 **Why**:
- The timeline previously tried to use `audioTracks` as an array, but it was being populated as a state object from Core, causing potential crashes or incorrect data usage.
- Users need to see where audio clips are placed on the timeline relative to the video.

📊 **Impact**:
- `Timeline` now correctly displays audio tracks as colored bars.
- `StudioContext` type definitions now match the runtime data flow from `Helios` core.
- Test suite is passing and more robust.

🔬 **Verification**:
- `npm test` in `packages/studio` passed (102 tests).
- Verified `Timeline.test.tsx` specifically checks for `.timeline-audio-track` elements and their positioning.

---
*PR created automatically by Jules for task [6710420583799331707](https://jules.google.com/task/6710420583799331707) started by @BintzGavin*