### PR TITLE
✨ PLAYER: Implement Audio Track UI

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -14,10 +14,12 @@ The `<helios-player>` component uses a Shadow DOM to encapsulate its styles and 
     - `.poster-container` (Poster image and Big Play Button)
     - `.captions-container` (Caption rendering overlay)
     - `.debug-overlay` (Diagnostics UI)
+    - `.audio-menu` (Audio Tracks UI - Popover for per-track volume/mute)
     - `.click-layer` (Captures clicks for play/pause when controls are hidden)
   - **Controls**: `.controls` (Flexbox container)
     - Play/Pause Button
     - Volume Control (Mute button + Slider)
+    - Audio Button (Toggles Audio Menu, hidden if no tracks)
     - CC Button (Captions toggle)
     - Export Button
     - Speed Selector

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.67.0
+- ✅ Completed: Audio Track UI - Implemented audio menu in player controls to mute/unmute and adjust volume of individual audio tracks.
+
 ## PLAYER v0.66.2
 - ✅ Completed: Handle Connection Timeouts - Implemented error state and event dispatching on connection timeout.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.66.2
+**Version**: v0.67.0
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -25,6 +25,7 @@
 - Displays actionable error messages with "Dismiss" option for failed client-side exports.
 - Supports Volume and Mute controls via UI and Bridge.
 - Supports Audio Track Volume and Mute controls via Controller API and Bridge.
+- **Audio Track UI**: Implements a dedicated Audio Menu in the player controls (toggled by '🎵' button) to mute/unmute and adjust volume for individual audio tracks.
 - Supports caption rendering overlay with toggleable "CC" button.
 - Supports WebM (VP9/Opus) client-side export via `export-format` attribute.
 - Implements Standard Media API (play, pause, currentTime, events) for better interoperability.
@@ -49,15 +50,16 @@
 - Supports auto-enabling of captions if a track is marked as `default`.
 - Supports audio fade-in/out in client-side export via `data-helios-fade-in` and `data-helios-fade-out` attributes.
 - Supports Shadow DOM Export: DOM-based client-side export now correctly captures Shadow DOM content (via Declarative Shadow DOM transformation), enabling support for Web Components in exports.
-- **Supports Environment Diagnostics UI**: Implemented `diagnose()` method in `HeliosController` and a visible Diagnostics UI overlay in `<helios-player>` (toggled via `Shift+D`) to expose environment capabilities (WebCodecs, WebGL, etc.) to the user.
-- **Supports Headless Audio Export**: Client-side export now includes audio tracks manually injected into Helios state (`availableAudioTracks`), enabling headless audio rendering without DOM elements.
-- **Supports Dynamic Composition Updates**: Exposes `setDuration`, `setFps`, `setSize`, and `setMarkers` via `HeliosController` (and Bridge), allowing host applications (like Studio) to update the composition structure dynamically.
-- **Supports Export Filename**: Implemented `export-filename` attribute to allow specifying the filename for client-side exports.
-- **Supports Active Cues**: Implemented `activeCues` property and `cuechange` event on `HeliosTextTrack` for Standard Media API parity.
+- Supports Environment Diagnostics UI: Implemented `diagnose()` method in `HeliosController` and a visible Diagnostics UI overlay in `<helios-player>` (toggled via `Shift+D`) to expose environment capabilities (WebCodecs, WebGL, etc.) to the user.
+- Supports Headless Audio Export: Client-side export now includes audio tracks manually injected into Helios state (`availableAudioTracks`), enabling headless audio rendering without DOM elements.
+- Supports Dynamic Composition Updates: Exposes `setDuration`, `setFps`, `setSize`, and `setMarkers` via `HeliosController` (and Bridge), allowing host applications (like Studio) to update the composition structure dynamically.
+- Supports Export Filename: Implemented `export-filename` attribute to allow specifying the filename for client-side exports.
+- Supports Active Cues: Implemented `activeCues` property and `cuechange` event on `HeliosTextTrack` for Standard Media API parity.
 
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.67.0] ✅ Completed: Audio Track UI - Implemented audio menu in player controls to mute/unmute and adjust volume of individual audio tracks.
 [v0.66.2] ✅ Completed: Handle Connection Timeouts - Implemented error state and event dispatching on connection timeout.
 [v0.66.1] ✅ Completed: Responsive Images - Implemented support for capturing currentSrc of responsive images during client-side export, ensuring high-fidelity output.
 [v0.66.0] ✅ Completed: Implement VideoTracks API - Implemented videoTracks property and VideoTrackList API on <helios-player> to complete Standard Media API parity.

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -3,6 +3,7 @@ import type { HeliosController } from "./controllers";
 import { ClientSideExporter } from "./features/exporter";
 import { HeliosTextTrack, HeliosTextTrackList, TrackHost } from "./features/text-tracks";
 import { HeliosAudioTrack, HeliosAudioTrackList, AudioTrackHost } from "./features/audio-tracks";
