### PR TITLE
✨ STUDIO: Resizable Layout

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -17,7 +17,11 @@ The Studio is a browser-based development environment for Helios. It consists of
 packages/studio/
 ├── bin/                # CLI entry point
 ├── src/
-│   ├── components/     # UI Components (Sidebar, Stage, Timeline, etc.)
+│   ├── components/     # UI Components
+│   │   ├── Layout/     # Layout system (StudioLayout, Resizer)
+│   │   ├── Sidebar/    # Sidebar panels
+│   │   ├── Stage/      # Preview area
+│   │   └── Timeline/   # Timeline area
 │   ├── context/        # React Context (StudioContext, ToastContext)
 │   ├── hooks/          # Custom hooks (usePersistentState)
 │   ├── server/         # Backend logic (discovery, render-manager, plugin)
@@ -50,6 +54,7 @@ Commands:
 
 ## Section D: UI Components
 
+-   **StudioLayout**: Main layout with resizable Sidebar, Inspector, and Timeline panels.
 -   **Sidebar**: Navigation tabs (Compositions, Assets, Components, Captions, Audio, Renders).
 -   **Stage**: Main preview area containing `<helios-player>`.
 -   **Timeline**: Track-based timeline for scrubbing, editing, and adjusting time-based prop markers (Stacked Audio Tracks).

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.100.0
+- ✅ Completed: Resizable Layout - Implemented resizable Sidebar, Inspector, and Timeline panels with persistence using `localStorage` and CSS variables.
+
 ## STUDIO v0.98.0
 - ✅ Completed: CLI Solid Init - Added SolidJS template support to `helios init` command.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### STUDIO v0.100.0
+- ✅ Completed: Resizable Layout - Implemented resizable Sidebar, Inspector, and Timeline panels with persistence using `localStorage` and CSS variables.
+
 ### RENDERER v1.72.0
 - ✅ Completed: Orchestrator Cancellation - Implemented robust cancellation in `RenderOrchestrator`. Now, if a single distributed worker fails, all concurrent workers are immediately aborted via `AbortController` to prevent resource waste. Verified with `verify-distributed-cancellation.ts`.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.99.0
+**Version**: 0.100.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.100.0] ✅ Completed: Resizable Layout - Implemented resizable Sidebar, Inspector, and Timeline panels with persistence using `localStorage` and CSS variables.
 - [v0.99.0] ✅ Completed: CLI List Command - Verified implementation of `helios list` command to display installed components from `helios.config.json`.
 - [v0.98.0] ✅ Completed: CLI Solid Init - Added SolidJS template support to `helios init` command.
 - [v0.97.1] ✅ Verified: Build & Tests - Verified studio build process and unit tests after ensuring dependencies (core, renderer, player) are built, confirming system integrity.

--- a/packages/studio/src/components/Layout/Resizer.css
+++ b/packages/studio/src/components/Layout/Resizer.css
@@ -1,0 +1,22 @@
+.resizer {
+  background-color: transparent;
+  z-index: 100;
+  transition: background-color 0.2s;
+  user-select: none;
+  touch-action: none;
+}
+
+.resizer:hover, .resizer.active {
+  background-color: #007fd4;
+}
+
+.resizer.horizontal {
+  width: 10px;
+  cursor: col-resize;
+  /* Visual adjustments handled by parent placement or transforms */
+}
+
+.resizer.vertical {
+  height: 10px;
+  cursor: row-resize;
+}

--- a/packages/studio/src/components/Layout/Resizer.tsx
+++ b/packages/studio/src/components/Layout/Resizer.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import './Resizer.css';
+
+interface ResizerProps {
+  onResize: (delta: number) => void;
+  direction?: 'horizontal' | 'vertical';
+  className?: string;
+}
+
+export const Resizer: React.FC<ResizerProps> = ({ onResize, direction = 'horizontal', className = '' }) => {
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    let lastPosition = direction === 'horizontal' ? e.clientX : e.clientY;
+    setIsDragging(true);
+
+    const handleMove = (moveEvent: MouseEvent) => {
+      const currentPosition = direction === 'horizontal' ? moveEvent.clientX : moveEvent.clientY;
+      const delta = currentPosition - lastPosition;
+
+      if (delta !== 0) {
+        onResize(delta);
+        lastPosition = currentPosition;
+      }
+    };
+
+    const handleUp = () => {
+      setIsDragging(false);
+      window.removeEventListener('mousemove', handleMove);
+      window.removeEventListener('mouseup', handleUp);
+    };
+
+    window.addEventListener('mousemove', handleMove);
+    window.addEventListener('mouseup', handleUp);
+  };
+
+  return (
+    <div
+      className={`resizer ${direction} ${isDragging ? 'active' : ''} ${className}`}
+      onMouseDown={handleMouseDown}
+    />
+  );
+};

--- a/packages/studio/src/components/Layout/StudioLayout.css
+++ b/packages/studio/src/components/Layout/StudioLayout.css
@@ -16,8 +16,8 @@ html, body, #root {
     "header header header"
     "sidebar stage inspector"
     "sidebar timeline inspector";
-  grid-template-columns: 250px 1fr 300px;
-  grid-template-rows: 40px 1fr 300px;
+  grid-template-columns: var(--sidebar-width, 250px) 1fr var(--inspector-width, 300px);
+  grid-template-rows: 40px 1fr var(--timeline-height, 300px);
   gap: 1px;
   background-color: #000;
 }
