### PR TITLE
✨ CLI: Implement Components Command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -20,6 +20,7 @@ packages/cli/
 ├── src/
 │   ├── commands/
 │   │   ├── add.ts          # helios add command
+│   │   ├── components.ts   # helios components command
 │   │   ├── init.ts         # helios init command
 │   │   └── studio.ts       # helios studio command
 │   ├── utils/
@@ -76,10 +77,19 @@ helios add <component>
 - Requires `helios.config.json` to exist.
 - Current registry includes: `timer`.
 
+### `helios components`
+
+Lists available components in the registry.
+
+```bash
+helios components
+```
+
+- Lists component names and types (e.g., `timer (react)`).
+
 ### Planned Commands (V2)
 
 - `helios render` - Trigger local or distributed rendering
-- `helios components` - Browse available registry components
 
 ## D. Configuration
 
@@ -91,7 +101,7 @@ The CLI uses `helios.config.json` for project configuration. Configuration logic
 ## E. Integration
 
 - **Studio**: The `studio` command launches `@helios-project/studio` via npm
-- **Registry**: Will integrate with component registry for `add` and `components` commands
+- **Registry**: Integrates with embedded component registry for `add` and `components` commands
 - **Renderer**: Will integrate with `@helios-project/renderer` for render commands
 
 ## F. Command Pattern

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.4.0
+
+- ✅ Implement `helios components` command to list registry items
+
 ## CLI v0.3.0
 
 - ✅ Scaffold `helios add` command and centralized configuration logic

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.3.0
+**Version**: 0.4.0
 
 ## Current State
 
@@ -15,7 +15,8 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 
 - `helios studio` - Launches the Helios Studio dev server
 - `helios init` - Initializes a new Helios project configuration
-- `helios add` - Scaffold for adding components (currently a stub)
+- `helios add` - Adds a component to the project
+- `helios components` - Lists available components in the registry
 
 ## V2 Roadmap
 
@@ -32,3 +33,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.1.1] ✅ Pass Project Root to Studio - Injected HELIOS_PROJECT_ROOT env var in studio command
 [v0.2.0] ✅ Scaffold Init Command - Implemented `helios init` to generate `helios.config.json`
 [v0.3.0] ✅ Scaffold Add Command - Implemented `helios add` command scaffold and centralized configuration logic
+[v0.4.0] ✅ Implement Components Command - Implemented `helios components` to list registry items

--- a/packages/cli/src/commands/components.ts
+++ b/packages/cli/src/commands/components.ts
@@ -1,0 +1,20 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { registry } from '../registry/manifest.js';
+
+export function registerComponentsCommand(program: Command) {
+  program
+    .command('components')
+    .description('List available components')
+    .action(() => {
+      if (registry.length === 0) {
+        console.log(chalk.yellow('No components found in registry.'));
+        return;
+      }
+
+      console.log(chalk.bold('Available components:'));
+      for (const component of registry) {
+        console.log(` - ${chalk.cyan(component.name)} ${chalk.gray(`(${component.type})`)}`);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { registerStudioCommand } from './commands/studio.js';
 import { registerInitCommand } from './commands/init.js';
 import { registerAddCommand } from './commands/add.js';
+import { registerComponentsCommand } from './commands/components.js';
 
 const program = new Command();
 
@@ -13,5 +14,6 @@ program
 registerStudioCommand(program);
 registerInitCommand(program);
 registerAddCommand(program);
+registerComponentsCommand(program);
 
 program.parse(process.argv);


### PR DESCRIPTION
Implemented the `helios components` command to list available registry components.
Verified by running `helios components` and confirming output.

---
*PR created automatically by Jules for task [5221028642486388031](https://jules.google.com/task/5221028642486388031) started by @BintzGavin*