### PR TITLE
PLAYER: Synchronize Caption Styling

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -84,3 +84,13 @@ The Shadow DOM contains:
 - `startAudioMetering()`: Enable audio level events (non-destructive).
 - `stopAudioMetering()`: Disable audio level events (maintains playback).
 - `export(options?: HeliosExportOptions): Promise<void>`: Trigger client-side export programmatically.
+
+## F. CSS Variables
+- `--helios-controls-bg`: Background color for controls.
+- `--helios-text-color`: Text color.
+- `--helios-accent-color`: Accent color (buttons, sliders).
+- `--helios-range-track-color`: Scrubber track color.
+- `--helios-caption-scale`: Caption font size scale relative to player height (default: 0.05).
+- `--helios-caption-bg`: Caption background color.
+- `--helios-caption-color`: Caption text color.
+- `--helios-caption-font-family`: Caption font family.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -34,6 +34,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### DEMO v1.118.0
 - ✅ Completed: Standardize Simple Animation Example - Modernized `examples/simple-animation` with TypeScript, `package.json`, and proper build config.
 
+## PLAYER v0.71.0
+- ✅ Completed: Synchronize Caption Styling - Implemented responsive caption sizing and configurable styling via CSS variables, ensuring visual parity between player preview and client-side export.
+
 ### PLAYER v0.70.5
 - ✅ Completed: Decouple Core - Decoupled `@helios-project/player` from `@helios-project/core` runtime dependency to fix UMD builds and enable drop-in usage.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.70.5
+**Version**: v0.71.0
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -14,6 +14,7 @@
 - Client-side export supports explicit configuration via `export-mode`, `canvas-selector`, and `export-caption-mode` attributes.
 - Supports specifying target export resolution via `export-width` and `export-height` attributes, enabling high-quality exports independent of player preview size.
 - Supports exporting captions as `.srt` files (`export-caption-mode="file"`) or burning them into the video (`burn-in`).
+- Supports **Synchronized Caption Styling**: Captions in the player match the export output (WYSIWYG), with configurable styling via CSS variables (`--helios-caption-scale`, `--helios-caption-bg`, etc.) and responsive font sizing.
 - Supports sandboxed iframes and cross-origin usage via `postMessage` bridge.
 - Includes visual feedback for loading and error states (connection timeouts).
 - Supports variable playback speed via UI and Controller API.
@@ -58,6 +59,7 @@
 - **Audio Metering**: Supports real-time audio metering via `startAudioMetering()` API and `audiometering` event, enabling visualization of audio levels (stereo/peak) in host applications.
 - **Export API**: Exposes public `export()` method for programmatic control over client-side exports, supporting Video (MP4/WebM) and Snapshot (PNG/JPEG) formats.
 
+[v0.71.0] ✅ Completed: Synchronize Caption Styling - Implemented responsive caption sizing and configurable styling via CSS variables, ensuring visual parity between player preview and client-side export.
 [v0.70.5] ✅ Completed: Decouple Core - Decoupled `@helios-project/player` from `@helios-project/core` runtime dependency to fix UMD builds and enable drop-in usage.
 [v0.70.4] ✅ Completed: Fix Poster Visibility - Implemented persistent `_hasPlayed` state to ensure poster remains hidden when seeking back to frame 0 after playback.
 [v0.70.3] ✅ Completed: Refactor Granular Playback - Refactored renderSettingsMenu to use dynamic generation for playback speed options.

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -14,6 +14,12 @@ export interface HeliosExportOptions {
     height?: number;
     bitrate?: number;
     includeCaptions?: boolean;
+    captionStyle?: {
+        color?: string;
+        backgroundColor?: string;
+        fontFamily?: string;
+        scale?: number;
+    };
     onProgress?: (progress: number) => void;
     signal?: AbortSignal;
     canvasSelector?: string;

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -46,6 +46,12 @@ template.innerHTML = `
       --helios-range-selected-color: rgba(255, 255, 255, 0.2);
       --helios-range-unselected-color: var(--helios-range-track-color);
       --helios-font-family: sans-serif;
+
+      /* Caption Styling */
+      --helios-caption-scale: 0.05;
+      --helios-caption-bg: rgba(0, 0, 0, 0.7);
+      --helios-caption-color: white;
+      --helios-caption-font-family: sans-serif;
     }
     iframe {
       width: 100%;
@@ -287,11 +293,12 @@ template.innerHTML = `
       z-index: 5;
     }
     .caption-cue {
-      background: rgba(0, 0, 0, 0.7);
-      color: white;
+      background: var(--helios-caption-bg);
+      color: var(--helios-caption-color);
+      font-family: var(--helios-caption-font-family);
+      font-size: var(--helios-internal-caption-font-size, 16px);
       padding: 4px 8px;
       border-radius: 4px;
-      font-size: 16px;
       text-shadow: 0 1px 2px black;
       white-space: pre-wrap;
     }
