### PR TITLE
RENDERER: Plan Refactor Concat to Pipe

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -243,3 +243,11 @@
 ## [2026-08-03] - Zero Disk I/O: Concat Refactor
 **Learning:** `concatenateVideos` was the last holdout for disk-based operations. Refactoring it to use pipe input completes the "Zero Disk I/O" vision.
 **Action:** Created plan to refactor `concat.ts` to use pipe input.
+
+## 2026-08-05 - Read File Truncation
+**Learning:** The `read_file` tool truncates output (around 1000 characters), which can lead to incomplete understanding of code logic. This is critical when verifying existing implementations before planning refactors.
+**Action:** Use `wc -l` to check file length and `tail` or `start_line` (if available/supported by bash tools) to read the full content of large files.
+
+## 2026-08-05 - Strict Plan Format
+**Learning:** `set_plan` requires a numbered list of executable steps for the *agent* (e.g. "Create spec file"), NOT the content of the spec file itself.
+**Action:** Ensure the plan body is a simple numbered list of actions, and put the spec content in the `write_file` call during execution.

--- a/.sys/plans/2026-08-05-RENDERER-Refactor-Concat-to-Pipe.md
+++ b/.sys/plans/2026-08-05-RENDERER-Refactor-Concat-to-Pipe.md
@@ -1,0 +1,65 @@
+# Plan: Refactor Concat to Pipe
+
+## 1. Context & Goal
+- **Objective**: Refactor `concatenateVideos` to pipe the file list to FFmpeg's `stdin` instead of writing a temporary text file to disk.
+- **Trigger**: "Zero Disk I/O" vision gap identified in journal `[2026-08-03]` and previous unexecuted plan `[2026-08-04]`.
+- **Impact**: Removes the last remaining disk write operation in the rendering pipeline (excluding final output), improving performance and security, and fully achieving the "Zero Disk I/O" architectural goal.
+
+## 2. File Inventory
+- **Modify**: `packages/renderer/src/concat.ts` (Refactor `concatenateVideos` to use stdin piping)
+- **Read-Only**: `packages/renderer/tests/verify-concat.ts` (Use for verification)
+
+## 3. Implementation Spec
+- **Architecture**:
+  - Update `concatenateVideos` to construct the file list string in memory (as it already does).
+  - Spawn FFmpeg with `-f concat -safe 0 -protocol_whitelist file,pipe -i -` (reading from stdin).
+  - Write the list content directly to the spawned process's `stdin` and close it.
+  - Remove all filesystem operations related to the temporary list file (`fs.writeFile`, `fs.unlink`).
+  - Handle stream errors and process exit codes properly.
+
+- **Pseudo-Code**:
+  ```typescript
+  FUNCTION concatenateVideos(inputPaths, outputPath, options)
+    VALIDATE inputPaths
+
+    // Create file list content (same as before)
+    SET listContent = inputPaths.MAP(path -> "file '" + ABSOLUTE_PATH(path) + "'").JOIN("\n")
+
+    SET args = [
+      '-f', 'concat',
+      '-safe', '0',
+      '-protocol_whitelist', 'file,pipe', // Allow reading files from disk via pipe list
+      '-i', '-', // Read list from stdin
+      '-c', 'copy',
+      '-y',
+      outputPath
+    ]
+
+    SPAWN ffmpeg with args
+
+    ON process error: REJECT
+
+    TRY
+      WRITE listContent to process.stdin
+      END process.stdin
+    CATCH error
+      REJECT
+
+    AWAIT process close
+      IF code == 0 RESOLVE
+      ELSE REJECT
+  END FUNCTION
+  ```
+
+## 4. Test Plan
+- **Verification**: `npx ts-node packages/renderer/tests/verify-concat.ts`
+- **Success Criteria**:
+  - The test script runs successfully and outputs "✅ Verification Passed!".
+  - No temporary `.txt` files are created in the output directory.
+- **Edge Cases**:
+  - Empty file list (handled by existing check).
+  - Paths with spaces/special characters (handled by existing logic, preserved).
+  - FFmpeg process failure (should propagate error).
+
+## 5. Pre-commit Steps
+- Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.


### PR DESCRIPTION
Created plan `/.sys/plans/2026-08-05-RENDERER-Refactor-Concat-to-Pipe.md` to refactor `concatenateVideos` to use stdin piping. This addresses the "Zero Disk I/O" vision gap. Also updated `.jules/RENDERER.md` with learnings about `read_file` truncation and plan formatting.

---
*PR created automatically by Jules for task [5579484368195191688](https://jules.google.com/task/5579484368195191688) started by @BintzGavin*