### PR TITLE
Enhance Keyboard Shortcuts & Fix Sandbox Getter

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.66.4
+- ✅ Completed: Enhance Keyboard Shortcuts & Fix Sandbox - Implemented standard shortcuts (Captions, Seek Home/End, 0-9) and fixed sandbox attribute behavior to support strict mode.
+
 ## PLAYER v0.66.3
 - ✅ Verified: Synced package.json version with status file and verified all tests pass.
 - ✅ Completed: Audio Track UI - Implemented audio menu in player controls to mute/unmute and adjust volume of individual audio tracks.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.66.3
+**Version**: v0.66.4
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -59,6 +59,7 @@
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.66.4] ✅ Completed: Enhance Keyboard Shortcuts & Fix Sandbox - Implemented standard shortcuts (Captions, Seek Home/End, 0-9) and fixed sandbox attribute behavior to support strict mode.
 [v0.66.3] ✅ Verified: Synced package.json version with status file and verified all tests pass.
 [v0.66.3] ✅ Completed: Audio Track UI - Implemented audio menu in player controls to mute/unmute and adjust volume of individual audio tracks.
 [v0.66.2] ✅ Completed: Handle Connection Timeouts - Implemented error state and event dispatching on connection timeout.

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -903,7 +903,8 @@ export class HeliosPlayer extends HTMLElement {
         this.setAttribute("preload", val);
     }
     get sandbox() {
-        return this.getAttribute("sandbox") || "allow-scripts allow-same-origin";
+        const val = this.getAttribute("sandbox");
+        return val === null ? "allow-scripts allow-same-origin" : val;
     }
     set sandbox(val) {
         this.setAttribute("sandbox", val);
@@ -1879,6 +1880,10 @@ export class HeliosPlayer extends HTMLElement {
                 e.preventDefault(); // Prevent scrolling
                 this.togglePlayPause();
                 break;
+            case "c":
+            case "C":
+                this.toggleCaptions();
+                break;
             case "f":
             case "F":
                 this.toggleFullscreen();
@@ -1898,6 +1903,18 @@ export class HeliosPlayer extends HTMLElement {
             case "j":
             case "J":
                 this.seekRelative(e.shiftKey ? -10 : -1);
+                break;
+            case "Home":
+                e.preventDefault();
+                this.controller.seek(0);
+                break;
+            case "End":
+                e.preventDefault();
+                {
+                    const s = this.controller.getState();
+                    const totalFrames = s.duration * s.fps;
+                    this.controller.seek(Math.floor(totalFrames));
+                }
                 break;
             case "m":
             case "M":
@@ -1935,6 +1952,17 @@ export class HeliosPlayer extends HTMLElement {
             case "x":
             case "X":
                 this.controller.clearPlaybackRange();
+                break;
+            default:
+                // Handle 0-9 seeking
+                if (e.key >= "0" && e.key <= "9") {
+                    e.preventDefault();
+                    const digit = parseInt(e.key, 10);
+                    const s = this.controller.getState();
+                    const totalFrames = s.duration * s.fps;
+                    // Seek to percentage: digit * 10%
+                    this.controller.seek(Math.floor(totalFrames * (digit / 10)));
+                }
                 break;
         }
     };

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -965,7 +965,8 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   }
 
   public get sandbox(): string {
-    return this.getAttribute("sandbox") || "allow-scripts allow-same-origin";
+    const val = this.getAttribute("sandbox");
+    return val === null ? "allow-scripts allow-same-origin" : val;
   }
 
   public set sandbox(val: string) {
@@ -2058,6 +2059,10 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
         e.preventDefault(); // Prevent scrolling
         this.togglePlayPause();
         break;
+      case "c":
+      case "C":
+        this.toggleCaptions();
+        break;
       case "f":
       case "F":
         this.toggleFullscreen();
@@ -2077,6 +2082,18 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
       case "j":
       case "J":
         this.seekRelative(e.shiftKey ? -10 : -1);
+        break;
+      case "Home":
+        e.preventDefault();
+        this.controller.seek(0);
+        break;
+      case "End":
+        e.preventDefault();
+        {
+          const s = this.controller.getState();
+          const totalFrames = s.duration * s.fps;
+          this.controller.seek(Math.floor(totalFrames));
+        }
         break;
       case "m":
       case "M":
@@ -2116,6 +2133,17 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
       case "x":
       case "X":
         this.controller.clearPlaybackRange();
+        break;
+      default:
+        // Handle 0-9 seeking
+        if (e.key >= "0" && e.key <= "9") {
+          e.preventDefault();
+          const digit = parseInt(e.key, 10);
+          const s = this.controller.getState();
+          const totalFrames = s.duration * s.fps;
+          // Seek to percentage: digit * 10%
+          this.controller.seek(Math.floor(totalFrames * (digit / 10)));
+        }
         break;
     }
   };

