### PR TITLE
📋 CORE: Expose Audio Fade Easing

### DIFF
--- a/.jules/CORE.md
+++ b/.jules/CORE.md
@@ -53,3 +53,7 @@
 ## [5.6.0] - Workspace Dependency Breakage
 **Learning:** `packages/studio` depends on `player@^0.59.0` but `packages/player` is at `0.62.0`. This causes `npm install` at root to fail with `ETARGET`, blocking all verification.
 **Action:** When working on Core, check `npm install` status early. If broken due to other packages, document it as a blocker in the Plan Dependencies.
+
+## [5.7.0] - Driver State Visibility
+**Learning:** `DomDriver` implemented `fadeEasing` logic internally but failed to expose the configuration in `AudioTrackMetadata`, causing a gap where the Renderer could not replicate the behavior.
+**Action:** When adding features to Drivers (like `DomDriver`), always ensure the configuration data is reflected in the public state (e.g. `availableAudioTracks` signal) for external consumers.

--- a/.sys/plans/2026-08-10-CORE-expose-fade-easing.md
+++ b/.sys/plans/2026-08-10-CORE-expose-fade-easing.md
@@ -1,0 +1,34 @@
+# Context & Goal
+- **Objective**: Expose the `fadeEasing` property in `AudioTrackMetadata` discovered by `DomDriver` via `data-helios-fade-easing`.
+- **Trigger**: Vision gap where `DomDriver` supports non-linear fades internally, but this configuration is hidden from the `availableAudioTracks` signal, preventing external renderers from replicating the behavior.
+- **Impact**: Enables the Renderer (and other consumers) to access the full audio fade configuration, ensuring WYSIWYG parity between the browser preview and the final render.
+
+# File Inventory
+- **Modify**: `packages/core/src/drivers/TimeDriver.ts` (Add `fadeEasing` to interface)
+- **Modify**: `packages/core/src/drivers/DomDriver.ts` (Extract attribute, update observer)
+- **Modify**: `packages/core/src/drivers/DomDriver-metadata.test.ts` (Add test cases)
+
+# Implementation Spec
+- **Architecture**: Extend the existing Metadata Discovery mechanism in `DomDriver` to parse and propagate the easing configuration.
+- **Pseudo-Code**:
+  - In `packages/core/src/drivers/TimeDriver.ts`:
+    - Add `fadeEasing?: string` to `AudioTrackMetadata` interface.
+  - In `packages/core/src/drivers/DomDriver.ts`:
+    - In `rebuildDiscoveredTracks`:
+      - Read `data-helios-fade-easing` attribute using `getAttribute`.
+      - Include it in the constructed metadata object if present.
+    - In `addScope` (MutationObserver):
+      - Add `'data-helios-fade-easing'` to the `attributeFilter` array to trigger updates on change.
+- **Public API Changes**:
+  - `AudioTrackMetadata`: Add optional `fadeEasing?: string` property.
+- **Dependencies**: None.
+
+# Test Plan
+- **Verification**: Run `npm test packages/core/src/drivers/DomDriver-metadata.test.ts`
+- **Success Criteria**:
+  - New test case "should discover fade easing metadata" passes.
+  - New test case "should update metadata when fade easing attribute changes" passes.
+  - Existing tests pass (regression check).
+- **Edge Cases**:
+  - Attribute missing (should be undefined).
+  - Attribute present but empty string (should match `getAttribute` behavior, likely empty string or treat as undefined if desired, but passing through string is safest).


### PR DESCRIPTION
Created plan /.sys/plans/2026-08-10-CORE-expose-fade-easing.md to expose fadeEasing in AudioTrackMetadata, addressing a vision gap where DomDriver internal state was not visible to consumers.

---
*PR created automatically by Jules for task [1867054155701177569](https://jules.google.com/task/1867054155701177569) started by @BintzGavin*