### PR TITLE
✨ RENDERER: Smart Codec Selection Update

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -9,7 +9,7 @@ The Renderer operates on a "Dual-Path" architecture to support different use cas
 2. **Canvas Strategy (`CanvasStrategy`)**: Used for WebGL/Canvas-heavy compositions (e.g., Three.js, PixiJS). It captures the `<canvas>` context directly.
    - **Drivers**: Uses `CdpTimeDriver` (Chrome DevTools Protocol) for precise virtual time control (supports Shadow DOM media sync, syncs media in iframes, enforces deterministic Jan 2024 epoch, ensures sync-before-render order, waits for budget expiration, enforces stability timeout via `Runtime.terminateExecution`, supports media looping and visual playback rate).
    - **Discovery**: Uses `dom-scanner` to recursively discover media elements (including Shadow DOM) for implicit audio inclusion (including `blob:` URLs via extraction), unifying behavior with `DomStrategy`.
-   - **Optimization**: Prioritizes H.264 (AVC) intermediate codec for hardware acceleration, falling back to VP8. Exposes `diagnose()` API to verify supported WebCodecs.
+   - **Optimization**: Prioritizes H.264 (AVC) -> VP9 -> AV1 -> VP8 intermediate codec for hardware acceleration and transparency support. Exposes `diagnose()` API to verify supported WebCodecs.
    - **Output**: Best for high-performance 2D/3D graphics.
 
 Both strategies pipe frame data directly to an FFmpeg process via stdin ("Zero Disk I/O"), ensuring high performance and low latency. Audio tracks from Blob URLs are extracted to memory and also piped to FFmpeg via additional pipes, avoiding temporary files. Video concatenation also constructs file lists in memory and pipes them to FFmpeg stdin, eliminating all temporary file creation.
@@ -63,6 +63,7 @@ packages/renderer/
     ├── verify-dom-audio-fades.ts # DOM audio fades test
     ├── verify-audio-fades.ts   # Audio fades test
     ├── verify-smart-audio-fades.ts # Smart Audio Fades verification
+    ├── verify-smart-codec-priority.ts # Smart Codec Priority verification
     ├── verify-audio-loop.ts    # Audio looping test
     ├── verify-audio-playback-rate.ts # Audio playback rate test
     ├── verify-audio-playback-seek.ts # Audio playback seek test (Rate + StartFrame)

--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,3 +1,6 @@
+## RENDERER v1.67.0
+- ✅ Completed: Smart Codec Selection Update - Updated `CanvasStrategy` to prioritize H.264 -> VP9 -> AV1 -> VP8, enabling hardware-accelerated transparency and better quality. Verified with `verify-smart-codec-priority.ts`.
+
 ## RENDERER v1.66.0
 - ✅ Completed: CdpTimeDriver Iframe Sync - Updated `CdpTimeDriver` to synchronize media elements across all frames (including iframes) by iterating `page.frames()` and executing sync logic in each context. Verified with `verify-cdp-iframe-media-sync.ts`.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,10 +1,11 @@
-**Version**: 1.66.0
+**Version**: 1.67.0
 
 **Posture**: MAINTENANCE WITH V2 EXPANSION
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.67.0] ✅ Completed: Smart Codec Selection Update - Updated `CanvasStrategy` to prioritize H.264 -> VP9 -> AV1 -> VP8, enabling hardware-accelerated transparency and better quality. Verified with `verify-smart-codec-priority.ts`.
 - [1.66.0] ✅ Completed: CdpTimeDriver Iframe Sync - Updated `CdpTimeDriver` to synchronize media elements across all frames (including iframes) by iterating `page.frames()` and executing sync logic in each context. Verified with `verify-cdp-iframe-media-sync.ts`.
 - [1.65.0] ✅ Completed: Smart Audio Fades - Updated `AudioTrackConfig` and `FFmpegBuilder` to calculate fade-out times relative to the clip's duration (if known and not looping) rather than the composition duration. Verified with `verify-smart-audio-fades.ts`.
 - [1.64.1] ✅ Completed: Verify and Sync - Verified v1.64.0 distributed rendering and synced documentation. Verified with `verify-distributed.ts` and `npm run test`.

