### PR TITLE
✨ CLI: Scaffold Add Command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -19,8 +19,11 @@ packages/cli/
 │   └── helios.js           # Shebang entry point
 ├── src/
 │   ├── commands/
+│   │   ├── add.ts          # helios add command
 │   │   ├── init.ts         # helios init command
 │   │   └── studio.ts       # helios studio command
+│   ├── utils/
+│   │   └── config.ts       # Config loading and types
 │   └── index.ts            # Main CLI setup
 ├── package.json
 └── tsconfig.json
@@ -61,15 +64,25 @@ Generates a `helios.config.json` file in the current directory with the followin
 }
 ```
 
+### `helios add`
+
+Scaffold for adding a component to the project.
+
+```bash
+helios add <component>
+```
+
+- **Note**: Currently a placeholder/scaffold. Logs a warning that registry lookup is not implemented.
+- Requires `helios.config.json` to exist.
+
 ### Planned Commands (V2)
 
-- `helios add [component]` - Fetch and copy components from registry
 - `helios render` - Trigger local or distributed rendering
 - `helios components` - Browse available registry components
 
 ## D. Configuration
 
-The CLI uses `helios.config.json` for project configuration:
+The CLI uses `helios.config.json` for project configuration. Configuration logic is centralized in `src/utils/config.ts`.
 
 - **directories.components**: Target directory for installed components
 - **directories.lib**: Location of the library directory

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.3.0
+
+- ✅ Scaffold `helios add` command and centralized configuration logic
+
 ## CLI v0.2.0
 
 - ✅ Implement `helios init` command to scaffold `helios.config.json`

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.2.0
+**Version**: 0.3.0
 
 ## Current State
 
@@ -15,6 +15,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 
 - `helios studio` - Launches the Helios Studio dev server
 - `helios init` - Initializes a new Helios project configuration
+- `helios add` - Scaffold for adding components (currently a stub)
 
 ## V2 Roadmap
 
@@ -30,3 +31,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.1.0] ✅ Initial CLI with `helios studio` command
 [v0.1.1] ✅ Pass Project Root to Studio - Injected HELIOS_PROJECT_ROOT env var in studio command
 [v0.2.0] ✅ Scaffold Init Command - Implemented `helios init` to generate `helios.config.json`
+[v0.3.0] ✅ Scaffold Add Command - Implemented `helios add` command scaffold and centralized configuration logic

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,0 +1,19 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { loadConfig } from '../utils/config.js';
+
+export function registerAddCommand(program: Command) {
+  program
+    .command('add <component>')
+    .description('Add a component to your project')
+    .action(async (component) => {
+      const config = loadConfig();
+
+      if (!config) {
+        console.error(chalk.red('Configuration file not found. Run "helios init" first.'));
+        process.exit(1);
+      }
+
+      console.warn(chalk.yellow(`Registry lookup not yet implemented. This is a placeholder for adding: ${component}`));
+    });
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
 import chalk from 'chalk';
+import { DEFAULT_CONFIG } from '../utils/config.js';
 
 export function registerInitCommand(program: Command) {
   program
@@ -17,15 +18,8 @@ export function registerInitCommand(program: Command) {
         process.exit(1);
       }
 
-      const defaultConfig = {
-        version: '1.0.0',
-        directories: {
-          components: 'src/components/helios',
-          lib: 'src/lib',
-        },
-      };
-
-      let config = { ...defaultConfig };
+      // Deep copy to avoid mutating the exported constant
+      let config = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
 
       if (!options.yes) {
         const rl = readline.createInterface({
@@ -45,11 +39,11 @@ export function registerInitCommand(program: Command) {
 
         const componentsDir = await ask(
           'Where would you like to install components?',
-          defaultConfig.directories.components
+          DEFAULT_CONFIG.directories.components
         );
         const libDir = await ask(
           'Where is your lib directory?',
-          defaultConfig.directories.lib
+          DEFAULT_CONFIG.directories.lib
         );
 
         config.directories.components = componentsDir;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { registerStudioCommand } from './commands/studio.js';
 import { registerInitCommand } from './commands/init.js';
+import { registerAddCommand } from './commands/add.js';
 
 const program = new Command();
 
@@ -11,5 +12,6 @@ program
 
 registerStudioCommand(program);
 registerInitCommand(program);
+registerAddCommand(program);
 
 program.parse(process.argv);

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface HeliosConfig {
+  version: string;
+  directories: {
+    components: string;
+    lib: string;
+  };
+}
+
+export const DEFAULT_CONFIG: HeliosConfig = {
+  version: '1.0.0',
+  directories: {
+    components: 'src/components/helios',
+    lib: 'src/lib',
+  },
+};
+
+export function loadConfig(cwd: string = process.cwd()): HeliosConfig | null {
+  const configPath = path.resolve(cwd, 'helios.config.json');
+
+  if (!fs.existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(configPath, 'utf-8');
+    const config = JSON.parse(content);
+    // TODO: Add validation here
+    return config as HeliosConfig;
+  } catch (error) {
+    throw new Error(`Failed to parse helios.config.json: ${(error as Error).message}`);
+  }
+}


### PR DESCRIPTION
💡 **What**:
- Centralized CLI configuration logic into `packages/cli/src/utils/config.ts`.
- Refactored `helios init` to use the shared configuration defaults.
- Implemented a scaffold for `helios add <component>` command.
- Registered the new command in the CLI entry point.

🎯 **Why**:
- To prepare for the implementation of the Shadcn-style component registry.
- To ensure consistency in configuration handling across CLI commands.
- To provide a placeholder for the `add` command as per the V2 roadmap.

📊 **Impact**:
- Users can now run `helios add [component]`, although it currently only logs a placeholder message.
- `helios init` continues to work as expected but now uses shared logic.
- Developers have a structured foundation (`config.ts`, `add.ts`) to build the full registry fetching logic.

🔬 **Verification**:
- Run `npm run build -w packages/cli`.
- Run `helios init -y` in a test directory -> Generates config.
- Run `helios add button` in the test directory -> Logs "Registry lookup not yet implemented. This is a placeholder for adding: button".
- Run `helios add button` without config -> Logs error "Configuration file not found".

---
*PR created automatically by Jules for task [6719628066470813262](https://jules.google.com/task/6719628066470813262) started by @BintzGavin*