### PR TITLE
✨ CLI: Implement list command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -15,6 +15,7 @@ packages/cli/
 │   │   ├── add.ts
 │   │   ├── components.ts
 │   │   ├── init.ts
+│   │   ├── list.ts
 │   │   ├── merge.ts
 │   │   ├── render.ts
 │   │   └── studio.ts
@@ -50,6 +51,9 @@ Launch the Studio development server.
 ### `add <component>`
 Add a component to the project.
 - `--no-install`: Skip dependency installation
+
+### `list`
+List installed components in the project.
 
 ### `components`
 List available components in the registry.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.11.0
+
+- ✅ Implement List Command - Implemented `helios list` to display installed components.
+
 ## CLI v0.10.1
 
 - ✅ Sync & Verify - Synced CLI version, updated context documentation, and verified distributed rendering concurrency flags.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### CLI v0.11.0
+- ✅ Completed: Implement List Command - Implemented `helios list` to display installed components.
+
 ### RENDERER v1.71.1
 - ✅ Completed: Deterministic Randomness - Enforced deterministic Math.random() in `CdpTimeDriver` and `SeekTimeDriver` by injecting a seeded Mulberry32 PRNG via `page.addInitScript`, ensuring consistent generative rendering. Verified with `verify-random-determinism.ts`.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.10.1
+**Version**: 0.11.0
 
 ## Current State
 
@@ -16,6 +16,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 - `helios studio` - Launches the Helios Studio dev server
 - `helios init` - Initializes a new Helios project configuration and scaffolds project structure
 - `helios add` - Adds a component to the project
+- `helios list` - Lists installed components in the project
 - `helios components` - Lists available components in the registry
 - `helios render` - Renders a composition to video
 - `helios merge` - Merges multiple video files into one without re-encoding
@@ -47,3 +48,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.9.0] ✅ Multi-Framework Support - Enabled `helios init` for Vue, Svelte, and Vanilla, and updated `helios studio` to load user config.
 [v0.9.2] ✅ SolidJS Support - Added SolidJS template to `helios init` and added `--framework` flag for automated scaffolding.
 [v0.10.0] ✅ Track Installed Components - Updated `helios add` to record installed components in `helios.config.json`.
+[v0.11.0] ✅ Implement List Command - Implemented `helios list` to display installed components.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10579,7 +10579,7 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.9.2",
+      "version": "0.11.0",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/renderer": "^0.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/cli",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "CLI for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,0 +1,32 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { loadConfig } from '../utils/config.js';
+
+export function registerListCommand(program: Command) {
+  program
+    .command('list')
+    .description('List installed components')
+    .action(() => {
+      try {
+        const config = loadConfig();
+
+        if (!config) {
+          console.error(chalk.red('No helios.config.json found. Run "helios init" to start a project.'));
+          process.exit(1);
+        }
+
+        if (!config.components || config.components.length === 0) {
+          console.log(chalk.yellow('No components installed yet. Use "helios add [component]" to install one.'));
+          return;
+        }
+
+        console.log(chalk.bold('Installed components:'));
+        for (const component of config.components) {
+          console.log(` - ${chalk.cyan(component)}`);
+        }
+      } catch (error: any) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,13 +5,14 @@ import { registerAddCommand } from './commands/add.js';
 import { registerComponentsCommand } from './commands/components.js';
 import { registerRenderCommand } from './commands/render.js';
 import { registerMergeCommand } from './commands/merge.js';
+import { registerListCommand } from './commands/list.js';
 
 const program = new Command();
 
 program
   .name('helios')
   .description('Helios CLI')
-  .version('0.10.1');
+  .version('0.11.0');
 
 registerStudioCommand(program);
 registerInitCommand(program);
@@ -19,5 +20,6 @@ registerAddCommand(program);
 registerComponentsCommand(program);
 registerRenderCommand(program);
 registerMergeCommand(program);
+registerListCommand(program);
 
 program.parse(process.argv);


### PR DESCRIPTION
💡 What: Implemented the helios list command to display installed components.
🎯 Why: To allow users to verify their inventory and track installed components as established in the "Track Installed Components" milestone.
📊 Impact: Users can now see what components are installed in their project without opening the config file.
🔬 Verification: Verified manually by running the command against various mock configurations (missing, empty, populated).

---
*PR created automatically by Jules for task [2406221698557168977](https://jules.google.com/task/2406221698557168977) started by @BintzGavin*