### PR TITLE
✨ PLAYER: Fix Test Configuration

### DIFF
--- a/packages/player/vitest.config.ts
+++ b/packages/player/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    include: ['src/**/*.test.ts'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Modified `packages/player/vitest.config.ts` to restrict test discovery to the package's source directory, preventing interference from other workspaces.

---
*PR created automatically by Jules for task [5983628095350226725](https://jules.google.com/task/5983628095350226725) started by @BintzGavin*