@@ -56,4 +56,31 @@ html, body, #root {
   grid-area: timeline;
   background-color: #1e1e1e;
   border-top: 1px solid #333;
+}
+
+.resizer-sidebar {
+  grid-column: 1;
+  grid-row: 2 / -1;
+  justify-self: end;
+  transform: translateX(50%);
+  z-index: 10;
+  height: 100%;
+}
+
+.resizer-inspector {
+  grid-column: 3;
+  grid-row: 2 / -1;
+  justify-self: start;
+  transform: translateX(-50%);
+  z-index: 10;
+  height: 100%;
+}
+
+.resizer-timeline {
+  grid-column: 2;
+  grid-row: 3;
+  align-self: start;
+  transform: translateY(-50%);
+  z-index: 10;
+  width: 100%;
 }

--- a/packages/studio/src/components/Layout/StudioLayout.tsx
+++ b/packages/studio/src/components/Layout/StudioLayout.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import './StudioLayout.css';
+import { Resizer } from './Resizer';
 
 interface StudioLayoutProps {
   header?: React.ReactNode;
@@ -9,6 +10,10 @@ interface StudioLayoutProps {
   timeline?: React.ReactNode;
 }
 
+const DEFAULT_SIDEBAR_WIDTH = 250;
+const DEFAULT_INSPECTOR_WIDTH = 300;
+const DEFAULT_TIMELINE_HEIGHT = 300;
+
 export const StudioLayout: React.FC<StudioLayoutProps> = ({
   header,
   sidebar,
@@ -16,13 +21,103 @@ export const StudioLayout: React.FC<StudioLayoutProps> = ({
   inspector,
   timeline,
 }) => {
+  const [sidebarWidth, setSidebarWidth] = useState(() => {
+    try {
+      const saved = localStorage.getItem('helios-layout-sidebar');
+      return saved ? parseInt(saved, 10) : DEFAULT_SIDEBAR_WIDTH;
+    } catch (e) {
+      return DEFAULT_SIDEBAR_WIDTH;
+    }
+  });
+
+  const [inspectorWidth, setInspectorWidth] = useState(() => {
+    try {
+      const saved = localStorage.getItem('helios-layout-inspector');
+      return saved ? parseInt(saved, 10) : DEFAULT_INSPECTOR_WIDTH;
+    } catch (e) {
+      return DEFAULT_INSPECTOR_WIDTH;
+    }
+  });
+
+  const [timelineHeight, setTimelineHeight] = useState(() => {
+    try {
+      const saved = localStorage.getItem('helios-layout-timeline');
+      return saved ? parseInt(saved, 10) : DEFAULT_TIMELINE_HEIGHT;
+    } catch (e) {
+      return DEFAULT_TIMELINE_HEIGHT;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('helios-layout-sidebar', sidebarWidth.toString());
+    } catch (e) {
+      // Ignore storage errors
+    }
+  }, [sidebarWidth]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('helios-layout-inspector', inspectorWidth.toString());
+    } catch (e) {
+      // Ignore storage errors
+    }
+  }, [inspectorWidth]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('helios-layout-timeline', timelineHeight.toString());
+    } catch (e) {
+      // Ignore storage errors
+    }
+  }, [timelineHeight]);
+
+  const handleResizeSidebar = (delta: number) => {
+    setSidebarWidth((prev) => Math.max(150, Math.min(600, prev + delta)));
+  };
+
+  const handleResizeInspector = (delta: number) => {
+    // Dragging right (positive) decreases width
+    setInspectorWidth((prev) => Math.max(200, Math.min(600, prev - delta)));
+  };
+
+  const handleResizeTimeline = (delta: number) => {
+    // Dragging down (positive) decreases height
+    setTimelineHeight((prev) => Math.max(100, Math.min(800, prev - delta)));
+  };
+
+  const style = {
+    '--sidebar-width': `${sidebarWidth}px`,
+    '--inspector-width': `${inspectorWidth}px`,
+    '--timeline-height': `${timelineHeight}px`,
+  } as React.CSSProperties;
+
   return (
-    <div className="studio-layout">
+    <div className="studio-layout" style={style}>
       <header className="area-header">{header}</header>
+
       <aside className="area-sidebar">{sidebar}</aside>
+      <Resizer
+        className="resizer-sidebar"
+        direction="horizontal"
+        onResize={handleResizeSidebar}
+      />
+
       <main className="area-stage">{stage}</main>
+
       <aside className="area-inspector">{inspector}</aside>
+      <Resizer
+        className="resizer-inspector"
+        direction="horizontal"
+        onResize={handleResizeInspector}
+      />
+
       <footer className="area-timeline">{timeline}</footer>
+      <Resizer
+        className="resizer-timeline"
+        direction="vertical"
+        onResize={handleResizeTimeline}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Implemented resizable layout for Helios Studio.

Changes:
- Created `packages/studio/src/components/Layout/Resizer.tsx` and `Resizer.css`.
- Updated `packages/studio/src/components/Layout/StudioLayout.tsx` to include state management and `Resizer` components.
- Updated `packages/studio/src/components/Layout/StudioLayout.css` to use CSS variables and position resizers.
- Added persistence via `localStorage` (keys: `helios-layout-sidebar`, `helios-layout-inspector`, `helios-layout-timeline`).

Verification:
- Run `npx helios studio` (after build) to test interactively.
- Verified with Playwright script (`verify_layout.py`).
- Existing tests passed.

---
*PR created automatically by Jules for task [13746203963186118218](https://jules.google.com/task/13746203963186118218) started by @BintzGavin*