### PR TITLE
✨ PLAYER: Fix Poster Visibility Logic

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -16,6 +16,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### DEMO v1.118.0
 - ✅ Completed: Standardize Simple Animation Example - Modernized `examples/simple-animation` with TypeScript, `package.json`, and proper build config.
 
+### PLAYER v0.70.4
+- ✅ Completed: Fix Poster Visibility - Implemented persistent `_hasPlayed` state to ensure poster remains hidden when seeking back to frame 0 after playback.
+
 ### PLAYER v0.70.3
 - ✅ Completed: Refactor Granular Playback - Refactored renderSettingsMenu to use dynamic generation for playback speed options.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.70.3
+**Version**: v0.70.4
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -58,6 +58,7 @@
 - **Audio Metering**: Supports real-time audio metering via `startAudioMetering()` API and `audiometering` event, enabling visualization of audio levels (stereo/peak) in host applications.
 - **Export API**: Exposes public `export()` method for programmatic control over client-side exports, supporting Video (MP4/WebM) and Snapshot (PNG/JPEG) formats.
 
+[v0.70.4] ✅ Completed: Fix Poster Visibility - Implemented persistent `_hasPlayed` state to ensure poster remains hidden when seeking back to frame 0 after playback.
 [v0.70.3] ✅ Completed: Refactor Granular Playback - Refactored renderSettingsMenu to use dynamic generation for playback speed options.
 [v0.70.2] ✅ Verified: Granular Playback - Verified expanded playback speed options (0.25x - 2x) via unit tests.
 [v0.70.1] ✅ Verified: Robust E2E Verification - Expanded E2E test coverage (Playback, Scrubber, Menus) and created a dependency-free mock fixture to ensure stability.

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -1218,6 +1218,28 @@ describe('HeliosPlayer', () => {
         expect(posterContainer!.classList.contains('hidden')).toBe(true);
     });
 
+    it('should keep poster hidden when seeking back to start after playing', () => {
+        player.setAttribute('poster', 'poster.jpg');
+        player.setAttribute('src', 'test.html');
+
+        // Load and connect controller
+        (player as any).setController(mockController);
+
+        const posterContainer = player.shadowRoot!.querySelector('.poster-container');
+
+        // 1. Play
+        mockController.getState.mockReturnValue({ currentFrame: 10, duration: 10, fps: 30, isPlaying: true });
+        (player as any).updateUI(mockController.getState());
+        expect(posterContainer!.classList.contains('hidden')).toBe(true);
+
+        // 2. Pause and Seek back to 0
+        mockController.getState.mockReturnValue({ currentFrame: 0, duration: 10, fps: 30, isPlaying: false });
+        (player as any).updateUI(mockController.getState());
+
+        // Should remain hidden
+        expect(posterContainer!.classList.contains('hidden')).toBe(true);
+    });
+
     it('should hide status overlay when poster is present (initial load)', () => {
         const p = new HeliosPlayer();
         p.setAttribute('poster', 'poster.jpg');

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -772,6 +772,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   private bigPlayBtn: HTMLDivElement;
   private pendingSrc: string | null = null;
   private isLoaded: boolean = false;
+  private _hasPlayed: boolean = false;
 
   private resizeObserver: ResizeObserver;
   private controller: HeliosController | null = null;
@@ -1866,6 +1867,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     this._error = null;
     this._networkState = HeliosPlayer.NETWORK_LOADING;
     this._readyState = HeliosPlayer.HAVE_NOTHING;
+    this._hasPlayed = false;
     this.dispatchEvent(new Event('loadstart'));
 
     this.iframe.src = src;
@@ -1901,15 +1903,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     }
 
     if (this.hasAttribute("poster")) {
-      let shouldHide = false;
-      if (this.controller) {
-        const state = this.controller.getState();
-        if (state.isPlaying || state.currentFrame > 0) {
-          shouldHide = true;
-        }
-      }
-
-      if (shouldHide) {
+      if (this._hasPlayed) {
         this.posterContainer.classList.add("hidden");
       } else {
         this.posterContainer.classList.remove("hidden");
@@ -2589,10 +2583,13 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
           }
       }
 
-      // Hide poster if we are playing or have advanced
+      // Update hasPlayed state
       if (state.isPlaying || state.currentFrame > 0) {
-         this.posterContainer.classList.add("hidden");
+        this._hasPlayed = true;
       }
+
+      // Consolidate poster visibility
+      this.updatePosterVisibility();
 
       // Event Dispatching
       if (this.lastState) {


### PR DESCRIPTION
This PR fixes an issue where the video poster would reappear when seeking back to frame 0 after playback had started. It introduces a persistent `_hasPlayed` state that ensures the poster remains hidden until the source is changed.

## Verification
- Added a regression test in `packages/player/src/index.test.ts`.
- Ran full test suite `npm run test` in `packages/player`.

---
*PR created automatically by Jules for task [14115828308070620520](https://jules.google.com/task/14115828308070620520) started by @BintzGavin*