### PR TITLE
📚 PLAYER: Update README and Docs with missing features

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -88,5 +88,5 @@ The `<helios-player>` uses a Shadow DOM for encapsulation:
 ## Architecture
 - **Direct Mode**: When same-origin, accesses `window.helios` directly.
 - **Bridge Mode**: When cross-origin, uses `postMessage` protocol.
-- **ClientSideExporter**: Handles in-browser rendering using `mediabunny`.
+- **ClientSideExporter**: Handles in-browser rendering using `mediabunny`. Supports audio fades via `data-helios-fade-in` and `data-helios-fade-out` attributes on media elements.
 - **Controllers**: `DirectController` and `BridgeController` normalize API access.

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,21 @@
+## PLAYER v0.59.1
+- ✅ Completed: Documentation Update - Added missing export attributes, audio fades, and diagnostics API to README.
+
+## PLAYER v0.59.0
+- ✅ Completed: Implement Diagnostics UI Overlay - Implemented a visible Diagnostics UI overlay in `<helios-player>` toggled via `Shift+D`, and exposed `diagnose()` as a public method.
+
+## PLAYER v0.58.0
+- ✅ Completed: Configurable Export Bitrate - Implemented `export-bitrate` attribute to control client-side export quality.
+
+## PLAYER v0.57.1
+- ✅ Completed: Fix Test Environment & Sync Version - Updated package version to match status file, installed missing dependencies, and verified all tests pass (including Shadow DOM export).
+
+## PLAYER v0.57.0
+- ✅ Completed: Configurable Export Resolution - Implemented `export-width` and `export-height` attributes to allow specifying target resolution for client-side exports, enabling high-quality DOM exports independent of player size.
+
+## PLAYER v0.56.2
+- ✅ Completed: Fix Core Dependency - Updated `packages/player/package.json` to depend on `@helios-project/core@^5.0.1` to resolve version mismatch and fix the build.
+
 ## PLAYER v0.56.1
 - ✅ Verified: Synced package.json version with status file.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -27,6 +27,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - If this is a new version, create the section at the top of the file (after any existing content)
 - Group multiple completions under the same version section if they're part of the same release
 
+## PLAYER v0.59.1
+- ✅ Completed: Documentation Update - Added missing export attributes, audio fades, and diagnostics API to README.
+
 ## STUDIO v0.82.0
 - ✅ Completed: Stacked Timeline - Implemented multi-lane stacked timeline for audio tracks with dynamic vertical scrolling and sticky ruler, improving visibility of overlapping tracks.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.59.0
+**Version**: v0.59.1
 
 # Status: PLAYER
 
@@ -52,6 +52,7 @@
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.59.1] ✅ Completed: Documentation Update - Added missing export attributes, audio fades, and diagnostics API to README.
 [v0.59.0] ✅ Completed: Implement Diagnostics UI Overlay - Implemented a visible Diagnostics UI overlay in `<helios-player>` toggled via `Shift+D`, and exposed `diagnose()` as a public method.
 [v0.58.0] ✅ Completed: Configurable Export Bitrate - Implemented `export-bitrate` attribute to control client-side export quality.
 [v0.57.1] ✅ Completed: Fix Test Environment & Sync Version - Updated package version to match status file, installed missing dependencies, and verified all tests pass (including Shadow DOM export).

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -67,6 +67,11 @@ The player will automatically attempt to access `window.helios` on the iframe's 
 | `interactive` | Enable direct interaction with the composition (disables click-to-pause). | `false` |
 | `controlslist` | Space-separated list of features to disable: `nodownload`, `nofullscreen`. | - |
 | `sandbox` | Security flags for the iframe. | `allow-scripts allow-same-origin` |
+| `export-width` | Target width for client-side export. | - |
+| `export-height` | Target height for client-side export. | - |
+| `export-bitrate` | Target bitrate for client-side export (bps). | - |
+| `export-caption-mode` | Strategy for caption export: `burn-in` or `file`. | `burn-in` |
+| `disablepictureinpicture` | Hides the Picture-in-Picture button. | `false` |
 
 ## CSS Variables
 
@@ -90,6 +95,7 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `pause(): void` - Pauses playback.
 - `load(): void` - Reloads the iframe (useful if `src` changed or to retry connection).
 - `addTextTrack(kind: string, label?: string, language?: string): TextTrack` - Adds a new text track to the media element.
+- `diagnose(): Promise<DiagnosticReport>` - Runs environment diagnostics (WebCodecs, WebGL) and returns a report.
 
 ### Properties
 
@@ -145,4 +151,12 @@ Configuration:
   export-mode="dom"
   export-format="webm"
 ></helios-player>
+```
+
+### Audio Fades
+
+To apply audio fades during client-side export, add `data-helios-fade-in` and/or `data-helios-fade-out` attributes to your audio elements within the composition. The value should be the duration in seconds.
+
+```html
+<audio src="music.mp3" data-helios-fade-in="2" data-helios-fade-out="3"></audio>
 ```


### PR DESCRIPTION
Documented existing but undocumented features in packages/player/README.md: export attributes (width, height, bitrate, caption-mode), disablepictureinpicture, audio fade data attributes, and diagnose() API. Bumped version to v0.59.1 in docs/status/PLAYER.md and updated docs/PROGRESS.md.

---
*PR created automatically by Jules for task [16738534955795805223](https://jules.google.com/task/16738534955795805223) started by @BintzGavin*