### PR TITLE
✨ RENDERER: Enable Audio Playback Rate

### DIFF
--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.60.0
+- ✅ Completed: Enable Audio Playback Rate - Updated `AudioTrackConfig` to include `playbackRate`, and implemented `atempo` filter chaining in `FFmpegBuilder` to support speed adjustments (including values outside 0.5-2.0 range). Also updated `DomScanner` to extract `playbackRate` from media elements.
+
 ## RENDERER v1.59.0
 - ✅ Completed: Local Distributed Rendering - Implemented `RenderOrchestrator` to split render jobs into concurrent chunks and concatenate them, enabling faster local rendering. Also refactored `Renderer` to its own file to support this architecture.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.59.0
+**Version**: 1.60.0
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.60.0] ✅ Completed: Enable Audio Playback Rate - Updated `AudioTrackConfig` to include `playbackRate`, and implemented `atempo` filter chaining in `FFmpegBuilder` to support speed adjustments (including values outside 0.5-2.0 range). Also updated `DomScanner` to extract `playbackRate` from media elements.
 - [1.59.0] ✅ Completed: Local Distributed Rendering - Implemented `RenderOrchestrator` to split render jobs into concurrent chunks and concatenate them, enabling faster local rendering. Also refactored `Renderer` to its own file to support this architecture.
 - [1.58.0] ✅ Completed: Zero Disk Audio - Refactored `blob-extractor.ts` and `FFmpegBuilder.ts` to pipe audio buffers directly to FFmpeg via stdio pipes (`pipe:N`), eliminating temporary file creation for Blob audio tracks and improving security and performance.
 - [1.57.3] ✅ Completed: Enable Looping Media Verification - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `5.1.1` (matching local workspace), allowing `verify-video-loop.ts` to run and confirm correct looping media implementation in `SeekTimeDriver` and `CdpTimeDriver`.

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -45,6 +45,12 @@ export interface AudioTrackConfig {
    * Defaults to false.
    */
   loop?: boolean;
+
+  /**
+   * Playback rate multiplier (e.g., 0.5, 1.0, 2.0).
+   * Defaults to 1.0.
+   */
+  playbackRate?: number;
 }
 
 export interface BrowserConfig {

--- a/packages/renderer/src/utils/dom-scanner.ts
+++ b/packages/renderer/src/utils/dom-scanner.ts
@@ -75,6 +75,9 @@ export async function scanForAudioTracks(page: Page): Promise<AudioTrackConfig[]
             const fadeIn = el.dataset.heliosFadeIn ? parseFloat(el.dataset.heliosFadeIn) : 0;
             const fadeOut = el.dataset.heliosFadeOut ? parseFloat(el.dataset.heliosFadeOut) : 0;
             const volume = el.muted ? 0 : el.volume;
+            // Get playbackRate from property or attribute
+            const rateAttr = el.getAttribute('playbackRate');
+            const rate = el.playbackRate !== undefined ? el.playbackRate : (rateAttr ? parseFloat(rateAttr) : 1.0);
 
             tracks.push({
               path: src,
@@ -83,7 +86,8 @@ export async function scanForAudioTracks(page: Page): Promise<AudioTrackConfig[]
               seek: isNaN(seek) ? 0 : seek,
               fadeInDuration: isNaN(fadeIn) ? 0 : fadeIn,
               fadeOutDuration: isNaN(fadeOut) ? 0 : fadeOut,
-              loop: el.loop
+              loop: el.loop,
+              playbackRate: isNaN(rate) ? 1.0 : rate
             });
           }
         });
@@ -111,6 +115,7 @@ export async function scanForAudioTracks(page: Page): Promise<AudioTrackConfig[]
       fadeInDuration: track.fadeInDuration,
       fadeOutDuration: track.fadeOutDuration,
       loop: track.loop,
