### PR TITLE
✨ PLAYER: Client-Side Audio Volume Support

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.65.2
+- ✅ Completed: Client-Side Audio Volume Support - Updated `getAudioAssets` to prioritize `audioTrackState` (volume/mute) over DOM attributes for robust client-side export parity.
+
 ## PLAYER v0.65.1
 - ✅ Completed: Maintenance and Documentation - Removed unnecessary TS suppressions and updated documentation with missing API members (media-* attributes, PiP control).
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.65.1
+**Version**: v0.65.2
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -58,6 +58,7 @@
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.65.2] ✅ Completed: Client-Side Audio Volume Support - Updated `getAudioAssets` to prioritize `audioTrackState` (volume/mute) over DOM attributes for robust client-side export parity.
 [v0.65.1] ✅ Completed: Maintenance and Documentation - Removed unnecessary TS suppressions and updated documentation with missing API members (media-* attributes, PiP control).
 [v0.65.0] ✅ Completed: Media Session Integration - Implemented HeliosMediaSession to support OS-level media keys and metadata display, observing media-* attributes.
 [v0.64.1] ✅ Verified: SRT Export Implementation - Verified existing implementation of SRT export and caption parsing against plan requirements.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10603,7 +10603,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.65.0",
+      "version": "0.65.1",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^5.8.0",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.65.1",
+  "version": "0.65.2",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/player/src/features/audio-utils.test.ts
+++ b/packages/player/src/features/audio-utils.test.ts
@@ -133,6 +133,20 @@ describe('audio-utils', () => {
       // Fetch mock returns array buffer, but we check properties
       expect(assets[0].volume).toBe(0.9); // Metadata (via state) wins
     });
+
+    it('should prioritize audioTrackState for DOM assets if ID matches', async () => {
+      document.body.innerHTML = `
+        <audio src="dom.mp3" data-helios-track-id="track-1" volume="0.5"></audio>
+      `;
+      const audioTrackState = {
+          'track-1': { volume: 0.8, muted: false }
+      };
+
+      const assets = await getAudioAssets(document, [], audioTrackState);
+      expect(assets).toHaveLength(1);
+      expect(assets[0].id).toBe('track-1');
+      expect(assets[0].volume).toBe(0.8);
+    });
   });
 
   describe('mixAudio', () => {

--- a/packages/player/src/features/audio-utils.ts
+++ b/packages/player/src/features/audio-utils.ts
@@ -45,10 +45,22 @@ export async function getAudioAssets(
     // 3. Fallback: generated "track-${index}" (Stable fallback for listing)
     const id = tag.getAttribute('data-helios-track-id') || tag.id || `track-${index}`;
     const volumeAttr = tag.getAttribute('volume');
+    const state = audioTrackState[id];
+
+    let volume = 1;
+    let muted = false;
+
+    if (state) {
+        volume = state.volume;
+        muted = state.muted;
+    } else {
+        volume = volumeAttr !== null ? parseFloat(volumeAttr) : tag.volume;
+        muted = tag.muted;
+    }
 
     return fetchAudioAsset(id, tag.src, {
-        volume: volumeAttr !== null ? parseFloat(volumeAttr) : tag.volume,
-        muted: tag.muted,
+        volume,
+        muted,
         loop: tag.loop,
         startTime: parseFloat(tag.getAttribute('data-start-time') || '0') || 0,
         fadeInDuration: parseFloat(tag.getAttribute('data-helios-fade-in') || '0') || 0,


### PR DESCRIPTION
Updated `getAudioAssets` to respect `audioTrackState` for DOM assets, ensuring correct volume/mute levels in client-side exports.

---
*PR created automatically by Jules for task [1798993768218257946](https://jules.google.com/task/1798993768218257946) started by @BintzGavin*