### PR TITLE
📋 RENDERER: Visual Playback Rate Plan

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -3,6 +3,7 @@
 # Renderer Agent Status
 
 ## Progress Log
+- [2026-08-05] ✅ Planned: Visual Playback Rate - Created plan `2026-08-05-RENDERER-Visual-Playback-Rate.md` to fix A/V desync by enabling `playbackRate` support in `SeekTimeDriver` and `CdpTimeDriver`.
 - [2026-08-03] ✅ Planned: Refactor Concat to Pipe - Created plan to refactor `concatenateVideos` to pipe file list to FFmpeg, completing the "Zero Disk I/O" vision.
 - [1.58.0] ✅ Completed: Zero Disk Audio - Refactored `blob-extractor.ts` and `FFmpegBuilder.ts` to pipe audio buffers directly to FFmpeg via stdio pipes (`pipe:N`), eliminating temporary file creation for Blob audio tracks and improving security and performance.
 - [1.57.3] ✅ Completed: Enable Looping Media Verification - Updated `packages/renderer/package.json` to depend on `@helios-project/core` version `5.1.1` (matching local workspace), allowing `verify-video-loop.ts` to run and confirm correct looping media implementation in `SeekTimeDriver` and `CdpTimeDriver`.
@@ -243,3 +244,7 @@
 ## [2026-08-03] - Zero Disk I/O: Concat Refactor
 **Learning:** `concatenateVideos` was the last holdout for disk-based operations. Refactoring it to use pipe input completes the "Zero Disk I/O" vision.
 **Action:** Created plan to refactor `concat.ts` to use pipe input.
+
+## [2026-08-05] - Visual Playback Rate Gap
+**Learning:** Identified a critical synchronization gap where `DomScanner` extracts `playbackRate` and `FFmpegBuilder` respects it (audio), but `TimeDriver` (visual) ignores it. This causes A/V desync.
+**Action:** Future feature implementations must verify end-to-end support across both Audio (FFmpeg) and Video (TimeDriver) subsystems.

