### PR TITLE
📋 STUDIO: Sync Playback Range

### DIFF
--- a/.jules/STUDIO.md
+++ b/.jules/STUDIO.md
@@ -65,3 +65,7 @@
 ## [0.94.3] - Test Environment Fragility
 **Learning:** `vitest` execution in workspace packages relies on the root `node_modules/.bin` being populated. If the environment is not fresh, tests may fail with "command not found". Also, `setupTests.ts` mechanism can be fragile if `vitest` globals are not configured, requiring explicit `expect.extend` in test files.
 **Action:** Always verify `npm install` state before running tests in a new session, and prefer explicit imports over implicit global setup for robust tests.
+
+## [0.96.0] - Core API Parity
+**Learning:** The Studio was implementing manual loop enforcement logic in `StudioContext`, duplicating logic that already existed in `packages/core` (`setPlaybackRange`). This led to inconsistencies where Client-Side Export (which relies on Core) ignored the Studio's range selection.
+**Action:** Before implementing logic in the Studio that duplicates engine behavior (looping, playback, timing), always verify if the `HeliosController` or Core API already provides a native solution.

--- a/.sys/plans/2026-09-09-STUDIO-Sync-Playback-Range.md
+++ b/.sys/plans/2026-09-09-STUDIO-Sync-Playback-Range.md
@@ -1,0 +1,64 @@
+# 2026-09-09 - STUDIO - Sync Playback Range
+
+#### 1. Context & Goal
+- **Objective**: Delegate playback looping and range enforcement to the `HeliosController` (Core/Player) instead of managing it manually in `StudioContext`.
+- **Trigger**: Vision Gap - "Client-Side Export" and "Preview" rely on inconsistent manual loop logic in Studio, while Core has native support for `playbackRange` that is ignored.
+- **Impact**: Enables native Engine looping (more precise) and ensures Client-Side Export respects the selected range.
+
+#### 2. File Inventory
+- **Modify**: `packages/studio/src/context/StudioContext.tsx`
+  - Remove manual `useEffect` loop enforcement.
+  - Add `useEffect` to sync `inPoint` / `outPoint` to `controller.setPlaybackRange`.
+  - Add `useEffect` to sync `loop` state to `controller.setLoop`.
+- **Read-Only**: `packages/player/src/controllers.ts` (Reference only).
+
+#### 3. Implementation Spec
+- **Architecture**:
+  - The `StudioContext` remains the source of truth for the UI (Timeline markers).
+  - It synchronizes this state to the `HeliosController` via `useEffect` hooks.
+  - The Core/Player engine takes over the responsibility of checking `currentFrame >= end` and seeking to `start`.
+
+- **Pseudo-Code**:
+  ```typescript
+  // packages/studio/src/context/StudioContext.tsx
+
+  // Sync Loop State
+  useEffect(() => {
+    if (controller) {
+      controller.setLoop(loop);
+    }
+  }, [controller, loop]);
+
+  // Sync Playback Range
+  useEffect(() => {
+    if (!controller) return;
+
+    const { duration, fps } = playerState;
+    // Default handling: if outPoint is 0, treat as full duration
+    const maxFrame = Math.floor(duration * fps);
+    const effectiveOut = outPoint === 0 ? maxFrame : outPoint;
+
+    // If range is full video (or invalid), clear it
+    if (inPoint === 0 && (outPoint === 0 || effectiveOut >= maxFrame)) {
+        controller.clearPlaybackRange();
+    } else {
+        // Otherwise set strict range
+        controller.setPlaybackRange(inPoint, effectiveOut);
+    }
+  }, [controller, inPoint, outPoint, playerState.duration, playerState.fps]);
+
+  // REMOVE: The old useEffect that manually checked currentFrame >= loopEnd
+  ```
+
+- **Public API Changes**: None.
+- **Dependencies**: `HeliosController.setPlaybackRange` (Verified present in Player).
+
+#### 4. Test Plan
+- **Verification**: `npx helios studio` (manual verification)
+- **Success Criteria**:
+  - Open Studio, set In/Out points.
+  - Enable Loop. Playback should loop at Out point.
+  - Client-Side Export (if supported by Player) should theoretically now respect range (though verifying this specifically requires Player internals, the Studio side is now correct).
+- **Edge Cases**:
+  - `outPoint` = 0 (should default to full duration).
+  - `inPoint` > `outPoint` (should be handled by Timeline logic to prevent, but Controller should be safe).


### PR DESCRIPTION
Created spec file `/.sys/plans/2026-09-09-STUDIO-Sync-Playback-Range.md` to delegate playback looping and range enforcement to the `HeliosController` (Core/Player). This resolves inconsistencies between Studio Preview and Client-Side Export.

Recorded critical learning in `.jules/STUDIO.md` regarding Core API parity.

---
*PR created automatically by Jules for task [13700467954207497017](https://jules.google.com/task/13700467954207497017) started by @BintzGavin*