### PR TITLE
Plan: Enable Remote Registry in Studio

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -45,3 +45,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.9.1] - Registry Tracking Gap
 **Learning:** `helios add` installs components but does not record them in `helios.config.json` or any lockfile. This prevents inventory management (`list --installed`) and future updates (`helios update`).
 **Action:** When designing package managers or registries, always include a mechanism to track installed assets (like `components.json` or `package.json` deps) to enable lifecycle management.
+
+## [0.10.0] - Studio Registry Disconnect
+**Learning:** `helios studio` was passing a static local registry to the UI, ignoring the remote registry logic implemented in `helios add` (via `RegistryClient`). This caused the Studio UI to show outdated component lists even if the CLI could fetch new ones.
+**Action:** When a shared resource (like Registry) is accessed by multiple commands (`add`, `studio`), ensure they all use the same client/abstraction (`RegistryClient`) to maintain consistency.

--- a/.sys/plans/2025-02-18-CLI-Studio-Remote-Registry.md
+++ b/.sys/plans/2025-02-18-CLI-Studio-Remote-Registry.md
@@ -1,0 +1,50 @@
+# Plan: Enable Remote Registry in Helios Studio
+
+## 1. Context & Goal
+- **Objective**: Update the `helios studio` command to fetch the component registry from a remote source (with local fallback) instead of using the hardcoded local manifest.
+- **Trigger**: Vision gap. `AGENTS.md` defines the CLI as the primary interface for the registry ("Shadcn-style"), but the Studio command currently passes a static local registry to the UI, causing inconsistency with `helios add` which supports remote fetching.
+- **Impact**: Users will see the full list of available components in the Studio UI, consistent with `helios components` and `helios add`, enabling a dynamic ecosystem.
+
+## 2. File Inventory
+- **Modify**: `packages/cli/src/commands/studio.ts` (Fetch registry before starting server)
+- **Read-Only**: `packages/cli/src/registry/client.ts` (To verify `RegistryClient` usage)
+- **Read-Only**: `packages/studio/src/server/plugin.ts` (To verify `studioApiPlugin` interface)
+
+## 3. Implementation Spec
+- **Architecture**:
+  - In `studio.ts` action handler:
+  - Initialize `defaultClient` (already exported from `client.ts`).
+  - Await `defaultClient.getComponents()` to retrieve the list of components (this handles the fetch with timeout and local fallback).
+  - Pass the result to `studioApiPlugin({ components: ... })`.
+  - Add a console log to indicate registry loading status.
+- **Pseudo-Code**:
+  ```typescript
+  import { defaultClient } from '../registry/client.js';
+  // ...
+  action(async (options) => {
+    console.log('Starting Studio...');
+    console.log('Loading component registry...');
+    const components = await defaultClient.getComponents();
+
+    // ... inside createServer ...
+    plugins: [
+      studioApiPlugin({
+        // ...
+        components: components,
+        // ...
+      })
+    ]
+  })
+  ```
+- **Public API Changes**: None.
+- **Dependencies**: None.
+
+## 4. Test Plan
+- **Verification**:
+  1.  Start a mock HTTP server returning a custom component list.
+  2.  Run `helios studio` with `HELIOS_REGISTRY_URL` pointing to the mock server.
+  3.  Query `http://localhost:5173/api/components` and verify it returns the custom list.
+  4.  Stop mock server and run `helios studio` again (fallback test).
+  5.  Query `http://localhost:5173/api/components` and verify it returns the local registry.
+- **Success Criteria**: Studio API returns remote components when available, and local components when offline.
+- **Edge Cases**: Registry fetch timeout (handled by `client.ts`), Registry returns invalid JSON (handled by `client.ts`).


### PR DESCRIPTION
Identified a gap where `helios studio` was using a static local registry while `helios add` supported remote fetching. Created a plan to unify this behavior by updating the studio command to use `RegistryClient`.

---
*PR created automatically by Jules for task [16189828114564874778](https://jules.google.com/task/16189828114564874778) started by @BintzGavin*