+import { HeliosVideoTrack, HeliosVideoTrackList, VideoTrackHost } from "./features/video-tracks";
 export { ClientSideExporter };
 export type { HeliosController };
 interface MediaError {
@@ -13,15 +14,18 @@ interface MediaError {
     readonly MEDIA_ERR_DECODE: number;
     readonly MEDIA_ERR_SRC_NOT_SUPPORTED: number;
 }
-export declare class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHost {
+export declare class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHost, VideoTrackHost {
     private iframe;
     private pipVideo;
     private _textTracks;
     private _audioTracks;
+    private _videoTracks;
     private _domTracks;
     private playPauseBtn;
     private volumeBtn;
     private volumeSlider;
+    private audioBtn;
+    private audioMenu;
     private scrubber;
     private scrubberWrapper;
     private scrubberTooltip;
@@ -142,12 +146,19 @@ export declare class HeliosPlayer extends HTMLElement implements TrackHost, Audi
     constructor();
     get textTracks(): HeliosTextTrackList;
     get audioTracks(): HeliosAudioTrackList;
+    get videoTracks(): HeliosVideoTrackList;
     addTextTrack(kind: string, label?: string, language?: string): HeliosTextTrack;
     handleAudioTrackEnabledChange(track: HeliosAudioTrack): void;
+    handleVideoTrackSelectedChange(track: HeliosVideoTrack): void;
     handleTrackModeChange(track: HeliosTextTrack): void;
     attributeChangedCallback(name: string, oldVal: string, newVal: string): void;
     private updateControlsVisibility;
     private updateCCButtonVisibility;
+    private updateAudioBtnVisibility;
+    private toggleAudioMenu;
+    private closeAudioMenu;
+    private closeAudioMenuIfOutside;
+    private renderAudioMenu;
     get inputProps(): Record<string, any> | null;
     set inputProps(val: Record<string, any> | null);
     connectedCallback(): void;

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -482,8 +482,84 @@ template.innerHTML = `
     .copy-debug-btn:hover {
       filter: brightness(0.9);
     }
+    .audio-menu {
+      position: absolute;
+      bottom: 60px;
+      left: 10px;
+      background: rgba(0, 0, 0, 0.9);
+      border: 1px solid var(--helios-range-track-color);
+      border-radius: 8px;
+      padding: 8px;
+      z-index: 20;
+      min-width: 200px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      backdrop-filter: blur(4px);
+    }
+    .audio-menu.hidden {
+      display: none;
+    }
+    .track-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: white;
+      font-size: 12px;
+    }
+    .track-name {
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 120px;
+    }
+    .track-volume {
+      width: 60px;
+      height: 4px;
+      -webkit-appearance: none;
+      background: var(--helios-range-track-color);
+      border-radius: 2px;
+      outline: none;
+    }
+    .track-volume::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 10px;
+      height: 10px;
+      background: var(--helios-text-color);
+      cursor: pointer;
+      border-radius: 50%;
+    }
+    .track-mute-btn {
+      background: none;
+      border: none;
+      color: var(--helios-text-color);
+      cursor: pointer;
+      padding: 0;
+      font-size: 14px;
+      width: 20px;
+      text-align: center;
+    }
+    .audio-btn {
+      background: none;
+      border: none;
+      color: var(--helios-text-color);
+      font-size: 20px;
+      cursor: pointer;
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: 4px;
+    }
+    .audio-btn:hover {
+      color: var(--helios-accent-color);
+    }
   </style>
   <slot></slot>
+  <div class="audio-menu hidden" part="audio-menu"></div>
   <div class="debug-overlay hidden" part="debug-overlay">
     <div class="debug-header">
       <span class="debug-title">Diagnostics</span>
@@ -512,6 +588,7 @@ template.innerHTML = `
       <button class="volume-btn" part="volume-button" aria-label="Mute">🔊</button>
       <input type="range" class="volume-slider" min="0" max="1" step="0.05" value="1" part="volume-slider" aria-label="Volume">
     </div>
+    <button class="audio-btn" part="audio-button" aria-label="Audio Tracks" style="display: none;">🎵</button>
     <button class="cc-btn" part="cc-button" aria-label="Toggle Captions">CC</button>
     <button class="export-btn" part="export-button" aria-label="Export video">Export</button>
     <select class="speed-selector" part="speed-selector" aria-label="Playback speed">
@@ -541,6 +618,8 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   private playPauseBtn: HTMLButtonElement;
   private volumeBtn: HTMLButtonElement;
   private volumeSlider: HTMLInputElement;
+  private audioBtn: HTMLButtonElement;
+  private audioMenu: HTMLDivElement;
   private scrubber: HTMLInputElement;
   private scrubberWrapper: HTMLDivElement;
   private scrubberTooltip: HTMLDivElement;
@@ -994,6 +1073,8 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     this.playPauseBtn = this.shadowRoot!.querySelector(".play-pause-btn")!;
     this.volumeBtn = this.shadowRoot!.querySelector(".volume-btn")!;
     this.volumeSlider = this.shadowRoot!.querySelector(".volume-slider")!;
+    this.audioBtn = this.shadowRoot!.querySelector(".audio-btn")!;
+    this.audioMenu = this.shadowRoot!.querySelector(".audio-menu")!;
     this.scrubber = this.shadowRoot!.querySelector(".scrubber")!;
     this.scrubberWrapper = this.shadowRoot!.querySelector(".scrubber-wrapper")!;
     this.scrubberTooltip = this.shadowRoot!.querySelector(".scrubber-tooltip")!;
@@ -1035,6 +1116,13 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     this._textTracks.addEventListener("removetrack", () => this.updateCCButtonVisibility());
 
     this._audioTracks = new HeliosAudioTrackList();
+    this._audioTracks.addEventListener("addtrack", () => this.updateAudioBtnVisibility());
+    this._audioTracks.addEventListener("removetrack", () => this.updateAudioBtnVisibility());
+    this._audioTracks.addEventListener("change", () => {
+        if (!this.audioMenu.classList.contains("hidden")) {
+            this.renderAudioMenu();
+        }
+    });
 
     this._videoTracks = new HeliosVideoTrackList();
     this._videoTracks.addTrack(new HeliosVideoTrack("main", "main", "Main Video", "en", true, this));
@@ -1234,6 +1322,103 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     }
   }
 
+  private updateAudioBtnVisibility() {
+    if (this._audioTracks.length > 0) {
+      this.audioBtn.style.removeProperty("display");
+    } else {
+      this.audioBtn.style.display = "none";
+    }
+  }
+
+  private toggleAudioMenu = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (this.audioMenu.classList.contains("hidden")) {
+      this.renderAudioMenu();
+      this.audioMenu.classList.remove("hidden");
+    } else {
+      this.audioMenu.classList.add("hidden");
+    }
+  }
+
+  private closeAudioMenu = () => {
+    this.audioMenu.classList.add("hidden");
+  }
+
+  private closeAudioMenuIfOutside = (e: MouseEvent) => {
+      // If menu is hidden, do nothing
+      if (this.audioMenu.classList.contains("hidden")) return;
+
+      const target = e.composedPath()[0] as Node;
+      // Check if click is inside the menu or on the button
+      if (this.audioMenu.contains(target) || this.audioBtn.contains(target)) {
+          return;
+      }
+      this.closeAudioMenu();
+  }
+
+  private renderAudioMenu() {
+    this.audioMenu.innerHTML = "";
+
+    const tracks = Array.from(this._audioTracks);
+
+    tracks.forEach(track => {
+      const item = document.createElement("div");
+      item.className = "track-item";
+
+      const name = document.createElement("span");
+      name.className = "track-name";
+      name.textContent = track.label || track.id;
+      name.title = name.textContent;
+
+      let currentVolume = 1;
+
+      if (this.controller) {
+          const state = this.controller.getState();
+          if (state.audioTracks && state.audioTracks[track.id]) {
+              currentVolume = state.audioTracks[track.id].volume ?? 1;
+          }
+      }
+
+      const volumeSlider = document.createElement("input");
+      volumeSlider.type = "range";
+      volumeSlider.className = "track-volume";
+      volumeSlider.min = "0";
+      volumeSlider.max = "1";
+      volumeSlider.step = "0.05";
+      volumeSlider.value = String(currentVolume);
+      volumeSlider.ariaLabel = `Volume for ${name.textContent}`;
+
+      volumeSlider.addEventListener("input", (e) => {
+          e.stopPropagation();
+          const vol = parseFloat(volumeSlider.value);
+          if (this.controller) {
+              this.controller.setAudioTrackVolume(track.id, vol);
+          }
+      });
+
+      volumeSlider.addEventListener("click", e => e.stopPropagation());
+
+      const muteBtn = document.createElement("button");
+      muteBtn.className = "track-mute-btn";
+      muteBtn.textContent = track.enabled ? "🔊" : "🔇";
+      muteBtn.title = track.enabled ? "Mute" : "Unmute";
+      muteBtn.ariaLabel = muteBtn.title;
+
+      muteBtn.addEventListener("click", (e) => {
+          e.stopPropagation();
+          track.enabled = !track.enabled;
+          // UI update is handled by the 'change' event listener on _audioTracks calling renderAudioMenu
+          // but for immediate feedback we can update button here too, though renderAudioMenu will overwrite it.
+      });
+
+      item.appendChild(name);
+      item.appendChild(volumeSlider);
+      item.appendChild(muteBtn);
+
+      this.audioMenu.appendChild(item);
+    });
+  }
+
   public get inputProps(): Record<string, any> | null {
     return this.pendingProps;
   }