--- a/packages/player/src/interaction.test.ts
+++ b/packages/player/src/interaction.test.ts
@@ -39,4 +39,85 @@ describe('HeliosPlayer Interaction Fixes', () => {
     // Expect player to be focused
     expect(document.activeElement).toBe(player);
   });
+
+  it('should toggle captions when "c" is pressed', () => {
+    // Setup mock controller
+    const mockController = {
+        getState: vi.fn(() => ({ fps: 30, duration: 10, currentFrame: 0 })),
+        subscribe: vi.fn(() => () => {}),
+        onError: vi.fn(() => () => {}),
+        setAudioVolume: vi.fn(),
+        setAudioMuted: vi.fn(),
+        setLoop: vi.fn(),
+        pause: vi.fn(),
+        dispose: vi.fn(),
+    };
+    (player as any).controller = mockController;
+
+    const ccBtn = player.shadowRoot!.querySelector('.cc-btn');
+    expect(ccBtn?.classList.contains('active')).toBe(false);
+
+    player.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', bubbles: true }));
+    expect(ccBtn?.classList.contains('active')).toBe(true);
+
+    player.dispatchEvent(new KeyboardEvent('keydown', { key: 'C', bubbles: true }));
+    expect(ccBtn?.classList.contains('active')).toBe(false);
+  });
+
+  it('should seek to start when Home is pressed', () => {
+    const mockSeek = vi.fn();
+    const mockController = {
+        getState: vi.fn(() => ({ fps: 30, duration: 10, currentFrame: 100 })),
+        seek: mockSeek,
+        subscribe: vi.fn(() => () => {}),
+        onError: vi.fn(() => () => {}),
+        pause: vi.fn(),
+        dispose: vi.fn(),
+    };
+    (player as any).controller = mockController;
+
+    player.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(mockSeek).toHaveBeenCalledWith(0);
+  });
+
+  it('should seek to end when End is pressed', () => {
+    const mockSeek = vi.fn();
+    const mockController = {
+        getState: vi.fn(() => ({ fps: 30, duration: 10, currentFrame: 0 })), // 300 frames total
+        seek: mockSeek,
+        subscribe: vi.fn(() => () => {}),
+        onError: vi.fn(() => () => {}),
+        pause: vi.fn(),
+        dispose: vi.fn(),
+    };
+    (player as any).controller = mockController;
+
+    player.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(mockSeek).toHaveBeenCalledWith(300);
+  });
+
+  it('should seek to percentage when number keys are pressed', () => {
+    const mockSeek = vi.fn();
+    const mockController = {
+        getState: vi.fn(() => ({ fps: 30, duration: 10, currentFrame: 0 })), // 300 frames total
+        seek: mockSeek,
+        subscribe: vi.fn(() => () => {}),
+        onError: vi.fn(() => () => {}),
+        pause: vi.fn(),
+        dispose: vi.fn(),
+    };
+    (player as any).controller = mockController;
+
+    // Press '0' -> 0% -> frame 0
+    player.dispatchEvent(new KeyboardEvent('keydown', { key: '0', bubbles: true }));
+    expect(mockSeek).toHaveBeenCalledWith(0);
+
+    // Press '5' -> 50% -> frame 150
+    player.dispatchEvent(new KeyboardEvent('keydown', { key: '5', bubbles: true }));
+    expect(mockSeek).toHaveBeenCalledWith(150);
+
+    // Press '9' -> 90% -> frame 270
+    player.dispatchEvent(new KeyboardEvent('keydown', { key: '9', bubbles: true }));
+    expect(mockSeek).toHaveBeenCalledWith(270);
+  });
 });

--- a/packages/player/src/sandbox.test.ts
+++ b/packages/player/src/sandbox.test.ts
@@ -52,6 +52,8 @@ describe('HeliosPlayer Sandbox', () => {
     const iframe = player.shadowRoot!.querySelector('iframe');
     // Attribute exists but is empty
     expect(iframe?.getAttribute('sandbox')).toBe('');
+    // Getter should return empty string, not default
+    expect(player.sandbox).toBe('');
   });
 
   it('should reload iframe when sandbox attribute changes if src is present', () => {


### PR DESCRIPTION
Implemented standard keyboard shortcuts (Captions, Seek Home/End, 0-9) and fixed `sandbox` getter for strict mode support. Verified with unit tests.

---
*PR created automatically by Jules for task [13125922418158341622](https://jules.google.com/task/13125922418158341622) started by @BintzGavin*