### PR TITLE
📋 DEMO: Standardize Three.js Canvas Example Plan

### DIFF
--- a/.jules/DEMO.md
+++ b/.jules/DEMO.md
@@ -71,3 +71,7 @@
 ## [1.110.0] - React Helios Instantiation
 **Learning:** Newer examples or setups might not export a singleton `helios` instance from core. React examples should instantiate `Helios` manually and expose it/use it via context or direct import to ensure proper configuration (like `autoSyncAnimations: false`).
 **Action:** Always verify how `Helios` is initialized and accessed in the specific framework context when creating new examples.
+
+## [1.115.0] - Legacy Example Portability
+**Learning:** Legacy examples (e.g., `threejs-canvas-animation`) rely on implicit hoisting and root build configs. They lack `package.json` and `tsconfig.json`, making them poor references for users who want to "eject" or copy-paste.
+**Action:** Standardize legacy examples by adding `package.json` and TypeScript configuration to ensure they are self-contained and "Professional".

--- a/.sys/plans/2026-09-13-DEMO-Standardize-ThreeJS.md
+++ b/.sys/plans/2026-09-13-DEMO-Standardize-ThreeJS.md
@@ -1,0 +1,34 @@
+# Plan: Standardize Three.js Canvas Example
+
+## 1. Context & Goal
+- **Objective**: Modernize the legacy `threejs-canvas-animation` example by converting it from inline JavaScript to a standard TypeScript + Vite project structure with a proper `package.json`.
+- **Trigger**: The current example uses legacy inline scripts, lacks `package.json`, and doesn't demonstrate the "Professional" Vite+TS pipeline promised in the Vision. It also relies on implicit root hoisting.
+- **Impact**: Improves the "Use What You Know" story for Three.js users, providing a copy-pasteable, self-contained example that follows modern best practices.
+
+## 2. File Inventory
+- **Create**:
+    - `examples/threejs-canvas-animation/package.json`: To declare dependencies (`three`, `vite`, `typescript`).
+    - `examples/threejs-canvas-animation/tsconfig.json`: To enable strict TypeScript checking.
+    - `examples/threejs-canvas-animation/src/main.ts`: The new entry point containing the Three.js logic (ported from HTML).
+- **Modify**:
+    - `examples/threejs-canvas-animation/composition.html`: Update `<script>` to point to `src/main.ts`.
+    - `examples/threejs-canvas-animation/vite.config.js`: Update to use proper aliases and plugins if needed (to support local dev).
+
+## 3. Implementation Spec
+- **Architecture**:
+    - Move logic from `composition.html` <script> tag to `src/main.ts`.
+    - Replace `../../packages/core/src/index.ts` import with `@helios-project/core`.
+    - Add explicit types for Three.js objects (e.g., `THREE.WebGLRenderer`, `THREE.Mesh`).
+    - Ensure `vite.config.js` maps `@helios-project/core` correctly for local development.
+- **Dependencies**:
+    - `three` (already in root)
+    - `@types/three` (already in root)
+    - `vite` (already in root)
+
+## 4. Test Plan
+- **Verification**:
+    - Run `npm run build:examples` to ensure the root build system picks up the changes and bundles correctly.
+    - (Optional) Run `npx vite build examples/threejs-canvas-animation` to verify isolated build.
+- **Success Criteria**:
+    - `output/example-build/examples/threejs-canvas-animation/composition.html` exists.
+    - The build process completes without errors.


### PR DESCRIPTION
This PR adds a planning spec file `/.sys/plans/2026-09-13-DEMO-Standardize-ThreeJS.md` that outlines the steps to standardize the existing `threejs-canvas-animation` example.

Key objectives:
1.  Add `package.json` and `tsconfig.json` to the example.
2.  Port inline JavaScript to TypeScript (`src/main.ts`).
3.  Update build configuration for portability.


---
*PR created automatically by Jules for task [8971853051864236266](https://jules.google.com/task/8971853051864236266) started by @BintzGavin*