### PR TITLE
✨ CLI: Distributed Rendering Support

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -94,6 +94,8 @@ Options:
 - `--duration <number>`: Duration in seconds (default: 1)
 - `--quality <number>`: CRF quality (0-51)
 - `--mode <mode>`: Render mode (canvas or dom) (default: "canvas")
+- `--start-frame <number>`: Frame to start rendering from
+- `--frame-count <number>`: Number of frames to render
 - `--no-headless`: Run in visible browser window (default: headless)
 
 ## D. Configuration

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -7,6 +7,7 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 
 - [ ] Implement stateless worker architecture.
 - [ ] Ensure deterministic frame seeking across all drivers.
+- [x] Support frame range rendering in CLI.
 - [x] Implement output stitching without re-encoding (verify `concat` demuxer workflow).
 - [ ] Cloud execution adapter (AWS Lambda / Google Cloud Run).
 

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.5.0
+
+- ✅ Distributed Rendering Support - Added `--start-frame` and `--frame-count` to `helios render`
+
 ## CLI v0.4.1
 
 - ✅ Implement `helios render` command to allow rendering compositions from the CLI

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.4.1
+**Version**: 0.5.0
 
 ## Current State
 
@@ -36,3 +36,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.3.0] ✅ Scaffold Add Command - Implemented `helios add` command scaffold and centralized configuration logic
 [v0.4.0] ✅ Implement Components Command - Implemented `helios components` to list registry items
 [v0.4.1] ✅ Implement Render Command - Implemented `helios render` command using `@helios-project/renderer`
+[v0.5.0] ✅ Distributed Rendering Support - Added `--start-frame` and `--frame-count` to `helios render`

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -14,6 +14,8 @@ export function registerRenderCommand(program: Command) {
     .option('--duration <number>', 'Duration in seconds', '1')
     .option('--quality <number>', 'CRF quality (0-51)')
     .option('--mode <mode>', 'Render mode (canvas or dom)', 'canvas')
+    .option('--start-frame <number>', 'Frame to start rendering from')
+    .option('--frame-count <number>', 'Number of frames to render')
     .option('--no-headless', 'Run in visible browser window (default: headless)')
     .action(async (input, options) => {
       try {
@@ -26,6 +28,16 @@ export function registerRenderCommand(program: Command) {
         console.log(`Input: ${url}`);
         console.log(`Output: ${outputPath}`);
 
+        const startFrame = options.startFrame ? parseInt(options.startFrame, 10) : undefined;
+        if (startFrame !== undefined && isNaN(startFrame)) {
+          throw new Error('start-frame must be a valid number');
+        }
+
+        const frameCount = options.frameCount ? parseInt(options.frameCount, 10) : undefined;
+        if (frameCount !== undefined && isNaN(frameCount)) {
+          throw new Error('frame-count must be a valid number');
+        }
+
         const renderer = new Renderer({
           width: parseInt(options.width, 10),
           height: parseInt(options.height, 10),
@@ -33,6 +45,8 @@ export function registerRenderCommand(program: Command) {
           durationInSeconds: parseInt(options.duration, 10),
           crf: options.quality ? parseInt(options.quality, 10) : undefined,
           mode: options.mode as 'canvas' | 'dom',
+          startFrame,
+          frameCount,
           browserConfig: {
             headless: options.headless, // 'no-headless' sets this to false
           },


### PR DESCRIPTION
💡 **What**: Added `--start-frame` and `--frame-count` CLI options to the `helios render` command.
🎯 **Why**: To enable distributed rendering where multiple workers render different parts of the same composition in parallel.
📊 **Impact**: Unlocks scalable rendering workflows for long videos or high-resolution outputs.
🔬 **Verification**:
- Verified manually using a custom test composition.
- `helios render ... --start-frame 5 --frame-count 2` correctly rendered 2 frames starting at 5 seconds.
- `helios render ... --frame-count 0` correctly fell back to full duration.
- Validated that non-numeric inputs throw descriptive errors.

---
*PR created automatically by Jules for task [3518912888738554959](https://jules.google.com/task/3518912888738554959) started by @BintzGavin*