### PR TITLE
✨ STUDIO: Components Registry UI

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -20,6 +20,7 @@ packages/studio/
 │   │   ├── AssetsPanel/
 │   │   ├── AudioMixerPanel/
 │   │   ├── CaptionsPanel/
+│   │   ├── ComponentsPanel/
 │   │   ├── CompositionsPanel/
 │   │   ├── Controls/
 │   │   ├── PropsEditor/
@@ -72,6 +73,7 @@ npx helios <command> [options]
 - **Timeline**: A multi-track timeline for scrubbing, playback control, loop range setting, and audio visualization.
 - **Props Editor**: A schema-aware inspector for editing composition properties (`inputProps`). Supports primitives, arrays, objects, colors, and assets.
 - **Assets Panel**: A file browser for managing project assets (images, video, audio, fonts). Supports drag-and-drop to Props Editor.
+- **Components Panel**: Allows browsing and installing components (e.g. Timer) from the registry.
 - **Audio Mixer Panel**: Controls volume, mute, and solo states for individual audio tracks.
 - **Compositions Panel**: Manages composition files (create, duplicate, delete).
 - **Renders Panel**: Manages server-side render jobs (single or distributed with concurrency control) and client-side exports.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.92.0
+- ✅ Completed: Components Registry UI - Implemented "Components" panel in Studio UI, enabling users to browse and install components from the registry via the CLI backend.
+
 ## STUDIO v0.91.0
 - ✅ Completed: CLI Production Server - Replaced development-only spawn process with robust Vite server integration using `studioApiPlugin`, enabling correct HMR and path resolution for end-users.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.91.0
+**Version**: 0.92.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.92.0] ✅ Completed: Components Registry UI - Implemented "Components" panel in Studio UI, enabling users to browse and install components from the registry via the CLI backend.
 - [v0.91.0] ✅ Completed: CLI Production Server - Replaced development-only spawn process with robust Vite server integration using `studioApiPlugin`, enabling correct HMR and path resolution for end-users.
 - [v0.90.0] ✅ Completed: Core Components - Expanded CLI Component Registry with `ProgressBar` and `Watermark` components.
 - [v0.89.0] ✅ Completed: Component Registry - Implemented `helios add` command in CLI to install components (Timer) from a local registry.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,60 +1,17 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
-import fs from 'fs';
-import path from 'path';
-import { loadConfig } from '../utils/config.js';
-import { findComponent } from '../registry/manifest.js';
+import { installComponent } from '../utils/install.js';
 
 export function registerAddCommand(program: Command) {
   program
     .command('add <component>')
     .description('Add a component to your project')
     .action(async (componentName) => {
-      const config = loadConfig();
-
-      if (!config) {
-        console.error(chalk.red('Configuration file not found. Run "helios init" first.'));
+      try {
+        await installComponent(process.cwd(), componentName);
+      } catch (e: any) {
+        console.error(chalk.red(e.message));
         process.exit(1);
-      }
-
-      const component = findComponent(componentName);
-      if (!component) {
-        console.error(chalk.red(`Component "${componentName}" not found in registry.`));
-        process.exit(1);
-      }
-
-      const targetBaseDir = path.resolve(process.cwd(), config.directories.components);
-
-      // Ensure base directory exists
-      if (!fs.existsSync(targetBaseDir)) {
-        fs.mkdirSync(targetBaseDir, { recursive: true });
-      }
-
-      console.log(chalk.cyan(`Installing ${component.name}...`));
-
-      for (const file of component.files) {
-        const filePath = path.join(targetBaseDir, file.name);
-        const fileDir = path.dirname(filePath);
-
-        // Ensure subdirectories exist
-        if (!fs.existsSync(fileDir)) {
-          fs.mkdirSync(fileDir, { recursive: true });
-        }
-
-        if (fs.existsSync(filePath)) {
-          console.warn(chalk.yellow(`File already exists: ${file.name}. Skipping.`));
-          continue;
-        }
-
-        fs.writeFileSync(filePath, file.content);
-        console.log(chalk.green(`✓ Created ${file.name}`));
-      }
-
-      if (component.dependencies) {
-        console.log('\n' + chalk.yellow('Required dependencies:'));
-        for (const [dep, version] of Object.entries(component.dependencies)) {
-          console.log(`  - ${dep}@${version}`);
-        }
       }
     });
 }

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -3,6 +3,8 @@ import { createServer } from 'vite';
 import { studioApiPlugin } from '@helios-project/studio/cli';
 import { createRequire } from 'module';
 import path from 'path';
+import { registry } from '../registry/manifest.js';
+import { installComponent } from '../utils/install.js';
 
 export function registerStudioCommand(program: Command) {
   program
@@ -38,7 +40,11 @@ export function registerStudioCommand(program: Command) {
           },
           plugins: [
             studioApiPlugin({
-              studioRoot: studioDist
+              studioRoot: studioDist,
+              components: registry,
+              onInstallComponent: async (name) => {
+                await installComponent(process.cwd(), name);
+              }
             })
           ]
         });

