### PR TITLE
CORE: Expose Audio Source in Metadata

### DIFF
--- a/.jules/CORE.md
+++ b/.jules/CORE.md
@@ -37,3 +37,7 @@
 ## [5.2.0] - Utility vs Runtime Integration
 **Learning:** Utilities like `sequencing.ts` can exist in isolation without being integrated into the core runtime (`Helios` class), creating a "Vision Gap" where a feature is technically "possible" but not "supported" by the engine.
 **Action:** When auditing features like "Sequencing", check not just for the existence of helper functions, but for the integration points (e.g. `bindTo` options) that make them usable in the core loop.
+
+## [5.2.1] - Audio Source Discovery
+**Learning:** Client-side export (WebCodecs) requires access to audio sources for muxing, but `AudioTrackMetadata` previously only exposed timing data, forcing consumers to scrape the DOM or re-fetch assets.
+**Action:** When designing "Headless" state, ensure it contains all data necessary for reconstruction (like `src`), not just simulation parameters.

--- a/.sys/plans/2026-08-01-CORE-Expose-Audio-Source.md
+++ b/.sys/plans/2026-08-01-CORE-Expose-Audio-Source.md
@@ -1,0 +1,40 @@
+# Spec: Expose Audio Source in Metadata
+
+#### 1. Context & Goal
+- **Objective**: Expose the source URL (`src`) of audio tracks in the `AudioTrackMetadata` interface.
+- **Trigger**: Roadmap item "Client-Side WebCodecs as Primary Export" requires access to audio sources for muxing without DOM scraping.
+- **Impact**: Enables `packages/studio` (Timeline visualization) and `packages/player` (Client-side export) to access audio data directly from the Core state.
+
+#### 2. File Inventory
+- **Modify**: `packages/core/src/drivers/TimeDriver.ts` (Add `src` to interface)
+- **Modify**: `packages/core/src/drivers/DomDriver.ts` (Populate `src`)
+- **Modify**: `packages/core/src/drivers/DomDriver-metadata.test.ts` (Verify `src` discovery)
+
+#### 3. Implementation Spec
+- **Architecture**: Update `AudioTrackMetadata` interface to include `src`. `DomDriver` extracts it from `HTMLMediaElement`.
+- **Pseudo-Code**:
+  ```typescript
+  // TimeDriver.ts
+  export interface AudioTrackMetadata {
+    // ...
+    src: string;
+  }
+
+  // DomDriver.ts
+  private rebuildDiscoveredTracks() {
+    // ...
+    const src = el.currentSrc || el.src || '';
+    // ...
+    this.discoveredTracks.set(id, {
+        // ...
+        src
+    });
+  }
+  ```
+- **Public API Changes**: `AudioTrackMetadata` gains `src` property.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm test -w packages/core`
+- **Success Criteria**: `DomDriver-metadata.test.ts` passes with new assertions checking for `src`.
+- **Edge Cases**: Empty `src` should be empty string.


### PR DESCRIPTION
Plan to add 'src' property to AudioTrackMetadata and populate it in DomDriver to support client-side export.

---
*PR created automatically by Jules for task [18205736972787910534](https://jules.google.com/task/18205736972787910534) started by @BintzGavin*