### PR TITLE
✨ CLI: Implement `helios render` command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -22,6 +22,7 @@ packages/cli/
 │   │   ├── add.ts          # helios add command
 │   │   ├── components.ts   # helios components command
 │   │   ├── init.ts         # helios init command
+│   │   ├── render.ts       # helios render command
 │   │   └── studio.ts       # helios studio command
 │   ├── utils/
 │   │   └── config.ts       # Config loading and types
@@ -54,16 +55,7 @@ helios init
 Options:
 - `-y, --yes`: Skip prompts and use defaults
 
-Generates a `helios.config.json` file in the current directory with the following structure:
-```json
-{
-  "version": "1.0.0",
-  "directories": {
-    "components": "src/components/helios",
-    "lib": "src/lib"
-  }
-}
-```
+Generates a `helios.config.json` file in the current directory.
 
 ### `helios add`
 
@@ -75,7 +67,6 @@ helios add <component>
 
 - Installs component source code and dependencies into the configured `components` directory.
 - Requires `helios.config.json` to exist.
-- Current registry includes: `timer`.
 
 ### `helios components`
 
@@ -87,9 +78,23 @@ helios components
 
 - Lists component names and types (e.g., `timer (react)`).
 
-### Planned Commands (V2)
+### `helios render`
 
-- `helios render` - Trigger local or distributed rendering
+Renders a composition to video using the underlying `@helios-project/renderer`.
+
+```bash
+helios render [options] <input>
+```
+
+Options:
+- `-o, --output <path>`: Output file path (default: "output.mp4")
+- `--width <number>`: Viewport width (default: 1920)
+- `--height <number>`: Viewport height (default: 1080)
+- `--fps <number>`: Frames per second (default: 30)
+- `--duration <number>`: Duration in seconds (default: 1)
+- `--quality <number>`: CRF quality (0-51)
+- `--mode <mode>`: Render mode (canvas or dom) (default: "canvas")
+- `--no-headless`: Run in visible browser window (default: headless)
 
 ## D. Configuration
 
@@ -102,7 +107,7 @@ The CLI uses `helios.config.json` for project configuration. Configuration logic
 
 - **Studio**: The `studio` command launches `@helios-project/studio` via npm
 - **Registry**: Integrates with embedded component registry for `add` and `components` commands
-- **Renderer**: Will integrate with `@helios-project/renderer` for render commands
+- **Renderer**: Integrates with `@helios-project/renderer` for `render` command
 
 ## F. Command Pattern
 

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.4.1
+
+- ✅ Implement `helios render` command to allow rendering compositions from the CLI
+
 ## CLI v0.4.0
 
 - ✅ Implement `helios components` command to list registry items

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.4.0
+**Version**: 0.4.1
 
 ## Current State
 
@@ -17,6 +17,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 - `helios init` - Initializes a new Helios project configuration
 - `helios add` - Adds a component to the project
 - `helios components` - Lists available components in the registry
+- `helios render` - Renders a composition to video
 
 ## V2 Roadmap
 
@@ -34,3 +35,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.2.0] ✅ Scaffold Init Command - Implemented `helios init` to generate `helios.config.json`
 [v0.3.0] ✅ Scaffold Add Command - Implemented `helios add` command scaffold and centralized configuration logic
 [v0.4.0] ✅ Implement Components Command - Implemented `helios components` to list registry items
+[v0.4.1] ✅ Implement Render Command - Implemented `helios render` command using `@helios-project/renderer`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10579,9 +10579,10 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "ELv2",
       "dependencies": {
+        "@helios-project/renderer": "^0.0.2",
         "chalk": "^5.4.1",
         "commander": "^13.1.0"
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/cli",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "description": "CLI for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",
@@ -38,7 +38,8 @@
   ],
   "dependencies": {
     "commander": "^13.1.0",
-    "chalk": "^5.4.1"
+    "chalk": "^5.4.1",
+    "@helios-project/renderer": "^0.0.2"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1,0 +1,48 @@
+import { Command } from 'commander';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { Renderer } from '@helios-project/renderer';
+
+export function registerRenderCommand(program: Command) {
+  program
+    .command('render <input>')
+    .description('Render a composition to video')
+    .option('-o, --output <path>', 'Output file path', 'output.mp4')
+    .option('--width <number>', 'Viewport width', '1920')
+    .option('--height <number>', 'Viewport height', '1080')
+    .option('--fps <number>', 'Frames per second', '30')
+    .option('--duration <number>', 'Duration in seconds', '1')
+    .option('--quality <number>', 'CRF quality (0-51)')
+    .option('--mode <mode>', 'Render mode (canvas or dom)', 'canvas')
+    .option('--no-headless', 'Run in visible browser window (default: headless)')
+    .action(async (input, options) => {
+      try {
+        const url = input.startsWith('http')
+          ? input
+          : pathToFileURL(path.resolve(process.cwd(), input)).href;
+        const outputPath = path.resolve(process.cwd(), options.output);
+
+        console.log(`Initializing renderer...`);
+        console.log(`Input: ${url}`);
+        console.log(`Output: ${outputPath}`);
+
+        const renderer = new Renderer({
+          width: parseInt(options.width, 10),
+          height: parseInt(options.height, 10),
+          fps: parseInt(options.fps, 10),
+          durationInSeconds: parseInt(options.duration, 10),
+          crf: options.quality ? parseInt(options.quality, 10) : undefined,
+          mode: options.mode as 'canvas' | 'dom',
+          browserConfig: {
+            headless: options.headless, // 'no-headless' sets this to false
+          },
+        });
+
+        await renderer.render(url, outputPath);
+        console.log('Render complete.');
+      } catch (err: any) {
+        console.error('Render failed:', err.message);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,17 +3,19 @@ import { registerStudioCommand } from './commands/studio.js';
 import { registerInitCommand } from './commands/init.js';
 import { registerAddCommand } from './commands/add.js';
 import { registerComponentsCommand } from './commands/components.js';
+import { registerRenderCommand } from './commands/render.js';
 
 const program = new Command();
 
 program
   .name('helios')
   .description('Helios CLI')
-  .version('0.3.0');
+  .version('0.4.1');
 
 registerStudioCommand(program);
 registerInitCommand(program);
 registerAddCommand(program);
 registerComponentsCommand(program);
+registerRenderCommand(program);
 
 program.parse(process.argv);


### PR DESCRIPTION
Implemented the `helios render` command using `@helios-project/renderer`. Added the dependency to `packages/cli`, registered the command in `src/index.ts`, and implemented the command logic in `src/commands/render.ts` with support for various renderer options like output path, dimensions, FPS, duration, and headless mode. Also fixed a potential cross-platform issue with file URL generation.

---
*PR created automatically by Jules for task [16003053781067377145](https://jules.google.com/task/16003053781067377145) started by @BintzGavin*