### PR TITLE
✨ STUDIO: Implement CLI Component Registry

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -14,7 +14,7 @@ Helios Studio is a browser-based development environment for creating video comp
 ```
 packages/studio/
 ├── bin/
-│   └── helios-studio.js      # CLI entry point
+│   └── helios-studio.js      # Studio server entry point
 ├── src/
 │   ├── components/           # UI Components
 │   │   ├── AssetsPanel/
@@ -53,7 +53,8 @@ npx helios <command> [options]
 - **`init`**: Initializes a new Helios project configuration (`helios.config.json`).
   - Scaffolds directory structure references.
 - **`add <component>`**: Adds a component to the project (Shadcn-style).
-  - Reads `helios.config.json` to determine installation path.
+  - Fetches component code from the registry (`packages/cli/src/registry/manifest.ts`).
+  - Installs component files (e.g. `Timer.tsx`) and dependencies into the configured `components` directory.
 
 ## D. UI Components
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -20,8 +20,8 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 ## Component Registry
 *Helios will support a Shadcn-style component registry.*
 
-- [ ] Design registry manifest format.
-- [ ] Implement CLI command to fetch and copy components.
+- [x] Design registry manifest format.
+- [x] Implement CLI command to fetch and copy components.
 - [ ] Create initial set of core components.
 
 ## Product Surface (Studio, CLI, Examples)
@@ -29,7 +29,7 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 
 - [x] **Studio**: Expand features to support distributed rendering configuration.
 - [x] **CLI**: Implement init command.
-- [ ] **CLI**: Implement registry commands.
+- [x] **CLI**: Implement registry commands.
 - [ ] **Examples**: Create examples demonstrating distributed rendering workflows.
 - [ ] **Examples**: Create examples demonstrating component usage.
 

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.89.0
+- ✅ Completed: Component Registry - Implemented `helios add` command in CLI to install components (Timer) from a local registry.
+
 ## STUDIO v0.88.0
 - ✅ Completed: CLI Scaffold - Implemented `helios init` and `helios add` commands to scaffold project configuration and component structure.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.88.0
+**Version**: 0.89.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.89.0] ✅ Completed: Component Registry - Implemented `helios add` command in CLI to install components (Timer) from a local registry.
 - [v0.88.0] ✅ Completed: CLI Scaffold - Implemented `helios init` and `helios add` commands to scaffold project configuration and component structure.
 - [v0.87.1] ✅ Verified: Distributed Rendering Config - Verified implementation of concurrency control in Renders Panel and RenderManager, ensuring correct usage of RenderOrchestrator.
 - [v0.87.0] ✅ Completed: Distributed Rendering Config - Implemented concurrency control in the Studio Renders Panel and updated backend to use `RenderOrchestrator` for parallel rendering.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10603,7 +10603,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.65.0",
+      "version": "0.65.1",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^5.8.0",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,12 +1,15 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
+import fs from 'fs';
+import path from 'path';
 import { loadConfig } from '../utils/config.js';
+import { findComponent } from '../registry/manifest.js';
 
 export function registerAddCommand(program: Command) {
   program
     .command('add <component>')
     .description('Add a component to your project')
-    .action(async (component) => {
+    .action(async (componentName) => {
       const config = loadConfig();
 
       if (!config) {
@@ -14,6 +17,44 @@ export function registerAddCommand(program: Command) {
         process.exit(1);
       }
 
-      console.warn(chalk.yellow(`Registry lookup not yet implemented. This is a placeholder for adding: ${component}`));
+      const component = findComponent(componentName);
+      if (!component) {
+        console.error(chalk.red(`Component "${componentName}" not found in registry.`));
+        process.exit(1);
+      }
+
+      const targetBaseDir = path.resolve(process.cwd(), config.directories.components);
+
+      // Ensure base directory exists
+      if (!fs.existsSync(targetBaseDir)) {
+        fs.mkdirSync(targetBaseDir, { recursive: true });
+      }
+
+      console.log(chalk.cyan(`Installing ${component.name}...`));
+
+      for (const file of component.files) {
+        const filePath = path.join(targetBaseDir, file.name);
+        const fileDir = path.dirname(filePath);
+
+        // Ensure subdirectories exist
+        if (!fs.existsSync(fileDir)) {
+          fs.mkdirSync(fileDir, { recursive: true });
+        }
+
+        if (fs.existsSync(filePath)) {
+          console.warn(chalk.yellow(`File already exists: ${file.name}. Skipping.`));
+          continue;
+        }
+
+        fs.writeFileSync(filePath, file.content);
+        console.log(chalk.green(`✓ Created ${file.name}`));
+      }
+
+      if (component.dependencies) {
+        console.log('\n' + chalk.yellow('Required dependencies:'));
+        for (const [dep, version] of Object.entries(component.dependencies)) {
+          console.log(`  - ${dep}@${version}`);
+        }
+      }
     });
 }

--- a/packages/cli/src/registry/manifest.ts
+++ b/packages/cli/src/registry/manifest.ts
@@ -1,0 +1,89 @@
+import { ComponentDefinition } from './types.js';
+
+const TIMER_CODE = `import React from 'react';
+import { useVideoFrame } from './useVideoFrame';
+import { Helios } from '@helios-project/core';
+
+interface TimerProps {
+  helios?: Helios;
+  style?: React.CSSProperties;
+}
+
+export const Timer: React.FC<TimerProps> = ({ helios: propHelios, style }) => {
+  const heliosInstance = propHelios || (typeof window !== 'undefined' ? (window as any).helios : null);
+  const frame = useVideoFrame(heliosInstance);
+
+  if (!heliosInstance) {
+     return <div style={style}>Helios instance not found</div>;
+  }
+
+  const fps = heliosInstance.config.fps || 30;
+  const time = frame / fps;
+
+  // Format time as MM:SS:FF
+  const minutes = Math.floor(time / 60);
+  const seconds = Math.floor(time % 60);
+  const frames = Math.floor(frame % fps);
+
+  const pad = (n: number) => n.toString().padStart(2, '0');
+
+  return (
+    <div style={{
+      fontFamily: 'monospace',
+      fontSize: '24px',
+      color: 'white',
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      padding: '8px 12px',
+      borderRadius: '4px',
+      ...style
+    }}>
+      {pad(minutes)}:{pad(seconds)}:{pad(frames)}
+    </div>
+  );
+};
+`;
+
+const USE_VIDEO_FRAME_CODE = `import { useState, useEffect } from 'react';
+import { Helios } from '@helios-project/core';
+
+export function useVideoFrame(helios: Helios | undefined) {
+    const [frame, setFrame] = useState(helios?.getState().currentFrame ?? 0);
+
+    useEffect(() => {
+        if (!helios) return;
+
+        // Update local state when helios state changes
+        const update = (state: any) => setFrame(state.currentFrame);
+
+        // Subscribe returns an unsubscribe function
+        return helios.subscribe(update);
+    }, [helios]);
+
+    return frame;
+}
+`;
+
+export const registry: ComponentDefinition[] = [
+  {
+    name: 'timer',
+    type: 'react',
+    files: [
+      {
+        name: 'Timer.tsx',
+        content: TIMER_CODE,
+      },
+      {
+        name: 'useVideoFrame.ts',
+        content: USE_VIDEO_FRAME_CODE,
+      },
+    ],
+    dependencies: {
+      'react': '^18.0.0',
+      '@helios-project/core': 'latest'
+    }
+  },
+];
+
+export function findComponent(name: string): ComponentDefinition | undefined {
+  return registry.find((c) => c.name === name);
+}

--- a/packages/cli/src/registry/types.ts
+++ b/packages/cli/src/registry/types.ts
@@ -1,0 +1,11 @@
+export interface ComponentFile {
+  name: string;
+  content: string;
+}
+
+export interface ComponentDefinition {
+  name: string;
+  type: 'react' | 'vue' | 'svelte' | 'vanilla';
+  files: ComponentFile[];
+  dependencies?: Record<string, string>;
+}


### PR DESCRIPTION
💡 **What**: Implemented `helios add` command to fetch and install components from a local registry. Added `Timer` component as the first entry.
🎯 **Why**: To enable shipping reusable Helios components (like Shadcn UI) to users, reducing boilerplate.
📊 **Impact**: Unlocks component ecosystem and easier onboarding.
🔬 **Verification**: Manual verification with `helios add timer` in a test project. verified file creation and content.

Reference: .sys/plans/2026-02-20-STUDIO-Component-Registry.md

---
*PR created automatically by Jules for task [10706150984141689958](https://jules.google.com/task/10706150984141689958) started by @BintzGavin*