### PR TITLE
✨ RENDERER: Fix Audio Playback Seek Calculation

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -59,6 +59,7 @@ packages/renderer/
     ├── verify-audio-fades.ts   # Audio fades test
     ├── verify-audio-loop.ts    # Audio looping test
     ├── verify-audio-playback-rate.ts # Audio playback rate test
+    ├── verify-audio-playback-rate-seek.ts # Audio playback rate seek test
     ├── verify-visual-playback-rate.ts # Visual playback rate test
     ├── verify-frame-count.ts   # Precision frame count test
     ├── verify-cdp-hang.ts      # CDP initialization order/deadlock test

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### RENDERER v1.61.1
+- ✅ Completed: Fix Audio Playback Seek Calculation - Fixed audio seek calculation in FFmpegBuilder to account for `playbackRate` when rendering ranges (`startFrame > 0`), ensuring correct audio synchronization for variable speed clips.
+
 ### PLAYER v0.62.0
 - ✅ Completed: Export Filename - Implemented `export-filename` attribute on `<helios-player>` to allow customizing the filename of client-side exported videos.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.61.0
+**Version**: 1.61.1
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.61.1] ✅ Completed: Fix Audio Playback Seek Calculation - Fixed audio seek calculation in FFmpegBuilder to account for `playbackRate` when rendering ranges (`startFrame > 0`), ensuring correct audio synchronization for variable speed clips.
 - [1.61.0] ✅ Completed: Enable Visual Playback Rate - Updated `SeekTimeDriver` and `CdpTimeDriver` to respect the `playbackRate` property (and attribute) on media elements, ensuring visual synchronization with audio speed changes.
 - [1.60.2] ✅ Completed: Fix Verification Suite - Updated `verify-audio-fades.ts` and `verify-audio-loop.ts` to handle the new `FFmpegConfig` return type from `getArgs`, resolving test failures and ensuring the verification suite passes.
 - [1.60.1] ✅ Completed: Refactor Concat to Pipe - Refactored `concatenateVideos` to pipe the file list to FFmpeg's stdin (`-i -`), removing temporary file creation and eliminating disk I/O for the concatenation process. Verified with `verify-concat.ts`.

--- a/packages/renderer/scripts/verify-advanced-audio.ts
+++ b/packages/renderer/scripts/verify-advanced-audio.ts
@@ -22,7 +22,7 @@ const runTest = () => {
     ]
   };
 
-  const argsVolume = domStrategy.getFFmpegArgs(optionsVolume, outputPath);
+  const argsVolume = domStrategy.getFFmpegArgs(optionsVolume, outputPath).args;
   console.log('Testing Volume Control...');
   // Expect: [1:a]aformat=channel_layouts=stereo,volume=0.5[a0]
   const filterGraphIdx = argsVolume.indexOf('-filter_complex');
@@ -40,7 +40,7 @@ const runTest = () => {
     ]
   };
 
-  const argsDelay = domStrategy.getFFmpegArgs(optionsDelay, outputPath);
+  const argsDelay = domStrategy.getFFmpegArgs(optionsDelay, outputPath).args;
   console.log('Testing Audio Delay...');
   const filterGraphIdxDelay = argsDelay.indexOf('-filter_complex');
   assert(filterGraphIdxDelay !== -1, 'Should include -filter_complex');
@@ -58,7 +58,7 @@ const runTest = () => {
     ]
   };
 
-  const argsSFDelay = domStrategy.getFFmpegArgs(optionsStartFrameDelay, outputPath);
+  const argsSFDelay = domStrategy.getFFmpegArgs(optionsStartFrameDelay, outputPath).args;
   console.log('Testing StartFrame + Delay...');
   const filterGraphSFDelay = argsSFDelay[argsSFDelay.indexOf('-filter_complex') + 1];
   assert(filterGraphSFDelay.includes('adelay=1000|1000'), `Should calculate correct relative delay (expected 1000, got graph: ${filterGraphSFDelay})`);
@@ -74,7 +74,7 @@ const runTest = () => {
     ]
   };
 
-  const argsSFSeek = domStrategy.getFFmpegArgs(optionsSFSeek, outputPath);
+  const argsSFSeek = domStrategy.getFFmpegArgs(optionsSFSeek, outputPath).args;
   console.log('Testing StartFrame + Seek...');
   // Check for -ss 1 before -i audio.mp3
   const inputIdx = argsSFSeek.indexOf('audio.mp3');
@@ -91,7 +91,7 @@ const runTest = () => {
     ]
   };
 
-  const argsMix = domStrategy.getFFmpegArgs(optionsMix, outputPath);
+  const argsMix = domStrategy.getFFmpegArgs(optionsMix, outputPath).args;
   console.log('Testing Mixing...');
   const filterGraphMix = argsMix[argsMix.indexOf('-filter_complex') + 1];
   assert(filterGraphMix.includes('volume=0.5'), 'Should include volume');