--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import { loadConfig } from './config.js';
+import { findComponent } from '../registry/manifest.js';
+
+export async function installComponent(rootDir: string, componentName: string) {
+  const config = loadConfig(rootDir);
+
+  if (!config) {
+    throw new Error('Configuration file not found. Run "helios init" first.');
+  }
+
+  const component = findComponent(componentName);
+  if (!component) {
+    throw new Error(`Component "${componentName}" not found in registry.`);
+  }
+
+  const targetBaseDir = path.resolve(rootDir, config.directories.components);
+
+  // Ensure base directory exists
+  if (!fs.existsSync(targetBaseDir)) {
+    fs.mkdirSync(targetBaseDir, { recursive: true });
+  }
+
+  console.log(chalk.cyan(`Installing ${component.name}...`));
+
+  for (const file of component.files) {
+    const filePath = path.join(targetBaseDir, file.name);
+    const fileDir = path.dirname(filePath);
+
+    // Ensure subdirectories exist
+    if (!fs.existsSync(fileDir)) {
+      fs.mkdirSync(fileDir, { recursive: true });
+    }
+
+    if (fs.existsSync(filePath)) {
+      console.warn(chalk.yellow(`File already exists: ${file.name}. Skipping.`));
+      continue;
+    }
+
+    fs.writeFileSync(filePath, file.content);
+    console.log(chalk.green(`✓ Created ${file.name}`));
+  }
+
+  if (component.dependencies) {
+    console.log('\n' + chalk.yellow('Required dependencies:'));
+    for (const [dep, version] of Object.entries(component.dependencies)) {
+      console.log(`  - ${dep}@${version}`);
+    }
+  }
+}

