### PR TITLE
Implement Active Cues for HeliosTextTrack

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -18,3 +18,6 @@
 
 ### DEMO v1.90.0
 - ✅ Completed: Vue Audio Visualization - Created `examples/vue-audio-visualization` demonstrating real-time audio analysis with Vue 3.
+
+## PLAYER v0.63.0
+- ✅ Completed: Implement Active Cues - Added `activeCues` property and `cuechange` event to `HeliosTextTrack`, and updated `HeliosPlayer` to drive cue updates via the main UI loop.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.62.1
+**Version**: v0.63.0
 
 # Status: PLAYER
 
@@ -51,10 +51,12 @@
 - **Supports Headless Audio Export**: Client-side export now includes audio tracks manually injected into Helios state (`availableAudioTracks`), enabling headless audio rendering without DOM elements.
 - **Supports Dynamic Composition Updates**: Exposes `setDuration`, `setFps`, `setSize`, and `setMarkers` via `HeliosController` (and Bridge), allowing host applications (like Studio) to update the composition structure dynamically.
 - **Supports Export Filename**: Implemented `export-filename` attribute to allow specifying the filename for client-side exports.
+- **Supports Active Cues**: Implemented `activeCues` property and `cuechange` event on `HeliosTextTrack` for Standard Media API parity.
 
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.63.0] ✅ Completed: Implement Active Cues - Added `activeCues` property and `cuechange` event to `HeliosTextTrack`, and updated `HeliosPlayer` to drive cue updates via the main UI loop.
 [v0.62.1] ✅ Completed: Fix SRT Export Filename - Updated SRT export to respect `export-filename` attribute instead of using hardcoded "captions.srt".
 [v0.62.0] ✅ Verified: Export Filename - Confirmed implementation and tests for `export-filename` attribute. Synced package.json version.
 [v0.62.0] ✅ Completed: Export Filename - Implemented `export-filename` attribute on `<helios-player>` to allow customizing the filename of client-side exported videos.

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -46,7 +46,7 @@
     "helios"
   ],
   "dependencies": {
-    "@helios-project/core": "5.5.0",
+    "@helios-project/core": "^5.7.0",
     "mediabunny": "^1.31.0"
   },
   "devDependencies": {

--- a/packages/player/src/features/text-tracks.test.ts
+++ b/packages/player/src/features/text-tracks.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HeliosTextTrack, CueClass, TrackHost } from './text-tracks';
+
+class MockTrackHost implements TrackHost {
+    handleTrackModeChange = vi.fn();
+}
+
+describe('HeliosTextTrack', () => {
+    let track: HeliosTextTrack;
+    let host: MockTrackHost;
+
+    beforeEach(() => {
+        host = new MockTrackHost();
+        track = new HeliosTextTrack('captions', 'English', 'en', host);
+    });
+
+    it('should initialize with empty cues', () => {
+        expect(track.cues).toHaveLength(0);
+        expect(track.activeCues).toHaveLength(0);
+    });
+
+    it('should add cues', () => {
+        const cue = new CueClass(0, 5, 'Hello');
+        track.addCue(cue);
+        expect(track.cues).toHaveLength(1);
+        expect(track.cues[0]).toBe(cue);
+    });
+
+    it('should update activeCues based on time', () => {
+        const cue1 = new CueClass(0, 5, 'Hello');
+        const cue2 = new CueClass(5, 10, 'World');
+        track.addCue(cue1);
+        track.addCue(cue2);
+
+        track.mode = 'showing';
+
+        // Time 2: Inside cue1
+        track.updateActiveCues(2);
+        expect(track.activeCues).toHaveLength(1);
+        expect(track.activeCues[0]).toBe(cue1);
+
+        // Time 5: End of cue1, Start of cue2
+        // HTML5 spec: start is inclusive, end is exclusive (usually)
+        // But let's check our implementation. We plan to use `startTime <= t < endTime`?
+        // Wait, standard WebVTT/HTML5 behavior:
+        // "A cue is active if... current playback position ... is within the cue's time interval."
+        // Usually [start, end).
+        track.updateActiveCues(5);
+        expect(track.activeCues).toHaveLength(1);
+        expect(track.activeCues[0]).toBe(cue2);
+
+        // Time 12: Outside all
+        track.updateActiveCues(12);
+        expect(track.activeCues).toHaveLength(0);
+    });
+
+    it('should dispatch cuechange event when activeCues changes', () => {
+        const cue = new CueClass(0, 5, 'Hello');
+        track.addCue(cue);
+        track.mode = 'showing';
+
+        const spy = vi.fn();
+        track.addEventListener('cuechange', spy);
+
+        // Enter cue
+        track.updateActiveCues(1);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(track.activeCues[0]).toBe(cue);
+
+        // Move within cue (no change)
+        track.updateActiveCues(2);
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        // Exit cue
+        track.updateActiveCues(6);
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(track.activeCues).toHaveLength(0);
+    });
+
+    it('should not update activeCues if mode is disabled', () => {
+        const cue = new CueClass(0, 5, 'Hello');
+        track.addCue(cue);
+        track.mode = 'disabled';
+
+        track.updateActiveCues(2);
+        expect(track.activeCues).toHaveLength(0);
+    });
+
+    it('should clear activeCues when switching to disabled', () => {
+        const cue = new CueClass(0, 5, 'Hello');
+        track.addCue(cue);
+        track.mode = 'showing';
+
+        track.updateActiveCues(2);
+        expect(track.activeCues).toHaveLength(1);
+
+        track.mode = 'disabled';
+        // Usually, disabling clears immediately or on next update?
+        // The spec says: "Whenever the text track mode ... is changed to disabled ... active cues ... is null".
+        // Our implementation of `mode` setter doesn't strictly clear it yet, but `updateActiveCues` should handle it.
+        // Let's assume we call updateActiveCues after mode change or next tick.
+
+        track.updateActiveCues(2);
+        expect(track.activeCues).toHaveLength(0);
+    });
+
+    it('should support oncuechange property', () => {
+        const spy = vi.fn();
+        (track as any).oncuechange = spy;
+
+        track.dispatchEvent(new Event('cuechange'));
+        expect(spy).toHaveBeenCalled();
+    });
+});

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1877,6 +1877,14 @@ export class HeliosPlayer extends HTMLElement implements TrackHost {
   };
 
   private updateUI(state: any) {
+      // Update text tracks active cues
+      if (state.fps) {
+          const currentTime = state.currentFrame / state.fps;
+          for (const track of this._textTracks) {
+              track.updateActiveCues(currentTime);
+          }
+      }
+
       // Hide poster if we are playing or have advanced
       if (state.isPlaying || state.currentFrame > 0) {
          this.posterContainer.classList.add("hidden");


### PR DESCRIPTION
Implemented `activeCues` property and `cuechange` event on `HeliosTextTrack` to achieve parity with the Standard Media API. Updated `HeliosPlayer` to call `updateActiveCues` on every frame update, ensuring cues are synchronized with playback time. Also fixed `oncuechange` setter implementation to correctly replace event handlers. Synced `packages/player/package.json` dependency on `@helios-project/core` to match the local workspace version.

---
*PR created automatically by Jules for task [7242457473953125582](https://jules.google.com/task/7242457473953125582) started by @BintzGavin*