### PR TITLE
feat(studio): Enrich Component Registry with descriptions and install status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10579,7 +10579,7 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/renderer": "^0.0.2",

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -3,8 +3,10 @@ import { createServer } from 'vite';
 import { studioApiPlugin } from '@helios-project/studio/cli';
 import { createRequire } from 'module';
 import path from 'path';
+import fs from 'fs';
 import { registry } from '../registry/manifest.js';
 import { installComponent } from '../utils/install.js';
+import { loadConfig } from '../utils/config.js';
 
 export function registerStudioCommand(program: Command) {
   program
@@ -38,6 +40,15 @@ export function registerStudioCommand(program: Command) {
               components: registry,
               onInstallComponent: async (name: string) => {
                 await installComponent(process.cwd(), name);
+              },
+              onCheckInstalled: async (name: string) => {
+                const config = loadConfig(process.cwd());
+                const componentsDir = config?.directories.components || 'src/components/helios';
+                const comp = registry.find(c => c.name === name);
+                if (!comp) return false;
+
+                const targetDir = path.resolve(process.cwd(), componentsDir);
+                return comp.files.every(f => fs.existsSync(path.join(targetDir, f.name)));
               }
             })
           ]

--- a/packages/cli/src/registry/manifest.ts
+++ b/packages/cli/src/registry/manifest.ts
@@ -162,6 +162,7 @@ export const Watermark: React.FC<WatermarkProps> = ({
 export const registry: ComponentDefinition[] = [
   {
     name: 'timer',
+    description: 'Displays a countdown or stopwatch synchronized with the video frame.',
     type: 'react',
     files: [
       {
@@ -180,6 +181,7 @@ export const registry: ComponentDefinition[] = [
   },
   {
     name: 'progress-bar',
+    description: 'Visualizes playback progress.',
     type: 'react',
     files: [
       {
@@ -198,6 +200,7 @@ export const registry: ComponentDefinition[] = [
   },
   {
     name: 'watermark',
+    description: 'Overlay text or image logo.',
     type: 'react',
     files: [
       {

--- a/packages/cli/src/registry/types.ts
+++ b/packages/cli/src/registry/types.ts
@@ -5,6 +5,7 @@ export interface ComponentFile {
 
 export interface ComponentDefinition {
   name: string;
+  description?: string;
   type: 'react' | 'vue' | 'svelte' | 'vanilla';
   files: ComponentFile[];
   dependencies?: Record<string, string>;

--- a/packages/studio/src/components/ComponentsPanel/ComponentsPanel.css
+++ b/packages/studio/src/components/ComponentsPanel/ComponentsPanel.css
@@ -76,3 +76,13 @@
 .install-button.success {
   background-color: var(--success-color, #4caf50);
 }
+
+.component-badge.installed {
+  background-color: var(--success-color, #4caf50);
+  color: white;
+  font-size: 0.7em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: 0; /* Handled by flex gap */
+  font-weight: 600;
+}


### PR DESCRIPTION
Enhanced the Component Registry in Studio and CLI to support component descriptions and track installation status.

- Updated CLI registry manifest with descriptions for core components.
- Added `description` field to `ComponentDefinition` types.
- Implemented `onCheckInstalled` in Studio Plugin (CLI side) to verify component files.
- Updated Studio API to return `installed` status.
- Updated Components Panel UI to show descriptions and installed badges.

---
*PR created automatically by Jules for task [10840070651487830833](https://jules.google.com/task/10840070651487830833) started by @BintzGavin*