### PR TITLE
✨ STUDIO: Implement Production CLI Server

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -4,8 +4,8 @@
 
 Helios Studio is a browser-based development environment for creating video compositions. It is built as a framework-agnostic tool that runs locally, serving the user's project files and providing a visual interface for editing and previewing.
 
-- **CLI**: The entry point (`packages/cli/bin/helios.js`) provides commands to initialize projects (`init`), add components (`add`), and launch the Studio (`studio`).
-- **Dev Server**: A customized Vite server (`packages/studio/src/server/`) that serves the Studio UI and provides API endpoints for filesystem operations (creating compositions, uploading assets, managing render jobs).
+- **CLI**: The entry point (`packages/cli/bin/helios.js`) provides commands to initialize projects (`init`), add components (`add`), render videos (`render`), and launch the Studio (`studio`).
+- **Dev Server**: The `studio` command launches a Vite server (as a library) configured with `studioApiPlugin` (`packages/studio/src/server/`), which serves the Studio UI (overlay) and provides API endpoints for filesystem operations and HMR.
 - **UI**: A React-based Single Page Application (SPA) that acts as the frontend. It communicates with the backend via REST API and connects to the `<helios-player>` component for preview.
 - **State Management**: `StudioContext` manages global state (compositions, assets, player controller, timeline).
 
@@ -14,7 +14,7 @@ Helios Studio is a browser-based development environment for creating video comp
 ```
 packages/studio/
 ├── bin/
-│   └── helios-studio.js      # Studio server entry point
+│   └── helios-studio.js      # Legacy server entry point
 ├── src/
 │   ├── components/           # UI Components
 │   │   ├── AssetsPanel/
@@ -30,11 +30,16 @@ packages/studio/
 │   ├── context/
 │   │   └── StudioContext.tsx # Global state
 │   ├── server/               # Backend logic (Vite plugins)
+│   │   ├── plugin.ts         # Main studioApiPlugin export
+│   │   ├── render-manager.ts # Render orchestration
+│   │   └── ...
 │   ├── App.tsx               # Main UI layout
 │   └── main.tsx              # Entry point
 ├── index.html                # HTML entry
 ├── package.json
-├── vite.config.ts            # Studio build config
+├── vite.config.ts            # Studio UI build config
+├── vite.config.cli.ts        # CLI plugin build config
+├── tsconfig.cli.json         # CLI types build config
 └── vitest.config.ts          # Test config
 ```
 
@@ -49,7 +54,12 @@ npx helios <command> [options]
 ### Commands
 
 - **`studio`**: Starts the Studio development server and opens the browser.
+  - Usage: `npx helios studio [options]`
+  - Options: `-p, --port <number>` (default: 5173)
   - Uses current working directory to discover compositions.
+- **`render <input>`**: Renders a composition to video.
+  - Usage: `npx helios render <input> [options]`
+  - Options: `-o, --output <path>`, `--width`, `--height`, `--fps`, `--duration`, `--quality`, `--mode`.
 - **`init`**: Initializes a new Helios project configuration (`helios.config.json`).
   - Scaffolds directory structure references.
 - **`add <component>`**: Adds a component to the project (Shadcn-style).

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.91.0
+- ✅ Completed: CLI Production Server - Replaced development-only spawn process with robust Vite server integration using `studioApiPlugin`, enabling correct HMR and path resolution for end-users.
+
 ## STUDIO v0.90.0
 - ✅ Completed: Core Components - Expanded CLI Component Registry with `ProgressBar` and `Watermark` components.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.90.0
+**Version**: 0.91.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.91.0] ✅ Completed: CLI Production Server - Replaced development-only spawn process with robust Vite server integration using `studioApiPlugin`, enabling correct HMR and path resolution for end-users.
 - [v0.90.0] ✅ Completed: Core Components - Expanded CLI Component Registry with `ProgressBar` and `Watermark` components.
 - [v0.89.0] ✅ Completed: Component Registry - Implemented `helios add` command in CLI to install components (Timer) from a local registry.
 - [v0.88.0] ✅ Completed: CLI Scaffold - Implemented `helios init` and `helios add` commands to scaffold project configuration and component structure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10583,8 +10583,10 @@
       "license": "ELv2",
       "dependencies": {
         "@helios-project/renderer": "^0.0.2",
+        "@helios-project/studio": "^0.82.0",
         "chalk": "^5.4.1",
-        "commander": "^13.1.0"
+        "commander": "^13.1.0",
+        "vite": "^7.1.2"
       },
       "bin": {
         "helios": "bin/helios.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,9 @@
   "dependencies": {
     "commander": "^13.1.0",
     "chalk": "^5.4.1",
-    "@helios-project/renderer": "^0.0.2"
+    "@helios-project/renderer": "^0.0.2",
+    "@helios-project/studio": "^0.82.0",
+    "vite": "^7.1.2"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "composite": true
+    "composite": true,
+    "moduleResolution": "bundler"
   },
   "include": ["src"]
 }

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -20,6 +20,13 @@
     "helios-studio": "./bin/helios-studio.js"
   },
   "main": "dist/index.html",
+  "exports": {
+    "./cli": {
+      "types": "./dist/types/server/plugin.d.ts",
+      "default": "./dist/cli/plugin.js"
+    },
+    ".": "./dist/index.html"
+  },
   "files": [
     "bin",
     "dist"
@@ -27,7 +34,8 @@
   "scripts": {
     "dev": "vite",
     "build:cli": "vite build -c vite.config.cli.ts",
-    "build": "tsc && vite build && npm run build:cli",
+    "build:types": "tsc -p tsconfig.cli.json",
+    "build": "tsc && vite build && npm run build:cli && npm run build:types",
     "lint": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest",

--- a/packages/studio/tsconfig.cli.json
+++ b/packages/studio/tsconfig.cli.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types",
+    "rootDir": "src",
+    "paths": {}
+  },
+  "include": ["src/server"]
+}


### PR DESCRIPTION
✨ STUDIO: Implement Production CLI Server

💡 What: Replaced the `spawn('npm', ['run', 'dev'])` logic in `packages/cli` with a direct `vite.createServer` call using the `studioApiPlugin` exported from `packages/studio`.
🎯 Why: To enable the Studio to run in production environments (where `packages/studio` source is not available) and to provide a more robust, integrated server experience.
📊 Impact: `npx helios studio` now works correctly for end-users outside the monorepo. It also ensures proper HMR and file serving.
🔬 Verification: Verified by building both packages, running `helios studio` in a temporary directory, and confirming the UI loads. Ran `packages/studio` tests to ensure no regressions.

---
*PR created automatically by Jules for task [12417207947777626536](https://jules.google.com/task/12417207947777626536) started by @BintzGavin*