### PR TITLE
✨ CORE: Fix Subscription Timing for Virtual Time Sync

### DIFF
--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v5.2.1
+- ✅ Completed: Fix Subscription Timing - Forced notification in `bindToDocumentTimeline` when virtual time is set to the same frame, ensuring external drivers (e.g. GSAP) remain synchronized during precise seeking.
+
 ## CORE v5.2.0
 - ✅ Completed: Expose Audio Fades - Updated `AudioTrackMetadata` to include `fadeInDuration` and `fadeOutDuration`, and updated `DomDriver` to automatically discover these values from `data-helios-fade-in` and `data-helios-fade-out` attributes.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 5.2.0
+**Version**: 5.2.1
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
 - **Last Updated**: 2026-08-01
 
+[v5.2.1] ✅ Completed: Fix Subscription Timing - Forced notification in `bindToDocumentTimeline` when virtual time is set to the same frame, ensuring external drivers (e.g. GSAP) remain synchronized during precise seeking.
 [v5.2.0] ✅ Completed: Expose Audio Fades - Updated `AudioTrackMetadata` to include `fadeInDuration` and `fadeOutDuration`, and updated `DomDriver` to automatically discover these values from `data-helios-fade-in` and `data-helios-fade-out` attributes.
 [v5.1.2] ✅ Completed: Fix GSAP Synchronization - Forced subscriber notification in `bindToDocumentTimeline` when virtual time is present to ensure initial state synchronization with external libraries like GSAP, resolving black frames in render output.
 [v5.1.1] ✅ Completed: Fix Virtual Time Synchronization - Enhanced `bindToDocumentTimeline` to robustly handle reactive binding failures (falling back to manual polling) and updated `waitUntilStable` to block until virtual time is fully synchronized, fixing race conditions in frame-by-frame rendering.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10383,7 +10383,7 @@
     },
     "packages/core": {
       "name": "@helios-project/core",
-      "version": "5.1.1",
+      "version": "5.2.1",
       "license": "ELv2",
       "devDependencies": {
         "typescript": "^5.0.0",
@@ -10395,7 +10395,7 @@
       "version": "0.57.1",
       "license": "ELv2",
       "dependencies": {
-        "@helios-project/core": "^5.1.0",
+        "@helios-project/core": "5.2.1",
         "mediabunny": "^1.31.0"
       },
       "devDependencies": {
@@ -10410,7 +10410,7 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/core": "5.1.1",
+        "@helios-project/core": "5.2.1",
         "playwright": "^1.42.1"
       },
       "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/core",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "type": "module",
   "description": "Core library for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",

--- a/packages/core/src/Helios.ts
+++ b/packages/core/src/Helios.ts
@@ -1001,6 +1001,11 @@ export class Helios<TInputProps = Record<string, any>> {
               const frame = (value / 1000) * this._fps.value;
               if (frame !== this._currentFrame.peek()) {
                 this._currentFrame.value = frame;
+              } else {
+                // Force notification to ensure subscribers are synced even if frame matches.
+                // This is critical for external drivers (like SeekTimeDriver) that rely on
+                // the "set" event to synchronize other systems (like GSAP timelines).
+                this._syncVersion.value++;
               }
 
               this.driver.update(value, {
@@ -1019,8 +1024,6 @@ export class Helios<TInputProps = Record<string, any>> {
         // Trigger initial update if value exists
         if (virtualTimeValue !== null) {
           (window as any).__HELIOS_VIRTUAL_TIME__ = virtualTimeValue;
-          // Force notification to ensure subscribers are synced even if frame matches
-          this._syncVersion.value++;
         }
       } catch (e) {
         console.warn('Failed to bind reactive virtual time. Helios will fall back to polling, which may affect synchronization accuracy.', e);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,4 +15,4 @@ export * from './ai.js';
 export * from './Helios.js';
 export * from './render-session.js';
 
-export const VERSION = '5.2.0';
+export const VERSION = '5.2.1';

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -46,7 +46,7 @@
     "helios"
   ],
   "dependencies": {
-    "@helios-project/core": "^5.1.0",
+    "@helios-project/core": "5.2.1",
     "mediabunny": "^1.31.0"
   },
   "devDependencies": {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/core": "5.1.1",
+    "@helios-project/core": "5.2.1",
     "playwright": "^1.42.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- **What**: Modified `Helios.ts` to force a `_syncVersion` update when `__HELIOS_VIRTUAL_TIME__` is set, even if the frame index hasn't changed.
- **Why**: To fix a synchronization issue where external drivers (e.g., GSAP via `SeekTimeDriver`) were not being updated during initial seeks or redundant time updates because the signal system optimized them away as "no change". This caused black frames in renders where GSAP timelines weren't seeked to the correct time.
- **Impact**: Ensures reliable frame-accurate rendering for GSAP and other external animation libraries driven by Helios subscriptions.
- **Verification**: Verified with a reproduction test case (`subscription-timing-edge.test.ts`) that confirmed the failure before the fix and success after. Existing tests passed.

---
*PR created automatically by Jules for task [12984376649180297100](https://jules.google.com/task/12984376649180297100) started by @BintzGavin*