### PR TITLE
✨ CLI: Implement init command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -19,6 +19,7 @@ packages/cli/
 │   └── helios.js           # Shebang entry point
 ├── src/
 │   ├── commands/
+│   │   ├── init.ts         # helios init command
 │   │   └── studio.ts       # helios studio command
 │   └── index.ts            # Main CLI setup
 ├── package.json
@@ -38,19 +39,40 @@ helios studio
 - Spawns `npm run dev` in the `packages/studio` directory
 - Sets `HELIOS_PROJECT_ROOT` environment variable to the current working directory
 
+### `helios init`
+
+Initializes a new Helios project configuration.
+
+```bash
+helios init
+```
+
+Options:
+- `-y, --yes`: Skip prompts and use defaults
+
+Generates a `helios.config.json` file in the current directory with the following structure:
+```json
+{
+  "version": "1.0.0",
+  "directories": {
+    "components": "src/components/helios",
+    "lib": "src/lib"
+  }
+}
+```
+
 ### Planned Commands (V2)
 
 - `helios add [component]` - Fetch and copy components from registry
-- `helios init` - Scaffold a new Helios project
 - `helios render` - Trigger local or distributed rendering
 - `helios components` - Browse available registry components
 
 ## D. Configuration
 
-No configuration files are currently used. Future plans may include:
+The CLI uses `helios.config.json` for project configuration:
 
-- `.heliosrc` or `helios.config.js` for project configuration
-- Registry configuration for custom component sources
+- **directories.components**: Target directory for installed components
+- **directories.lib**: Location of the library directory
 
 ## E. Integration
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -28,6 +28,7 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 *Studio, CLI, and examples are first class product surfaces in V2.*
 
 - [x] **Studio**: Expand features to support distributed rendering configuration.
+- [x] **CLI**: Implement init command.
 - [ ] **CLI**: Implement registry commands.
 - [ ] **Examples**: Create examples demonstrating distributed rendering workflows.
 - [ ] **Examples**: Create examples demonstrating component usage.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.2.0
+
+- ✅ Implement `helios init` command to scaffold `helios.config.json`
+
 ## CLI v0.1.1
 
 - ✅ Implement `HELIOS_PROJECT_ROOT` injection in `helios studio` command

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.1.1
+**Version**: 0.2.0
 
 ## Current State
 
@@ -14,6 +14,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 ## Existing Commands
 
 - `helios studio` - Launches the Helios Studio dev server
+- `helios init` - Initializes a new Helios project configuration
 
 ## V2 Roadmap
 
@@ -28,3 +29,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 
 [v0.1.0] ✅ Initial CLI with `helios studio` command
 [v0.1.1] ✅ Pass Project Root to Studio - Injected HELIOS_PROJECT_ROOT env var in studio command
+[v0.2.0] ✅ Scaffold Init Command - Implemented `helios init` to generate `helios.config.json`

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,69 @@
+import { Command } from 'commander';
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import chalk from 'chalk';
+
+export function registerInitCommand(program: Command) {
+  program
+    .command('init')
+    .description('Initialize a new Helios project configuration')
+    .option('-y, --yes', 'Skip prompts and use defaults')
+    .action(async (options) => {
+      const configPath = path.resolve(process.cwd(), 'helios.config.json');
+
+      if (fs.existsSync(configPath)) {
+        console.error(chalk.red('Configuration file already exists.'));
+        process.exit(1);
+      }
+
+      const defaultConfig = {
+        version: '1.0.0',
+        directories: {
+          components: 'src/components/helios',
+          lib: 'src/lib',
+        },
+      };
+
+      let config = { ...defaultConfig };
+
+      if (!options.yes) {
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+
+        const ask = (question: string, defaultValue: string): Promise<string> => {
+          return new Promise((resolve) => {
+            rl.question(`${question} ${chalk.gray(`(${defaultValue})`)}: `, (answer) => {
+              resolve(answer.trim() || defaultValue);
+            });
+          });
+        };
+
+        console.log(chalk.cyan('Initializing Helios configuration...'));
+
+        const componentsDir = await ask(
+          'Where would you like to install components?',
+          defaultConfig.directories.components
+        );
+        const libDir = await ask(
+          'Where is your lib directory?',
+          defaultConfig.directories.lib
+        );
+
+        config.directories.components = componentsDir;
+        config.directories.lib = libDir;
+
+        rl.close();
+      }
+
+      try {
+        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+        console.log(chalk.green('Initialized helios.config.json'));
+      } catch (error) {
+        console.error(chalk.red('Failed to write configuration file:'), error);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { registerStudioCommand } from './commands/studio.js';
+import { registerInitCommand } from './commands/init.js';
 
 const program = new Command();
 
@@ -9,5 +10,6 @@ program
   .version('0.0.1');
 
 registerStudioCommand(program);
+registerInitCommand(program);
 
 program.parse(process.argv);


### PR DESCRIPTION
💡 **What**: Implemented `helios init` command in the CLI.
🎯 **Why**: To provide a standardized way to scaffold new Helios projects and generate configuration files.
📊 **Impact**: Enables users to easily set up project configuration for future features like component registry.
🔬 **Verification**: Verified manually by running `helios init` and checking `helios.config.json` generation.

---
*PR created automatically by Jules for task [13674530080791170161](https://jules.google.com/task/13674530080791170161) started by @BintzGavin*