### PR TITLE
📋 STUDIO: Persist Input Props

### DIFF
--- a/.jules/STUDIO.md
+++ b/.jules/STUDIO.md
@@ -57,3 +57,7 @@
 ## [0.93.2] - Ephemeral Render Config
 **Learning:** The `RenderConfig` in `StudioContext` was implemented as in-memory state only, causing users to lose complex FFmpeg settings (bitrate, codec) on every page reload. This gap in persistence significantly degrades the "IDE" experience.
 **Action:** For all configuration-heavy UIs (like Render Settings), state persistence via `localStorage` must be part of the MVP, not a follow-up.
+
+## [0.94.1] - Input Props Persistence
+**Learning:** While `composition.json` existed for metadata (fps, size), it did not store the most critical user configuration: input props. Users lost their work on reload. This was a vision gap in "WYSIWYG" editing.
+**Action:** Ensure all user-configurable state in the Studio (including props) is persisted to the project filesystem (`composition.json`) to serve as the single source of truth.

--- a/.sys/plans/2026-02-18-STUDIO-persist-input-props.md
+++ b/.sys/plans/2026-02-18-STUDIO-persist-input-props.md
@@ -1,0 +1,75 @@
+#### 1. Context & Goal
+- **Objective**: Allow users to save their tweaked input props as defaults for the composition, persisting them to `composition.json`.
+- **Trigger**: Currently, any changes made to input props in the Studio UI are lost upon page reload, breaking the "WYSIWYG" editor promise.
+- **Impact**: This unlocks a true "Studio" workflow where the UI can be used to permanently configure compositions, not just preview them. It improves the Developer Experience by removing the need to manually copy-paste JSON into files.
+
+#### 2. File Inventory
+- **Modify**: `packages/studio/src/server/templates/types.ts` (Update `CompositionOptions` interface to include `defaultProps`).
+- **Modify**: `packages/studio/src/context/StudioContext.tsx` (Update `CompositionMetadata` interface, handle `defaultProps` loading logic).
+- **Modify**: `packages/studio/src/components/PropsEditor.tsx` (Add "Save Defaults" button to `PropsToolbar`).
+- **Read-Only**: `packages/studio/src/server/discovery.ts` (Backend logic already supports merging metadata, but should be verified).
+
+#### 3. Implementation Spec
+- **Architecture**:
+  - The `composition.json` file serves as the source of truth for metadata. We will extend it to store `defaultProps`.
+  - The Backend (`discovery.ts`) already implements a generic merge strategy for metadata updates, so it likely requires no code changes if types are aligned.
+  - The Frontend (`StudioContext`) needs to:
+    1.  Awareness: Include `defaultProps` in the `CompositionMetadata` type.
+    2.  Hydration: When a composition is loaded (or controller connects), check `activeComposition.metadata.defaultProps`. If present, inject them into the Player via `controller.setInputProps()`.
+    3.  Persistence: Expose a way to save current props.
+  - The UI (`PropsEditor`) will add a "Save Defaults" button that invokes the persistence logic.
+
+- **Pseudo-Code**:
+  ```typescript
+  // packages/studio/src/server/templates/types.ts
+  export interface CompositionOptions {
+    // ... existing fields
+    defaultProps?: Record<string, any>;
+  }
+
+  // packages/studio/src/context/StudioContext.tsx
+  export interface CompositionMetadata {
+    // ... existing fields
+    defaultProps?: Record<string, any>;
+  }
+
+  // Inside StudioProvider
+  useEffect(() => {
+    // When composition or controller changes, if we have saved defaults, apply them
+    // Note: We should probably only do this once per composition load to avoid fighting the user
+    if (activeComposition?.metadata?.defaultProps && controller) {
+       // Logic to ensure we don't overwrite if the user has already started editing?
+       // For MVP: Apply on load. If HMR happens, maybe we re-apply?
+       // Ideally: Apply only if playerState.inputProps is empty or matching defaults?
+       // Simple approach: controller.setInputProps(metadata.defaultProps)
+    }
+  }, [activeComposition?.id, controller]); // Be careful with deps
+
+  const saveCompositionProps = async () => {
+     if (!activeComposition) return;
+     await updateCompositionMetadata(activeComposition.id, {
+       defaultProps: playerState.inputProps
+     });
+  }
+  ```
+
+- **Public API Changes**:
+  - `CompositionMetadata` and `CompositionOptions` types extended.
+
+- **Dependencies**:
+  - None.
+
+#### 4. Test Plan
+- **Verification**:
+  1.  Launch Studio: `npm run dev` in `packages/studio`.
+  2.  Select a composition.
+  3.  Modify an input prop in the Props Editor.
+  4.  Click the new "Save Defaults" button.
+  5.  Reload the browser page.
+  6.  Verify that the modified prop value is restored automatically.
+  7.  Inspect `examples/[composition]/composition.json` to confirm `defaultProps` field exists.
+- **Success Criteria**: Input props persist across a full page reload.
+- **Edge Cases**:
+  - `inputProps` containing complex objects (JSON).
+  - Saving when `composition.json` does not exist (should create it).
+  - Saving empty props.


### PR DESCRIPTION
Created specification for persisting input props in Helios Studio to `composition.json`. This ensures users do not lose their configuration changes upon page reload, fulfilling the "WYSIWYG" vision.

---
*PR created automatically by Jules for task [1960416553736707636](https://jules.google.com/task/1960416553736707636) started by @BintzGavin*