### PR TITLE
✨ RENDERER: Fix Audio Playback Seek

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -59,6 +59,7 @@ packages/renderer/
     ├── verify-audio-fades.ts   # Audio fades test
     ├── verify-audio-loop.ts    # Audio looping test
     ├── verify-audio-playback-rate.ts # Audio playback rate test
+    ├── verify-audio-playback-seek.ts # Audio playback seek test (Rate + StartFrame)
     ├── verify-visual-playback-rate.ts # Visual playback rate test
     ├── verify-frame-count.ts   # Precision frame count test
     ├── verify-cdp-hang.ts      # CDP initialization order/deadlock test
@@ -95,6 +96,7 @@ The `DistributedRenderOptions` interface extends `RendererOptions` with:
 
 ## D. FFmpeg Interface
 The renderer spawns an FFmpeg process with the following key flags:
+- `-ss`: Input seek (for audio synchronization with range rendering).
 - `-f image2pipe`: Reads frames from stdin.
 - `-f concat -safe 0 -protocol_whitelist file,pipe -i -`: Reads concat list from stdin (for concatenation jobs).
 - `pipe:N`: Additional inputs for audio buffers (mapped to file descriptors).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### RENDERER v1.61.1
+- ✅ Completed: Fix Audio Playback Seek - Updated `FFmpegBuilder` to correctly calculate input seek time (`-ss`) when using `playbackRate` with `startFrame > 0`.
+
 ### CORE v5.7.0
 - ✅ Completed: Enable Audio State Persistence - Added `audioTracks` to `HeliosOptions` and updated constructor to initialize mixer state (volume/muted per track) from configuration, enabling full session save/load.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,8 +1,9 @@
-**Version**: 1.61.0
+**Version**: 1.61.1
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.61.1] ✅ Completed: Fix Audio Playback Seek - Updated `FFmpegBuilder` to correctly calculate the audio input seek time (`-ss`) when using `playbackRate` and a `startFrame` > 0. Verified with `verify-audio-playback-seek.ts`.
 - [1.61.0] ✅ Completed: Enable Visual Playback Rate - Updated `SeekTimeDriver` and `CdpTimeDriver` to respect the `playbackRate` property (and attribute) on media elements, ensuring visual synchronization with audio speed changes.
 - [1.60.2] ✅ Completed: Fix Verification Suite - Updated `verify-audio-fades.ts` and `verify-audio-loop.ts` to handle the new `FFmpegConfig` return type from `getArgs`, resolving test failures and ensuring the verification suite passes.
 - [1.60.1] ✅ Completed: Refactor Concat to Pipe - Refactored `concatenateVideos` to pipe the file list to FFmpeg's stdin (`-i -`), removing temporary file creation and eliminating disk I/O for the concatenation process. Verified with `verify-concat.ts`.

--- a/packages/renderer/src/utils/FFmpegBuilder.ts
+++ b/packages/renderer/src/utils/FFmpegBuilder.ts
@@ -65,7 +65,8 @@ export class FFmpegBuilder {
         // Track starts before or at the render window
         // We need to skip the part of the track that happened before renderStart
         delayMs = 0;
-        inputSeek = (track.seek || 0) + (renderStartTime - globalStart);
+        const playbackRate = track.playbackRate && Number.isFinite(track.playbackRate) && track.playbackRate > 0 ? track.playbackRate : 1.0;
+        inputSeek = (track.seek || 0) + (renderStartTime - globalStart) * playbackRate;
       }
 
       // Add input arguments

