### PR TITLE
feat(studio): implement hierarchical composition tree view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10579,7 +10579,7 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/renderer": "^0.0.2",

--- a/packages/studio/src/components/CompositionsPanel/CompositionItem.tsx
+++ b/packages/studio/src/components/CompositionsPanel/CompositionItem.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Composition } from '../../context/StudioContext';
+
+interface CompositionItemProps {
+  composition: Composition;
+  isActive: boolean;
+  onSelect: (comp: Composition) => void;
+  onDuplicate: (e: React.MouseEvent, comp: Composition) => void;
+  onDelete: (e: React.MouseEvent, comp: Composition) => void;
+}
+
+export const CompositionItem: React.FC<CompositionItemProps> = ({
+  composition,
+  isActive,
+  onSelect,
+  onDuplicate,
+  onDelete
+}) => {
+  return (
+    <div
+      className={`composition-item ${isActive ? 'active' : ''}`}
+      onClick={() => onSelect(composition)}
+    >
+      <div className="composition-thumbnail">
+        {composition.thumbnailUrl ? (
+          <img src={composition.thumbnailUrl} alt={composition.name} />
+        ) : (
+          <div className="composition-placeholder">
+            <span>🎬</span>
+          </div>
+        )}
+        <div className="composition-actions">
+          <button
+            className="composition-action-btn duplicate"
+            onClick={(e) => onDuplicate(e, composition)}
+            title="Duplicate"
+          >
+            📑
+          </button>
+          <button
+            className="composition-action-btn delete"
+            onClick={(e) => onDelete(e, composition)}
+            title="Delete"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+      <div className="composition-name" title={composition.name}>
+        {composition.name}
+      </div>
+    </div>
+  );
+};

--- a/packages/studio/src/components/CompositionsPanel/CompositionTree.css
+++ b/packages/studio/src/components/CompositionsPanel/CompositionTree.css
@@ -1,0 +1,53 @@
+.composition-tree {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.composition-folder {
+  display: flex;
+  flex-direction: column;
+}
+
+.composition-folder-header {
+  display: flex;
+  align-items: center;
+  padding: 6px 4px;
+  cursor: pointer;
+  color: #aaa;
+  font-weight: 500;
+  font-size: 0.85rem;
+  border-radius: 4px;
+  user-select: none;
+  transition: color 0.2s, background-color 0.2s;
+}
+
+.composition-folder-header:hover {
+  background-color: #2a2a2a;
+  color: #fff;
+}
+
+.folder-icon {
+  margin-right: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+}
+
+.composition-folder-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-left: 12px;
+  margin-top: 4px;
+  border-left: 1px solid #333;
+  margin-left: 8px;
+}
+
+.compositions-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}

