### PR TITLE
✨ PLAYER: Sync version to 0.66.3

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -83,6 +83,6 @@ The component observes or reads the following attributes:
 ## D. Public API
 The `HeliosPlayer` class exposes properties and methods closely mirroring `HTMLMediaElement`:
 
-- **Properties**: `currentTime`, `duration`, `paused`, `ended`, `volume`, `muted`, `playbackRate`, `src`, `currentSrc`, `error`, `readyState`, `networkState`, `buffered`, `seekable`, `played`, `videoWidth`, `videoHeight`, `textTracks`, `audioTracks`, `videoTracks`, `disablePictureInPicture`.
+- **Properties**: `currentTime`, `duration`, `paused`, `ended`, `volume`, `muted`, `playbackRate`, `src`, `currentSrc`, `error`, `readyState`, `networkState`, `buffered`, `seekable`, `played`, `videoWidth`, `videoHeight`, `textTracks`, `audioTracks`, `videoTracks`, `disablePictureInPicture`, `inputProps`.
 - **Methods**: `play()`, `pause()`, `load()`, `addTextTrack()`, `requestPictureInPicture()`, `diagnose()`.
 - **Getters**: `getController()` (Returns internal controller instance).

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,4 +1,5 @@
-## PLAYER v0.67.0
+## PLAYER v0.66.3
+- ✅ Verified: Synced package.json version with status file and verified all tests pass.
 - ✅ Completed: Audio Track UI - Implemented audio menu in player controls to mute/unmute and adjust volume of individual audio tracks.
 
 ## PLAYER v0.66.2

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.67.0
+**Version**: v0.66.3
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -59,7 +59,8 @@
 ## Critical Task
 - **None**: All critical tasks completed.
 
-[v0.67.0] ✅ Completed: Audio Track UI - Implemented audio menu in player controls to mute/unmute and adjust volume of individual audio tracks.
+[v0.66.3] ✅ Verified: Synced package.json version with status file and verified all tests pass.
+[v0.66.3] ✅ Completed: Audio Track UI - Implemented audio menu in player controls to mute/unmute and adjust volume of individual audio tracks.
 [v0.66.2] ✅ Completed: Handle Connection Timeouts - Implemented error state and event dispatching on connection timeout.
 [v0.66.1] ✅ Completed: Responsive Images - Implemented support for capturing currentSrc of responsive images during client-side export, ensuring high-fidelity output.
 [v0.66.0] ✅ Completed: Implement VideoTracks API - Implemented videoTracks property and VideoTrackList API on <helios-player> to complete Standard Media API parity.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10579,7 +10579,7 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.4.1",
+      "version": "0.6.0",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/renderer": "^0.0.2",
@@ -10606,7 +10606,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.66.2",
+      "version": "0.66.3",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^5.8.0",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.66.2",
+  "version": "0.66.3",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",


### PR DESCRIPTION
Synchronizes the `@helios-project/player` package version to `0.66.3` to reflect the implemented Audio Track UI feature while respecting the strict dependency constraint in `@helios-project/studio` (`^0.66.0`).

Changes:
- Bumped `packages/player/package.json` to `0.66.3`.
- Updated `docs/status/PLAYER.md` and `docs/PROGRESS-PLAYER.md` to reflect `v0.66.3`.
- Regenerated `/.sys/llmdocs/context-player.md` to include `inputProps` in Public API.
- Updated `package-lock.json` via `npm install`.

Note: The version was bumped to `0.66.3` (patch) instead of `0.67.0` (minor) to avoid breaking the build for `packages/studio`, which is locked to `^0.66.0`. Future minor bumps will require coordination with the Studio domain.

---
*PR created automatically by Jules for task [14857174850991867113](https://jules.google.com/task/14857174850991867113) started by @BintzGavin*