### PR TITLE
✨ PLAYER: Expose Export API

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -81,3 +81,4 @@ The Shadow DOM contains:
 - `diagnose(): Promise<DiagnosticReport>`: Run environment diagnostics.
 - `startAudioMetering()`: Enable audio level events.
 - `stopAudioMetering()`: Disable audio level events.
+- `export(options?: HeliosExportOptions): Promise<void>`: Trigger client-side export programmatically.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -40,3 +40,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ## RENDERER v1.65.0
 - ✅ Completed: Smart Audio Fades - Updated audio fading logic to respect clip duration for accurate fade-out timing.
+
+## PLAYER v0.68.0
+- ✅ Completed: Expose Export API - Implemented public `export()` method on `<helios-player>` to allow programmatic triggering of client-side exports with configurable options (format, resolution, bitrate, etc.).

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.67.0
+**Version**: v0.68.0
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -56,10 +56,12 @@
 - Supports Export Filename: Implemented `export-filename` attribute to allow specifying the filename for client-side exports.
 - Supports Active Cues: Implemented `activeCues` property and `cuechange` event on `HeliosTextTrack` for Standard Media API parity.
 - **Audio Metering**: Supports real-time audio metering via `startAudioMetering()` API and `audiometering` event, enabling visualization of audio levels (stereo/peak) in host applications.
+- **Export API**: Exposes public `export()` method for programmatic control over client-side exports.
 
 ## Critical Task
 - **None**: All critical tasks completed.
 
+[v0.68.0] ✅ Completed: Expose Export API - Implemented public `export()` method on `<helios-player>` to allow programmatic triggering of client-side exports with configurable options (format, resolution, bitrate, etc.).
 [v0.67.0] ✅ Verified: Integrity - Ran full unit test suite (276 tests) and E2E verification script (verify-player.ts).
 [v0.67.0] ✅ Completed: Audio Metering Bridge - Implemented real-time audio metering system exposing stereo RMS and Peak levels via `audiometering` event and Bridge protocol.
 [v0.66.5] ✅ Completed: Smart PiP Visibility - Implemented auto-hiding of Picture-in-Picture button when environment lacks support or `export-mode="dom"` is active.

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -6,6 +6,18 @@ import { HeliosAudioTrack, HeliosAudioTrackList, AudioTrackHost } from "./featur
 import { HeliosVideoTrack, HeliosVideoTrackList, VideoTrackHost } from "./features/video-tracks";
 export { ClientSideExporter };
 export type { HeliosController };
