### PR TITLE
📋 CORE: Define Composition Schema

### DIFF
--- a/.jules/CORE.md
+++ b/.jules/CORE.md
@@ -65,3 +65,7 @@
 ## [5.10.0] - Test State Leakage
 **Learning:** Static registries in singletons (like `Helios._virtualTimeRegistry`) persist across tests in the same suite, causing "state leakage" if instances are not disposed. This leads to flaky tests where one test's cleanup (deleting a global) breaks another test's assumptions (that the global is hooked).
 **Action:** Always ensure test setups isolate state or explicitly dispose of instances in `afterEach` to clear static registries.
+
+## [5.10.0] - Schema-First Development
+**Learning:** "Prompt to Composition" features were blocked because `HeliosOptions` mixed runtime callbacks with configuration, lacking a pure JSON-serializable schema for the composition itself.
+**Action:** When planning "Generation" or "Serialization" features, first identify or define the data contract (JSON interfaces) in a dedicated types file before attempting to implement the logic.

--- a/.sys/plans/2026-08-14-CORE-composition-schema.md
+++ b/.sys/plans/2026-08-14-CORE-composition-schema.md
@@ -1,0 +1,61 @@
+# Context & Goal
+- **Objective**: Define a pure JSON-serializable schema for Helios compositions (`HeliosComposition`, `HeliosTimeline`, `HeliosClip`) to enable "Prompt to Composition" workflows and distributed rendering.
+- **Trigger**: "Prompt to Composition" vision gap and `docs/BACKLOG.md` requirement for "structured prompt schema".
+- **Impact**: Enables AI agents to generate valid compositions as structured JSON, and lays the groundwork for saving/loading projects and distributed rendering logic.
+
+# File Inventory
+- **Create**:
+  - `packages/core/src/types.ts`: Will contain `HeliosConfig`, `HeliosClip`, `HeliosTrack`, `HeliosTimeline`, `HeliosComposition` interfaces.
+  - `packages/core/src/types.test.ts`: Unit tests to verify the types can be instantiated and type-checked.
+- **Modify**:
+  - `packages/core/src/Helios.ts`: Refactor `HeliosOptions` to extend `HeliosConfig` and ensure constructor compatibility.
+  - `packages/core/src/index.ts`: Export the new types.
+- **Read-Only**:
+  - `packages/core/src/schema.ts`: Reference for `HeliosSchema` (input props validation).
+
+# Implementation Spec
+- **Architecture**:
+  - **Separation of Concerns**: Extract JSON-serializable properties (config) from runtime-only callbacks (options).
+  - **Data Structure**: Define a recursive or hierarchical structure for the Timeline -> Track -> Clip model.
+  - **Inheritance**: `HeliosOptions` extends `HeliosConfig` to maintain backward compatibility while promoting the Config as the "save format".
+- **Pseudo-Code**:
+  ```typescript
+  // packages/core/src/types.ts
+
+  export interface HeliosConfig {
+    width: number;
+    height: number;
+    duration: number;
+    fps: number;
+    // ... other serializable props
+  }
+
+  export interface HeliosClip {
+    id: string;
+    source: string;
+    start: number;
+    duration: number;
+    // ...
+  }
+
+  export interface HeliosTimeline {
+    tracks: HeliosTrack[];
+  }
+
+  export interface HeliosComposition extends HeliosConfig {
+    timeline?: HeliosTimeline;
+  }
+  ```
+- **Public API Changes**:
+  - New exports: `HeliosConfig`, `HeliosComposition`, `HeliosTimeline`, `HeliosTrack`, `HeliosClip`.
+  - `HeliosOptions` now extends `HeliosConfig`.
+- **Dependencies**: None.
+
+# Test Plan
+- **Verification**: `npm test -w packages/core`
+- **Success Criteria**:
+  - All existing tests pass (ensuring `HeliosOptions` refactor is non-breaking).
+  - New test `packages/core/src/types.test.ts` passes, confirming that objects matching the new interfaces can be created and used.
+- **Edge Cases**:
+  - `HeliosOptions` properties that overlap with `HeliosConfig` (e.g. `duration`) must work correctly when passed via the constructor.
+  - Optional fields in `HeliosConfig` should be handled gracefully.


### PR DESCRIPTION
This plan defines the structured JSON schema for Helios compositions, addressing the "Prompt to Composition" vision gap and enabling AI agents to generate valid compositions. It separates runtime options from serializable configuration.

---
*PR created automatically by Jules for task [14142690222086826768](https://jules.google.com/task/14142690222086826768) started by @BintzGavin*