### PR TITLE
📋 RENDERER: Distributed Implicit Audio Plan

### DIFF
--- a/.sys/plans/2026-03-07-RENDERER-Distributed-Implicit-Audio.md
+++ b/.sys/plans/2026-03-07-RENDERER-Distributed-Implicit-Audio.md
@@ -1,46 +1,63 @@
-# Plan: Enable Implicit Audio in Distributed Rendering
+# 2026-03-07-RENDERER-Distributed-Implicit-Audio.md
 
 ## 1. Context & Goal
-- **Objective**: Ensure that implicit audio (from DOM `<audio>`/`<video>` elements) captured in distributed rendering chunks is preserved and mixed in the final output.
-- **Trigger**: Currently, the `RenderOrchestrator` drops the audio stream from the concatenated intermediate file during the final mix step because `FFmpegBuilder` defaults to ignoring input audio (`0:a`) when generating mix arguments.
-- **Impact**: Unlocks correct audio rendering for distributed jobs where the audio comes from the DOM (implicit) rather than explicit `audioTracks`. Without this, such jobs result in silent video.
+- **Objective**: Ensure implicit audio (DOM `<audio>`/`<video>`) preserved in distributed rendering chunks is included in the final output mix.
+- **Trigger**: Distributed rendering drops implicit audio during the final mix step because `FFmpegBuilder` ignores the input video's audio stream (`0:a`) when explicit audio tracks are present.
+- **Impact**: Enables fully correct distributed rendering for compositions that use both implicit DOM audio and explicit background tracks.
 
 ## 2. File Inventory
 - **Modify**: `packages/renderer/src/types.ts` (Add `mixInputAudio` option)
-- **Modify**: `packages/renderer/src/utils/FFmpegBuilder.ts` (Implement logic to mix `0:a` if requested)
-- **Modify**: `packages/renderer/src/Orchestrator.ts` (Enable `mixInputAudio` in final step)
-- **Create**: `packages/renderer/tests/verify-distributed-implicit-audio.ts` (Verification script)
+- **Modify**: `packages/renderer/src/utils/FFmpegBuilder.ts` (Implement `mixInputAudio` logic)
+- **Modify**: `packages/renderer/src/Orchestrator.ts` (Enable `mixInputAudio` in final mix step)
+- **Create**: `tests/verify-ffmpeg-builder.ts` (Unit test for FFmpegBuilder argument generation)
 
 ## 3. Implementation Spec
-- **Architecture**: Explicit Configuration. The `Orchestrator` knows the input file contains valid audio that must be kept, so it explicitly instructs `FFmpegBuilder` via `mixInputAudio: true`.
-- **Public API Changes**:
-  - `RendererOptions` gets a new optional property `mixInputAudio?: boolean`.
-- **Pseudo-Code**:
-  - **FFmpegBuilder.ts**:
-    - In `getArgs`:
-    - Initialize `sources` array.
-    - If `options.mixInputAudio` is true, add `[0:a]` to `sources`.
-    - Add explicit tracks (already processed into `[a0]`, `[a1]`, etc.) to `sources`.
-    - If `sources` has items:
-      - If singular and source is `[0:a]`:
-        - Set `audioMap = '0:a'`.
-        - `audioFilterGraph` is empty (unless we add filters to input audio later, but for now raw is fine).
-      - If singular and source is `[a0]`:
-        - Use existing single-track logic (map `[a0]`, graph = chain).
-      - If multiple (mix needed):
-        - Construct `amix` filter with all `sources`.
-        - `audioFilterGraph` = (track chains joined) + `;` + (sources joined) + `amix=inputs=${sources.length}:duration=longest[aout]`.
-        - `audioMap = '[aout]'`.
-  - **Orchestrator.ts**:
-    - In `render` method, when defining `mixOptions`:
-      - Set `mixInputAudio: true`.
+
+### Architecture
+- **Strategy Pattern**: Enhance `FFmpegBuilder` to optionally treat the input video (stream `0:a`) as a mixable audio source.
+- **Configuration**: Expose `mixInputAudio` in `RendererOptions` to allow explicit control over this behavior.
+
+### Pseudo-Code
+
+**types.ts**:
+```typescript
+interface RendererOptions {
+  // ... existing options
+  /**
+   * Whether to include the input video's audio stream (0:a) in the final mix.
+   * Useful when post-processing a video that already contains audio.
+   */
+  mixInputAudio?: boolean;
+}
+```
+
+**FFmpegBuilder.ts**:
+- In `getArgs`:
+  - Check `options.mixInputAudio`.
+  - If `true`:
+    - Identify input 0 audio as `[0:a]`.
+    - If `tracks` exist:
+      - Add `[0:a]` to the inputs of the `amix` filter.
+      - Increment `inputs` count for `amix`.
+      - Prepend `[0:a]` to the filter chain string: `[0:a][a0][a1]...amix...`.
+    - If `tracks` do NOT exist:
+      - Set `audioMap` to `'0:a'` (ensure input audio is passed through).
+
+**Orchestrator.ts**:
+- In the final mixing step (after concatenation):
+  - Set `mixInputAudio: true` in `mixOptions`.
+
+### Public API Changes
+- `RendererOptions` gains optional `mixInputAudio` property.
+
+### Dependencies
+- None.
 
 ## 4. Test Plan
-- **Verification**: Run `npx tsx packages/renderer/tests/verify-distributed-implicit-audio.ts`.
+- **Verification**: Run `npx ts-node tests/verify-ffmpeg-builder.ts`
 - **Success Criteria**:
-  - The script renders a distributed job (e.g. 2 chunks) of a composition with implicit audio (e.g. a simple sine wave or local audio file).
-  - The output file contains an audio stream.
-  - `ffprobe` confirms audio duration matches video duration.
+  - The script asserts that generated FFmpeg arguments contain `[0:a]` in the `filter_complex` string when `mixInputAudio` is true.
+  - Verifies correct behavior for both "tracks + input audio" (mixing) and "no tracks + input audio" (passthrough) cases.
 - **Edge Cases**:
-  - **Explicit + Implicit**: Verify that `audioTracks` are mixed with the implicit audio.
-  - **No Implicit**: If `mixInputAudio: true` is set but input has no audio stream, FFmpeg might fail. `Orchestrator` ensures input is `.mov` with PCM, so it always has a stream (even if silent).
+  - `mixInputAudio: true` with no audio tracks -> Should map `0:a`.
+  - `mixInputAudio: false` (default) -> Should behave as before (ignore `0:a` if tracks exist).


### PR DESCRIPTION
Created a detailed spec file `2026-03-07-RENDERER-Distributed-Implicit-Audio.md` which outlines the changes required to ensure DOM-based implicit audio is not lost during the final concatenation and mixing phase of distributed rendering. This involves adding a `mixInputAudio` flag to `RendererOptions` and updating `FFmpegBuilder` to treat the input video as a mixable audio source.

---
*PR created automatically by Jules for task [2971284718882676489](https://jules.google.com/task/2971284718882676489) started by @BintzGavin*