@@ -1255,6 +1440,8 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     this.playPauseBtn.addEventListener("click", this.togglePlayPause);
     this.volumeBtn.addEventListener("click", this.toggleMute);
     this.volumeSlider.addEventListener("input", this.handleVolumeInput);
+    this.audioBtn.addEventListener("click", this.toggleAudioMenu);
+    document.addEventListener("click", this.closeAudioMenuIfOutside);
     this.scrubber.addEventListener("input", this.handleScrubberInput);
     this.scrubber.addEventListener("mousedown", this.handleScrubStart);
     this.scrubber.addEventListener("change", this.handleScrubEnd);
@@ -1320,6 +1507,8 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     this.playPauseBtn.removeEventListener("click", this.togglePlayPause);
     this.volumeBtn.removeEventListener("click", this.toggleMute);
     this.volumeSlider.removeEventListener("input", this.handleVolumeInput);
+    this.audioBtn.removeEventListener("click", this.toggleAudioMenu);
+    document.removeEventListener("click", this.closeAudioMenuIfOutside);
     this.scrubber.removeEventListener("input", this.handleScrubberInput);
     this.scrubber.removeEventListener("mousedown", this.handleScrubStart);
     this.scrubber.removeEventListener("change", this.handleScrubEnd);
@@ -1956,9 +2145,9 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
                   const isMuted = state.audioTracks && state.audioTracks[meta.id] ? state.audioTracks[meta.id].muted : false;
                   track = new HeliosAudioTrack(
                       meta.id,
-                      "", // Kind
-                      meta.id, // Label (fallback to ID)
-                      "", // Language
+                      meta.kind || "", // Kind
+                      meta.label || meta.id, // Label
+                      meta.language || "", // Language
                       !isMuted, // Enabled
                       this
                   );


### PR DESCRIPTION
Implemented a dedicated Audio Menu in `<helios-player>` to allow users to mute/unmute and adjust volume for individual audio tracks.

**Changes:**
- **UI**: Added `audio-btn` and `audio-menu` to Shadow DOM.
- **Logic**: Implemented `toggleAudioMenu`, `renderAudioMenu`, `updateAudioBtnVisibility` in `HeliosPlayer`.
- **Fix**: Corrected `HeliosAudioTrack` initialization to use `label` from metadata.
- **CSS**: Added styles for the popover menu and track items.

**Impact**:
Enables users to debug and preview multi-track audio compositions directly in the player.

**Verification**:
- `npm run build -w packages/player` passed.
- `npm test packages/player` passed (including `audio-tracks.test.ts`).
- Visual verification script `verify_audio_ui.py` passed and confirmed Audio Menu functionality.

---
*PR created automatically by Jules for task [14739602528603218181](https://jules.google.com/task/14739602528603218181) started by @BintzGavin*