### PR TITLE
✨ PLAYER: Sync version to 0.62.0

### DIFF
--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -55,6 +55,7 @@
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.62.0] ✅ Verified: Export Filename - Confirmed implementation and tests for `export-filename` attribute. Synced package.json version.
 [v0.62.0] ✅ Completed: Export Filename - Implemented `export-filename` attribute on `<helios-player>` to allow customizing the filename of client-side exported videos.
 [v0.61.0] ✅ Completed: Expose Composition Setters - Implemented `setDuration`, `setFps`, `setSize`, and `setMarkers` in `HeliosController` and updated Bridge protocol to support dynamic composition updates from the host.
 [v0.60.0] ✅ Completed: Headless Audio Support - Updated `getAudioAssets` and controllers to include audio tracks from Helios state metadata in client-side exports, prioritizing them over DOM elements.

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.59.0",
+  "version": "0.62.0",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",


### PR DESCRIPTION
💡 **What**: Synced `packages/player/package.json` version to `0.62.0` to match the project status file. Added a verification entry to `docs/status/PLAYER.md`.
🎯 **Why**: The 'Export Filename' feature (v0.62.0) was previously implemented and documented in status files, but the package version was left at `0.59.0`. This commit reconciles the state.
📊 **Impact**: ensures accurate versioning for the package registry and build artifacts.
🔬 **Verification**:
- `npm run build -w packages/player` (Succeeded)
- `npx vitest run src/features/exporter.test.ts` (Passed 14 tests, including 'should use custom filename')

---
*PR created automatically by Jules for task [7465980080154470969](https://jules.google.com/task/7465980080154470969) started by @BintzGavin*