### PR TITLE
Verify Render Presets Implementation

### DIFF
--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.94.1
+- ✅ Verified: Render Presets - Added unit tests for RenderConfig and StudioContext persistence, ensuring robustness.
+
 ## STUDIO v0.94.0
 - ✅ Completed: Render Presets - Implemented render configuration presets (Draft, HD, 4K) and persistence for render settings.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.94.0
+**Version**: 0.94.1
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -126,3 +126,4 @@
 - [v0.2.0] ✅ Completed: Scaffold CLI Package - Created @helios-project/cli and studio command.
 - [v0.1.0] ✅ Completed: Scaffold Studio Package - Created package structure, config, and basic UI.
 - [2026-02-18] Initialized domain status and created scaffold plan.
+- [v0.94.1] ✅ Verified: Render Presets - Added unit tests for RenderConfig and StudioContext persistence, ensuring robustness.

--- a/packages/studio/src/components/RendersPanel/RenderConfig.test.tsx
+++ b/packages/studio/src/components/RendersPanel/RenderConfig.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { RenderConfig, type RenderConfigData } from './RenderConfig';
+
+describe('RenderConfig', () => {
+  const defaultConfig: RenderConfigData = {
+    mode: 'canvas',
+    concurrency: 1
+  };
+
+  const mockOnChange = vi.fn();
+
+  it('renders all config fields', () => {
+    render(<RenderConfig config={defaultConfig} onChange={mockOnChange} />);
+
+    expect(screen.getByText('Preset')).toBeInTheDocument();
+    expect(screen.getByText('Mode')).toBeInTheDocument();
+    expect(screen.getByText('Video Bitrate')).toBeInTheDocument();
+    expect(screen.getByText('Video Codec')).toBeInTheDocument();
+    expect(screen.getByText('Concurrency (Workers)')).toBeInTheDocument();
+  });
+
+  it('applies preset values when selected', () => {
+    render(<RenderConfig config={defaultConfig} onChange={mockOnChange} />);
+
+    const presetSelect = screen.getByRole('combobox', { name: /preset/i });
+
+    // Changing the select value
+    fireEvent.change(presetSelect, { target: { value: 'HD (1080p)' } });
+
+    expect(mockOnChange).toHaveBeenCalledWith(expect.objectContaining({
+      mode: 'canvas',
+      videoBitrate: '5000k',
+      videoCodec: 'libx264'
+    }));
+  });
+
+  it('detects active preset based on values', () => {
+    const hdConfig: RenderConfigData = {
+      mode: 'canvas',
+      videoBitrate: '5000k',
+      videoCodec: 'libx264',
+      concurrency: 1 // Concurrency isn't part of HD preset definition in the component, so it shouldn't affect matching if implementation ignores extras?
+      // Wait, let's check implementation:
+      // isMatch = Object.entries(preset).every(([key, value]) => config[key] === value);
+      // So extra keys in config don't matter.
+    };
+
+    render(<RenderConfig config={hdConfig} onChange={mockOnChange} />);
+
+    const presetSelect = screen.getAllByRole('combobox')[0] as HTMLSelectElement;
+    expect(presetSelect.value).toBe('HD (1080p)');
+  });
+
+  it('shows "Custom" when values do not match any preset', () => {
+    const customConfig: RenderConfigData = {
+      mode: 'canvas',
+      videoBitrate: '1234k', // Custom bitrate
+      videoCodec: 'libx264'
+    };
+
+    render(<RenderConfig config={customConfig} onChange={mockOnChange} />);
+
+    const presetSelect = screen.getAllByRole('combobox')[0] as HTMLSelectElement;
+    expect(presetSelect.value).toBe('Custom');
+  });
+
+  it('updates individual fields', () => {
+    render(<RenderConfig config={defaultConfig} onChange={mockOnChange} />);
+
+    const bitrateInput = screen.getByPlaceholderText('e.g. 5M, 1000k');
+    fireEvent.change(bitrateInput, { target: { value: '8000k' } });
+
+    expect(mockOnChange).toHaveBeenCalledWith({
+      ...defaultConfig,
+      videoBitrate: '8000k'
+    });
+  });
+});

--- a/packages/studio/src/components/RendersPanel/RenderConfig.tsx
+++ b/packages/studio/src/components/RendersPanel/RenderConfig.tsx
@@ -71,8 +71,9 @@ export const RenderConfig: React.FC<RenderConfigProps> = ({ config, onChange }) 
   return (
     <div className="render-config" style={{ padding: '8px', background: '#252526', borderRadius: '4px', marginBottom: '8px', border: '1px solid #333' }}>
       <div style={{ marginBottom: '8px' }}>
-        <label style={labelStyle}>Preset</label>
+        <label htmlFor="render-preset" style={labelStyle}>Preset</label>
         <select
+          id="render-preset"
           value={getActivePreset()}
           onChange={(e) => applyPreset(e.target.value)}
           style={inputStyle}
@@ -84,8 +85,9 @@ export const RenderConfig: React.FC<RenderConfigProps> = ({ config, onChange }) 
       </div>
 
       <div style={{ marginBottom: '8px' }}>
-        <label style={labelStyle}>Mode</label>
+        <label htmlFor="render-mode" style={labelStyle}>Mode</label>
         <select
+          id="render-mode"
           value={config.mode}
           onChange={(e) => handleChange('mode', e.target.value as 'canvas' | 'dom')}
           style={inputStyle}
@@ -96,8 +98,9 @@ export const RenderConfig: React.FC<RenderConfigProps> = ({ config, onChange }) 
       </div>
 
       <div style={{ marginBottom: '8px' }}>
-        <label style={labelStyle}>Video Bitrate</label>
+        <label htmlFor="render-bitrate" style={labelStyle}>Video Bitrate</label>
         <input
+          id="render-bitrate"
           type="text"
           placeholder="e.g. 5M, 1000k"
           value={config.videoBitrate || ''}
@@ -107,8 +110,9 @@ export const RenderConfig: React.FC<RenderConfigProps> = ({ config, onChange }) 
       </div>
 
       <div style={{ marginBottom: '8px' }}>
-        <label style={labelStyle}>Video Codec</label>
+        <label htmlFor="render-codec" style={labelStyle}>Video Codec</label>
         <input
+          id="render-codec"
           type="text"
           placeholder="e.g. libx264"
           value={config.videoCodec || ''}
@@ -118,8 +122,9 @@ export const RenderConfig: React.FC<RenderConfigProps> = ({ config, onChange }) 
       </div>
 
       <div style={{ marginBottom: '8px' }}>
-        <label style={labelStyle}>Concurrency (Workers)</label>
+        <label htmlFor="render-concurrency" style={labelStyle}>Concurrency (Workers)</label>
         <input
+          id="render-concurrency"
           type="number"
           min="1"
           max="32"


### PR DESCRIPTION
Added `RenderConfig.test.tsx` to verify UI logic for presets and fields.
Updated `StudioContext.test.tsx` to verify `renderConfig` persistence to `localStorage`.
Fixed accessibility issues in `RenderConfig.tsx` (missing labels/ids) identified during testing.

---
*PR created automatically by Jules for task [16485706125100560901](https://jules.google.com/task/16485706125100560901) started by @BintzGavin*