### PR TITLE
📋 PLAYER: Sync Version & Documentation

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -1,3 +1,7 @@
+## 0.66.1 - Version Synchronization
+**Learning:** Version drift between `package.json` and status files can occur if not explicitly checked, leading to confusion about released features.
+**Action:** Always verify `package.json` version matches `docs/status/PLAYER.md` during the Discovery phase of planning.
+
 ## 0.66.0 - VideoTracks API Implementation
 **Learning:** Implementing `EventTarget` based lists like `VideoTrackList` requires manual index management (e.g., `(this as any)[index] = track`) to support array-like access (`list[0]`) while maintaining event dispatching capabilities.
 **Action:** When implementing similar list-based APIs in the future, follow this pattern or consider using a `Proxy` if the environment supports it fully and performance allows.

--- a/.sys/plans/2024-05-24-PLAYER-Sync-Version.md
+++ b/.sys/plans/2024-05-24-PLAYER-Sync-Version.md
@@ -1,0 +1,37 @@
+# Sync Version & Documentation
+
+## 1. Context & Goal
+- **Objective**: Synchronize the `packages/player` version to `0.66.1` and update the README to document the recently added `audioTracks` and `videoTracks` APIs.
+- **Trigger**: A discrepancy exists between `package.json` (0.65.2) and the released status in `docs/status/PLAYER.md` (0.66.1). Additionally, the Standard Media API documentation is missing the tracks properties.
+- **Impact**: Ensures the package version reflects the feature set (preventing confusion) and provides complete API documentation for developers.
+
+## 2. File Inventory
+- **Create**: None
+- **Modify**:
+  - `packages/player/package.json`: Update version.
+  - `packages/player/README.md`: Add API documentation.
+- **Read-Only**:
+  - `docs/status/PLAYER.md`
+  - `packages/player/src/index.ts` (for reference)
+
+## 3. Implementation Spec
+- **Architecture**: Configuration and Documentation update only. No functional code changes.
+- **Pseudo-Code**:
+  1.  **packages/player/package.json**:
+      - Change `version` from `0.65.2` to `0.66.1`.
+  2.  **packages/player/README.md**:
+      - Under **Properties**:
+        - Add `audioTracks` (AudioTrackList, read-only).
+        - Add `videoTracks` (VideoTrackList, read-only).
+- **Public API Changes**: None (Documentation only).
+- **Dependencies**: None.
+
+## 4. Test Plan
+- **Verification**:
+  - Run `npm run build -w packages/player` to ensure the package builds with the new version.
+  - Run `npm test -w packages/player` to ensure no regressions.
+- **Success Criteria**:
+  - `package.json` version is `0.66.1`.
+  - `README.md` contains entries for `audioTracks` and `videoTracks`.
+  - Build and tests pass.
+- **Edge Cases**: None.


### PR DESCRIPTION
This plan outlines the steps to:
1. Update `packages/player/package.json` version to `0.66.1`.
2. Update `packages/player/README.md` to include `audioTracks` and `videoTracks` documentation.

This addresses the discrepancy between the released status and the package version, and completes the Standard Media API documentation.

---
*PR created automatically by Jules for task [10247696388842102603](https://jules.google.com/task/10247696388842102603) started by @BintzGavin*