### PR TITLE
✨ PLAYER: Implement Standard Track Events

### DIFF
--- a/packages/player/src/features/audio-tracks.ts
+++ b/packages/player/src/features/audio-tracks.ts
@@ -43,6 +43,9 @@ export class HeliosAudioTrack {
 
 export class HeliosAudioTrackList extends EventTarget implements Iterable<HeliosAudioTrack> {
   private tracks: HeliosAudioTrack[] = [];
+  private _onaddtrack: ((event: any) => void) | null = null;
+  private _onremovetrack: ((event: any) => void) | null = null;
+  private _onchange: ((event: any) => void) | null = null;
 
   get length() { return this.tracks.length; }
 
@@ -89,19 +92,34 @@ export class HeliosAudioTrackList extends EventTarget implements Iterable<Helios
   }
 
   // Standard event handler properties
+  get onaddtrack() { return this._onaddtrack; }
   set onaddtrack(handler: ((event: any) => void) | null) {
+    if (this._onaddtrack) {
+      this.removeEventListener('addtrack', this._onaddtrack);
+    }
+    this._onaddtrack = handler;
     if (handler) {
       this.addEventListener('addtrack', handler);
     }
   }
 
+  get onremovetrack() { return this._onremovetrack; }
   set onremovetrack(handler: ((event: any) => void) | null) {
+    if (this._onremovetrack) {
+      this.removeEventListener('removetrack', this._onremovetrack);
+    }
+    this._onremovetrack = handler;
     if (handler) {
       this.addEventListener('removetrack', handler);
     }
   }
 
+  get onchange() { return this._onchange; }
   set onchange(handler: ((event: any) => void) | null) {
+    if (this._onchange) {
+      this.removeEventListener('change', this._onchange);
+    }
+    this._onchange = handler;
     if (handler) {
       this.addEventListener('change', handler);
     }

--- a/packages/player/src/features/text-tracks.ts
+++ b/packages/player/src/features/text-tracks.ts
@@ -125,6 +125,9 @@ export class HeliosTextTrack extends EventTarget {
 
 export class HeliosTextTrackList extends EventTarget implements Iterable<HeliosTextTrack> {
     private tracks: HeliosTextTrack[] = [];
+    private _onaddtrack: ((event: any) => void) | null = null;
+    private _onremovetrack: ((event: any) => void) | null = null;
+    private _onchange: ((event: any) => void) | null = null;
 
     get length() { return this.tracks.length; }
 
@@ -165,10 +168,40 @@ export class HeliosTextTrackList extends EventTarget implements Iterable<HeliosT
         }
     }
 
-    // Stub for standard event handler property
+    dispatchChangeEvent() {
+        this.dispatchEvent(new Event('change'));
+    }
+
+    get onaddtrack() { return this._onaddtrack; }
     set onaddtrack(handler: ((event: any) => void) | null) {
+        if (this._onaddtrack) {
+            this.removeEventListener('addtrack', this._onaddtrack);
+        }
+        this._onaddtrack = handler;
         if (handler) {
             this.addEventListener('addtrack', handler);
+        }
+    }
+
+    get onremovetrack() { return this._onremovetrack; }
+    set onremovetrack(handler: ((event: any) => void) | null) {
+        if (this._onremovetrack) {
+            this.removeEventListener('removetrack', this._onremovetrack);
+        }
+        this._onremovetrack = handler;
+        if (handler) {
+            this.addEventListener('removetrack', handler);
+        }
+    }
+
+    get onchange() { return this._onchange; }
+    set onchange(handler: ((event: any) => void) | null) {
+        if (this._onchange) {
+            this.removeEventListener('change', this._onchange);
+        }
+        this._onchange = handler;
+        if (handler) {
+            this.addEventListener('change', handler);
         }
     }
 }

--- a/packages/player/src/features/track-events.test.ts
+++ b/packages/player/src/features/track-events.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HeliosTextTrackList, HeliosTextTrack } from './text-tracks';
+import { HeliosAudioTrackList, HeliosAudioTrack } from './audio-tracks';
+
+describe('Track Events Standard Compliance', () => {
+    describe('HeliosTextTrackList', () => {
+        let list: HeliosTextTrackList;
+
+        beforeEach(() => {
+            list = new HeliosTextTrackList();
+        });
+
+        it('should replace onaddtrack handler', () => {
+            const handler1 = vi.fn();
+            const handler2 = vi.fn();
+
+            list.onaddtrack = handler1;
+            list.onaddtrack = handler2;
+
+            const track = new HeliosTextTrack('captions', 'Test', 'en', { handleTrackModeChange: () => {} });
+            list.addTrack(track);
+
+            expect(handler1).not.toHaveBeenCalled();
+            expect(handler2).toHaveBeenCalledTimes(1);
+        });
+
+        it('should replace onremovetrack handler', () => {
+            const handler1 = vi.fn();
+            const handler2 = vi.fn();
+            const track = new HeliosTextTrack('captions', 'Test', 'en', { handleTrackModeChange: () => {} });
+            list.addTrack(track);
+
+            list.onremovetrack = handler1;
+            list.onremovetrack = handler2;
+
+            list.removeTrack(track);
+
+            expect(handler1).not.toHaveBeenCalled();
+            expect(handler2).toHaveBeenCalledTimes(1);
+        });
+
+        it('should replace onchange handler', () => {
+             const handler1 = vi.fn();
+             const handler2 = vi.fn();
+
+             list.onchange = handler1;
+             list.onchange = handler2;
+
+             // Use the helper method
+             list.dispatchChangeEvent();
+
+             expect(handler1).not.toHaveBeenCalled();
+             expect(handler2).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('HeliosAudioTrackList', () => {
+        let list: HeliosAudioTrackList;
+
+        beforeEach(() => {
+            list = new HeliosAudioTrackList();
+        });
+
+        it('should replace onaddtrack handler', () => {
+            const handler1 = vi.fn();
+            const handler2 = vi.fn();
+
+            list.onaddtrack = handler1;
+            list.onaddtrack = handler2;
+
+            const track = new HeliosAudioTrack('1', 'main', 'Main', 'en', true, { handleAudioTrackEnabledChange: () => {} });
+            list.addTrack(track);
+
+            expect(handler1).not.toHaveBeenCalled();
+            expect(handler2).toHaveBeenCalledTimes(1);
+        });
+
+        it('should replace onchange handler', () => {
+            const handler1 = vi.fn();
+            const handler2 = vi.fn();
+
+            list.onchange = handler1;
+            list.onchange = handler2;
+
+            list.dispatchChangeEvent();
+
+            expect(handler1).not.toHaveBeenCalled();
+            expect(handler2).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1064,9 +1064,11 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     if (!this.controller) return;
     // Helios "muted" is the inverse of AudioTrack "enabled"
     this.controller.setAudioTrackMuted(track.id, !track.enabled);
+    this._audioTracks.dispatchChangeEvent();
   }
 
   public handleTrackModeChange(track: HeliosTextTrack) {
+    this._textTracks.dispatchChangeEvent();
     if (!this.controller) return;
 
     if (track.mode === 'showing') {


### PR DESCRIPTION
Implemented standard EventTarget behavior for HeliosTextTrackList and HeliosAudioTrackList event handlers (onaddtrack, onremovetrack, onchange). Fixed listeners accumulating instead of replacing. Added dispatchChangeEvent() to TextTrackList and wired up dispatching in HeliosPlayer when track states change. Added verification tests.

---
*PR created automatically by Jules for task [8525812848534576799](https://jules.google.com/task/8525812848534576799) started by @BintzGavin*