### PR TITLE
✨ CLI: Remote Registry Support

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -21,3 +21,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.6.0] - Registry Architecture
 **Learning:** The existing component registry was hardcoded in `manifest.ts` (V1 MVP), conflicting with the V2 "Shadcn-style" vision which requires dynamic/remote fetching.
 **Action:** Created plan `2026-03-01-CLI-Remote-Registry.md` to decouple the registry. Future implementations must prioritize externalizing data sources over embedding them in the binary.
+
+## [0.7.0] - Remote Data Validation
+**Learning:** Fetching data from a remote registry introduced risks of runtime crashes (e.g., trying to iterate over an error object). Simple `res.json()` is insufficient.
+**Action:** Always validate the structure of remote data (e.g., `Array.isArray()`) before consuming it, and handle timeouts to prevent CLI hangs.

--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -1,155 +1,90 @@
-# CLI Domain Context
+# CLI Context
 
 ## A. Architecture
 
-The Helios CLI (`@helios-project/cli`) is the primary command-line interface for the Helios video engine. It is built with Commander.js and serves as the entry point for:
+The Helios CLI is the primary interface for managing Helios projects, rendering compositions, and interacting with the component registry. It is built with `commander` and compiled to a Node.js binary.
 
-- Launching Helios Studio
-- Managing the component registry (V2)
-- Triggering rendering workflows (V2)
-- Project scaffolding (V2)
-
-The CLI follows a subcommand pattern where each command is implemented in a separate file and registered with the main program.
+**Key Components:**
+- **Entry Point**: `bin/helios.js` (shebang) calls `dist/index.js`.
+- **Command Registration**: `src/index.ts` initializes the program and registers commands from `src/commands/`.
+- **Registry Client**: `src/registry/client.ts` handles component fetching (remote with local fallback).
+- **Utilities**: `src/utils/` contains helpers for config loading (`config.ts`) and installation logic (`install.ts`).
 
 ## B. File Tree
 
 ```
 packages/cli/
 ├── bin/
-│   └── helios.js           # Shebang entry point
+│   └── helios.js           # Executable entry point
 ├── src/
+│   ├── index.ts            # Main application setup
 │   ├── commands/
-│   │   ├── add.ts          # helios add command
-│   │   ├── components.ts   # helios components command
-│   │   ├── init.ts         # helios init command
-│   │   ├── merge.ts        # helios merge command
-│   │   ├── render.ts       # helios render command
-│   │   └── studio.ts       # helios studio command
+│   │   ├── add.ts          # 'helios add' command
+│   │   ├── components.ts   # 'helios components' command
+│   │   ├── init.ts         # 'helios init' command
+│   │   ├── merge.ts        # 'helios merge' command
+│   │   ├── render.ts       # 'helios render' command
+│   │   └── studio.ts       # 'helios studio' command
 │   ├── registry/
-│   │   ├── manifest.ts     # Component registry definitions
-│   │   └── types.ts        # Registry types
-│   ├── templates/
-│   │   └── basic.ts        # Project scaffolding templates
-│   ├── utils/
-│   │   └── config.ts       # Config loading and types
-│   └── index.ts            # Main CLI setup
-├── package.json
-└── tsconfig.json
+│   │   ├── client.ts       # RegistryClient implementation
+│   │   ├── manifest.ts     # Local fallback registry data
+│   │   └── types.ts        # Registry type definitions
+│   └── utils/
+│       ├── config.ts       # Config file loader
+│       └── install.ts      # Component installation logic
+└── package.json
 ```
 
 ## C. Commands
 
-### `helios studio`
+### `helios init [options]`
+Initializes a new Helios project configuration and scaffolds structure if missing.
+- **Options**:
+  - `-y, --yes`: Skip prompts and use defaults.
 
-Launches the Helios Studio development server.
-
-```bash
-helios studio
-```
-
-- Spawns `npm run dev` in the `packages/studio` directory
-- Sets `HELIOS_PROJECT_ROOT` environment variable to the current working directory
-
-### `helios init`
-
-Initializes a new Helios project.
-
-```bash
-helios init
-```
-
-Options:
-- `-y, --yes`: Skip prompts and use defaults
-
-Behavior:
-1. Checks for `package.json`. If missing, prompts to scaffold a new React+Vite+Helios project structure.
-2. Checks for `helios.config.json`. If missing, prompts for configuration (component directory, etc.) or uses defaults if scaffolded.
-
-### `helios add`
-
-Adds a component to the project from the embedded registry.
-
-```bash
-helios add <component>
-```
-
-- Installs component source code and dependencies into the configured `components` directory.
-- Requires `helios.config.json` to exist.
+### `helios add <component>`
+Adds a component (and its dependencies) to the project.
+- **Arguments**:
+  - `component`: Name of the component to install.
 
 ### `helios components`
