### PR TITLE
✨ STUDIO: Persist Input Props

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -45,7 +45,7 @@ Options:
 -   **Sidebar**: Navigation tabs (Compositions, Assets, Components, Captions, Audio, Renders).
 -   **Stage**: Main preview area containing `<helios-player>`.
 -   **Timeline**: Track-based timeline for scrubbing and editing (Stacked Audio Tracks).
--   **PropsEditor**: Form for editing composition input props (`HeliosSchema`).
+-   **PropsEditor**: Form for editing composition input props (`HeliosSchema`) with auto-save persistence.
 -   **RendersPanel**: Configures and manages render jobs.
     -   **RenderConfig**: Settings for Mode, Bitrate, Codec, Concurrency (with Presets).
 -   **AssetsPanel**: Drag-and-drop asset management.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.95.0
+- ✅ Completed: Persist Input Props - Implemented auto-saving of user-configured input props to `composition.json`, ensuring persistence across reloads.
+
 ## STUDIO v0.94.3
 - ✅ Fixed: Concurrency Input - Fixed concurrency input validation in Render Config, ensuring values are clamped between 1 and 32.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.94.3
+**Version**: 0.95.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.95.0] ✅ Completed: Persist Input Props - Implemented auto-saving of user-configured input props to `composition.json`, ensuring persistence across reloads.
 - [v0.94.3] ✅ Fixed: Concurrency Input - Fixed concurrency input validation in Render Config, ensuring values are clamped between 1 and 32.
 - [v0.94.2] ✅ Verified: Stacked Timeline - Verified implementation of multi-lane stacked timeline with existing unit tests `Timeline.test.tsx`.
 - [v0.94.1] ✅ Verified: Render Presets - Added unit tests for RenderConfig and StudioContext persistence, ensuring robustness.

--- a/packages/studio/src/components/PropsEditor.tsx
+++ b/packages/studio/src/components/PropsEditor.tsx
@@ -41,8 +41,34 @@ const PropsToolbar: React.FC<{
 };
 
 export const PropsEditor: React.FC = () => {
-  const { controller, playerState } = useStudio();
+  const { controller, playerState, activeComposition, updateCompositionMetadata } = useStudio();
   const { inputProps, schema } = playerState;
+
+  // Auto-save input props to composition metadata
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (activeComposition && inputProps && Object.keys(inputProps).length > 0) {
+        const currentDefaults = activeComposition.metadata?.defaultProps;
+        // Only save if changed to avoid infinite loops/unnecessary writes
+        if (JSON.stringify(currentDefaults) !== JSON.stringify(inputProps)) {
+          // Ensure we preserve existing metadata
+          const metadata = activeComposition.metadata || {
+            width: 1920,
+            height: 1080,
+            fps: 30,
+            duration: 10
+          };
+
+          updateCompositionMetadata(activeComposition.id, {
+            ...metadata,
+            defaultProps: inputProps
+          });
+        }
+      }
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [inputProps, activeComposition, updateCompositionMetadata]);
 
   const groupedProps = useMemo(() => {
     const groups: Record<string, string[]> = {};

--- a/packages/studio/src/components/Stage/Stage.tsx
+++ b/packages/studio/src/components/Stage/Stage.tsx
@@ -16,7 +16,7 @@ interface HeliosPlayerElement extends HTMLElement {
 }
 
 export const Stage: React.FC<StageProps> = ({ src }) => {
-  const { setController, canvasSize, setCanvasSize, playerState, controller, takeSnapshot, setSettingsOpen } = useStudio();
+  const { setController, canvasSize, setCanvasSize, playerState, controller, takeSnapshot, setSettingsOpen, activeComposition } = useStudio();
   const playerRef = useRef<HeliosPlayerElement>(null);
 
   // State
@@ -79,12 +79,21 @@ export const Stage: React.FC<StageProps> = ({ src }) => {
           } catch (e) {
             console.warn('Failed to restore state after HMR', e);
           }
+        } else {
+          // Fresh load or new composition - apply default props if available
+          if (activeComposition?.metadata?.defaultProps) {
+            try {
+              freshCtrl.setInputProps(activeComposition.metadata.defaultProps);
+            } catch (e) {
+              console.warn('Failed to apply default props', e);
+            }
+          }
         }
       }
     }, 200);
 
     return () => clearInterval(interval);
-  }, [src, controller, setController]);
+  }, [src, controller, setController, activeComposition]);
 
   // Event Handlers
   const handleWheel = (e: WheelEvent) => {

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -8,6 +8,7 @@ export interface CompositionMetadata {
   height: number;
   fps: number;
   duration: number;
+  defaultProps?: Record<string, any>;
 }
 
 export interface TemplateInfo {

--- a/packages/studio/src/server/plugin.ts
+++ b/packages/studio/src/server/plugin.ts
@@ -328,7 +328,7 @@ function configureMiddlewares(server: ViteDevServer | PreviewServer, isPreview: 
           if (req.method === 'PATCH') {
             try {
               const body = await getBody(req);
-              const { id, name, width, height, fps, duration } = body;
+              const { id, name, width, height, fps, duration, defaultProps } = body;
 
               if (!id) {
                 res.statusCode = 400;
@@ -356,6 +356,7 @@ function configureMiddlewares(server: ViteDevServer | PreviewServer, isPreview: 
               if (height !== undefined) options.height = Number(height);
               if (fps !== undefined) options.fps = Number(fps);
               if (duration !== undefined) options.duration = Number(duration);
+              if (defaultProps !== undefined) options.defaultProps = defaultProps;
 
               const updatedComp = updateCompositionMetadata(process.cwd(), currentId, options);
               res.setHeader('Content-Type', 'application/json');

--- a/packages/studio/src/server/templates/types.ts
+++ b/packages/studio/src/server/templates/types.ts
@@ -8,6 +8,7 @@ export interface CompositionOptions {
   height: number;
   fps: number;
   duration: number;
+  defaultProps?: Record<string, any>;
 }
 
 export interface Template {


### PR DESCRIPTION
Implemented auto-saving of user-configured input props to `composition.json`.
- Updated backend to support `defaultProps` in composition metadata.
- Updated `PropsEditor` to auto-save props with debounce.
- Updated `Stage` to restore persisted props on load.

---
*PR created automatically by Jules for task [3706530649631791269](https://jules.google.com/task/3706530649631791269) started by @BintzGavin*