### PR TITLE
✨ PLAYER: Robust Audio Metering

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -79,6 +79,6 @@ The Shadow DOM contains:
 - `requestPictureInPicture(): Promise<PictureInPictureWindow>`: Enter PiP mode.
 - `addTextTrack(kind, label, language): HeliosTextTrack`: Create a new text track.
 - `diagnose(): Promise<DiagnosticReport>`: Run environment diagnostics.
-- `startAudioMetering()`: Enable audio level events.
-- `stopAudioMetering()`: Disable audio level events.
+- `startAudioMetering()`: Enable audio level events (non-destructive).
+- `stopAudioMetering()`: Disable audio level events (maintains playback).
 - `export(options?: HeliosExportOptions): Promise<void>`: Trigger client-side export programmatically.

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.68.1
+- ✅ Completed: Robust Audio Metering - Refactored `AudioMeter` to support non-destructive toggling, preventing audio playback from stopping when metering is disabled.
+
 ## PLAYER v0.66.5
 - ✅ Completed: Smart PiP Visibility - Implemented auto-hiding of Picture-in-Picture button when environment lacks support or `export-mode="dom"` is active.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -41,5 +41,8 @@ Each agent should update **their own dedicated progress file** instead of this f
 ## RENDERER v1.65.0
 - ✅ Completed: Smart Audio Fades - Updated audio fading logic to respect clip duration for accurate fade-out timing.
 
+## PLAYER v0.68.1
+- ✅ Completed: Robust Audio Metering - Refactored `AudioMeter` to support non-destructive toggling, preventing audio playback from stopping when metering is disabled.
+
 ## PLAYER v0.68.0
 - ✅ Completed: Expose Export API - Implemented public `export()` method on `<helios-player>` to allow programmatic triggering of client-side exports with configurable options (format, resolution, bitrate, etc.).

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.68.0
+**Version**: v0.68.1
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -61,6 +61,7 @@
 ## Critical Task
 - **Robust Audio Metering**: Refactor AudioMeter to support non-destructive toggling.
 
