### PR TITLE
Audio Metering Bridge

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -49,6 +49,7 @@ The `<helios-player>` component dispatches standard HTMLMediaElement events and 
 - `enterpictureinpicture`: Entered PiP mode.
 - `leavepictureinpicture`: Left PiP mode.
 - `cuechange`: Active cues changed (dispatched by TextTrack, but bubbles or handled).
+- `audiometering`: Audio metering data available (custom event with `detail: AudioLevels`).
 
 ## C. Attributes
 The component observes or reads the following attributes:
@@ -84,5 +85,5 @@ The component observes or reads the following attributes:
 The `HeliosPlayer` class exposes properties and methods closely mirroring `HTMLMediaElement`:
 
 - **Properties**: `currentTime`, `duration`, `paused`, `ended`, `volume`, `muted`, `playbackRate`, `src`, `currentSrc`, `error`, `readyState`, `networkState`, `buffered`, `seekable`, `played`, `videoWidth`, `videoHeight`, `textTracks`, `audioTracks`, `videoTracks`, `disablePictureInPicture`, `inputProps`.
-- **Methods**: `play()`, `pause()`, `load()`, `addTextTrack()`, `requestPictureInPicture()`, `diagnose()`.
+- **Methods**: `play()`, `pause()`, `load()`, `addTextTrack()`, `requestPictureInPicture()`, `diagnose()`, `startAudioMetering()`, `stopAudioMetering()`.
 - **Getters**: `getController()` (Returns internal controller instance).

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.66.5
+**Version**: v0.67.0
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -50,15 +50,17 @@
 - Supports auto-enabling of captions if a track is marked as `default`.
 - Supports audio fade-in/out in client-side export via `data-helios-fade-in` and `data-helios-fade-out` attributes.
 - Supports Shadow DOM Export: DOM-based client-side export now correctly captures Shadow DOM content (via Declarative Shadow DOM transformation), enabling support for Web Components in exports.
-- Supports Environment Diagnostics UI: Implemented `diagnose()` method in `HeliosController` and a visible Diagnostics UI overlay in `<helios-player>` (toggled via `Shift+D`) to expose environment capabilities (WebCodecs, WebGL, etc.) to the user.
+- Supports Environment Diagnostics UI: Implemented `diagnose()` method in `HeliosController` and a visible Diagnostics UI overlay in `<helios-player>` (toggled via `Shift+D`) to expose environment capabilities (WebCodecs, etc.) to the user.
 - Supports Headless Audio Export: Client-side export now includes audio tracks manually injected into Helios state (`availableAudioTracks`), enabling headless audio rendering without DOM elements.
 - Supports Dynamic Composition Updates: Exposes `setDuration`, `setFps`, `setSize`, and `setMarkers` via `HeliosController` (and Bridge), allowing host applications (like Studio) to update the composition structure dynamically.
 - Supports Export Filename: Implemented `export-filename` attribute to allow specifying the filename for client-side exports.
 - Supports Active Cues: Implemented `activeCues` property and `cuechange` event on `HeliosTextTrack` for Standard Media API parity.
+- **Audio Metering**: Supports real-time audio metering via `startAudioMetering()` API and `audiometering` event, enabling visualization of audio levels (stereo/peak) in host applications.
 
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.67.0] ✅ Completed: Audio Metering Bridge - Implemented real-time audio metering system exposing stereo RMS and Peak levels via `audiometering` event and Bridge protocol.
 [v0.66.5] ✅ Completed: Smart PiP Visibility - Implemented auto-hiding of Picture-in-Picture button when environment lacks support or `export-mode="dom"` is active.
 [v0.66.4] ✅ Completed: Enhance Keyboard Shortcuts & Fix Sandbox - Implemented standard shortcuts (Captions, Seek Home/End, 0-9) and fixed sandbox attribute behavior to support strict mode.
 [v0.66.3] ✅ Verified: Synced package.json version with status file and verified all tests pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10606,7 +10606,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.66.3",
+      "version": "0.66.5",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^5.8.0",

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -197,6 +197,8 @@ export declare class HeliosPlayer extends HTMLElement implements TrackHost, Audi
     getController(): HeliosController | null;
     getSchema(): Promise<HeliosSchema | undefined>;
     diagnose(): Promise<DiagnosticReport>;
+    startAudioMetering(): void;
+    stopAudioMetering(): void;
     private retryConnection;
     private renderClientSide;
 }

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -1707,6 +1707,9 @@ export class HeliosPlayer extends HTMLElement {
             this.updateUI(state);
         }
         const unsubState = this.controller.subscribe((s) => this.updateUI(s));
