### PR TITLE
✨ CLI: Track Installed Components

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -1,103 +1,89 @@
 # CLI Context
 
 ## A. Architecture
-
-The Helios CLI is the primary interface for managing Helios projects, rendering compositions, and interacting with the component registry. It is built with `commander` and compiled to a Node.js binary.
-
-**Key Components:**
-- **Entry Point**: `bin/helios.js` (shebang) calls `dist/index.js`.
-- **Command Registration**: `src/index.ts` initializes the program and registers commands from `src/commands/`.
-- **Registry Client**: `src/registry/client.ts` handles component fetching (remote with local fallback).
-- **Utilities**: `src/utils/` contains helpers for config loading (`config.ts`), installation logic (`install.ts`), and package management (`package-manager.ts`).
-- **Templates**: `src/templates/` contains project scaffolds for React, Vue, Svelte, Solid, and Vanilla.
+The Helios CLI uses `commander` to define commands.
+Entry point is `bin/helios.js` which runs the built `dist/index.js`.
+`src/index.ts` registers commands imported from `src/commands/`.
 
 ## B. File Tree
-
-```
 packages/cli/
 ├── bin/
-│   └── helios.js           # Executable entry point
+│   └── helios.js
 ├── src/
-│   ├── index.ts            # Main application setup
+│   ├── index.ts
 │   ├── commands/
-│   │   ├── add.ts          # 'helios add' command
-│   │   ├── components.ts   # 'helios components' command
-│   │   ├── init.ts         # 'helios init' command
-│   │   ├── merge.ts        # 'helios merge' command
-│   │   ├── render.ts       # 'helios render' command
-│   │   ├── studio.ts       # 'helios studio' command
-│   └── registry/
-│       ├── client.ts       # RegistryClient implementation
-│       ├── manifest.ts     # Local fallback registry data
-│       └── types.ts        # Registry type definitions
-│   └── templates/
-│       ├── react.ts        # React scaffold
-│       ├── solid.ts        # SolidJS scaffold
-│       ├── svelte.ts       # Svelte scaffold
-│       ├── vanilla.ts      # Vanilla scaffold
-│       └── vue.ts          # Vue scaffold
+│   │   ├── add.ts
+│   │   ├── components.ts
+│   │   ├── init.ts
+│   │   ├── merge.ts
+│   │   ├── render.ts
+│   │   └── studio.ts
+│   ├── registry/
+│   │   ├── client.ts
+│   │   └── types.ts
+│   ├── templates/
+│   │   ├── react.ts
+│   │   ├── solid.ts
+│   │   ├── svelte.ts
+│   │   ├── vanilla.ts
+│   │   └── vue.ts
 │   └── utils/
-│       ├── config.ts       # Config file loader
-│       ├── install.ts      # Component installation logic
-│       └── package-manager.ts # Package manager detection & installation
-└── package.json
-```
+│       ├── config.ts
+│       ├── install.ts
+│       ├── logger.ts
+│       └── package-manager.ts
+├── package.json
+└── tsconfig.json
 
 ## C. Commands
 
-### `helios init [options]`
-Initializes a new Helios project configuration and scaffolds structure if missing. Supports React, Vue, Svelte, Solid, and Vanilla templates.
-- **Options**:
-  - `-y, --yes`: Skip prompts and use defaults (React).
-  - `-f, --framework <framework>`: Specify framework (react, vue, svelte, solid, vanilla).
+### `init`
+Initialize a new Helios project.
+- `-y, --yes`: Skip prompts
+- `-f, --framework <framework>`: Specify framework (react, vue, svelte, solid, vanilla)
 
-### `helios add <component> [options]`
-Adds a component (and its dependencies) to the project.
-- **Arguments**:
-  - `component`: Name of the component to install.
-- **Options**:
-  - `--no-install`: Skip dependency installation.
+### `studio`
+Launch the Studio development server.
+- `--port <number>`: Port (default: 3000)
+- `--open`: Open browser
 
-### `helios components`
-Lists available components in the registry.
+### `add <component>`
+Add a component to the project.
+- `--no-install`: Skip dependency installation
 
-### `helios studio [options]`
-Launches the Helios Studio development server. Respects user's `vite.config.ts`.
-- **Options**:
-  - `-p, --port <number>`: Port to run on (default: 3000).
+### `components`
+List available components in the registry.
 
-### `helios render [options]`
-Renders a composition to video using `@helios-project/renderer`.
-- **Options**:
-  - `-c, --composition <id>`: Composition ID to render.
-  - `-o, --output <path>`: Output file path.
-  - `--start-frame <number>`: Start frame (inclusive).
-  - `--frame-count <number>`: Number of frames to render.
+### `render <input>`
+Render a composition to video.
+- `-o, --output <path>`: Output path
+- `--width <number>`
+- `--height <number>`
+- `--fps <number>`
+- `--duration <number>`
+- `--quality <number>`
+- `--mode <canvas|dom>`
+- `--concurrency <number>`: Number of concurrent render jobs
 
