### PR TITLE
✨ PLAYER: Fix cuechange event on track disable

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### PLAYER v0.63.1
+- ✅ Completed: Fix cuechange on Disable - Fixed bug where disabling a track cleared active cues without dispatching the cuechange event.
+
 ### CORE v5.8.0
 - ✅ Completed: Expose Fade Easing Metadata - Added `fadeEasing` to `AudioTrackMetadata` and updated `DomDriver` to parse `data-helios-fade-easing` attribute, exposing non-linear fade configurations to consumers.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.63.0
+**Version**: v0.63.1
 
 # Status: PLAYER
 
@@ -56,6 +56,7 @@
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.63.1] ✅ Completed: Fix cuechange on Disable - Fixed bug where disabling a track cleared active cues without dispatching the cuechange event.
 [v0.63.0] ✅ Completed: Implement Active Cues - Added `activeCues` property and `cuechange` event to `HeliosTextTrack`, and updated `HeliosPlayer` to drive cue updates via the main UI loop.
 [v0.62.1] ✅ Completed: Fix SRT Export Filename - Updated SRT export to respect `export-filename` attribute instead of using hardcoded "captions.srt".
 [v0.62.0] ✅ Verified: Export Filename - Confirmed implementation and tests for `export-filename` attribute. Synced package.json version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10594,7 +10594,7 @@
     },
     "packages/core": {
       "name": "@helios-project/core",
-      "version": "5.5.0",
+      "version": "5.8.0",
       "license": "ELv2",
       "devDependencies": {
         "typescript": "^5.0.0",
@@ -10603,10 +10603,10 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.59.0",
+      "version": "0.63.1",
       "license": "ELv2",
       "dependencies": {
-        "@helios-project/core": "5.5.0",
+        "@helios-project/core": "^5.8.0",
         "mediabunny": "^1.31.0"
       },
       "devDependencies": {
@@ -10621,7 +10621,7 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/core": "5.5.0",
+        "@helios-project/core": "^5.8.0",
         "playwright": "^1.42.1"
       },
       "devDependencies": {
@@ -10654,7 +10654,7 @@
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^5.4.0",
-        "@helios-project/player": "^0.59.0",
+        "@helios-project/player": "^0.63.1",
         "@helios-project/renderer": "^0.0.2",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "react": "^19.2.3",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.62.0",
+  "version": "0.63.1",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",
@@ -46,7 +46,7 @@
     "helios"
   ],
   "dependencies": {
-    "@helios-project/core": "^5.7.0",
+    "@helios-project/core": "^5.8.0",
     "mediabunny": "^1.31.0"
   },
   "devDependencies": {

--- a/packages/player/src/features/text-tracks.test.ts
+++ b/packages/player/src/features/text-tracks.test.ts
@@ -112,4 +112,21 @@ describe('HeliosTextTrack', () => {
         track.dispatchEvent(new Event('cuechange'));
         expect(spy).toHaveBeenCalled();
     });
+
+    it('should dispatch cuechange event when activeCues are cleared due to disabling', () => {
+        const cue = new CueClass(0, 5, 'Hello');
+        track.addCue(cue);
+        track.mode = 'showing';
+        track.updateActiveCues(2);
+        expect(track.activeCues).toHaveLength(1);
+
+        const spy = vi.fn();
+        track.addEventListener('cuechange', spy);
+
+        track.mode = 'disabled';
+        track.updateActiveCues(2);
+
+        expect(track.activeCues).toHaveLength(0);
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/player/src/features/text-tracks.ts
+++ b/packages/player/src/features/text-tracks.ts
@@ -75,6 +75,7 @@ export class HeliosTextTrack extends EventTarget {
     if (this._mode === 'disabled') {
       if (this._activeCues.length > 0) {
         this._activeCues = [];
+        this.dispatchEvent(new Event('cuechange'));
       }
       return;
     }

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "@helios-project/core": "^5.4.0",
-    "@helios-project/player": "^0.59.0",
+    "@helios-project/player": "^0.63.1",
     "@helios-project/renderer": "^0.0.2",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "react": "^19.2.3",


### PR DESCRIPTION
This change fixes a bug where disabling a text track (e.g., turning off captions) would clear the active cues but fail to dispatch the `cuechange` event, leaving listeners (like the UI overlay) unaware of the change. 

It also performs necessary dependency updates to synchronize `player`, `studio`, and `core` versions in the workspace.

---
*PR created automatically by Jules for task [10729752237341351188](https://jules.google.com/task/10729752237341351188) started by @BintzGavin*