### PR TITLE
✨ CLI: Activate Multi-Framework Support (v0.9.0) and Fix Studio Build

### DIFF
--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -44,3 +44,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.6.0] ✅ Implement Merge Command - Implemented `helios merge` for stitching video clips
 [v0.7.0] ✅ Remote Registry Support - Implemented `RegistryClient` to fetch components from a remote URL with local fallback
 [v0.8.0] ✅ Auto-Install Dependencies - Implemented automatic dependency installation for `helios add` with `--no-install` flag
+[v0.9.0] ✅ Multi-Framework Support - Enabled `helios init` for Vue, Svelte, and Vanilla, and updated `helios studio` to load user config.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10579,7 +10579,7 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.6.0",
+      "version": "0.9.0",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/renderer": "^0.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/cli",
-  "version": "0.6.0",
+  "version": "0.9.0",
   "description": "CLI for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name('helios')
   .description('Helios CLI')
-  .version('0.6.0');
+  .version('0.9.0');
 
 registerStudioCommand(program);
 registerInitCommand(program);

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -774,10 +774,8 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     // Create new abort controller
     exportAbortControllerRef.current = new AbortController();
 
-    // Instantiate exporter with dummy iframe (unused in export method)
-    // Note: We cast to unknown then HTMLIFrameElement to satisfy type requirements
-    const dummyIframe = document.createElement('iframe');
-    const exporter = new ClientSideExporter(controller, dummyIframe);
+    // Instantiate exporter
+    const exporter = new ClientSideExporter(controller);
 
     try {
       await exporter.export({


### PR DESCRIPTION
Syncs CLI version to 0.9.0, reflecting the existing Multi-Framework Support in init command.
Fixes a build error in StudioContext caused by mismatched ClientSideExporter constructor signature.
Updates status documentation.
Verified by manual execution of CLI commands and successful build.

---
*PR created automatically by Jules for task [6795678711019331379](https://jules.google.com/task/6795678711019331379) started by @BintzGavin*