-
 Lists available components in the registry.
 
-```bash
-helios components
-```
+### `helios studio [options]`
+Launches the Helios Studio development server.
+- **Options**:
+  - `-p, --port <number>`: Port to run on (default: 3000).
 
-- Lists component names and types (e.g., `timer (react)`).
+### `helios render [options]`
+Renders a composition to video using `@helios-project/renderer`.
+- **Options**:
+  - `-c, --composition <id>`: Composition ID to render.
+  - `-o, --output <path>`: Output file path.
+  - `--start-frame <number>`: Start frame (inclusive).
+  - `--frame-count <number>`: Number of frames to render.
 
-### `helios render`
-
-Renders a composition to video using the underlying `@helios-project/renderer`.
-
-```bash
-helios render [options] <input>
-```
-
-Options:
-- `-o, --output <path>`: Output file path (default: "output.mp4")
-- `--width <number>`: Viewport width (default: 1920)
-- `--height <number>`: Viewport height (default: 1080)
-- `--fps <number>`: Frames per second (default: 30)
-- `--duration <number>`: Duration in seconds (default: 1)
-- `--quality <number>`: CRF quality (0-51)
-- `--mode <mode>`: Render mode (canvas or dom) (default: "canvas")
-- `--start-frame <number>`: Frame to start rendering from
-- `--frame-count <number>`: Number of frames to render
-- `--no-headless`: Run in visible browser window (default: headless)
-
-### `helios merge`
-
-Merges multiple video files into one without re-encoding.
-
-```bash
-helios merge <output> [inputs...]
-```
-
-- Uses `@helios-project/renderer`'s `concatenateVideos` function (FFmpeg concat demuxer).
+### `helios merge <output> [inputs...]`
+Merges multiple video files into a single output without re-encoding.
+- **Arguments**:
+  - `output`: Output filename.
+  - `inputs`: List of input video files.
 
 ## D. Configuration
 
-The CLI uses `helios.config.json` for project configuration. Configuration logic is centralized in `src/utils/config.ts`.
+The CLI reads `helios.config.json` in the project root.
 
