### PR TITLE
✨ RENDERER: Fix GSAP Sync & Promo Render

### DIFF
--- a/examples/promo-video/render.ts
+++ b/examples/promo-video/render.ts
@@ -4,15 +4,19 @@
  * Run with: npx ts-node render.ts
  * 
  * Make sure the dev server is running first:
- * npm run dev (from the project root)
+ * npm run dev:promo (from the project root)
  */
 
 import { Renderer } from '../../packages/renderer/src/index.ts';
 import path from 'path';
+import fs from 'fs';
 
 async function main() {
-  const compositionUrl = 'http://localhost:3002/examples/promo-video/composition.html';
+  const compositionUrl = 'http://localhost:3001/composition.html';
   const outputPath = path.resolve(__dirname, 'output/helios-promo.mp4');
+
+  // Ensure output directory exists
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
   console.log('🎬 Starting Helios Promo Video Render...');
   console.log(`   Source: ${compositionUrl}`);

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -39,7 +39,7 @@ export class SeekTimeDriver implements TimeDriver {
     try {
       await page.waitForFunction(
         () => typeof (window as any).__helios_gsap_timeline__ !== 'undefined' || typeof (window as any).helios !== 'undefined',
-        { timeout: 5000 }
+        { timeout: this.timeout }
       );
     } catch (e) {
       // Ignore - likely a static page or initialization took too long.


### PR DESCRIPTION
Updated SeekTimeDriver to use stabilityTimeout for app initialization and fixed examples/promo-video render script.

---
*PR created automatically by Jules for task [13337342718778291057](https://jules.google.com/task/13337342718778291057) started by @BintzGavin*