+        const unsubMetering = this.controller.onAudioMetering((levels) => {
+            this.dispatchEvent(new CustomEvent('audiometering', { detail: levels }));
+        });
         const unsubError = this.controller.onError((err) => {
             const message = err.message || String(err);
             this._error = {
@@ -1726,6 +1729,7 @@ export class HeliosPlayer extends HTMLElement {
         this.unsubscribe = () => {
             unsubState();
             unsubError();
+            unsubMetering();
         };
         if (this.hasAttribute("autoplay")) {
             this.controller.play();
@@ -2192,6 +2196,16 @@ export class HeliosPlayer extends HTMLElement {
             throw new Error("Cannot run diagnostics: Player is not connected.");
         }
         return this.controller.diagnose();
+    }
+    startAudioMetering() {
+        if (this.controller) {
+            this.controller.startAudioMetering();
+        }
+    }
+    stopAudioMetering() {
+        if (this.controller) {
+            this.controller.stopAudioMetering();
+        }
     }
     retryConnection() {
         this.showStatus("Retrying...", false);

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -240,7 +240,7 @@ describe('HeliosPlayer API Parity', () => {
       setInputProps: vi.fn(), setCaptions: vi.fn(),
       setAudioMuted: vi.fn(),
       setAudioVolume: vi.fn(),
-      setPlaybackRate: vi.fn(),
+      setPlaybackRate: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
     };
     (player as any).setController(mockController);
 

--- a/packages/player/src/captions.test.ts
+++ b/packages/player/src/captions.test.ts
@@ -39,7 +39,11 @@ describe('HeliosPlayer Captions', () => {
       dispose: vi.fn(),
       captureFrame: vi.fn(),
       getAudioTracks: vi.fn(),
-      getSchema: vi.fn()
+      getSchema: vi.fn(),
+      startAudioMetering: vi.fn(),
+      stopAudioMetering: vi.fn(),
+      onAudioMetering: vi.fn().mockReturnValue(() => {}),
+      diagnose: vi.fn()
     };
 
     // Create Player

--- a/packages/player/src/features/audio-menu.test.ts
+++ b/packages/player/src/features/audio-menu.test.ts
@@ -57,7 +57,7 @@ describe('Audio Menu Accessibility', () => {
         setPlaybackRange: vi.fn(),
         clearPlaybackRange: vi.fn(),
         captureFrame: vi.fn(),
-        getAudioTracks: vi.fn()
+        getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
     };
     (player as any).setController(mockController);
   });

--- a/packages/player/src/features/audio-metering.ts
+++ b/packages/player/src/features/audio-metering.ts
@@ -1,0 +1,141 @@
+export interface AudioLevels {
+  left: number;
+  right: number;
+  peakLeft: number;
+  peakRight: number;
+}
+
+export class AudioMeter {
+  private ctx: AudioContext;
+  private splitter: ChannelSplitterNode;
+  private analyserLeft: AnalyserNode;
+  private analyserRight: AnalyserNode;
+  private dataArrayLeft: Float32Array;
+  private dataArrayRight: Float32Array;
+  private sources: Map<HTMLMediaElement, MediaElementAudioSourceNode> = new Map();
+  private elementListeners: Map<HTMLMediaElement, { listener: () => void, gainNode: GainNode }> = new Map();
+
+  constructor() {
+    const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
+    this.ctx = new AudioContextClass();
+    this.splitter = this.ctx.createChannelSplitter(2);
+    this.analyserLeft = this.ctx.createAnalyser();
+    this.analyserRight = this.ctx.createAnalyser();
+
+    // Use a small buffer for responsiveness
+    this.analyserLeft.fftSize = 256;
+    this.analyserRight.fftSize = 256;
+
+    this.dataArrayLeft = new Float32Array(this.analyserLeft.fftSize);
+    this.dataArrayRight = new Float32Array(this.analyserRight.fftSize);
+
+    this.splitter.connect(this.analyserLeft, 0);
+    this.splitter.connect(this.analyserRight, 1);
+  }
+
+  connect(doc: Document) {
+    if (this.ctx.state === 'suspended') {
+      this.ctx.resume().catch(e => console.warn("AudioMeter: Failed to resume context", e));
+    }
+
+    const mediaElements = Array.from(doc.querySelectorAll('audio, video')) as HTMLMediaElement[];
+
+    mediaElements.forEach(el => {
+      if (this.sources.has(el)) return;
+
+      try {
+        // Create source
+        const source = this.ctx.createMediaElementSource(el);
+        const gainNode = this.ctx.createGain();
+
+        // Sync initial state
+        gainNode.gain.value = el.muted ? 0 : el.volume;
+
+        // Create listener
+        const listener = () => {
+            try {
+                gainNode.gain.value = el.muted ? 0 : el.volume;
+            } catch (e) {
+                // Ignore if disconnected
+            }
+        };
+        el.addEventListener('volumechange', listener);
+
+        // Store for cleanup
+        this.elementListeners.set(el, { listener, gainNode });
+
+        // Metering path (Pre-fader to visualize activity even if muted)
+        source.connect(this.splitter);
+
+        // Playback path (Post-fader to respect volume controls)
+        source.connect(gainNode);
+        gainNode.connect(this.ctx.destination);
+
+        this.sources.set(el, source);
+      } catch (e) {
+        // This often happens if the element is already connected to another context
+        // or if there's a CORS issue (though CORS usually just gives silence)
+        console.warn('AudioMeter: Failed to connect element', e);
+      }
+    });
+  }
+
+  getLevels(): AudioLevels {
+    this.analyserLeft.getFloatTimeDomainData(this.dataArrayLeft as any);
+    this.analyserRight.getFloatTimeDomainData(this.dataArrayRight as any);
+
+    return {
+      left: this.calculateRMS(this.dataArrayLeft),
+      right: this.calculateRMS(this.dataArrayRight),
+      peakLeft: this.calculatePeak(this.dataArrayLeft),
+      peakRight: this.calculatePeak(this.dataArrayRight)
+    };
+  }
+
+  private calculateRMS(data: Float32Array): number {
+    let sum = 0;
+    for (let i = 0; i < data.length; i++) {
+      sum += data[i] * data[i];
+    }
+    return Math.sqrt(sum / data.length);
+  }
+
+  private calculatePeak(data: Float32Array): number {
+    let max = 0;
+    for (let i = 0; i < data.length; i++) {
+      const val = Math.abs(data[i]);
+      if (val > max) max = val;
+    }
+    return max;
+  }
+
+  dispose() {
+    this.elementListeners.forEach(({ listener, gainNode }, el) => {
+        el.removeEventListener('volumechange', listener);
+        try {
+            gainNode.disconnect();
+        } catch (e) {
+            // ignore
+        }
+    });
+    this.elementListeners.clear();
+
+    this.sources.forEach(source => {
+        try {
+            source.disconnect();
+        } catch (e) {
+            // ignore
+        }
+    });
+    this.sources.clear();
+
+    try {
+        this.splitter.disconnect();
+        this.analyserLeft.disconnect();
+        this.analyserRight.disconnect();
+        this.ctx.close();
+    } catch (e) {
+        console.warn("AudioMeter: Error during dispose", e);
+    }
+  }
+}

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -69,12 +69,12 @@ describe('HeliosPlayer', () => {
         onError: vi.fn().mockReturnValue(() => {}),
         dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
-        setAudioVolume: vi.fn(),
+        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn()
+        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
     };
 
     // Inject controller (using private access workaround)
@@ -115,12 +115,12 @@ describe('HeliosPlayer', () => {
         onError: vi.fn().mockReturnValue(() => {}),
         dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
-        setAudioVolume: vi.fn(),
+        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn()
+        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
     };
 
     // Inject controller (using private access workaround)
@@ -206,8 +206,8 @@ describe('HeliosPlayer', () => {
         dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn(),
-        setAudioVolume: vi.fn(),
+        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn()
@@ -277,12 +277,12 @@ describe('HeliosPlayer', () => {
         onError: vi.fn().mockReturnValue(() => {}),
         dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
-        setAudioVolume: vi.fn(),
+        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn()
+        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
     };
     (player as any).setController(mockController);
 
@@ -356,12 +356,12 @@ describe('HeliosPlayer', () => {
       onError: vi.fn().mockReturnValue(() => {}),
       dispose: vi.fn(), setCaptions: vi.fn(),
       setPlaybackRate: vi.fn(),
-      setAudioVolume: vi.fn(),
+      setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
       setAudioMuted: vi.fn(),
       setInputProps: vi.fn(),
       setLoop: vi.fn(),
       setPlaybackRange: vi.fn(),
-      clearPlaybackRange: vi.fn()
+      clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
     };
     (player as any).setController(mockController);
 
@@ -409,12 +409,12 @@ describe('HeliosPlayer', () => {
             onError: vi.fn().mockReturnValue(() => {}),
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn()
+            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -534,10 +534,10 @@ describe('HeliosPlayer', () => {
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
         setAudioMuted: vi.fn(),
-        setAudioVolume: vi.fn(),
+        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn()
+        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -624,12 +624,12 @@ describe('HeliosPlayer', () => {
         onError: vi.fn().mockReturnValue(() => {}),
         dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
-        setAudioVolume: vi.fn(),
+        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn()
+        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
       };
       (player as any).setController(mockController);
 
@@ -658,12 +658,12 @@ describe('HeliosPlayer', () => {
         onError: vi.fn().mockReturnValue(() => {}),
         dispose: vi.fn(), setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
-        setAudioVolume: vi.fn(),
+        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn()
+        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
       };
       (player as any).setController(mockController);
 
@@ -693,12 +693,12 @@ describe('HeliosPlayer', () => {
             onError: vi.fn().mockReturnValue(() => {}),
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn()
+            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
         (player as any).setController(mockController);
 
@@ -737,12 +737,12 @@ describe('HeliosPlayer', () => {
             onError: vi.fn().mockReturnValue(() => {}),
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn()
+            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
         (player as any).setController(mockController);
 
@@ -778,11 +778,11 @@ describe('HeliosPlayer', () => {
             onError: vi.fn().mockReturnValue(() => {}),
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
-            getAudioTracks: vi.fn()
+            getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -868,7 +868,7 @@ describe('HeliosPlayer', () => {
             play: vi.fn(),
             pause: vi.fn(),
             seek: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
@@ -876,7 +876,7 @@ describe('HeliosPlayer', () => {
             dispose: vi.fn(), setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
-            getAudioTracks: vi.fn()
+            getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
         (player as any).setController(mockController);
         (player as any).isLoaded = true;
@@ -1050,7 +1050,7 @@ describe('HeliosPlayer', () => {
             play: vi.fn(),
             pause: vi.fn(),
             seek: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
@@ -1058,7 +1058,7 @@ describe('HeliosPlayer', () => {
             dispose: vi.fn(), setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
-            getAudioTracks: vi.fn()
+            getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
         // Reset player pending props
         player.inputProps = null;
@@ -1123,11 +1123,11 @@ describe('HeliosPlayer', () => {
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
         setInputProps: vi.fn(),
-        setAudioVolume: vi.fn(),
+        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn()
+        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
     });
 
@@ -1238,7 +1238,7 @@ describe('HeliosPlayer', () => {
             play: vi.fn(),
             pause: vi.fn(),
             seek: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
@@ -1246,7 +1246,7 @@ describe('HeliosPlayer', () => {
             dispose: vi.fn(), setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
-            getAudioTracks: vi.fn()
+            getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
     });
 
@@ -1289,14 +1289,14 @@ describe('HeliosPlayer', () => {
             onError: vi.fn().mockReturnValue(() => {}),
             dispose: vi.fn(), setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(),
+            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             captureFrame: vi.fn(),
-            getAudioTracks: vi.fn()
+            getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -1373,10 +1373,10 @@ describe('HeliosPlayer', () => {
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn()
+            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
     });
 
@@ -1519,10 +1519,10 @@ describe('HeliosPlayer', () => {
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn()
+            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -1597,10 +1597,10 @@ describe('HeliosPlayer', () => {
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn(),
-            setAudioVolume: vi.fn(),
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn()
+            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -1721,7 +1721,7 @@ describe('HeliosPlayer', () => {
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn(),
-            setAudioVolume: vi.fn()
+            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
         };
     });
 


### PR DESCRIPTION
Implemented audio metering in `packages/player`:
- Added `AudioMeter` class in `features/audio-metering.ts` using Web Audio API.
- Updated `HeliosController` interface and implementations (`DirectController`, `BridgeController`) to support `startAudioMetering`, `stopAudioMetering`, and `onAudioMetering`.
- Updated `bridge.ts` to handle `HELIOS_START_METERING` / `HELIOS_STOP_METERING` messages and broadcast `HELIOS_AUDIO_LEVELS`.
- Updated `HeliosPlayer` component to expose public metering API and dispatch `audiometering` CustomEvent.
- Updated documentation and status file.
- Addressed code review feedback:
    - Fixed volume/mute bypass issue by routing source through a synchronized GainNode to destination.
    - Updated selector to include `<video>` elements.
    - Updated tests to mock new controller methods.

---
*PR created automatically by Jules for task [5788831465545521148](https://jules.google.com/task/5788831465545521148) started by @BintzGavin*