### PR TITLE
📋 CLI: Implement Remote Registry Fetching

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -17,3 +17,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.4.1] - Init Scope Gap
 **Learning:** `helios init` was documented as "implemented" but only generated a config file, lacking the project scaffolding required by the Vision ("scaffold new Helios projects"). "Implemented" status can obscure scope gaps.
 **Action:** Verify "implemented" commands against the Vision (`AGENTS.md`) to distinguish between "MVP exists" and "Vision Complete".
+
+## [0.6.0] - Registry Architecture
+**Learning:** The existing component registry was hardcoded in `manifest.ts` (V1 MVP), conflicting with the V2 "Shadcn-style" vision which requires dynamic/remote fetching.
+**Action:** Created plan `2026-03-01-CLI-Remote-Registry.md` to decouple the registry. Future implementations must prioritize externalizing data sources over embedding them in the binary.

--- a/.sys/plans/2026-03-01-CLI-Remote-Registry.md
+++ b/.sys/plans/2026-03-01-CLI-Remote-Registry.md
@@ -1,0 +1,54 @@
+# CLI: Implement Remote Registry Fetching
+
+#### 1. Context & Goal
+- **Objective**: Decouple the component registry from the CLI binary by implementing remote registry fetching.
+- **Trigger**: The current registry is hardcoded in `manifest.ts`, which prevents dynamic updates and community contributions ("Shadcn-style" registry requirement).
+- **Impact**: Enables the CLI to fetch components from a remote source, allowing the ecosystem to grow independently of CLI releases.
+
+#### 2. File Inventory
+- **Create**:
+  - `packages/cli/src/registry/api.ts` (Registry fetching and caching logic)
+- **Modify**:
+  - `packages/cli/src/registry/types.ts` (Export registry types for API use)
+  - `packages/cli/src/utils/config.ts` (Add `registryUrl` to `HeliosConfig`)
+  - `packages/cli/src/utils/install.ts` (Accept `ComponentDefinition` instead of looking it up)
+  - `packages/cli/src/commands/add.ts` (Use `fetchRegistry` and pass definition to install)
+  - `packages/cli/src/commands/components.ts` (Use `fetchRegistry` to list items)
+- **Read-Only**: `packages/cli/src/registry/manifest.ts` (Used as fallback/default)
+
+#### 3. Implementation Spec
+- **Architecture**:
+  - Introduce a `fetchRegistry(url?: string)` function in `api.ts`.
+  - It checks for a `--registry` flag, then `helios.config.json`, then env var, then falls back to `manifest.ts`.
+  - Uses `fetch` (Node 18+) to retrieve the JSON.
+  - Validates the schema.
+- **Pseudo-Code**:
+  ```typescript
+  // registry/api.ts
+  async function fetchRegistry(urlOverride?: string): Promise<ComponentDefinition[]> {
+    const url = urlOverride || config.registryUrl || DEFAULT_REGISTRY_URL;
+    try {
+      if (url) {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error('Failed to fetch');
+        return await res.json();
+      }
+    } catch (e) {
+      // warn and fallback
+    }
+    return localRegistry;
+  }
+  ```
+- **Public API Changes**:
+  - `helios add` and `helios components` accept new `--registry <url>` flag.
+  - `helios.config.json` supports `registryUrl` field.
+- **Dependencies**: None (uses native `fetch`).
+
+#### 4. Test Plan
+- **Verification**:
+  - Run `helios components` (verifies fallback to local works).
+  - Run `helios add timer` (verifies fallback install works).
+  - (Manual) Run `helios components --registry <invalid-url>` (verify fallback/error handling).
+- **Success Criteria**:
+  - Existing commands continue to work using the local manifest (fallback).
+  - Code structure supports remote fetching for future V2 platform expansion.


### PR DESCRIPTION
Created spec file .sys/plans/2026-03-01-CLI-Remote-Registry.md to plan the architecture for remote registry fetching, decoupling the registry from the CLI binary.

---
*PR created automatically by Jules for task [10422362948511519961](https://jules.google.com/task/10422362948511519961) started by @BintzGavin*