+[v0.68.1] ✅ Completed: Robust Audio Metering - Refactored `AudioMeter` to support non-destructive toggling, preventing audio playback from stopping when metering is disabled.
 [v0.68.0] ✅ Completed: Expose Export API - Implemented public `export()` method on `<helios-player>` to allow programmatic triggering of client-side exports with configurable options (format, resolution, bitrate, etc.).
 [v0.67.0] ✅ Verified: Integrity - Ran full unit test suite (276 tests) and E2E verification script (verify-player.ts).
 [v0.67.0] ✅ Completed: Audio Metering Bridge - Implemented real-time audio metering system exposing stereo RMS and Peak levels via `audiometering` event and Bridge protocol.

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.66.5",
+  "version": "0.68.1",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/player/src/bridge.ts
+++ b/packages/player/src/bridge.ts
@@ -110,8 +110,11 @@ export function connectToParent(helios: Helios) {
       case 'HELIOS_START_METERING':
         if (!audioMeter) {
           audioMeter = new AudioMeter();
-          audioMeter.connect(document);
+        }
+        audioMeter.connect(document);
+        audioMeter.enable();
 
+        if (!audioMeterRaf) {
           const loop = () => {
             if (audioMeter) {
               const levels = audioMeter.getLevels();
@@ -128,8 +131,7 @@ export function connectToParent(helios: Helios) {
           audioMeterRaf = null;
         }
         if (audioMeter) {
-          audioMeter.dispose();
-          audioMeter = null;
+          audioMeter.disable();
         }
         break;
       case 'HELIOS_DIAGNOSE':

--- a/packages/player/src/features/audio-metering.test.ts
+++ b/packages/player/src/features/audio-metering.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AudioMeter } from './audio-metering';
+
+describe('AudioMeter', () => {
+  let audioMeter: AudioMeter;
+  let mockAudioContext: any;
+  let mockMediaElementSource: any;
+  let mockGainNode: any;
+  let mockSplitter: any;
+  let mockAnalyser: any;
+  let mockDestination: any;
+
+  beforeEach(() => {
+    mockMediaElementSource = {
+      connect: vi.fn(),
+      disconnect: vi.fn()
+    };
+    mockGainNode = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      gain: { value: 1 }
+    };
+    mockSplitter = {
+      connect: vi.fn(),
+      disconnect: vi.fn()
+    };
+    mockAnalyser = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      getFloatTimeDomainData: vi.fn(),
+      fftSize: 2048
+    };
+    mockDestination = {};
+
+    mockAudioContext = {
+      createMediaElementSource: vi.fn(() => mockMediaElementSource),
+      createGain: vi.fn(() => mockGainNode),
+      createChannelSplitter: vi.fn(() => mockSplitter),
+      createAnalyser: vi.fn(() => mockAnalyser),
+      destination: mockDestination,
+      state: 'suspended',
+      resume: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined)
+    };
+
+    (window as any).AudioContext = vi.fn().mockImplementation(function() { return mockAudioContext; });
+    (window as any).webkitAudioContext = vi.fn().mockImplementation(function() { return mockAudioContext; });
+
+    audioMeter = new AudioMeter();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should initialize correctly', () => {
+    expect(mockAudioContext.createChannelSplitter).toHaveBeenCalledWith(2);
+    expect(mockAudioContext.createAnalyser).toHaveBeenCalledTimes(2);
+    expect(mockSplitter.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('should connect playback path immediately but not metering path', () => {
+    const mockElement = document.createElement('audio');
+    const doc = { querySelectorAll: vi.fn(() => [mockElement]) } as any;
+
+    audioMeter.connect(doc);
+
+    // Verify context resumed
+    expect(mockAudioContext.resume).toHaveBeenCalled();
+
+    // Verify nodes created
+    expect(mockAudioContext.createMediaElementSource).toHaveBeenCalledWith(mockElement);
+    expect(mockAudioContext.createGain).toHaveBeenCalled();
+
+    // Verify Playback Path (Source -> Gain -> Destination)
+    expect(mockMediaElementSource.connect).toHaveBeenCalledWith(mockGainNode);
+    expect(mockGainNode.connect).toHaveBeenCalledWith(mockDestination);
+
+    // Verify Metering Path NOT connected (Source -> Splitter)
+    expect(mockMediaElementSource.connect).not.toHaveBeenCalledWith(mockSplitter);
+  });
+
+  it('should connect metering path when enabled', () => {
+    const mockElement = document.createElement('audio');
+    const doc = { querySelectorAll: vi.fn(() => [mockElement]) } as any;
+
+    audioMeter.connect(doc);
+    audioMeter.enable();
+
+    // Verify Metering Path Connected
+    expect(mockMediaElementSource.connect).toHaveBeenCalledWith(mockSplitter);
+  });
+
+  it('should connect metering path immediately if already enabled', () => {
+    const mockElement = document.createElement('audio');
+    const doc = { querySelectorAll: vi.fn(() => [mockElement]) } as any;
+
+    audioMeter.enable();
+    audioMeter.connect(doc);
+
+    // Verify Metering Path Connected
+    expect(mockMediaElementSource.connect).toHaveBeenCalledWith(mockSplitter);
+  });
+
+  it('should disconnect only metering path when disabled', () => {
+    const mockElement = document.createElement('audio');
+    const doc = { querySelectorAll: vi.fn(() => [mockElement]) } as any;
+
+    audioMeter.connect(doc);
+    audioMeter.enable();
+
+    // Reset mocks to clear previous calls
+    mockMediaElementSource.disconnect.mockClear();
+
+    audioMeter.disable();
+
+    // Verify Metering Path Disconnected
+    expect(mockMediaElementSource.disconnect).toHaveBeenCalledWith(mockSplitter);
+
+    // Verify we didn't call disconnect() without args (which would disconnect everything)
+    expect(mockMediaElementSource.disconnect).not.toHaveBeenCalledWith();
+    // Verify we didn't disconnect gain node
+    expect(mockMediaElementSource.disconnect).not.toHaveBeenCalledWith(mockGainNode);
+  });
+
+  it('should return zero levels when disabled', () => {
+    const levels = audioMeter.getLevels();
+    expect(levels).toEqual({ left: 0, right: 0, peakLeft: 0, peakRight: 0 });
+    expect(mockAnalyser.getFloatTimeDomainData).not.toHaveBeenCalled();
+  });
+
+  it('should dispose correctly', () => {
+    const mockElement = document.createElement('audio');
+    const doc = { querySelectorAll: vi.fn(() => [mockElement]) } as any;
+
+    audioMeter.connect(doc);
+
+    audioMeter.dispose();
+
+    expect(mockMediaElementSource.disconnect).toHaveBeenCalled();
+    expect(mockGainNode.disconnect).toHaveBeenCalled();
+    expect(mockSplitter.disconnect).toHaveBeenCalled();
+    expect(mockAudioContext.close).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
💡 **What**: Refactored `AudioMeter` to support non-destructive toggling via `enable`/`disable` methods. Updated `DirectController` and `bridge.ts` to maintain the `AudioMeter` instance and audio context lifecycle.
🎯 **Why**: Previously, stopping audio metering destroyed the `AudioMeter` instance, which closed the `AudioContext`. This permanently silenced any media elements connected via `createMediaElementSource` because they were not reconnected to the default destination.
📊 **Impact**: Users can now toggle audio metering (e.g., via Diagnostics UI or API) without interrupting audio playback.
🔬 **Verification**: Added `src/features/audio-metering.test.ts` to verify connection logic and `enable`/`disable` behavior. Ran `npm test -w packages/player` (all tests passed).

---
*PR created automatically by Jules for task [6524147348536397533](https://jules.google.com/task/6524147348536397533) started by @BintzGavin*