### PR TITLE
✨ RENDERER: Refactor Concat to Pipe

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -11,7 +11,7 @@ The Renderer operates on a "Dual-Path" architecture to support different use cas
    - **Optimization**: Prioritizes H.264 (AVC) intermediate codec for hardware acceleration, falling back to VP8. Exposes `diagnose()` API to verify supported WebCodecs.
    - **Output**: Best for high-performance 2D/3D graphics.
 
-Both strategies pipe frame data directly to an FFmpeg process via stdin ("Zero Disk I/O"), ensuring high performance and low latency. Audio tracks from Blob URLs are extracted to memory and also piped to FFmpeg via additional pipes, avoiding temporary files.
+Both strategies pipe frame data directly to an FFmpeg process via stdin ("Zero Disk I/O"), ensuring high performance and low latency. Audio tracks from Blob URLs are extracted to memory and also piped to FFmpeg via additional pipes, avoiding temporary files. Video concatenation also constructs file lists in memory and pipes them to FFmpeg stdin, eliminating all temporary file creation.
 
 The **RenderOrchestrator** enables Local Distributed Rendering by splitting a job into concurrent chunks and merging the results, utilizing multiple cores for faster processing.
 
@@ -93,6 +93,7 @@ The `DistributedRenderOptions` interface extends `RendererOptions` with:
 ## D. FFmpeg Interface
 The renderer spawns an FFmpeg process with the following key flags:
 - `-f image2pipe`: Reads frames from stdin.
+- `-f concat -safe 0 -protocol_whitelist file,pipe -i -`: Reads concat list from stdin (for concatenation jobs).
 - `pipe:N`: Additional inputs for audio buffers (mapped to file descriptors).
 - `-c:v`: Video codec (e.g., `libx264`).
 - `-pix_fmt`: Pixel format (e.g., `yuv420p`).

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.60.1
+- ✅ Completed: Refactor Concat to Pipe - Refactored `concatenateVideos` to pipe the file list to FFmpeg's stdin (`-i -`), removing temporary file creation and eliminating disk I/O for the concatenation process. Verified with `verify-concat.ts`.
+
 ## RENDERER v1.60.0
 - ✅ Completed: Enable Audio Playback Rate - Updated `AudioTrackConfig` to include `playbackRate`, and implemented `atempo` filter chaining in `FFmpegBuilder` to support speed adjustments (including values outside 0.5-2.0 range). Also updated `DomScanner` to extract `playbackRate` from media elements.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.60.0
+**Version**: 1.60.1
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.60.1] ✅ Completed: Refactor Concat to Pipe - Refactored `concatenateVideos` to pipe the file list to FFmpeg's stdin (`-i -`), removing temporary file creation and eliminating disk I/O for the concatenation process. Verified with `verify-concat.ts`.
 - [1.60.0] ✅ Completed: Enable Audio Playback Rate - Updated `AudioTrackConfig` to include `playbackRate`, and implemented `atempo` filter chaining in `FFmpegBuilder` to support speed adjustments (including values outside 0.5-2.0 range). Also updated `DomScanner` to extract `playbackRate` from media elements.
 - [1.59.0] ✅ Completed: Local Distributed Rendering - Implemented `RenderOrchestrator` to split render jobs into concurrent chunks and concatenate them, enabling faster local rendering. Also refactored `Renderer` to its own file to support this architecture.
 - [1.58.0] ✅ Completed: Zero Disk Audio - Refactored `blob-extractor.ts` and `FFmpegBuilder.ts` to pipe audio buffers directly to FFmpeg via stdio pipes (`pipe:N`), eliminating temporary file creation for Blob audio tracks and improving security and performance.


### PR DESCRIPTION
Refactored `concatenateVideos` to pipe the file list to FFmpeg's stdin (`-i -`) instead of writing a temporary file. This achieves the "Zero Disk I/O" architectural goal and improves performance/security by eliminating temporary files. Verified with `packages/renderer/tests/verify-concat.ts`.

---
*PR created automatically by Jules for task [9873802591757830797](https://jules.google.com/task/9873802591757830797) started by @BintzGavin*