### PR TITLE
✨ CLI: Framework-Aware Registry

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -63,6 +63,6 @@ interface HeliosConfig {
 ```
 
 ## E. Integration
-- **Registry**: `src/registry/client.ts` fetches components from the remote registry (with local fallback).
-- **Studio**: `helios studio` wraps the Studio dev server and injects the registry via `studioApiPlugin`.
+- **Registry**: `src/registry/client.ts` fetches components from the remote registry (with local fallback). Supports framework-based filtering.
+- **Studio**: `helios studio` wraps the Studio dev server and injects the registry via `studioApiPlugin`. Filters registry based on `helios.config.json` framework.
 - **Renderer**: `helios render` invokes `@helios-project/renderer`.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.12.0
+
+- ✅ Framework-Aware Registry - Implemented framework filtering in `RegistryClient` and updated `helios studio` and `helios add` to respect project framework. Added SolidJS support to registry types.
+
 ## CLI v0.11.2
 
 - ✅ Unify Studio Registry - Updated `helios studio` to use the unified `RegistryClient`, enabling remote registry fetching and consistency with `helios add`.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.11.2
+**Version**: 0.12.0
 
 ## Current State
 
@@ -52,3 +52,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.11.0] ✅ Verified List Command - Verified `helios list` correctly lists installed components, handles empty lists, and missing config.
 [v0.11.1] ✅ Update Context & Verify - Updated context documentation for list command and re-verified functionality.
 [v0.11.2] ✅ Unify Studio Registry - Updated `helios studio` to use the unified `RegistryClient`, enabling remote registry fetching and consistency with `helios add`.
+[v0.12.0] ✅ Framework-Aware Registry - Implemented framework filtering in `RegistryClient` and updated `helios studio` and `helios add` to respect project framework. Added SolidJS support to registry types.

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -17,8 +17,11 @@ export function registerStudioCommand(program: Command) {
     .action(async (options) => {
       try {
         console.log(chalk.blue('Starting Studio...'));
-        console.log(chalk.dim('Fetching component registry...'));
-        const components = await defaultClient.getComponents();
+
+        const config = loadConfig(process.cwd());
+        console.log(chalk.dim(`Fetching component registry${config?.framework ? ` (${config.framework})` : ''}...`));
+
+        const components = await defaultClient.getComponents(config?.framework);
 
         const require = createRequire(import.meta.url);
 

--- a/packages/cli/src/registry/types.ts
+++ b/packages/cli/src/registry/types.ts
@@ -6,7 +6,7 @@ export interface ComponentFile {
 export interface ComponentDefinition {
   name: string;
   description?: string;
-  type: 'react' | 'vue' | 'svelte' | 'vanilla';
+  type: 'react' | 'vue' | 'svelte' | 'solid' | 'vanilla';
   files: ComponentFile[];
   dependencies?: Record<string, string>;
 }

--- a/packages/cli/src/utils/install.ts
+++ b/packages/cli/src/utils/install.ts
@@ -16,7 +16,7 @@ export async function installComponent(
     throw new Error('Configuration file not found. Run "helios init" first.');
   }
 
-  const component = await defaultClient.findComponent(componentName);
+  const component = await defaultClient.findComponent(componentName, config.framework);
   if (!component) {
     throw new Error(`Component "${componentName}" not found in registry.`);
   }


### PR DESCRIPTION
* 💡 **What**: Implemented framework filtering in `RegistryClient` and updated `helios studio` and `helios add` to respect project framework. Added SolidJS support to registry types.
* 🎯 **Why**: To prevent showing irrelevant components (e.g. React components in a Vue project) and enable SolidJS component support.
* 📊 **Impact**: Improves DX by filtering registry results and unblocks SolidJS component implementation.
* 🔬 **Verification**: Verified using `packages/cli/verify-framework-filter.ts` script which mocked registry responses and asserted correct filtering behavior for React, Vue, and Solid frameworks.

---
*PR created automatically by Jules for task [17435554600591756760](https://jules.google.com/task/17435554600591756760) started by @BintzGavin*