### PR TITLE
📋 CLI: Track Installed Components Plan

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -37,3 +37,11 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.9.0] - Phantom Implementation
 **Learning:** System memory stated that `helios render` supported `--concurrency` via `RenderOrchestrator`, but the code (`render.ts`) showed it only used the basic `Renderer` class. Documentation and Memory can drift from Code Reality.
 **Action:** Trust Code over Memory. Always verify the existence of a feature in `src/` before assuming it is implemented, even if status files claim it exists.
+
+## [0.9.1] - Render Concurrency Reality
+**Learning:** Contrary to the [0.9.0] entry, `helios render` DOES support `--concurrency` and uses `RenderOrchestrator`. The previous observation was incorrect or outdated.
+**Action:** Double-check imports when verifying code. `render.ts` correctly delegates to `RenderOrchestrator`.
+
+## [0.9.1] - Registry Tracking Gap
+**Learning:** `helios add` installs components but does not record them in `helios.config.json` or any lockfile. This prevents inventory management (`list --installed`) and future updates (`helios update`).
+**Action:** When designing package managers or registries, always include a mechanism to track installed assets (like `components.json` or `package.json` deps) to enable lifecycle management.

--- a/.sys/plans/2026-03-02-CLI-Track-Installed-Components.md
+++ b/.sys/plans/2026-03-02-CLI-Track-Installed-Components.md
@@ -1,0 +1,31 @@
+#### 1. Context & Goal
+- **Objective**: Update the CLI to track which components are installed by recording them in `helios.config.json`.
+- **Trigger**: Currently, `helios add` installs files but leaves no record of what was installed, making future updates or auditing impossible (Gap in "Registry Management").
+- **Impact**: Enables future features like `helios update` and `helios list --installed`, aligning with the "Shadcn-style registry" vision.
+
+#### 2. File Inventory
+- **Modify**: `packages/cli/src/utils/config.ts` (Add `components` to interface, add `saveConfig` function)
+- **Modify**: `packages/cli/src/utils/install.ts` (Update config after installation)
+- **Modify**: `packages/cli/src/commands/init.ts` (Initialize with empty components list)
+
+#### 3. Implementation Spec
+- **Architecture**:
+    - Extend `HeliosConfig` interface to include `components: string[]`.
+    - Implement `saveConfig` to write JSON back to disk (preserving format if possible, or just `JSON.stringify(..., null, 2)`).
+    - In `installComponent`:
+        - Load config.
+        - Perform installation.
+        - If successful, push `componentName` to `config.components` (checking for duplicates).
+        - Call `saveConfig`.
+- **Public API Changes**:
+    - `helios.config.json` will now have a `components` property.
+    - `saveConfig` utility exported from `utils/config.ts`.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**:
+    1.  Run `helios init` in a temp dir. Verify `helios.config.json` has `components: []`.
+    2.  Run `helios add timer`.
+    3.  Check `helios.config.json`. It should contain `"components": ["timer"]`.
+    4.  Run `helios add timer` again. It should not duplicate the entry.
+- **Success Criteria**: Config file accurately reflects installed components after add operations.


### PR DESCRIPTION
Created design specification to enable tracking of installed components in `helios.config.json`. This is a prerequisite for future `helios update` and inventory management features.

Ref: .sys/plans/2026-03-02-CLI-Track-Installed-Components.md

---
*PR created automatically by Jules for task [302275726293298695](https://jules.google.com/task/302275726293298695) started by @BintzGavin*