--- a/packages/renderer/tests/verify-audio-playback-seek.ts
+++ b/packages/renderer/tests/verify-audio-playback-seek.ts
@@ -1,0 +1,129 @@
+import { FFmpegBuilder } from '../src/utils/FFmpegBuilder';
+import { RendererOptions } from '../src/types';
+
+function runTests() {
+  console.log('Running Audio Playback Seek Verification...');
+  let hasError = false;
+
+  const baseOptions: RendererOptions = {
+    width: 1920,
+    height: 1080,
+    fps: 30,
+    durationInSeconds: 10,
+    mode: 'canvas',
+  };
+
+  const dummyInputArgs = ['-f', 'image2pipe', '-i', '-'];
+  const outputPath = 'output.mp4';
+
+  function getSeekTime(args: string[], inputPath: string): number | null {
+    // Find the input path
+    const inputIndex = args.indexOf(inputPath);
+    if (inputIndex === -1) return null;
+
+    // Look for -ss before the input
+    // The args structure is like: ... -ss SEEK -i INPUT ...
+    // So if INPUT is at index I, -i is at I-1, SEEK is at I-2, -ss is at I-3
+    if (args[inputIndex - 1] === '-i' && args[inputIndex - 3] === '-ss') {
+      return parseFloat(args[inputIndex - 2]);
+    }
+    return null;
+  }
+
+  // Scenario:
+  // Render Start: 5s (startFrame = 150, fps = 30)
+  // Audio Offset: 0s (starts at beginning of timeline)
+  // Audio Seek: 0s (start of audio file)
+  // We are skipping 5s of timeline time.
+
+  const startFrame = 150; // 5 seconds at 30fps
+
+  // Test 1: Rate 1.0
+  // Expected seek: 0 + (5 - 0) * 1.0 = 5.0
+  console.log('\nTest 1: Rate 1.0 (Normal)');
+  const options1: RendererOptions = {
+    ...baseOptions,
+    startFrame: startFrame,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 1.0 }]
+  };
+  const args1 = FFmpegBuilder.getArgs(options1, outputPath, dummyInputArgs);
+  const seek1 = getSeekTime(args1.args, 'audio.mp3');
+
+  if (seek1 === 5.0) {
+    console.log('✅ Passed: Seek is 5.0s');
+  } else {
+    console.error(`❌ Failed: Expected 5.0s, got ${seek1}s`);
+    hasError = true;
+  }
+
+  // Test 2: Rate 2.0
+  // Timeline elapsed: 5s
+  // Media elapsed: 5s * 2.0 = 10s
+  // Expected seek: 0 + 10 = 10.0
+  console.log('\nTest 2: Rate 2.0 (Double Speed)');
+  const options2: RendererOptions = {
+    ...baseOptions,
+    startFrame: startFrame,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 2.0 }]
+  };
+  const args2 = FFmpegBuilder.getArgs(options2, outputPath, dummyInputArgs);
+  const seek2 = getSeekTime(args2.args, 'audio.mp3');
+
+  if (seek2 === 10.0) {
+    console.log('✅ Passed: Seek is 10.0s');
+  } else {
+    console.error(`❌ Failed: Expected 10.0s, got ${seek2}s`);
+    hasError = true;
+  }
+
+  // Test 3: Rate 0.5
+  // Timeline elapsed: 5s
+  // Media elapsed: 5s * 0.5 = 2.5s
+  // Expected seek: 0 + 2.5 = 2.5
+  console.log('\nTest 3: Rate 0.5 (Half Speed)');
+  const options3: RendererOptions = {
+    ...baseOptions,
+    startFrame: startFrame,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 0.5 }]
+  };
+  const args3 = FFmpegBuilder.getArgs(options3, outputPath, dummyInputArgs);
+  const seek3 = getSeekTime(args3.args, 'audio.mp3');
+
+  if (seek3 === 2.5) {
+    console.log('✅ Passed: Seek is 2.5s');
+  } else {
+    console.error(`❌ Failed: Expected 2.5s, got ${seek3}s`);
+    hasError = true;
+  }
+
+  // Test 4: Rate 1.5 with Initial Seek
+  // Audio Seek: 2s (start playing from 2s into the file)
+  // Timeline elapsed: 5s
+  // Media elapsed: 5s * 1.5 = 7.5s
+  // Expected seek: 2 + 7.5 = 9.5s
+  console.log('\nTest 4: Rate 1.5 with Initial Seek');
+  const options4: RendererOptions = {
+    ...baseOptions,
+    startFrame: startFrame,
+    audioTracks: [{ path: 'audio.mp3', playbackRate: 1.5, seek: 2.0 }]
+  };
+  const args4 = FFmpegBuilder.getArgs(options4, outputPath, dummyInputArgs);
+  const seek4 = getSeekTime(args4.args, 'audio.mp3');
+
+  if (seek4 === 9.5) {
+    console.log('✅ Passed: Seek is 9.5s');
+  } else {
+    console.error(`❌ Failed: Expected 9.5s, got ${seek4}s`);
+    hasError = true;
+  }
+
+  if (hasError) {
+    console.error('\n❌ Verification Failed.');
+    process.exit(1);
+  } else {
+    console.log('\n✅ All verification tests passed!');
+    process.exit(0);
+  }
+}
+
+runTests();


### PR DESCRIPTION
💡 **What**: Fixed `FFmpegBuilder` to correctly calculate the audio input seek time (`-ss`) when using `playbackRate` with a `startFrame > 0`.
🎯 **Why**: When rendering a partial range (startFrame > 0) of a composition where audio tracks have a non-default `playbackRate` (e.g., 2.0x), the previous logic assumed a 1:1 mapping between timeline time and media time, causing audio to be desynchronized (skipping too little or too much audio).
📊 **Impact**: Ensures frame-accurate audio synchronization for accelerated or decelerated clips during range rendering, essential for distributed rendering workflows.
🔬 **Verification**:
- Created `packages/renderer/tests/verify-audio-playback-seek.ts`.
- Confirmed correct seek calculation for rates 1.0, 2.0, 0.5, and 1.5 with offsets.
- Verified regression tests `verify-audio-playback-rate.ts` pass.

---
*PR created automatically by Jules for task [1621450397801511792](https://jules.google.com/task/1621450397801511792) started by @BintzGavin*