### PR TITLE
✨ STUDIO: Open in Editor

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -67,7 +67,7 @@ Commands:
 
 ## Section E: Integration
 
--   **StudioContext**: Central store for Studio state (compositions, assets, render jobs, player state). Syncs loop and playback range to `HeliosController`.
+-   **StudioContext**: Central store for Studio state (compositions, assets, render jobs, player state). Syncs loop and playback range to `HeliosController`. Provides `openInEditor(path)` to open files in default editor.
 -   **HeliosPlayer**: The web component used for playback. Studio controls it via `HeliosController`.
 -   **Backend API**:
     -   `GET /api/compositions`: List available compositions.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.101.0
+- ✅ Completed: Open in Editor - Implemented "Open in Editor" buttons for assets and compositions, allowing users to open source files directly in their default editor.
+
 ## STUDIO v0.100.0
 - ✅ Completed: Resizable Layout - Implemented resizable Sidebar, Inspector, and Timeline panels with persistence using `localStorage` and CSS variables.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### STUDIO v0.101.0
+- ✅ Completed: Open in Editor - Implemented "Open in Editor" buttons for assets and compositions, allowing users to open source files directly in their default editor.
+
 ### STUDIO v0.100.0
 - ✅ Completed: Resizable Layout - Implemented resizable Sidebar, Inspector, and Timeline panels with persistence using `localStorage` and CSS variables.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.100.0
+**Version**: 0.101.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.101.0] ✅ Completed: Open in Editor - Implemented "Open in Editor" buttons for assets and compositions, allowing users to open source files directly in their default editor.
 - [v0.100.0] ✅ Completed: Resizable Layout - Implemented resizable Sidebar, Inspector, and Timeline panels with persistence using `localStorage` and CSS variables.
 - [v0.99.0] ✅ Completed: CLI List Command - Verified implementation of `helios list` command to display installed components from `helios.config.json`.
 - [v0.98.0] ✅ Completed: CLI Solid Init - Added SolidJS template support to `helios init` command.

--- a/packages/studio/src/components/AssetsPanel/AssetItem.css
+++ b/packages/studio/src/components/AssetsPanel/AssetItem.css
@@ -35,6 +35,40 @@
   z-index: 10;
 }
 
+.rename-btn {
+  position: absolute;
+  top: 4px;
+  right: 28px;
+  width: 20px;
+  height: 20px;
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 12px;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.open-btn {
+  position: absolute;
+  top: 4px;
+  right: 52px;
+  width: 20px;
+  height: 20px;
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 12px;
+  cursor: pointer;
+  z-index: 10;
+}
+
 .asset-preview {
   width: 100%;
   height: 60px;

--- a/packages/studio/src/components/AssetsPanel/AssetItem.tsx
+++ b/packages/studio/src/components/AssetsPanel/AssetItem.tsx
@@ -10,7 +10,7 @@ interface AssetItemProps {
 
 export const AssetItem: React.FC<AssetItemProps> = ({ asset }) => {
   const { addToast } = useToast();
-  const { deleteAsset, renameAsset } = useStudio();
+  const { deleteAsset, renameAsset, openInEditor } = useStudio();
   const [isHovering, setIsHovering] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -55,6 +55,11 @@ export const AssetItem: React.FC<AssetItemProps> = ({ asset }) => {
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
     setShowDeleteConfirm(true);
+  };
+
+  const handleOpenInEditor = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    openInEditor(asset.id);
   };
 
   const handleConfirmDelete = () => {
@@ -215,24 +220,15 @@ export const AssetItem: React.FC<AssetItemProps> = ({ asset }) => {
             className="rename-btn"
             onClick={handleRenameClick}
             title="Rename Asset"
-            style={{
-              position: 'absolute',
-              top: '4px',
-              right: '28px',
-              width: '20px',
-              height: '20px',
-              background: 'rgba(0, 0, 0, 0.7)',
-              borderRadius: '50%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: '#fff',
-              fontSize: '12px',
-              cursor: 'pointer',
-              zIndex: 10
-            }}
           >
             ✎
+          </div>
+          <div
+            className="open-btn"
+            onClick={handleOpenInEditor}
+            title="Open in Editor"
+          >
+            📝
           </div>
         </>
       )}

--- a/packages/studio/src/components/CompositionsPanel/CompositionItem.tsx
+++ b/packages/studio/src/components/CompositionsPanel/CompositionItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Composition } from '../../context/StudioContext';
+import { Composition, useStudio } from '../../context/StudioContext';
 
 interface CompositionItemProps {
   composition: Composition;
@@ -16,6 +16,8 @@ export const CompositionItem: React.FC<CompositionItemProps> = ({
   onDuplicate,
   onDelete
 }) => {
+  const { openInEditor } = useStudio();
+
   return (
     <div
       className={`composition-item ${isActive ? 'active' : ''}`}
@@ -30,6 +32,16 @@ export const CompositionItem: React.FC<CompositionItemProps> = ({
           </div>
         )}
         <div className="composition-actions">
+          <button
+            className="composition-action-btn open-editor"
+            onClick={(e) => {
+              e.stopPropagation();
+              openInEditor(composition.id);
+            }}
+            title="Open in Editor"
+          >
+            📝
+          </button>
           <button
             className="composition-action-btn duplicate"
             onClick={(e) => onDuplicate(e, composition)}

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -173,6 +173,9 @@ interface StudioContextType {
   exportProgress: number;
   exportVideo: (format: 'mp4' | 'webm') => Promise<void>;
   cancelExport: () => void;
+
+  // Editor Integration
+  openInEditor: (path: string) => void;
 }
 
 export const StudioContext = createContext<StudioContextType | undefined>(undefined);
@@ -808,6 +811,12 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }
   };
 
+  const openInEditor = (path: string) => {
+    const safePath = path.replace(/^\/@fs/, '');
+    fetch('/__open-in-editor?file=' + encodeURIComponent(safePath))
+      .catch(err => console.error('Failed to open in editor', err));
+  };
+
   return (
     <StudioContext.Provider
       value={{
@@ -864,7 +873,8 @@ export const StudioProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         isExporting,
         exportProgress,
         exportVideo,
-        cancelExport
+        cancelExport,
+        openInEditor
       }}
     >
       {children}


### PR DESCRIPTION
Implemented "Open in Editor" functionality in Helios Studio.

Changes:
- Added `openInEditor` to `StudioContext`.
- Added "Open in Editor" button to `CompositionItem`.
- Added "Open in Editor" button to `AssetItem` and refactored its CSS to avoid inline styles.
- Updated documentation.


---
*PR created automatically by Jules for task [6376488285825425576](https://jules.google.com/task/6376488285825425576) started by @BintzGavin*