+      playbackRate: track.playbackRate
     }));
 
   if (validTracks.length > 0) {

--- a/packages/renderer/tests/verify-audio-codecs.ts
+++ b/packages/renderer/tests/verify-audio-codecs.ts
@@ -19,7 +19,7 @@ function runTests() {
 
   // Test 1: Default (AAC)
   console.log('\nTest 1: Default Audio Codec');
-  const args1 = FFmpegBuilder.getArgs(baseOptions, outputPath, dummyInputArgs);
+  const args1 = FFmpegBuilder.getArgs(baseOptions, outputPath, dummyInputArgs).args;
   if (!args1.includes('aac')) {
      console.error('❌ Failed: Expected default audio codec to be aac');
      hasError = true;
@@ -30,7 +30,7 @@ function runTests() {
   // Test 2: Explicit Audio Codec
   console.log('\nTest 2: Explicit Audio Codec (libopus)');
   const options2 = { ...baseOptions, audioCodec: 'libopus' };
-  const args2 = FFmpegBuilder.getArgs(options2, outputPath, dummyInputArgs);
+  const args2 = FFmpegBuilder.getArgs(options2, outputPath, dummyInputArgs).args;
   if (!args2.includes('libopus')) {
      console.error('❌ Failed: Expected audio codec to be libopus');
      hasError = true;
@@ -41,7 +41,7 @@ function runTests() {
   // Test 3: WebM Default (libvorbis)
   console.log('\nTest 3: WebM Default (libvpx implies libvorbis)');
   const options3 = { ...baseOptions, videoCodec: 'libvpx-vp9' };
-  const args3 = FFmpegBuilder.getArgs(options3, 'output.webm', dummyInputArgs);
+  const args3 = FFmpegBuilder.getArgs(options3, 'output.webm', dummyInputArgs).args;
   if (!args3.includes('libvorbis')) {
      console.error('❌ Failed: Expected audio codec to be libvorbis when video is libvpx');
      hasError = true;
@@ -52,7 +52,7 @@ function runTests() {
   // Test 4: Audio Bitrate
   console.log('\nTest 4: Audio Bitrate');
   const options4 = { ...baseOptions, audioBitrate: '192k' };
-  const args4 = FFmpegBuilder.getArgs(options4, outputPath, dummyInputArgs);
+  const args4 = FFmpegBuilder.getArgs(options4, outputPath, dummyInputArgs).args;
   if (!args4.includes('-b:a') || !args4.includes('192k')) {
      console.error('❌ Failed: Expected -b:a 192k');
      hasError = true;

--- a/packages/renderer/tests/verify-audio-playback-rate.ts
+++ b/packages/renderer/tests/verify-audio-playback-rate.ts
@@ -1,0 +1,177 @@
+import { FFmpegBuilder } from '../src/utils/FFmpegBuilder';
+import { RendererOptions } from '../src/types';
+
+function runTests() {
+  console.log('Running Audio Playback Rate Verification...');
+  let hasError = false;
+
+  const baseOptions: RendererOptions = {
+    width: 1920,
+    height: 1080,
+    fps: 30,
+    durationInSeconds: 1,
+    mode: 'canvas',
+  };
+
+  const dummyInputArgs = ['-f', 'image2pipe', '-i', '-'];
+  const outputPath = 'output.mp4';
+
+  function getAudioFilter(args: string[]): string {
+    const complexFilterIndex = args.indexOf('-filter_complex');
+    if (complexFilterIndex === -1) return '';
+    return args[complexFilterIndex + 1];
+  }
+
+  // Test 1: Rate = 1.0 (No atempo)
+  console.log('\nTest 1: Rate 1.0 (Default)');
+  const options1: RendererOptions = {
+    ...baseOptions,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 1.0 }]
+  };
+  const args1 = FFmpegBuilder.getArgs(options1, outputPath, dummyInputArgs);
+  const filter1 = getAudioFilter(args1.args);
+  if (filter1.includes('atempo')) {
+     console.error('❌ Failed: Expected no atempo filter for rate 1.0');
+     console.error('Filter:', filter1);
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  // Test 2: Rate = 2.0 (Single atempo)
+  console.log('\nTest 2: Rate 2.0');
+  const options2: RendererOptions = {
+    ...baseOptions,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 2.0 }]
+  };
+  const args2 = FFmpegBuilder.getArgs(options2, outputPath, dummyInputArgs);
+  const filter2 = getAudioFilter(args2.args);
+  if (!filter2.includes('atempo=2')) {
+     console.error('❌ Failed: Expected atempo=2.0');
+     console.error('Filter:', filter2);
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  // Test 3: Rate = 0.5 (Single atempo)
+  console.log('\nTest 3: Rate 0.5');
+  const options3: RendererOptions = {
+    ...baseOptions,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 0.5 }]
+  };
+  const args3 = FFmpegBuilder.getArgs(options3, outputPath, dummyInputArgs);
+  const filter3 = getAudioFilter(args3.args);
+  if (!filter3.includes('atempo=0.5')) {
+     console.error('❌ Failed: Expected atempo=0.5');
+     console.error('Filter:', filter3);
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  // Test 4: Rate = 4.0 (Chained atempo)
+  console.log('\nTest 4: Rate 4.0 (Chained)');
+  const options4: RendererOptions = {
+    ...baseOptions,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 4.0 }]
+  };
+  const args4 = FFmpegBuilder.getArgs(options4, outputPath, dummyInputArgs);
+  const filter4 = getAudioFilter(args4.args);
+  // Expected: atempo=2.0,atempo=2.0 (or similar logic)
+  // We check for occurrence count
+  const atempoCount4 = (filter4.match(/atempo=2/g) || []).length;
+  if (atempoCount4 < 2) {
+     console.error('❌ Failed: Expected chained atempo for rate 4.0');
+     console.error('Filter:', filter4);
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  // Test 5: Rate = 0.25 (Chained atempo)
+  console.log('\nTest 5: Rate 0.25 (Chained)');
+  const options5: RendererOptions = {
+    ...baseOptions,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 0.25 }]
+  };
+  const args5 = FFmpegBuilder.getArgs(options5, outputPath, dummyInputArgs);
+  const filter5 = getAudioFilter(args5.args);
+  const atempoCount5 = (filter5.match(/atempo=0.5/g) || []).length;
+  if (atempoCount5 < 2) {
+     console.error('❌ Failed: Expected chained atempo for rate 0.25');
+     console.error('Filter:', filter5);
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  // Test 6: Rate = 3.0 (Chained + Remainder)
+  console.log('\nTest 6: Rate 3.0 (Chained + Remainder)');
+  const options6: RendererOptions = {
+    ...baseOptions,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 3.0 }]
+  };
+  const args6 = FFmpegBuilder.getArgs(options6, outputPath, dummyInputArgs);
+  const filter6 = getAudioFilter(args6.args);
+  // Expected: atempo=2.0,atempo=1.5
+  if (!filter6.includes('atempo=2') || !filter6.includes('atempo=1.5')) {
+     console.error('❌ Failed: Expected atempo=2.0 and atempo=1.5 for rate 3.0');
+     console.error('Filter:', filter6);
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  // Test 7: Integration with Delay
+  console.log('\nTest 7: Integration with Delay');
+  const options7: RendererOptions = {
+    ...baseOptions,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 2.0, offset: 5 }]
+  };
+  const args7 = FFmpegBuilder.getArgs(options7, outputPath, dummyInputArgs);
+  const filter7 = getAudioFilter(args7.args);
+
+  // Verify order: atempo must come before adelay
+  const atempoIndex = filter7.indexOf('atempo=2');
+  const adelayIndex = filter7.indexOf('adelay=');
+
+  if (atempoIndex === -1 || adelayIndex === -1) {
+    console.error('❌ Failed: Missing filter components');
+    hasError = true;
+  } else if (atempoIndex > adelayIndex) {
+    console.error('❌ Failed: atempo must be applied before adelay');
+    console.error('Filter:', filter7);
+    hasError = true;
+  } else {
+    console.log('✅ Passed');
+  }
+
+  // Test 8: Invalid Rate (Infinity)
+  console.log('\nTest 8: Invalid Rate (Infinity)');
+  const options8: RendererOptions = {
+    ...baseOptions,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: Infinity }]
+  };
+  const args8 = FFmpegBuilder.getArgs(options8, outputPath, dummyInputArgs);
+  const filter8 = getAudioFilter(args8.args);
+
+  // Expected: No atempo filter (reset to 1.0)
+  if (filter8.includes('atempo')) {
+     console.error('❌ Failed: Expected no atempo filter for Infinity rate');
+     console.error('Filter:', filter8);
+     hasError = true;
+  } else {
+     console.log('✅ Passed');
+  }
+
+  if (hasError) {
+    console.error('\n❌ Verification Failed.');
+    process.exit(1);
+  } else {
+    console.log('\n✅ All verification tests passed!');
+    process.exit(0);
+  }
+}
+
+runTests();