-### `helios merge <output> [inputs...]`
-Merges multiple video files into a single output without re-encoding.
-- **Arguments**:
-  - `output`: Output filename.
-  - `inputs`: List of input video files.
+### `merge`
+Merge multiple video files.
+- `-o, --output <path>`: Output path
 
 ## D. Configuration
-
-The CLI reads `helios.config.json` in the project root.
-
-**Example `helios.config.json`:**
-```json
-{
-  "version": "1.0.0",
-  "directories": {
-    "components": "src/components/helios",
-    "lib": "src/lib"
-  },
-  "framework": "react"
+`helios.config.json`
+```typescript
+interface HeliosConfig {
+  version: string;
+  directories: {
+    components: string; // e.g., "src/components/helios"
+    lib: string;        // e.g., "src/lib"
+  };
+  framework?: 'react' | 'vue' | 'svelte' | 'solid' | 'vanilla';
+  components: string[]; // List of installed components
 }
 ```
 
 ## E. Integration
-
-- **Registry**: Uses `RegistryClient` to fetch components from `HELIOS_REGISTRY_URL` (env var) or falls back to internal manifest.
-- **Renderer**: Invokes `@helios-project/renderer` for rendering tasks.
-- **Studio**: Spawns `@helios-project/studio` for the UI.
+- **Registry**: Fetches components via `registry/client.ts`.
+- **Renderer**: Delegates to `@helios-project/renderer` for `render` and `merge`.
+- **Studio**: Delegates to `@helios-project/studio` for `studio` command.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.10.0
+
+- ✅ Track Installed Components - Updated `helios add` to automatically record installed components in `helios.config.json` and persist config changes.
+
 ## CLI v0.9.2
 
 - ✅ SolidJS Support Verified - Verified SolidJS template functionality and added `--framework` CLI flag for automation.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.9.2
+**Version**: 0.10.0
 
 ## Current State
 
@@ -46,3 +46,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.8.0] ✅ Auto-Install Dependencies - Implemented automatic dependency installation for `helios add` with `--no-install` flag
 [v0.9.0] ✅ Multi-Framework Support - Enabled `helios init` for Vue, Svelte, and Vanilla, and updated `helios studio` to load user config.
 [v0.9.2] ✅ SolidJS Support - Added SolidJS template to `helios init` and added `--framework` flag for automated scaffolding.
+[v0.10.0] ✅ Track Installed Components - Updated `helios add` to record installed components in `helios.config.json`.

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -7,7 +7,8 @@ export interface HeliosConfig {
     components: string;
     lib: string;
   };
-  framework?: 'react' | 'vue' | 'svelte' | 'vanilla';
+  framework?: 'react' | 'vue' | 'svelte' | 'solid' | 'vanilla';
+  components: string[];
 }
 
 export const DEFAULT_CONFIG: HeliosConfig = {
@@ -16,6 +17,7 @@ export const DEFAULT_CONFIG: HeliosConfig = {
     components: 'src/components/helios',
     lib: 'src/lib',
   },
+  components: [],
 };
 
 export function loadConfig(cwd: string = process.cwd()): HeliosConfig | null {
@@ -32,5 +34,14 @@ export function loadConfig(cwd: string = process.cwd()): HeliosConfig | null {
     return config as HeliosConfig;
   } catch (error) {
     throw new Error(`Failed to parse helios.config.json: ${(error as Error).message}`);
+  }
+}
+
+export function saveConfig(config: HeliosConfig, cwd: string = process.cwd()): void {
+  const configPath = path.resolve(cwd, 'helios.config.json');
+  try {
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+  } catch (error) {
+    throw new Error(`Failed to save helios.config.json: ${(error as Error).message}`);
   }
 }

--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
-import { loadConfig } from './config.js';
+import { loadConfig, saveConfig } from './config.js';
 import { defaultClient } from '../registry/client.js';
 import { installPackage } from './package-manager.js';
 
@@ -86,5 +86,16 @@ export async function installComponent(
     } else if (depsToInstall.length > 0) {
       console.log(chalk.gray(`\nSkipping installation (--no-install)`));
     }
+  }
+
+  // Update config
+  if (!config.components) {
+    config.components = [];
+  }
+
+  if (!config.components.includes(componentName)) {
+    config.components.push(componentName);
+    saveConfig(config, rootDir);
+    console.log(chalk.green(`✓ Added ${componentName} to helios.config.json`));
   }
 }


### PR DESCRIPTION
Updated `helios add` to record installed components in `helios.config.json` and persist config changes. Added `components` array to `HeliosConfig` and implemented `saveConfig`. Validated using a custom test script.

---
*PR created automatically by Jules for task [9878579148195323344](https://jules.google.com/task/9878579148195323344) started by @BintzGavin*