--- a/packages/renderer/scripts/verify-audio-args.ts
+++ b/packages/renderer/scripts/verify-audio-args.ts
@@ -32,7 +32,7 @@ const runTest = () => {
   const domStrategy = new DomStrategy({ width: 1920, height: 1080, fps: 30, durationInSeconds: 1 });
 
   // Case 1: DomStrategy with Audio
-  const argsDomWithAudio = domStrategy.getFFmpegArgs(optionsWithAudio, outputPath);
+  const argsDomWithAudio = domStrategy.getFFmpegArgs(optionsWithAudio, outputPath).args;
   console.log('Testing DomStrategy with Audio...');
   assert(argsDomWithAudio.includes('-i'), 'DomStrategy should include -i');
   assert(argsDomWithAudio.includes('/path/to/audio.mp3'), 'DomStrategy should include audio path');
@@ -45,7 +45,7 @@ const runTest = () => {
   assert(!argsDomWithAudio.includes('-shortest'), 'DomStrategy should NOT include -shortest');
 
   // Case 2: DomStrategy without Audio
-  const argsDomNoAudio = domStrategy.getFFmpegArgs(optionsWithoutAudio, outputPath);
+  const argsDomNoAudio = domStrategy.getFFmpegArgs(optionsWithoutAudio, outputPath).args;
   console.log('Testing DomStrategy without Audio...');
   assert(!argsDomNoAudio.includes('/path/to/audio.mp3'), 'DomStrategy should NOT include audio path');
   assert(!argsDomNoAudio.includes('-c:a'), 'DomStrategy should NOT include -c:a');
@@ -56,7 +56,7 @@ const runTest = () => {
   const canvasStrategy = new CanvasStrategy(optionsWithAudio);
 
   // Case 3: CanvasStrategy with Audio
-  const argsCanvasWithAudio = canvasStrategy.getFFmpegArgs(optionsWithAudio, outputPath);
+  const argsCanvasWithAudio = canvasStrategy.getFFmpegArgs(optionsWithAudio, outputPath).args;
   console.log('Testing CanvasStrategy with Audio...');
   assert(argsCanvasWithAudio.includes('-i'), 'CanvasStrategy should include -i');
   assert(argsCanvasWithAudio.includes('/path/to/audio.mp3'), 'CanvasStrategy should include audio path');
@@ -69,7 +69,7 @@ const runTest = () => {
   assert(!argsCanvasWithAudio.includes('-shortest'), 'CanvasStrategy should NOT include -shortest');
 
   // Case 4: CanvasStrategy without Audio
-  const argsCanvasNoAudio = canvasStrategy.getFFmpegArgs(optionsWithoutAudio, outputPath);
+  const argsCanvasNoAudio = canvasStrategy.getFFmpegArgs(optionsWithoutAudio, outputPath).args;
   console.log('Testing CanvasStrategy without Audio...');
   assert(!argsCanvasNoAudio.includes('/path/to/audio.mp3'), 'CanvasStrategy should NOT include audio path');
   assert(!argsCanvasNoAudio.includes('-c:a'), 'CanvasStrategy should NOT include -c:a');

--- a/packages/renderer/src/utils/FFmpegBuilder.ts
+++ b/packages/renderer/src/utils/FFmpegBuilder.ts
@@ -65,7 +65,9 @@ export class FFmpegBuilder {
         // Track starts before or at the render window
         // We need to skip the part of the track that happened before renderStart
         delayMs = 0;
-        inputSeek = (track.seek || 0) + (renderStartTime - globalStart);
+        const timelineDiff = renderStartTime - globalStart;
+        const mediaDiff = timelineDiff * (track.playbackRate || 1.0);
+        inputSeek = (track.seek || 0) + mediaDiff;
       }
 
       // Add input arguments

--- a/packages/renderer/tests/verify-audio-playback-rate-seek.ts
+++ b/packages/renderer/tests/verify-audio-playback-rate-seek.ts
@@ -1,0 +1,67 @@
+
+import { FFmpegBuilder } from '../src/utils/FFmpegBuilder';
+import { RendererOptions } from '../src/types';
+import * as assert from 'assert';
+
+console.log('Verifying Audio Playback Rate Seek Calculation...');
+
+const baseOptions: RendererOptions = {
+  width: 1920,
+  height: 1080,
+  fps: 30,
+  durationInSeconds: 10,
+  startFrame: 0,
+  videoCodec: 'libx264',
+  audioTracks: []
+};
+
+function testPlaybackRateSeek(rate: number, renderStartTime: number, expectedSeek: number, description: string) {
+  const options: RendererOptions = {
+    ...baseOptions,
+    startFrame: renderStartTime * 30, // Convert seconds to frames
+    audioTracks: [
+      {
+        path: 'test.mp3',
+        offset: 0,
+        seek: 0,
+        playbackRate: rate
+      }
+    ]
+  };
+
+  const { args } = FFmpegBuilder.getArgs(options, 'output.mp4', ['-i', 'video.mp4']);
+
+  // Find -ss argument for the audio input
+  // Audio input args are added after video input args
+  // Logic: video inputs... audio inputs...
+  // -ss seek -i path
+
+  const ssIndex = args.indexOf('-ss');
+  const seekValue = parseFloat(args[ssIndex + 1]);
+
+  if (Math.abs(seekValue - expectedSeek) < 0.001) {
+    console.log(`✅ Passed: ${description} (Rate: ${rate}, Start: ${renderStartTime}s) -> Seek: ${seekValue}`);
+  } else {
+    console.error(`❌ Failed: ${description} (Rate: ${rate}, Start: ${renderStartTime}s)`);
+    console.error(`   Expected Seek: ${expectedSeek}, Got: ${seekValue}`);
+    process.exit(1);
+  }
+}
+
+// Case 1: Normal playback rate (1.0), render start at 5s
+// Expected: Seek 5s
+testPlaybackRateSeek(1.0, 5, 5.0, 'Normal Rate');
+
+// Case 2: Fast playback rate (2.0), render start at 5s
+// Timeline: 0s -> Media: 0s
+// Timeline: 5s -> Media: 10s (because we played 5s of timeline at 2x speed)
+// Expected: Seek 10s
+testPlaybackRateSeek(2.0, 5, 10.0, 'Fast Rate (2x)');
+
+// Case 3: Slow playback rate (0.5), render start at 5s
+// Timeline: 0s -> Media: 0s
+// Timeline: 5s -> Media: 2.5s (because we played 5s of timeline at 0.5x speed)
+// Expected: Seek 2.5s
+testPlaybackRateSeek(0.5, 5, 2.5, 'Slow Rate (0.5x)');
+
+console.log('All tests passed!');

--- a/packages/renderer/tests/verify-stream-copy.ts
+++ b/packages/renderer/tests/verify-stream-copy.ts
@@ -17,7 +17,7 @@ const videoInputArgs = ['-i', 'pipe:0'];
 // Test Case 1: Standard Encoding (Default)
 {
   console.log('Test 1: Standard Encoding (Default)');
-  const args = FFmpegBuilder.getArgs(baseOptions, outputPath, videoInputArgs);
+  const args = FFmpegBuilder.getArgs(baseOptions, outputPath, videoInputArgs).args;
 
   assert.ok(args.includes('-c:v'), 'Should include video codec flag');
   assert.ok(args.includes('libx264'), 'Should default to libx264');
@@ -33,7 +33,7 @@ const videoInputArgs = ['-i', 'pipe:0'];
     ...baseOptions,
     videoCodec: 'copy'
   };
-  const args = FFmpegBuilder.getArgs(copyOptions, outputPath, videoInputArgs);
+  const args = FFmpegBuilder.getArgs(copyOptions, outputPath, videoInputArgs).args;
 
   // Assertions for presence
   const codecIndex = args.indexOf('-c:v');
@@ -62,7 +62,7 @@ const videoInputArgs = ['-i', 'pipe:0'];
     videoBitrate: '5M',
     pixelFormat: 'yuv444p'
   };
-  const args = FFmpegBuilder.getArgs(copyOptions, outputPath, videoInputArgs);
+  const args = FFmpegBuilder.getArgs(copyOptions, outputPath, videoInputArgs).args;
 
   assert.strictEqual(args.includes('-pix_fmt'), false, 'Should NOT include -pix_fmt even if specified');
   assert.strictEqual(args.includes('-crf'), false, 'Should NOT include -crf even if specified');


### PR DESCRIPTION
💡 **What**: Fixed audio seek calculation in FFmpegBuilder to account for playbackRate when rendering ranges (startFrame > 0), ensuring correct audio synchronization for variable speed clips. Also updated verification scripts to match the new FFmpegConfig return type and verified regression tests.
🎯 **Why**: Previously, the seek calculation ignored playbackRate, assuming 1 timeline second equals 1 media second, leading to desynchronization when skipping parts of the timeline.
📊 **Impact**: Enables correct rendering of variable speed audio tracks in distributed rendering and range-based rendering scenarios.
🔬 **Verification**: Ran verify-audio-playback-rate-seek.ts (new), verify-advanced-audio.ts, verify-audio-args.ts, verify-stream-copy.ts, and render:canvas-example.

---
*PR created automatically by Jules for task [12449378895050267312](https://jules.google.com/task/12449378895050267312) started by @BintzGavin*