@@ -1161,11 +1168,17 @@ export class HeliosPlayer extends HTMLElement {
         this.resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
                 const width = entry.contentRect.width;
+                const height = entry.contentRect.height;
                 const controls = this.shadowRoot.querySelector(".controls");
                 if (controls) {
                     controls.classList.toggle("layout-compact", width < 500);
                     controls.classList.toggle("layout-tiny", width < 350);
                 }
+                // Responsive Caption Sizing
+                const computedStyle = getComputedStyle(this);
+                const scale = parseFloat(computedStyle.getPropertyValue('--helios-caption-scale').trim()) || 0.05;
+                const fontSize = Math.max(16, height * scale);
+                this.style.setProperty('--helios-internal-caption-font-size', `${fontSize}px`);
             }
         });
     }
@@ -2524,7 +2537,8 @@ export class HeliosPlayer extends HTMLElement {
                 canvasSelector: options.canvasSelector || this.getAttribute('canvas-selector') || 'canvas',
                 includeCaptions: options.includeCaptions ?? this.showCaptions,
                 onProgress: options.onProgress || (() => { }),
-                signal: options.signal
+                signal: options.signal,
+                captionStyle: options.captionStyle
             };
             // Handle export-caption-mode='file' logic if not explicitly overridden by options
             // If options.includeCaptions is undefined, we use this.showCaptions.
@@ -2547,6 +2561,16 @@ export class HeliosPlayer extends HTMLElement {
                     exporter.saveCaptionsAsSRT(cues, `${finalOptions.filename}.srt`);
                 }
                 finalOptions.includeCaptions = false;
+            }
+            // Extract computed styles for captions
+            if (finalOptions.includeCaptions) {
+                const computedStyle = getComputedStyle(this);
+                finalOptions.captionStyle = {
+                    color: computedStyle.getPropertyValue('--helios-caption-color').trim() || 'white',
+                    backgroundColor: computedStyle.getPropertyValue('--helios-caption-bg').trim() || 'rgba(0, 0, 0, 0.7)',
+                    fontFamily: computedStyle.getPropertyValue('--helios-caption-font-family').trim() || 'sans-serif',
+                    scale: parseFloat(computedStyle.getPropertyValue('--helios-caption-scale').trim()) || 0.05
+                };
             }
             await exporter.export(finalOptions);
         }

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.70.2",
+  "version": "0.71.0",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",


### PR DESCRIPTION
Implemented `Synchronize Caption Styling` as per plan `2026-10-02-PLAYER-Synchronize-Caption-Styling.md`.

Changes:
- Modified `packages/player/src/index.ts` to add CSS variables for caption styling and a `ResizeObserver` to calculate responsive font size.
- Updated `packages/player/src/features/exporter.ts` to accept `captionStyle` options and use them when rendering burned-in captions.
- Added tests in `packages/player/src/index.test.ts` to verify style extraction and export logic.
- Bumped version to `v0.71.0`.

---
*PR created automatically by Jules for task [4212230257243765266](https://jules.google.com/task/4212230257243765266) started by @BintzGavin*