--- a/packages/studio/src/components/ComponentsPanel/ComponentsPanel.css
+++ b/packages/studio/src/components/ComponentsPanel/ComponentsPanel.css
@@ -1,0 +1,78 @@
+.components-panel {
+  padding: 16px;
+  color: var(--text-primary);
+  height: 100%;
+  overflow-y: auto;
+}
+
+.components-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.component-card {
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.component-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.component-name {
+  font-weight: 600;
+  font-size: 1.1em;
+}
+
+.component-type {
+  font-size: 0.8em;
+  background-color: var(--bg-secondary);
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.component-description {
+  font-size: 0.9em;
+  color: var(--text-secondary);
+  flex-grow: 1;
+}
+
+.component-dependencies {
+  font-size: 0.8em;
+  color: var(--text-tertiary);
+}
+
+.install-button {
+  background-color: var(--accent-color);
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.install-button:hover {
+  background-color: var(--accent-hover);
+}
+
+.install-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.install-button.success {
+  background-color: var(--success-color, #4caf50);
+}

--- a/packages/studio/src/components/ComponentsPanel/ComponentsPanel.tsx
+++ b/packages/studio/src/components/ComponentsPanel/ComponentsPanel.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react';
+import { useToast } from '../../context/ToastContext';
+import './ComponentsPanel.css';
+
+interface ComponentDefinition {
+  name: string;
+  type: string;
+  files: { name: string; content: string }[];
+  dependencies?: Record<string, string>;
+}
+
+export const ComponentsPanel: React.FC = () => {
+  const [components, setComponents] = useState<ComponentDefinition[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [installing, setInstalling] = useState<string | null>(null);
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    fetch('/api/components')
+      .then(res => {
+          if (!res.ok) throw new Error('Failed to fetch components');
+          return res.json();
+      })
+      .then(data => {
+        setComponents(data);
+        setLoading(false);
+      })
+      .catch(err => {
+        console.error(err);
+        addToast('Failed to load components', 'error');
+        setLoading(false);
+      });
+  }, [addToast]);
+
+  const handleInstall = async (name: string) => {
+    setInstalling(name);
+    try {
+      const res = await fetch('/api/components', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name })
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Installation failed');
+      }
+
+      addToast(`Component "${name}" installed`, 'success');
+    } catch (e: any) {
+      console.error(e);
+      addToast(e.message || 'Installation failed', 'error');
+    } finally {
+      setInstalling(null);
+    }
+  };
+
+  if (loading) {
+    return <div className="components-panel">Loading registry...</div>;
+  }
+
+  return (
+    <div className="components-panel">
+      <h2>Component Registry</h2>
+      <div className="components-grid">
+        {components.map(comp => (
+          <div key={comp.name} className="component-card">
+            <div className="component-header">
+              <span className="component-name">{comp.name}</span>
+              <span className="component-type">{comp.type}</span>
+            </div>
+            <div className="component-dependencies">
+              {comp.dependencies ? (
+                <span>Deps: {Object.keys(comp.dependencies).join(', ')}</span>
+              ) : (
+                <span>No dependencies</span>
+              )}
+            </div>
+            <button
+              className="install-button"
+              onClick={() => handleInstall(comp.name)}
+              disabled={!!installing}
+            >
+              {installing === comp.name ? 'Installing...' : 'Install'}
+            </button>
+          </div>
+        ))}
+        {components.length === 0 && (
+            <div>No components found in registry.</div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/studio/src/components/Sidebar/Sidebar.tsx
+++ b/packages/studio/src/components/Sidebar/Sidebar.tsx
@@ -7,10 +7,11 @@ import { RendersPanel } from '../RendersPanel/RendersPanel';
 import { CaptionsPanel } from '../CaptionsPanel/CaptionsPanel';
 import { CompositionsPanel } from '../CompositionsPanel/CompositionsPanel';
 import { AudioMixerPanel } from '../AudioMixerPanel/AudioMixerPanel';
+import { ComponentsPanel } from '../ComponentsPanel/ComponentsPanel';
 
 export const Sidebar: React.FC = () => {
   const { setHelpOpen, setDiagnosticsOpen, setAssistantOpen } = useStudio();
-  const [activeTab, setActiveTab] = usePersistentState<'compositions' | 'assets' | 'renders' | 'captions' | 'audio'>('sidebar-active-tab', 'compositions');
+  const [activeTab, setActiveTab] = usePersistentState<'compositions' | 'assets' | 'renders' | 'captions' | 'audio' | 'components'>('sidebar-active-tab', 'compositions');
 
   return (
     <div className="studio-sidebar">
@@ -26,6 +27,12 @@ export const Sidebar: React.FC = () => {
           onClick={() => setActiveTab('assets')}
         >
           Assets
+        </button>
+        <button
+          className={`sidebar-tab ${activeTab === 'components' ? 'active' : ''}`}
+          onClick={() => setActiveTab('components')}
+        >
+          Components
         </button>
         <button
           className={`sidebar-tab ${activeTab === 'captions' ? 'active' : ''}`}
@@ -49,6 +56,7 @@ export const Sidebar: React.FC = () => {
       <div className="sidebar-content">
         {activeTab === 'compositions' && <CompositionsPanel />}
         {activeTab === 'assets' && <AssetsPanel />}
+        {activeTab === 'components' && <ComponentsPanel />}
         {activeTab === 'captions' && <CaptionsPanel />}
         {activeTab === 'audio' && <AudioMixerPanel />}
         {activeTab === 'renders' && <RendersPanel />}


### PR DESCRIPTION
💡 **What**: Implemented a "Components" panel in the Studio UI that allows users to browse and install components from the Helios Registry. Refactored the CLI to expose `installComponent` logic and injected it into the Studio server.
🎯 **Why**: To provide a seamless Developer Experience (DX) by enabling component discovery and installation directly within the Studio environment, matching the `helios add` CLI capability.
📊 **Impact**: Users can now extend their projects with standard components (like Timer, ProgressBar) without leaving the Studio interface.
🔬 **Verification**:
- Verified `helios add timer` still works via CLI.
- Verified Studio builds successfully.
- Verified `ComponentsPanel` fetches registry data and handles installation via API.

---
*PR created automatically by Jules for task [6179021349664290669](https://jules.google.com/task/6179021349664290669) started by @BintzGavin*