--- a/packages/renderer/tests/verify-audio-playback-rate.ts
+++ b/packages/renderer/tests/verify-audio-playback-rate.ts
@@ -3,6 +3,7 @@ import { RendererOptions } from '../src/types';
 
 function runTests() {
   // Verifies that audio playbackRate is correctly translated to FFmpeg atempo filters
+  // Retrying CI trigger
   console.log('Running Audio Playback Rate Verification...');
   let hasError = false;
 

--- a/packages/renderer/tests/verify-audio-playback-rate.ts
+++ b/packages/renderer/tests/verify-audio-playback-rate.ts
@@ -2,6 +2,7 @@ import { FFmpegBuilder } from '../src/utils/FFmpegBuilder';
 import { RendererOptions } from '../src/types';
 
 function runTests() {
+  // Verifies that audio playbackRate is correctly translated to FFmpeg atempo filters
   console.log('Running Audio Playback Rate Verification...');
   let hasError = false;
 


### PR DESCRIPTION
Enable support for `playbackRate` in audio tracks, allowing speed adjustments (e.g. 0.5x, 2.0x) to be correctly rendered using FFmpeg `atempo` filters. Includes support for rates outside the standard 0.5-2.0 range via filter chaining and DOM integration.

---
*PR created automatically by Jules for task [11363006760995004833](https://jules.google.com/task/11363006760995004833) started by @BintzGavin*