### PR TITLE
✨ PLAYER: Headless Audio Support

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -88,5 +88,5 @@ The `<helios-player>` uses a Shadow DOM for encapsulation:
 ## Architecture
 - **Direct Mode**: When same-origin, accesses `window.helios` directly.
 - **Bridge Mode**: When cross-origin, uses `postMessage` protocol.
-- **ClientSideExporter**: Handles in-browser rendering using `mediabunny`. Supports audio fades via `data-helios-fade-in` and `data-helios-fade-out` attributes on media elements.
+- **ClientSideExporter**: Handles in-browser rendering using `mediabunny`. Supports audio fades via `data-helios-fade-in` and `data-helios-fade-out` attributes on media elements. Now supports **Headless Audio**: includes audio tracks injected via `availableAudioTracks` metadata, enabling export without DOM elements.
 - **Controllers**: `DirectController` and `BridgeController` normalize API access.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -27,6 +27,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - If this is a new version, create the section at the top of the file (after any existing content)
 - Group multiple completions under the same version section if they're part of the same release
 
+## PLAYER v0.60.0
+- ✅ Completed: Headless Audio Support - Updated `getAudioAssets` and controllers to include audio tracks from Helios state metadata in client-side exports, prioritizing them over DOM elements.
+
 ## PLAYER v0.59.1
 - ✅ Completed: Documentation Update - Added missing export attributes, audio fades, and diagnostics API to README.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.59.1
+**Version**: v0.60.0
 
 # Status: PLAYER
 
@@ -48,10 +48,12 @@
 - Supports audio fade-in/out in client-side export via `data-helios-fade-in` and `data-helios-fade-out` attributes.
 - Supports Shadow DOM Export: DOM-based client-side export now correctly captures Shadow DOM content (via Declarative Shadow DOM transformation), enabling support for Web Components in exports.
 - **Supports Environment Diagnostics UI**: Implemented `diagnose()` method in `HeliosController` and a visible Diagnostics UI overlay in `<helios-player>` (toggled via `Shift+D`) to expose environment capabilities (WebCodecs, WebGL, etc.) to the user.
+- **Supports Headless Audio Export**: Client-side export now includes audio tracks manually injected into Helios state (`availableAudioTracks`), enabling headless audio rendering without DOM elements.
 
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.60.0] ✅ Completed: Headless Audio Support - Updated `getAudioAssets` and controllers to include audio tracks from Helios state metadata in client-side exports, prioritizing them over DOM elements.
 [v0.59.1] ✅ Completed: Documentation Update - Added missing export attributes, audio fades, and diagnostics API to README.
 [v0.59.0] ✅ Completed: Implement Diagnostics UI Overlay - Implemented a visible Diagnostics UI overlay in `<helios-player>` toggled via `Shift+D`, and exposed `diagnose()` as a public method.
 [v0.58.0] ✅ Completed: Configurable Export Bitrate - Implemented `export-bitrate` attribute to control client-side export quality.

--- a/packages/player/dist/bridge.js
+++ b/packages/player/dist/bridge.js
@@ -9,7 +9,8 @@ export function connectToParent(helios) {
         const { type, frame } = event.data;
         switch (type) {
             case 'HELIOS_GET_AUDIO_TRACKS':
-                const assets = await getAudioAssets(document);
+                const state = helios.getState();
+                const assets = await getAudioAssets(document, state.availableAudioTracks, state.audioTracks);
                 const buffers = assets.map(a => a.buffer);
                 window.parent.postMessage({ type: 'HELIOS_AUDIO_DATA', assets }, '*', buffers);
                 break;

--- a/packages/player/src/bridge.ts
+++ b/packages/player/src/bridge.ts
@@ -10,7 +10,8 @@ export function connectToParent(helios: Helios) {
     const { type, frame } = event.data;
     switch (type) {
       case 'HELIOS_GET_AUDIO_TRACKS':
-        const assets = await getAudioAssets(document);
+        const state = helios.getState();
+        const assets = await getAudioAssets(document, state.availableAudioTracks, state.audioTracks);
         const buffers = assets.map(a => a.buffer);
         window.parent.postMessage({ type: 'HELIOS_AUDIO_DATA', assets }, '*', buffers);
         break;

--- a/packages/player/src/controllers.ts
+++ b/packages/player/src/controllers.ts
@@ -76,7 +76,8 @@ export class DirectController implements HeliosController {
 
   async getAudioTracks(): Promise<AudioAsset[]> {
      const doc = this.iframe?.contentDocument || document;
-     return getAudioAssets(doc);
+     const state = this.instance.getState();
+     return getAudioAssets(doc, state.availableAudioTracks, state.audioTracks);
   }
 
   async getSchema(): Promise<HeliosSchema | undefined> {


### PR DESCRIPTION
*   💡 **What**: Updated `packages/player` to support exporting audio tracks that are defined in Helios state metadata (`availableAudioTracks`) but not present in the DOM.
*   🎯 **Why**: To enable audio export in headless environments (e.g. Node.js or when audio is not rendered to DOM) and to support the Core feature `2026-08-01-CORE-Expose-Audio-Source.md`.
*   📊 **Impact**: `ClientSideExporter` now correctly includes headless audio tracks, prioritizing explicit metadata over DOM discovery if IDs collide.
*   🔬 **Verification**: Added unit tests in `src/features/audio-utils.test.ts` verifying metadata track inclusion and ID prioritization. Ran `npm test -w packages/player` and `npm run build -w packages/player`.

---
*PR created automatically by Jules for task [14153264213729426281](https://jules.google.com/task/14153264213729426281) started by @BintzGavin*