### PR TITLE
✨ CORE: Enable Audio State Persistence

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### CORE v5.7.0
+- ✅ Completed: Enable Audio State Persistence - Added `audioTracks` to `HeliosOptions` and updated constructor to initialize mixer state (volume/muted per track) from configuration, enabling full session save/load.
+
 ### CORE v5.6.0
 - ✅ Completed: Audio Fade Easing - Implemented `data-helios-fade-easing` support in `DomDriver`, allowing non-linear audio fades (e.g. "quad.in").
 

--- a/docs/status/CORE.md
+++ b/docs/status/CORE.md
@@ -1,11 +1,12 @@
 # Status: CORE
 
-**Version**: 5.6.0
+**Version**: 5.7.0
 
 - **Status**: Active
 - **Current Focus**: Maintenance, Optimization, and Stability
-- **Last Updated**: 2026-08-08
+- **Last Updated**: 2026-08-09
 
+[v5.7.0] ✅ Completed: Enable Audio State Persistence - Added `audioTracks` to `HeliosOptions` and updated constructor to initialize mixer state (volume/muted per track) from configuration, enabling full session save/load.
 [v5.6.0] ✅ Completed: Audio Fade Easing - Implemented `data-helios-fade-easing` support in `DomDriver`, enabling non-linear audio fades (e.g., "quad.in") using the Easing library.
 [v5.5.0] ✅ Verified: Maintenance - Verified core package integrity by running full test suite (27 files, 428 tests passed).
 [v5.5.0] ✅ Completed: Audio Visualization Hooks - Added `getAudioContext()` and `getAudioSourceNode(trackId)` methods to `Helios` and `DomDriver`, allowing consumers to hook into the audio graph for visualization.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/core",
-  "version": "5.5.0",
+  "version": "5.7.0",
   "type": "module",
   "description": "Core library for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",

--- a/packages/core/src/Helios.ts
+++ b/packages/core/src/Helios.ts
@@ -50,6 +50,7 @@ export interface HeliosOptions<TInputProps = Record<string, any>> {
   playbackRate?: number;
   volume?: number;
   muted?: boolean;
+  audioTracks?: Record<string, AudioTrackState>;
   availableAudioTracks?: AudioTrackMetadata[];
   captions?: string | CaptionCue[];
   markers?: Marker[];
@@ -481,7 +482,7 @@ export class Helios<TInputProps = Record<string, any>> {
     this._playbackRate = signal(options.playbackRate ?? 1);
     this._volume = signal(options.volume ?? 1);
     this._muted = signal(options.muted ?? false);
-    this._audioTracks = signal({});
+    this._audioTracks = signal(options.audioTracks || {});
     this._availableAudioTracks = signal(options.availableAudioTracks || []);
     this._captions = signal(initialCaptions);
     this._markers = signal(initialMarkers);

--- a/packages/core/src/audio-state.test.ts
+++ b/packages/core/src/audio-state.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { Helios } from './Helios';
+
+describe('Helios Audio State Persistence', () => {
+  it('should initialize with provided audioTracks', () => {
+    const audioTracks = {
+      'track-1': { volume: 0.5, muted: true },
+      'track-2': { volume: 1.0, muted: false }
+    };
+
+    const helios = new Helios({
+      fps: 30,
+      duration: 10,
+      audioTracks
+    });
+
+    const state = helios.getState();
+    expect(state.audioTracks).toEqual(audioTracks);
+  });
+
+  it('should default audioTracks to empty object if not provided', () => {
+    const helios = new Helios({
+      fps: 30,
+      duration: 10
+    });
+
+    const state = helios.getState();
+    expect(state.audioTracks).toEqual({});
+  });
+
+  it('should handle undefined audioTracks explicitly', () => {
+    const helios = new Helios({
+      fps: 30,
+      duration: 10,
+      audioTracks: undefined
+    });
+
+    const state = helios.getState();
+    expect(state.audioTracks).toEqual({});
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,4 +15,4 @@ export * from './ai.js';
 export * from './Helios.js';
 export * from './render-session.js';
 
-export const VERSION = '5.5.0';
+export const VERSION = '5.7.0';


### PR DESCRIPTION
* 💡 **What**: Added `audioTracks` property to `HeliosOptions` and updated the constructor to initialize the mixer state (volume/muted) from this configuration.
* 🎯 **Why**: To enable full session save/load functionality (persistence) for audio mixing settings in applications like Helios Studio.
* 📊 **Impact**: Consumers can now re-hydrate a `Helios` instance with the exact audio state of a previous session.
* 🔬 **Verification**: Run `npm test -w packages/core` to verify the new `audio-state.test.ts` passes.

---
*PR created automatically by Jules for task [6108121674669295433](https://jules.google.com/task/6108121674669295433) started by @BintzGavin*