-- **directories.components**: Target directory for installed components
-- **directories.lib**: Location of the library directory
-
-## E. Integration
-
-- **Studio**: The `studio` command launches `@helios-project/studio` via npm
-- **Registry**: Integrates with embedded component registry for `add` and `components` commands
-- **Renderer**: Integrates with `@helios-project/renderer` for `render` command
-
-## F. Command Pattern
-
-Each command is implemented as:
-
-```typescript
-// src/commands/[name].ts
-import { Command } from 'commander';
-
-export function register[Name]Command(program: Command) {
-  program
-    .command('[name]')
-    .description('[description]')
-    .action(async () => {
-      // Implementation
-    });
+**Example `helios.config.json`:**
+```json
+{
+  "directories": {
+    "components": "src/components",
+    "output": "output"
+  }
 }
 ```
 
-Commands are registered in `src/index.ts`:
+## E. Integration
 
-```typescript
-import { register[Name]Command } from './commands/[name].js';
-register[Name]Command(program);
-```
+- **Registry**: Uses `RegistryClient` to fetch components from `HELIOS_REGISTRY_URL` (env var) or falls back to internal manifest.
+- **Renderer**: Invokes `@helios-project/renderer` for rendering tasks.
+- **Studio**: Spawns `@helios-project/studio` for the UI.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.7.0
+
+- ✅ Remote Registry Support - Implemented `RegistryClient` to fetch components from a remote URL with local fallback
+
 ## CLI v0.6.0
 
 - ✅ Implement Merge Command - Implemented `helios merge` command to stitch multiple video files into a single output without re-encoding

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### CLI v0.7.0
+- ✅ Completed: Remote Registry Support - Implemented `RegistryClient` to fetch components from a remote URL with local fallback.
+
 ### CLI v0.6.0
 - ✅ Completed: Implement Merge Command - Implemented `helios merge` command to stitch multiple video files into a single output without re-encoding.
 - **DOCS**: Update `docs/PROGRESS-DOCS.md`

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.6.0
+**Version**: 0.7.0
 
 ## Current State
 
@@ -42,3 +42,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.5.1] ✅ Fix Registry Components - Updated component registry to use V2 Helios Signals (`fps.value`, `duration.value`)
 [v0.5.2] ✅ Project Scaffolding - Updated `helios init` to scaffold a full React+Vite project structure when `package.json` is missing
 [v0.6.0] ✅ Implement Merge Command - Implemented `helios merge` for stitching video clips
+[v0.7.0] ✅ Remote Registry Support - Implemented `RegistryClient` to fetch components from a remote URL with local fallback

--- a/packages/cli/src/commands/components.ts
+++ b/packages/cli/src/commands/components.ts
@@ -1,19 +1,21 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { registry } from '../registry/manifest.js';
+import { defaultClient } from '../registry/client.js';
 
 export function registerComponentsCommand(program: Command) {
   program
     .command('components')
     .description('List available components')
-    .action(() => {
-      if (registry.length === 0) {
+    .action(async () => {
+      const components = await defaultClient.getComponents();
+
+      if (components.length === 0) {
         console.log(chalk.yellow('No components found in registry.'));
         return;
       }
 
       console.log(chalk.bold('Available components:'));
-      for (const component of registry) {
+      for (const component of components) {
         console.log(` - ${chalk.cyan(component.name)} ${chalk.gray(`(${component.type})`)}`);
       }
     });

--- a/packages/cli/src/registry/client.ts
+++ b/packages/cli/src/registry/client.ts
@@ -1,0 +1,43 @@
+import { registry as localRegistry } from './manifest.js';
+import { ComponentDefinition } from './types.js';
+
+export class RegistryClient {
+  private url: string | undefined;
+
+  constructor(url?: string) {
+    this.url = url || process.env.HELIOS_REGISTRY_URL;
+  }
+
+  async getComponents(): Promise<ComponentDefinition[]> {
+    if (this.url) {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+        try {
+          const res = await fetch(this.url, { signal: controller.signal });
+          if (res.ok) {
+            const data = await res.json();
+            if (Array.isArray(data)) {
+               return data as ComponentDefinition[];
+            } else {
+               console.warn('Remote registry response is not an array, falling back to local.');
+            }
+          }
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      } catch (e) {
+        console.warn('Failed to fetch remote registry (or timed out), falling back to local.');
+      }
+    }
+    return localRegistry;
+  }
+
+  async findComponent(name: string): Promise<ComponentDefinition | undefined> {
+    const components = await this.getComponents();
+    return components.find(c => c.name === name);
+  }
+}
+
+export const defaultClient = new RegistryClient();

--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import { loadConfig } from './config.js';
-import { findComponent } from '../registry/manifest.js';
+import { defaultClient } from '../registry/client.js';
 
 export async function installComponent(rootDir: string, componentName: string) {
   const config = loadConfig(rootDir);
@@ -11,7 +11,7 @@ export async function installComponent(rootDir: string, componentName: string) {
     throw new Error('Configuration file not found. Run "helios init" first.');
   }
 
-  const component = findComponent(componentName);
+  const component = await defaultClient.findComponent(componentName);
   if (!component) {
     throw new Error(`Component "${componentName}" not found in registry.`);
   }


### PR DESCRIPTION
💡 **What**: Implemented `RegistryClient` to support fetching components from a remote URL defined by `HELIOS_REGISTRY_URL`, with a fallback to the internal `manifest.ts`.

🎯 **Why**: To support the V2 vision of a dynamic, "Shadcn-style" component registry that can be updated independently of the CLI binary.

📊 **Impact**: allows users (and the team) to host custom or updated registries.

🔬 **Verification**:
- Ran `helios components` with default env -> listed local components.
- Ran `HELIOS_REGISTRY_URL=... helios components` -> attempted fetch, fell back to local on failure (verified via log message).
- Verified `helios add` still works.
- Built `packages/cli` successfully.

---
*PR created automatically by Jules for task [11232262424358912710](https://jules.google.com/task/11232262424358912710) started by @BintzGavin*