--- a/.sys/plans/2026-08-05-RENDERER-Visual-Playback-Rate.md
+++ b/.sys/plans/2026-08-05-RENDERER-Visual-Playback-Rate.md
@@ -1,0 +1,53 @@
+# RENDERER: Enable Visual Playback Rate
+
+#### 1. Context & Goal
+- **Objective**: Implement `playbackRate` support for `<video>` elements in `SeekTimeDriver` and `CdpTimeDriver` to ensure visual media synchronizes correctly with the timeline when speed changes are applied.
+- **Trigger**: `DomScanner` already discovers and exports `playbackRate` for audio processing (via FFmpeg `atempo`), but the visual rendering drivers (TimeDrivers) ignore this property, calculating video time as if it were always 1.0x. This causes Audio/Video desynchronization.
+- **Impact**: Enables correct rendering of speed-ramped video clips (e.g., slow motion, fast forward) in both DOM and Canvas modes, fulfilling the "Dual-Path Architecture" and "Correctness" vision.
+
+#### 2. File Inventory
+- **Modify**: `packages/renderer/src/drivers/SeekTimeDriver.ts` (Update `mediaSyncScript` to respect playbackRate)
+- **Modify**: `packages/renderer/src/drivers/CdpTimeDriver.ts` (Update `mediaSyncScript` to respect playbackRate)
+- **Create**: `packages/renderer/tests/verify-visual-playback-rate.ts` (Verification script)
+- **Read-Only**: `packages/renderer/tests/verify-seek-driver-offsets.ts` (Reference implementation)
+
+#### 3. Implementation Spec
+- **Architecture**: The `TimeDriver` is responsible for forcing the state of the DOM to match the virtual timeline time `t`. Currently, it calculates media time as `t - offset + seek`. It must be updated to scale the time delta by the element's `playbackRate`.
+- **Pseudo-Code**:
+  ```javascript
+  // Inside mediaSyncScript (injected into browser)
+  FOREACH mediaElement in Document:
+    GET offset = parseFloat(attr('data-helios-offset') || 0)
+    GET seek = parseFloat(attr('data-helios-seek') || 0)
+    GET rateAttr = attr('playbackRate')
+    GET rate = element.playbackRate ?? (rateAttr ? parseFloat(rateAttr) : 1.0)
+
+    // Validate rate (default to 1.0 if invalid/zero)
+    IF rate <= 0 OR !isFinite(rate) SET rate = 1.0
+
+    // Calculate target time
+    // Formula: (GlobalTime - Offset) * Rate + Seek
+    SET targetTime = (t - offset) * rate + seek
+    MAX targetTime with 0
+
+    // Handle Looping
+    IF element.loop AND element.duration > 0:
+      SET targetTime = targetTime % element.duration
+
+    SET element.currentTime = targetTime
+  ```
+- **Public API Changes**: None.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npx ts-node packages/renderer/tests/verify-visual-playback-rate.ts`
+- **Success Criteria**:
+  - The test script initializes `SeekTimeDriver`.
+  - It loads a page with `<video data-helios-offset="0" playbackRate="2.0">`.
+  - It sets time to `1.0`.
+  - It asserts that `video.currentTime` is `2.0` (±0.1s tolerance).
+  - It repeats the test for `0.5x` speed.
+  - It repeats the verification for `CdpTimeDriver` (if possible in headless env, otherwise relies on `SeekTimeDriver` test as logic is identical).
+- **Edge Cases**:
+  - `playbackRate` = 0 (Should fallback to 1.0 or pause? Spec says fallback to 1.0 for safety, or handle as static frame). Logic: `rate` should be sanitized.
+  - `playbackRate` < 0 (Reverse playback not fully supported by FFmpeg/Helios yet, sanitizer should clamp or fallback).

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -3,6 +3,8 @@
 # Renderer Agent Status
 
 ## Progress Log
+- [2026-08-05] ✅ Planned: Visual Playback Rate - Created plan `2026-08-05-RENDERER-Visual-Playback-Rate.md` to fix A/V desync by enabling `playbackRate` support in `SeekTimeDriver` and `CdpTimeDriver`.
+- [2026-08-03] ✅ Planned: Refactor Concat to Pipe - Created plan to refactor `concatenateVideos` to pipe file list to FFmpeg, completing the "Zero Disk I/O" vision.
 - [1.60.0] ✅ Completed: Enable Audio Playback Rate - Updated `AudioTrackConfig` to include `playbackRate`, and implemented `atempo` filter chaining in `FFmpegBuilder` to support speed adjustments (including values outside 0.5-2.0 range). Also updated `DomScanner` to extract `playbackRate` from media elements.
 - [1.59.0] ✅ Completed: Local Distributed Rendering - Implemented `RenderOrchestrator` to split render jobs into concurrent chunks and concatenate them, enabling faster local rendering. Also refactored `Renderer` to its own file to support this architecture.
 - [1.58.0] ✅ Completed: Zero Disk Audio - Refactored `blob-extractor.ts` and `FFmpegBuilder.ts` to pipe audio buffers directly to FFmpeg via stdio pipes (`pipe:N`), eliminating temporary file creation for Blob audio tracks and improving security and performance.


### PR DESCRIPTION
Created plan to implement `playbackRate` support in `SeekTimeDriver` and `CdpTimeDriver` to fix A/V desynchronization when using speed controls on `<video>` elements.

This plan addresses a gap where `DomScanner` detects `playbackRate` (used for audio retiming via FFmpeg), but the visual TimeDrivers ignore it, causing video to play at 1.0x regardless of the attribute setting. The plan involves updating the media sync logic in both drivers and adding a new verification script.

---
*PR created automatically by Jules for task [5322391359491527813](https://jules.google.com/task/5322391359491527813) started by @BintzGavin*