### PR TITLE
✨ CORE: Expose Audio Source

### DIFF
--- a/.sys/llmdocs/context-core.md
+++ b/.sys/llmdocs/context-core.md
@@ -45,6 +45,7 @@ packages/core/src/
 ```typescript
 export interface AudioTrackMetadata {
   id: string;
+  src: string;
   startTime: number;
   duration: number;
   fadeInDuration?: number;

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -42,6 +42,7 @@
 ### 8. Maintenance
 - [x] Synchronize package versions (Fix CORE 2.7.1 dependency mismatch in PLAYER/RENDERER).
 - [x] Fix workspace version mismatch between packages/renderer and packages/core (Core 2.11.0 vs Renderer req 2.10.0).
+- [x] Expose Audio Source in Metadata (`AudioTrackMetadata.src`) to enable client-side access to audio URLs.
 - [x] **Fix GSAP Timeline Synchronization in SeekTimeDriver**
   - **Problem**: Promo video (`examples/promo-video/composition.html`) renders a black video with only the background visible. All scenes (Logo Reveal, Tagline, Code to Video, Frameworks, CTA, End Card) are missing because GSAP timeline animations aren't being seeked during rendering.
   - **Last Working State**: Commit `9558e19` (Jan 29, 2026) - "✨ PROMO: Add Promo Video Example and Render Script"

--- a/docs/PROGRESS-CORE.md
+++ b/docs/PROGRESS-CORE.md
@@ -1,5 +1,8 @@
 # CORE Progress Log
 
+## CORE v5.3.0
+- ✅ Completed: Expose Audio Source - Updated `AudioTrackMetadata` to include `src` property, populated by `DomDriver` from `currentSrc` or `src` attribute, enabling access to audio source URLs in metadata.
+
 ## CORE v5.2.1
 - ✅ Completed: Fix Subscription Timing - Forced notification in `bindToDocumentTimeline` when virtual time is set to the same frame, ensuring external drivers (e.g. GSAP) remain synchronized during precise seeking.
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 5.2.1
+**Version**: 5.3.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
 - **Last Updated**: 2026-08-01
 
+[v5.3.0] ✅ Completed: Expose Audio Source - Updated `AudioTrackMetadata` to include `src` property, populated by `DomDriver` from `currentSrc` or `src` attribute, enabling access to audio source URLs in metadata.
 [v5.2.1] ✅ Completed: Fix Subscription Timing - Forced notification in `bindToDocumentTimeline` when virtual time is set to the same frame, ensuring external drivers (e.g. GSAP) remain synchronized during precise seeking.
 [v5.2.0] ✅ Completed: Expose Audio Fades - Updated `AudioTrackMetadata` to include `fadeInDuration` and `fadeOutDuration`, and updated `DomDriver` to automatically discover these values from `data-helios-fade-in` and `data-helios-fade-out` attributes.
 [v5.1.2] ✅ Completed: Fix GSAP Synchronization - Forced subscriber notification in `bindToDocumentTimeline` when virtual time is present to ensure initial state synchronization with external libraries like GSAP, resolving black frames in render output.

--- a/packages/core/src/drivers/DomDriver.ts
+++ b/packages/core/src/drivers/DomDriver.ts
@@ -71,7 +71,7 @@ export class DomDriver implements TimeDriver {
         childList: true,
         subtree: true,
         attributes: true,
-        attributeFilter: ['data-helios-track-id', 'data-helios-offset', 'data-helios-fade-in', 'data-helios-fade-out']
+        attributeFilter: ['data-helios-track-id', 'data-helios-offset', 'data-helios-fade-in', 'data-helios-fade-out', 'src']
       });
       this.observers.set(scope, observer);
     }
@@ -183,9 +183,11 @@ export class DomDriver implements TimeDriver {
             const duration = (!isNaN(el.duration) && isFinite(el.duration)) ? el.duration : 0;
             const fadeInDuration = parseFloat(el.getAttribute('data-helios-fade-in') || '0');
             const fadeOutDuration = parseFloat(el.getAttribute('data-helios-fade-out') || '0');
+            const src = el.currentSrc || el.src || '';
 
             this.discoveredTracks.set(id, {
                 id,
+                src,
                 startTime,
                 duration,
                 fadeInDuration,
@@ -206,7 +208,7 @@ export class DomDriver implements TimeDriver {
               this.emitMetadata();
               return;
           }
-          if (oldMeta.startTime !== meta.startTime || oldMeta.duration !== meta.duration || oldMeta.fadeInDuration !== meta.fadeInDuration || oldMeta.fadeOutDuration !== meta.fadeOutDuration) {
+          if (oldMeta.startTime !== meta.startTime || oldMeta.duration !== meta.duration || oldMeta.fadeInDuration !== meta.fadeInDuration || oldMeta.fadeOutDuration !== meta.fadeOutDuration || oldMeta.src !== meta.src) {
               this.emitMetadata();
               return;
           }

--- a/packages/core/src/drivers/TimeDriver.ts
+++ b/packages/core/src/drivers/TimeDriver.ts
@@ -1,5 +1,6 @@
 export interface AudioTrackMetadata {
   id: string;
+  src: string;
   startTime: number;
   duration: number;
   fadeInDuration?: number;


### PR DESCRIPTION
Exposed `src` property in `AudioTrackMetadata` to allow consumers to access the audio source URL. Updated `DomDriver` to populate this property from discovered `HTMLMediaElement`s. This is required for client-side export workflows where the audio data needs to be fetched and processed.

---
*PR created automatically by Jules for task [9686116344757334654](https://jules.google.com/task/9686116344757334654) started by @BintzGavin*