### PR TITLE
✨ CLI: Sync Version and Update Documentation

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -66,14 +66,15 @@ Generates a `helios.config.json` file in the current directory with the followin
 
 ### `helios add`
 
-Scaffold for adding a component to the project.
+Adds a component to the project from the embedded registry.
 
 ```bash
 helios add <component>
 ```
 
-- **Note**: Currently a placeholder/scaffold. Logs a warning that registry lookup is not implemented.
+- Installs component source code and dependencies into the configured `components` directory.
 - Requires `helios.config.json` to exist.
+- Current registry includes: `timer`.
 
 ### Planned Commands (V2)
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/cli",
-  "version": "0.0.1",
+  "version": "0.3.0",
   "description": "CLI for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,7 +8,7 @@ const program = new Command();
 program
   .name('helios')
   .description('Helios CLI')
-  .version('0.0.1');
+  .version('0.3.0');
 
 registerStudioCommand(program);
 registerInitCommand(program);


### PR DESCRIPTION
This change synchronizes the CLI package version with the documented status and updates the context documentation to accurately reflect the functionality of the `helios add` command. Manual verification confirmed that both `init` and `add` commands are functional.

---
*PR created automatically by Jules for task [9265804180106906653](https://jules.google.com/task/9265804180106906653) started by @BintzGavin*