--- a/packages/studio/src/components/CompositionsPanel/CompositionTree.tsx
+++ b/packages/studio/src/components/CompositionsPanel/CompositionTree.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect } from 'react';
+import { TreeNode } from '../../utils/tree';
+import { Composition } from '../../context/StudioContext';
+import { CompositionItem } from './CompositionItem';
+import './CompositionTree.css';
+
+interface CompositionTreeProps {
+  nodes: TreeNode[];
+  activeCompositionId: string | undefined;
+  onSelect: (comp: Composition) => void;
+  onDuplicate: (e: React.MouseEvent, comp: Composition) => void;
+  onDelete: (e: React.MouseEvent, comp: Composition) => void;
+}
+
+export const CompositionTree: React.FC<CompositionTreeProps> = ({
+  nodes,
+  activeCompositionId,
+  onSelect,
+  onDuplicate,
+  onDelete
+}) => {
+  // Split root nodes
+  const folders = nodes.filter(n => n.type === 'folder');
+  const comps = nodes.filter(n => n.type === 'composition');
+
+  return (
+    <div className="composition-tree">
+      {folders.map(node => (
+        <CompositionFolder
+          key={node.id}
+          node={node}
+          activeCompositionId={activeCompositionId}
+          onSelect={onSelect}
+          onDuplicate={onDuplicate}
+          onDelete={onDelete}
+        />
+      ))}
+
+      {comps.length > 0 && (
+        <div className="compositions-grid">
+          {comps.map(node => (
+             node.data && (
+                <CompositionItem
+                    key={node.id}
+                    composition={node.data}
+                    isActive={activeCompositionId === node.data.id}
+                    onSelect={onSelect}
+                    onDuplicate={onDuplicate}
+                    onDelete={onDelete}
+                />
+             )
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface CompositionFolderProps {
+  node: TreeNode;
+  activeCompositionId: string | undefined;
+  onSelect: (comp: Composition) => void;
+  onDuplicate: (e: React.MouseEvent, comp: Composition) => void;
+  onDelete: (e: React.MouseEvent, comp: Composition) => void;
+}
+
+const CompositionFolder: React.FC<CompositionFolderProps> = ({
+  node,
+  activeCompositionId,
+  onSelect,
+  onDuplicate,
+  onDelete
+}) => {
+  const [isExpanded, setIsExpanded] = useState(node.isExpanded ?? false);
+
+  useEffect(() => {
+    if (node.isExpanded !== undefined) {
+      setIsExpanded(node.isExpanded);
+    }
+  }, [node.isExpanded]);
+
+  const children = node.children || [];
+  const folders = children.filter(n => n.type === 'folder');
+  const comps = children.filter(n => n.type === 'composition');
+
+  return (
+    <div className="composition-folder">
+      <div className="composition-folder-header" onClick={() => setIsExpanded(!isExpanded)}>
+        <span className="folder-icon">{isExpanded ? '📂' : '📁'}</span>
+        <span className="folder-label">{node.label}</span>
+      </div>
+
+      {isExpanded && (
+        <div className="composition-folder-body">
+          {folders.map(child => (
+            <CompositionFolder
+              key={child.id}
+              node={child}
+              activeCompositionId={activeCompositionId}
+              onSelect={onSelect}
+              onDuplicate={onDuplicate}
+              onDelete={onDelete}
+            />
+          ))}
+
+          {comps.length > 0 && (
+            <div className="compositions-grid">
+              {comps.map(child => (
+                child.data && (
+                   <CompositionItem
+                       key={child.id}
+                       composition={child.data}
+                       isActive={activeCompositionId === child.data.id}
+                       onSelect={onSelect}
+                       onDuplicate={onDuplicate}
+                       onDelete={onDelete}
+                   />
+                )
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/studio/src/utils/tree.test.ts
+++ b/packages/studio/src/utils/tree.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { buildCompositionTree } from './tree';
+import { Composition } from '../context/StudioContext';
+
+describe('buildCompositionTree', () => {
+  const mockCompositions: Composition[] = [
+    { id: 'root-comp', name: 'Root Comp', url: '' },
+    { id: 'folder/comp-a', name: 'Comp A', url: '' },
+    { id: 'folder/sub/comp-b', name: 'Comp B', url: '' },
+    { id: 'folder/comp-c', name: 'Comp C', url: '' },
+    { id: 'other/comp-d', name: 'Comp D', url: '' }
+  ];
+
+  it('builds a hierarchical tree', () => {
+    const tree = buildCompositionTree(mockCompositions);
+
+    // Sort order: folders first
+    expect(tree[0].type).toBe('folder');
+    expect(tree[0].label).toBe('Folder');
+    expect(tree[1].type).toBe('folder');
+    expect(tree[1].label).toBe('Other');
+    expect(tree[2].type).toBe('composition');
+    expect(tree[2].label).toBe('Root Comp');
+
+    // Check Folder children
+    const folder = tree[0];
+    expect(folder.children).toHaveLength(3); // sub (folder), comp-a, comp-c
+    // sub folder should be first
+    expect(folder.children![0].type).toBe('folder');
+    expect(folder.children![0].label).toBe('Sub');
+
+    const sub = folder.children![0];
+    expect(sub.children).toHaveLength(1);
+    expect(sub.children![0].label).toBe('Comp B');
+  });
+
+  it('filters the tree and expands matches', () => {
+    const tree = buildCompositionTree(mockCompositions, 'Comp B');
+
+    // Should contain Folder -> Sub -> Comp B
+    expect(tree).toHaveLength(1);
+    expect(tree[0].label).toBe('Folder');
+    expect(tree[0].isExpanded).toBe(true);
+
+    const sub = tree[0].children![0];
+    expect(sub.label).toBe('Sub');
+    expect(sub.isExpanded).toBe(true);
+
+    expect(sub.children![0].label).toBe('Comp B');
+  });
+
+  it('filters folders by name', () => {
+    const tree = buildCompositionTree(mockCompositions, 'Sub');
+    // Should show Folder -> Sub -> Comp B
+    // Because Sub matches, we show it.
+    expect(tree).toHaveLength(1);
+    expect(tree[0].label).toBe('Folder');
+
+    const sub = tree[0].children![0];
+    expect(sub.label).toBe('Sub');
+    // Children of matching folder are included?
+    // My logic: if matchesSelf, return true.
+    // Logic for children filtering is:
+    // const matchingChildren = node.children.filter...
+    // if matchingChildren > 0, keep children.
+    // if not, but matchesSelf, return true.
+    // So 'Sub' matches. 'Comp B' does not match 'Sub'.
+    // So 'Sub' has 0 matching children.
+    // But 'Sub' matches self. So 'Sub' is returned.
+    // 'Sub' children list will be empty?
+    // Let's check logic:
+    // `const matchingChildren = node.children.filter(...)`
+    // If length 0, `node.children` is NOT updated (stays original full list? No).
+    // Wait, I didn't update `node.children` if length 0.
+    // `if (matchingChildren.length > 0) { node.children = matchingChildren; ... }`
+    // So if 0 matches, node.children remains UNTOUCHED (all children).
+    // And matchesSelf is true.
+    // So we return true.
+    // So we see Sub and ALL its children.
+    // This is correct behavior for folder match.
+
+    expect(sub.children).toHaveLength(1);
+    expect(sub.children![0].label).toBe('Comp B');
+  });
+});

--- a/packages/studio/src/utils/tree.ts
+++ b/packages/studio/src/utils/tree.ts
@@ -1,0 +1,130 @@
+import { Composition } from '../context/StudioContext';
+
+export interface TreeNode {
+  id: string;
+  label: string;
+  type: 'folder' | 'composition';
+  children?: TreeNode[];
+  data?: Composition;
+  isExpanded?: boolean; // Hint for initial render (e.g. search match)
+}
+
+export function buildCompositionTree(compositions: Composition[], filterText: string = ''): TreeNode[] {
+  const root: TreeNode[] = [];
+  const map: Record<string, TreeNode> = {};
+  const query = filterText.toLowerCase().trim();
+
+  // Helper to get or create folder node
+  const getOrCreateFolder = (pathSegments: string[], fullPath: string): TreeNode => {
+    if (map[fullPath]) return map[fullPath];
+
+    const label = pathSegments[pathSegments.length - 1]
+      .split('-')
+      .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ');
+
+    const node: TreeNode = {
+      id: fullPath,
+      label,
+      type: 'folder',
+      children: [],
+      isExpanded: undefined
+    };
+
+    map[fullPath] = node;
+
+    // Attach to parent
+    if (pathSegments.length > 1) {
+      const parentPath = pathSegments.slice(0, -1).join('/');
+      const parentSegments = pathSegments.slice(0, -1);
+      const parent = getOrCreateFolder(parentSegments, parentPath);
+      parent.children!.push(node);
+    } else {
+      root.push(node);
+    }
+
+    return node;
+  };
+
+  // 1. Build full tree first
+  compositions.forEach(comp => {
+    const parts = comp.id.split('/');
+
+    // If it's at root (no slashes), just add to root
+    if (parts.length === 1) {
+      root.push({
+        id: comp.id,
+        label: comp.name,
+        type: 'composition',
+        data: comp
+      });
+      return;
+    }
+
+    // It's in a folder
+    const folderParts = parts.slice(0, -1);
+    const folderPath = folderParts.join('/');
+    const folder = getOrCreateFolder(folderParts, folderPath);
+
+    folder.children!.push({
+      id: comp.id,
+      label: comp.name,
+      type: 'composition',
+      data: comp
+    });
+  });
+
+  // 2. Sort function
+  const sortNodes = (nodes: TreeNode[]) => {
+    nodes.sort((a, b) => {
+      if (a.type === b.type) return a.label.localeCompare(b.label);
+      return a.type === 'folder' ? -1 : 1; // Folders first
+    });
+    nodes.forEach(n => {
+      if (n.children) sortNodes(n.children);
+    });
+  };
+
+  // 3. Filter logic
+  if (!query) {
+    sortNodes(root);
+    return root;
+  }
+
+  // Recursive filter function
+  // Returns true if node or any child matches
+  const filterNode = (node: TreeNode): boolean => {
+    const matchesSelf = node.label.toLowerCase().includes(query);
+
+    if (node.type === 'composition') {
+      return matchesSelf;
+    }
+
+    // It's a folder
+    if (!node.children) return false;
+
+    // Filter children
+    const matchingChildren = node.children.filter(child => filterNode(child));
+
+    if (matchingChildren.length > 0) {
+      node.children = matchingChildren;
+      node.isExpanded = true; // Expand if children match
+      return true;
+    }
+
+    // If folder itself matches, keep it (and maybe show empty? or all children?)
+    // Standard behavior: if folder matches, show all children.
+    // But here we filtered children recursively.
+    // Let's say if folder matches, we keep matching children.
+    // If folder matches but no children match, do we show it? Yes.
+    // If folder matches, should we show ALL children?
+    // Often yes. But let's stick to strict filtering for now to avoid clutter.
+    return matchesSelf;
+  };
+
+  // Apply filter
+  const filteredRoot = root.filter(node => filterNode(node));
+  sortNodes(filteredRoot);
+
+  return filteredRoot;
+}


### PR DESCRIPTION
This PR implements a hierarchical tree view for the Studio Compositions Panel. Previously, compositions were displayed as a flat list, which caused confusion when multiple compositions had the same name but resided in different folders (e.g., `client-a/promo` vs `client-b/promo`). The new view parses the composition IDs (which contain relative paths) into a folder structure, allowing users to browse their project organization naturally.

Key changes:
- `packages/studio/src/utils/tree.ts`: Utility to build tree structure from composition list.
- `packages/studio/src/components/CompositionsPanel/CompositionTree.tsx`: Recursive component for rendering folders and items.
- `packages/studio/src/components/CompositionsPanel/CompositionsPanel.tsx`: Updated to use the tree view.
- `packages/studio/src/components/CompositionsPanel/CompositionItem.tsx`: Extracted item rendering logic.

Verified with unit tests and Playwright visual inspection.

---
*PR created automatically by Jules for task [3308313447395542826](https://jules.google.com/task/3308313447395542826) started by @BintzGavin*