### PR TITLE
✨ RENDERER: Fix Verification Suite

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -56,6 +56,8 @@ packages/renderer/
     ├── verify-shadow-dom-images.ts # Shadow DOM image discovery test
     ├── verify-enhanced-dom-preload.ts # Enhanced DOM preloading test
     ├── verify-dom-audio-fades.ts # DOM audio fades test
+    ├── verify-audio-fades.ts   # Audio fades test
+    ├── verify-audio-loop.ts    # Audio looping test
     ├── verify-audio-playback-rate.ts # Audio playback rate test
     ├── verify-frame-count.ts   # Precision frame count test
     ├── verify-cdp-hang.ts      # CDP initialization order/deadlock test

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -14,6 +14,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 - **DOCS**: Update `docs/PROGRESS-DOCS.md`
 
+## RENDERER v1.60.2
+- ✅ Completed: Fix Verification Suite - Fixed verification scripts to match the new FFmpegConfig object structure, restoring test suite health.
+
 ## Instructions for Each Agent
 
 ### CORE Agent

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.60.1
+**Version**: 1.60.2
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.60.2] ✅ Completed: Fix Verification Suite - Updated `verify-audio-fades.ts` and `verify-audio-loop.ts` to handle the new `FFmpegConfig` return type from `getArgs`, resolving test failures and ensuring the verification suite passes.
 - [1.60.1] ✅ Completed: Refactor Concat to Pipe - Refactored `concatenateVideos` to pipe the file list to FFmpeg's stdin (`-i -`), removing temporary file creation and eliminating disk I/O for the concatenation process. Verified with `verify-concat.ts`.
 - [1.60.0] ✅ Completed: Enable Audio Playback Rate - Updated `AudioTrackConfig` to include `playbackRate`, and implemented `atempo` filter chaining in `FFmpegBuilder` to support speed adjustments (including values outside 0.5-2.0 range). Also updated `DomScanner` to extract `playbackRate` from media elements.
 - [1.59.0] ✅ Completed: Local Distributed Rendering - Implemented `RenderOrchestrator` to split render jobs into concurrent chunks and concatenate them, enabling faster local rendering. Also refactored `Renderer` to its own file to support this architecture.

--- a/packages/renderer/tests/verify-audio-fades.ts
+++ b/packages/renderer/tests/verify-audio-fades.ts
@@ -24,7 +24,7 @@ async function main() {
         fadeInDuration: 2
       }]
     };
-    const args = FFmpegBuilder.getArgs(options, 'out.mp4', videoInputArgs);
+    const { args } = FFmpegBuilder.getArgs(options, 'out.mp4', videoInputArgs);
     const filterComplex = args[args.indexOf('-filter_complex') + 1];
 
     // Expect: afade=t=in:st=0:d=2
@@ -51,7 +51,7 @@ async function main() {
         fadeOutDuration: 3
       }]
     };
-    const args = FFmpegBuilder.getArgs(options, 'out.mp4', videoInputArgs);
+    const { args } = FFmpegBuilder.getArgs(options, 'out.mp4', videoInputArgs);
     const filterComplex = args[args.indexOf('-filter_complex') + 1];
 
     // Expect: afade=t=out:st=7:d=3  (10 - 3 = 7)
@@ -77,7 +77,7 @@ async function main() {
         fadeInDuration: 2
       }]
     };
-    const args = FFmpegBuilder.getArgs(options, 'out.mp4', videoInputArgs);
+    const { args } = FFmpegBuilder.getArgs(options, 'out.mp4', videoInputArgs);
     const filterComplex = args[args.indexOf('-filter_complex') + 1];
 
     // Offset 5s. Delay = 5000ms. startTime = 5.
@@ -106,7 +106,7 @@ async function main() {
         fadeOutDuration: 1
       }]
     };
-    const args = FFmpegBuilder.getArgs(options, 'out.mp4', videoInputArgs);
+    const { args } = FFmpegBuilder.getArgs(options, 'out.mp4', videoInputArgs);
     const filterComplex = args[args.indexOf('-filter_complex') + 1];
 
     // Composition Duration = 150/30 = 5s.
@@ -134,7 +134,7 @@ async function main() {
         { path: 't2.mp3', fadeOutDuration: 1 }
       ]
     };
-    const args = FFmpegBuilder.getArgs(options, 'out.mp4', videoInputArgs);
+    const { args } = FFmpegBuilder.getArgs(options, 'out.mp4', videoInputArgs);
     const filterComplex = args[args.indexOf('-filter_complex') + 1];
 
     // t1: afade=t=in:st=0:d=1

--- a/packages/renderer/tests/verify-audio-loop.ts
+++ b/packages/renderer/tests/verify-audio-loop.ts
@@ -56,7 +56,7 @@ async function run() {
   await strategy.prepare(page);
 
   console.log('Generating FFmpeg arguments...');
-  const args = strategy.getFFmpegArgs(options, 'output.mp4');
+  const { args } = strategy.getFFmpegArgs(options, 'output.mp4');
 
   // Verify args
   console.log('FFmpeg Args:', args);


### PR DESCRIPTION
💡 What: Updated verify-audio-fades.ts and verify-audio-loop.ts to correctly handle the new FFmpegConfig object returned by getFFmpegArgs.
🎯 Why: Recent refactors changed the return type of getFFmpegArgs from string[] to { args: string[], inputBuffers: Buffer[] }, causing tests to fail with "args.indexOf is not a function".
📊 Impact: Restores the health of the verification suite, ensuring regression testing is reliable.
🔬 Verification: Ran npx tsx packages/renderer/tests/verify-audio-fades.ts and npx tsx packages/renderer/tests/verify-audio-loop.ts, both passed.

---
*PR created automatically by Jules for task [8882612424680554519](https://jules.google.com/task/8882612424680554519) started by @BintzGavin*