--- a/packages/renderer/src/strategies/CanvasStrategy.ts
+++ b/packages/renderer/src/strategies/CanvasStrategy.ts
@@ -191,13 +191,17 @@ export class CanvasStrategy implements RenderStrategy {
         addCandidate(this.options.intermediateVideoCodec);
     } else if (this.options.videoCodec === 'copy') {
         // Smart Selection for Copy Mode
-        // Prioritize H.264 (AVC) -> VP8
+        // Prioritize H.264 (AVC) -> VP9 -> AV1 -> VP8
         addCandidate('avc1.4d002a'); // H.264 High Profile
+        addCandidate('vp9');
+        addCandidate('av01.0.05M.08'); // AV1
         addCandidate('vp8');
     } else {
         // Default behavior
-        // Prioritize H.264 (Hardware) -> VP8 (Software Fallback)
+        // Prioritize H.264 (Hardware) -> VP9 -> AV1 -> VP8
         addCandidate('avc1.4d002a');
+        addCandidate('vp9');
+        addCandidate('av01.0.05M.08');
         addCandidate('vp8');
     }
 

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -48,6 +48,8 @@ const tests = [
   'tests/verify-shadow-dom-background.ts',
   'tests/verify-shadow-dom-images.ts',
   'tests/verify-shadow-dom-sync.ts',
+  'tests/verify-smart-audio-fades.ts',
+  'tests/verify-smart-codec-priority.ts',
   'tests/verify-smart-codec-selection.ts',
   'tests/verify-stream-copy.ts',
   'tests/verify-video-loop.ts',

--- a/packages/renderer/tests/verify-smart-codec-priority.ts
+++ b/packages/renderer/tests/verify-smart-codec-priority.ts
@@ -1,0 +1,144 @@
+
+import { CanvasStrategy } from '../src/strategies/CanvasStrategy.js';
+import { RendererOptions } from '../src/types.js';
+import { Page } from 'playwright';
+
+// Mock Page
+class MockPage {
+  viewportSize() {
+    return { width: 1920, height: 1080 };
+  }
+
+  async evaluate(fnOrScript: any, args?: any) {
+    // If it's the font check
+    if (fnOrScript.toString().includes('document.fonts.ready')) {
+      return true;
+    }
+
+    // If it's the canvas finder
+    if (fnOrScript.toString().includes('findCanvas')) {
+      return true; // Found
+    }
+
+    // If it's the codec selection script
+    if (typeof fnOrScript === 'string' && fnOrScript.includes('window.heliosWebCodecs')) {
+      // args should be the config object
+      // We can intercept the candidates here
+      // But wait, the script is passed as a string and args is passed as the second argument?
+      // In CanvasStrategy:
+      // page.evaluate<...>(`...`, args)
+      // Wait, passing args to evaluate with a string script:
+      // page.evaluate(`(config) => { ... }(${JSON.stringify(args)})`)
+
+      // Ah, looking at CanvasStrategy:
+      // const result = await page.evaluate(...)
+      // It constructs a string: `(async (config) => { ... })(${JSON.stringify(args)})`
+      // So the args are embedded in the script string as JSON.
+
+      // We need to parse the script to extract the args.
+      const jsonMatch = fnOrScript.match(/\)\((\{.*\})\)\s*$/);
+      if (jsonMatch) {
+        const config = JSON.parse(jsonMatch[1]);
+        if (config.candidates) {
+            (this as any).capturedCandidates = config.candidates;
+        }
+      }
+
+      // Return a dummy supported result to avoid errors
+      return { supported: true, codec: 'mock-codec', isH264: true };
+    }
+
+    // If it's scanForAudioTracks (which uses evaluate)
+    if (fnOrScript.includes('scanForAudioTracks') || (args && args.toString().includes('scanForAudioTracks'))) {
+        return [];
+    }
+
+    return null;
+  }
+
+  frames() {
+      // For dom-scanner
+      return [{
+          evaluate: async () => []
+      }];
+  }
+}
+
+async function runTest() {
+  console.log('Running Smart Codec Priority Verification...');
+
+  const options: RendererOptions = {
+    width: 1920,
+    height: 1080,
+    fps: 30,
+    durationInSeconds: 1,
+    mode: 'canvas',
+    // Default videoCodec
+  };
+
+  const strategy = new CanvasStrategy(options);
+  const mockPage = new MockPage() as unknown as Page;
+
+  // We need to stub extractBlobTracks to avoid filesystem errors
+  // But extractBlobTracks is imported. We can't easily mock it in ESM without a loader.
+  // However, extractBlobTracks calls scanForAudioTracks which calls page.frames().
+  // If scanForAudioTracks returns empty, extractBlobTracks does nothing.
+
+  try {
+    await strategy.prepare(mockPage);
+  } catch (e) {
+    console.error('Strategy prepare failed:', e);
+    process.exit(1);
+  }
+
+  const candidates = (mockPage as any).capturedCandidates;
+
+  if (!candidates) {
+      console.error('❌ Failed to capture candidates from page.evaluate');
+      process.exit(1);
+  }
+
+  console.log('Captured candidates:', candidates.map((c: any) => c.codecString));
+
+  // Expected Order: H.264 -> VP9 -> AV1 -> VP8
+  const expectedOrder = [
+      { codec: 'avc1.4d002a', isH264: true },
+      { codec: 'vp9', isH264: false },
+      { codec: 'av01.0.05M.08', isH264: false },
+      { codec: 'vp8', isH264: false }
+  ];
+
+  let passed = true;
+
+  // Note: Currently (before fix), we expect H.264 -> VP8
+  // After fix, we expect H.264 -> VP9 -> AV1 -> VP8
+  // This test validates the NEW expectation.
+
+  // Basic check for existence
+  const hasH264 = candidates.some((c: any) => c.codecString === 'avc1.4d002a');
+  const hasVP9 = candidates.some((c: any) => c.codecString === 'vp9');
+  const hasAV1 = candidates.some((c: any) => c.codecString === 'av01.0.05M.08');
+  const hasVP8 = candidates.some((c: any) => c.codecString === 'vp8');
+
+  if (!hasH264) { console.error('❌ Missing H.264 candidate'); passed = false; }
+  if (!hasVP9) { console.error('❌ Missing VP9 candidate'); passed = false; }
+  if (!hasAV1) { console.error('❌ Missing AV1 candidate'); passed = false; }
+  if (!hasVP8) { console.error('❌ Missing VP8 candidate'); passed = false; }
+
+  // Check order
+  if (passed) {
+      if (candidates[0].codecString !== 'avc1.4d002a') { console.error('❌ First candidate is not H.264'); passed = false; }
+      if (candidates[1].codecString !== 'vp9') { console.error('❌ Second candidate is not VP9'); passed = false; }
+      if (candidates[2].codecString !== 'av01.0.05M.08') { console.error('❌ Third candidate is not AV1'); passed = false; }
+      if (candidates[3].codecString !== 'vp8') { console.error('❌ Fourth candidate is not VP8'); passed = false; }
+  }
+
+  if (passed) {
+      console.log('✅ All candidates present in correct order.');
+  } else {
+      console.error('❌ verification failed.');
+      process.exit(1);
+  }
+}
+
+runTest();


### PR DESCRIPTION
Updates `CanvasStrategy` to include VP9 and AV1 in the default candidate list, prioritized after H.264. This allows the renderer to automatically select VP9 when alpha channel transparency is required (which H.264 does not support), preventing fallback to the slower software-based VP8 codec.

Also adds `verify-smart-codec-priority.ts` and `verify-smart-audio-fades.ts` to the main test runner `run-all.ts` to ensure regression testing.

---
*PR created automatically by Jules for task [15180877811284322117](https://jules.google.com/task/15180877811284322117) started by @BintzGavin*