+export interface HeliosExportOptions {
+    format?: 'mp4' | 'webm';
+    filename?: string;
+    mode?: 'auto' | 'canvas' | 'dom';
+    width?: number;
+    height?: number;
+    bitrate?: number;
+    includeCaptions?: boolean;
+    onProgress?: (progress: number) => void;
+    signal?: AbortSignal;
+    canvasSelector?: string;
+}
 interface MediaError {
     readonly code: number;
     readonly message: string;
@@ -196,6 +208,7 @@ export declare class HeliosPlayer extends HTMLElement implements TrackHost, Audi
     private hideStatus;
     getController(): HeliosController | null;
     getSchema(): Promise<HeliosSchema | undefined>;
+    export(options?: HeliosExportOptions): Promise<void>;
     diagnose(): Promise<DiagnosticReport>;
     startAudioMetering(): void;
     stopAudioMetering(): void;

--- a/packages/player/src/features/export-api.test.ts
+++ b/packages/player/src/features/export-api.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { HeliosPlayer } from '../index';
+import { ClientSideExporter } from './exporter';
+
+// Mock ClientSideExporter
+vi.mock('./exporter', () => {
+    return {
+        ClientSideExporter: vi.fn().mockImplementation(function() {
+            return {
+                export: vi.fn().mockResolvedValue(undefined),
+                saveCaptionsAsSRT: vi.fn()
+            };
+        })
+    };
+});
+
+// Mock ResizeObserver
+vi.stubGlobal('ResizeObserver', class {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+});
+
+describe('HeliosPlayer Export API', () => {
+    let player: HeliosPlayer;
+    let mockController: any;
+
+    beforeEach(() => {
+        // Create player element
+        player = new HeliosPlayer();
+
+        // Mock controller
+        mockController = {
+            dispose: vi.fn(),
+            pause: vi.fn(),
+            play: vi.fn(),
+            seek: vi.fn(),
+            getState: vi.fn().mockReturnValue({ duration: 1, fps: 30 }),
+            subscribe: vi.fn().mockReturnValue(() => {}),
+            onError: vi.fn().mockReturnValue(() => {}),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            setAudioVolume: vi.fn(),
+            setPlaybackRate: vi.fn(),
+            setAudioMuted: vi.fn(),
+            setInputProps: vi.fn(),
+        };
+
+        // Manually inject controller (since setController is private)
+        // We can access private members using 'as any' for testing
+        (player as any).controller = mockController;
+
+        // Reset mocks
+        vi.clearAllMocks();
+    });
+
+    it('should expose public export method', () => {
+        expect(typeof player.export).toBe('function');
+    });
+
+    it('should throw if not connected', async () => {
+        (player as any).controller = null;
+        await expect(player.export()).rejects.toThrow("Not connected");
+    });
+
+    it('should call ClientSideExporter.export with correct options', async () => {
+        const options = {
+            format: 'webm' as const,
+            filename: 'test-video',
+            width: 1920,
+            height: 1080
+        };
+
+        await player.export(options);
+
+        expect(ClientSideExporter).toHaveBeenCalledWith(mockController);
+
+        const mockExporterInstance = (ClientSideExporter as any).mock.results[0].value;
+        expect(mockExporterInstance.export).toHaveBeenCalledWith(expect.objectContaining({
+            format: 'webm',
+            filename: 'test-video',
+            width: 1920,
+            height: 1080
+        }));
+    });
+
+    it('should prevent concurrent exports', async () => {
+        // Make export hang
+        const mockExporterInstance = {
+            export: vi.fn().mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100))),
+            saveCaptionsAsSRT: vi.fn()
+        };
+        (ClientSideExporter as any).mockImplementation(function() { return mockExporterInstance; });
+
+        // Start first export
+        const p1 = player.export();
+
+        // Start second export immediately
+        await expect(player.export()).rejects.toThrow("Already exporting");
+
+        await p1;
+    });
+
+    it('should respect export-caption-mode="file" logic', async () => {
+        const mockExporterInstance = {
+            export: vi.fn().mockResolvedValue(undefined),
+            saveCaptionsAsSRT: vi.fn()
+        };
+        (ClientSideExporter as any).mockImplementation(function() { return mockExporterInstance; });
+
+        // Setup captions
+        (player as any).showCaptions = true;
+        (player as any)._textTracks = [
+            { kind: 'captions', mode: 'showing', cues: [{ startTime: 0, endTime: 1, text: 'test' }] }
+        ];
+
+        player.setAttribute('export-caption-mode', 'file');
+
+        await player.export({ filename: 'my-video' }); // includeCaptions implicitly undefined
+
+        // Should save SRT
+        expect(mockExporterInstance.saveCaptionsAsSRT).toHaveBeenCalled();
+
+        // Should pass includeCaptions: false to export
+        expect(mockExporterInstance.export).toHaveBeenCalledWith(expect.objectContaining({
+            includeCaptions: false,
+            filename: 'my-video'
+        }));
+    });
+
+    it('should override caption mode if includeCaptions is explicitly true', async () => {
+        const mockExporterInstance = {
+            export: vi.fn().mockResolvedValue(undefined),
+            saveCaptionsAsSRT: vi.fn()
+        };
+        (ClientSideExporter as any).mockImplementation(function() { return mockExporterInstance; });
+
+        player.setAttribute('export-caption-mode', 'file');
+
+        await player.export({ includeCaptions: true });
+
+        // Should NOT save SRT
+        expect(mockExporterInstance.saveCaptionsAsSRT).not.toHaveBeenCalled();
+
+        // Should pass includeCaptions: true
+        expect(mockExporterInstance.export).toHaveBeenCalledWith(expect.objectContaining({
+            includeCaptions: true
+        }));
+    });
+
+    it('should lock playback controls during export', async () => {
+        const lockSpy = vi.spyOn(player as any, 'lockPlaybackControls');
+
+        await player.export();
+
+        expect(lockSpy).toHaveBeenCalledWith(true);
+        expect(lockSpy).toHaveBeenCalledWith(false); // In finally block
+    });
+
+    it('should handle default values correctly when attributes are missing', async () => {
+        const mockExporterInstance = {
+            export: vi.fn().mockResolvedValue(undefined),
+            saveCaptionsAsSRT: vi.fn()
+        };
+        (ClientSideExporter as any).mockImplementation(function() { return mockExporterInstance; });
+
+        await player.export();
+
+        expect(mockExporterInstance.export).toHaveBeenCalledWith(expect.objectContaining({
+            width: undefined,
+            height: undefined,
+            bitrate: undefined
+        }));
+    });
+});

--- a/packages/player/src/features/exporter.test.ts
+++ b/packages/player/src/features/exporter.test.ts
@@ -122,7 +122,6 @@ if (typeof URL.createObjectURL === 'undefined') {
 describe('ClientSideExporter', () => {
     let mockController: HeliosController;
     let exporter: ClientSideExporter;
-    let mockIframe: HTMLIFrameElement;
     let mockAnchor: any;
 
     beforeEach(() => {
@@ -143,9 +142,7 @@ describe('ClientSideExporter', () => {
             getAudioTracks: vi.fn().mockResolvedValue([])
         } as unknown as HeliosController;
 
-        mockIframe = {} as HTMLIFrameElement;
-
-        exporter = new ClientSideExporter(mockController, mockIframe);
+        exporter = new ClientSideExporter(mockController);
 
         // Mock document.createElement('a')
         mockAnchor = {

--- a/packages/player/src/features/exporter.ts
+++ b/packages/player/src/features/exporter.ts
@@ -17,13 +17,12 @@ import { mixAudio } from "./audio-utils";
 
 export class ClientSideExporter {
   constructor(
-    private controller: HeliosController,
-    private iframe: HTMLIFrameElement // Kept for compatibility
+    private controller: HeliosController
   ) {}
 
   public async export(options: {
     onProgress: (progress: number) => void;
-    signal: AbortSignal;
+    signal?: AbortSignal;
     mode?: 'auto' | 'canvas' | 'dom';
     canvasSelector?: string;
     format?: 'mp4' | 'webm';
@@ -137,7 +136,7 @@ export class ClientSideExporter {
       onProgress(1 / totalFrames);
 
       for (let i = 1; i < totalFrames; i++) {
-        if (signal.aborted) {
+        if (signal?.aborted) {
             throw new Error("Export aborted");
         }
 


### PR DESCRIPTION
Exposed a public `export()` method on the `<helios-player>` Web Component to allow programmatic triggering of client-side exports.
Refactored `ClientSideExporter` to remove unused iframe dependency.
Fixed type issues with `AbortSignal`.
Added `HeliosExportOptions` interface.
Verified with new unit tests `src/features/export-api.test.ts`.

---
*PR created automatically by Jules for task [6371630024919476001](https://jules.google.com/task/6371630024919476001) started by @BintzGavin*