### PR TITLE
Player Export Menu

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -11,6 +11,7 @@ The Shadow DOM contains:
 - `.poster-container`: Poster image overlay.
 - `.audio-menu`: Popup menu for individual audio track control.
 - `.settings-menu`: Popup menu for Playback Speed (0.25x - 2x), Loop, Playback Range, Shortcuts, and Diagnostics.
+- `.export-menu`: Popup menu for Export and Snapshot configuration.
 - `.shortcuts-overlay`: Overlay displaying keyboard shortcuts.
 - `.captions-container`: Overlay for rendering captions.
 - `.debug-overlay`: Diagnostics UI (toggled via Settings or Shift+D).

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,15 @@
+## PLAYER v0.72.0
+- ✅ Completed: Export Menu - Implemented a dedicated Export Menu UI to allow users to configure export options (format, resolution, filename, captions) and take snapshots directly from the player.
+
+## PLAYER v0.71.0
+- ✅ Completed: Synchronize Caption Styling - Implemented responsive caption sizing and configurable styling via CSS variables, ensuring visual parity between player preview and client-side export.
+
+## PLAYER v0.70.5
+- ✅ Completed: Decouple Core - Decoupled `@helios-project/player` from `@helios-project/core` runtime dependency to fix UMD builds and enable drop-in usage.
+
+## PLAYER v0.70.4
+- ✅ Completed: Fix Poster Visibility - Implemented persistent `_hasPlayed` state to ensure poster remains hidden when seeking back to frame 0 after playback.
+
 ## PLAYER v0.70.3
 - ✅ Completed: Refactor Granular Playback - Refactored renderSettingsMenu to use dynamic generation for playback speed options.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.71.0
+**Version**: v0.72.0
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -58,7 +58,9 @@
 - Supports Active Cues: Implemented `activeCues` property and `cuechange` event on `HeliosTextTrack` for Standard Media API parity.
 - **Audio Metering**: Supports real-time audio metering via `startAudioMetering()` API and `audiometering` event, enabling visualization of audio levels (stereo/peak) in host applications.
 - **Export API**: Exposes public `export()` method for programmatic control over client-side exports, supporting Video (MP4/WebM) and Snapshot (PNG/JPEG) formats.
+- **Export Menu**: Implements a dedicated Export Menu in the player UI (replacing the direct export button action) to allow configuring format, resolution, filename, and captions before exporting or taking a snapshot.
 
+[v0.72.0] ✅ Completed: Export Menu - Implemented a dedicated Export Menu UI to allow users to configure export options (format, resolution, filename, captions) and take snapshots directly from the player.
 [v0.71.0] ✅ Completed: Synchronize Caption Styling - Implemented responsive caption sizing and configurable styling via CSS variables, ensuring visual parity between player preview and client-side export.
 [v0.70.5] ✅ Completed: Decouple Core - Decoupled `@helios-project/player` from `@helios-project/core` runtime dependency to fix UMD builds and enable drop-in usage.
 [v0.70.4] ✅ Completed: Fix Poster Visibility - Implemented persistent `_hasPlayed` state to ensure poster remains hidden when seeking back to frame 0 after playback.

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -679,10 +679,89 @@ template.innerHTML = `
       border-radius: 4px;
       color: var(--helios-accent-color);
     }
+    /* Export Menu */
+    .export-menu {
+      position: absolute;
+      bottom: 60px;
+      right: 10px;
+      background: rgba(0, 0, 0, 0.9);
+      border: 1px solid var(--helios-range-track-color);
+      border-radius: 8px;
+      padding: 12px;
+      z-index: 20;
+      min-width: 240px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      backdrop-filter: blur(4px);
+    }
+    .export-menu.hidden {
+      display: none;
+    }
+    .export-item {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      color: white;
+      font-size: 12px;
+    }
+    .export-label {
+      font-weight: bold;
+      color: var(--helios-text-color);
+      font-size: 11px;
+      text-transform: uppercase;
+      opacity: 0.8;
+    }
+    .export-input, .export-select {
+       background: rgba(255, 255, 255, 0.1);
+       color: white;
+       border: 1px solid var(--helios-range-track-color);
+       border-radius: 4px;
+       padding: 6px 8px;
+       font-size: 13px;
+       width: 100%;
+       box-sizing: border-box;
+       font-family: inherit;
+    }
+    .export-input:focus, .export-select:focus {
+        outline: 1px solid var(--helios-accent-color);
+        border-color: var(--helios-accent-color);
+    }
+    .export-checkbox-label {
+       display: flex;
+       align-items: center;
+       gap: 8px;
+       cursor: pointer;
+       font-size: 13px;
+       user-select: none;
+    }
+    .export-checkbox-label input {
+        accent-color: var(--helios-accent-color);
+        width: 16px;
+        height: 16px;
+        margin: 0;
+    }
+    .export-action-btn {
+       background: var(--helios-accent-color);
+       border: none;
+       color: white;
+       border-radius: 4px;
+       padding: 10px;
+       cursor: pointer;
+       font-size: 14px;
+       font-weight: bold;
+       margin-top: 4px;
+       width: 100%;
+       transition: filter 0.2s;
+    }
+    .export-action-btn:hover {
+       filter: brightness(1.1);
+    }
   </style>
   <slot></slot>
   <div class="audio-menu hidden" part="audio-menu" id="audio-menu-container" role="dialog" aria-label="Audio Tracks"></div>
   <div class="settings-menu hidden" part="settings-menu" id="settings-menu-container" role="dialog" aria-label="Settings"></div>
+  <div class="export-menu hidden" part="export-menu" id="export-menu-container" role="dialog" aria-label="Export Options"></div>
 
   <div class="shortcuts-overlay hidden" part="shortcuts-overlay">
     <div class="debug-header">
@@ -724,7 +803,7 @@ template.innerHTML = `
     </div>
     <button class="audio-btn" part="audio-button" aria-label="Audio Tracks" style="display: none;" aria-haspopup="true" aria-controls="audio-menu-container" aria-expanded="false">🎵</button>
     <button class="cc-btn" part="cc-button" aria-label="Toggle Captions">CC</button>
-    <button class="export-btn" part="export-button" aria-label="Export video">Export</button>
+    <button class="export-btn" part="export-button" aria-label="Export options" aria-haspopup="true" aria-controls="export-menu-container" aria-expanded="false">Export</button>
     <div class="scrubber-wrapper">
       <div class="scrubber-tooltip hidden" part="tooltip"></div>
       <div class="markers-container" part="markers"></div>
@@ -751,6 +830,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   private audioMenu: HTMLDivElement;
   private settingsBtn: HTMLButtonElement;
   private settingsMenu: HTMLDivElement;
+  private exportMenu: HTMLDivElement;
   private scrubber: HTMLInputElement;
   private scrubberWrapper: HTMLDivElement;
   private scrubberTooltip: HTMLDivElement;
@@ -1214,6 +1294,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     this.audioMenu = this.shadowRoot!.querySelector(".audio-menu")!;
     this.settingsBtn = this.shadowRoot!.querySelector(".settings-btn")!;
     this.settingsMenu = this.shadowRoot!.querySelector(".settings-menu")!;
+    this.exportMenu = this.shadowRoot!.querySelector(".export-menu")!;
     this.scrubber = this.shadowRoot!.querySelector(".scrubber")!;
     this.scrubberWrapper = this.shadowRoot!.querySelector(".scrubber-wrapper")!;
     this.scrubberTooltip = this.shadowRoot!.querySelector(".scrubber-tooltip")!;
@@ -1493,6 +1574,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     e.stopPropagation();
     if (this.audioMenu.classList.contains("hidden")) {
       this.closeSettingsMenu(); // Close other menu
+      this.closeExportMenu();
       this.renderAudioMenu();
       this.audioMenu.classList.remove("hidden");
       this.audioBtn.setAttribute("aria-expanded", "true");
@@ -1515,6 +1597,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     e.stopPropagation();
     if (this.settingsMenu.classList.contains("hidden")) {
       this.closeAudioMenu(); // Close other menu
+      this.closeExportMenu();
       this.renderSettingsMenu();
       this.settingsMenu.classList.remove("hidden");
       this.settingsBtn.setAttribute("aria-expanded", "true");
@@ -1537,6 +1620,13 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
              this.closeSettingsMenu();
          }
       }
+
+      if (!this.exportMenu.classList.contains("hidden")) {
+         const target = e.composedPath()[0] as Node;
+         if (!this.exportMenu.contains(target) && !this.exportBtn.contains(target)) {
+             this.closeExportMenu();
+         }
+      }
   }
 
   private closeAudioMenuIfOutside = (e: MouseEvent) => {
@@ -1549,6 +1639,160 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
           return;
       }
       this.closeAudioMenu();
+  }
+
+  private toggleExportMenu = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (this.exportMenu.classList.contains("hidden")) {
+      this.closeAudioMenu();
+      this.closeSettingsMenu();
+      this.renderExportMenu();
+      this.exportMenu.classList.remove("hidden");
+      this.exportBtn.setAttribute("aria-expanded", "true");
+
+      const firstFocusable = this.exportMenu.querySelector("input, select, button") as HTMLElement;
+      if (firstFocusable) firstFocusable.focus();
+    } else {
+      this.closeExportMenu();
+    }
+  }
+
+  private closeExportMenu = () => {
+    this.exportMenu.classList.add("hidden");
+    this.exportBtn.setAttribute("aria-expanded", "false");
+  }
+
+  private renderExportMenu() {
+    this.exportMenu.innerHTML = "";
+
+    // 1. Filename
+    const filenameItem = document.createElement("div");
+    filenameItem.className = "export-item";
+    filenameItem.innerHTML = `<span class="export-label">Filename</span>`;
+    const filenameInput = document.createElement("input");
+    filenameInput.className = "export-input";
+    filenameInput.type = "text";
+    filenameInput.value = this.getAttribute("export-filename") || "video";
+    filenameItem.appendChild(filenameInput);
+    this.exportMenu.appendChild(filenameItem);
+
+    // 2. Format
+    const formatItem = document.createElement("div");
+    formatItem.className = "export-item";
+    formatItem.innerHTML = `<span class="export-label">Format</span>`;
+    const formatSelect = document.createElement("select");
+    formatSelect.className = "export-select";
+    ["mp4", "webm", "png", "jpeg"].forEach(fmt => {
+        const opt = document.createElement("option");
+        opt.value = fmt;
+        opt.textContent = fmt.toUpperCase();
+        formatSelect.appendChild(opt);
+    });
+    formatSelect.value = this.getAttribute("export-format") || "mp4";
+    formatItem.appendChild(formatSelect);
+    this.exportMenu.appendChild(formatItem);
+
+    // 3. Resolution (Scale)
+    const scaleItem = document.createElement("div");
+    scaleItem.className = "export-item";
+    scaleItem.innerHTML = `<span class="export-label">Resolution</span>`;
+    const scaleSelect = document.createElement("select");
+    scaleSelect.className = "export-select";
+
+    const w = this.videoWidth || 1920;
+    const h = this.videoHeight || 1080;
+
+    [1, 0.5].forEach(scale => {
+        const opt = document.createElement("option");
+        opt.value = String(scale);
+        const label = scale === 1 ? "Original" : "Half";
+        opt.textContent = `${label} (${Math.round(w * scale)}x${Math.round(h * scale)})`;
+        scaleSelect.appendChild(opt);
+    });
+    scaleSelect.value = "1";
+    scaleItem.appendChild(scaleSelect);
+    this.exportMenu.appendChild(scaleItem);
+
+    // 4. Captions
+    const captionsItem = document.createElement("div");
+    captionsItem.className = "export-item";
+    const captionsLabel = document.createElement("label");
+    captionsLabel.className = "export-checkbox-label";
+    const captionsCheckbox = document.createElement("input");
+    captionsCheckbox.type = "checkbox";
+    captionsCheckbox.checked = this.showCaptions;
+    captionsLabel.appendChild(captionsCheckbox);
+    captionsLabel.appendChild(document.createTextNode("Burn-in Captions"));
+    captionsItem.appendChild(captionsLabel);
+    this.exportMenu.appendChild(captionsItem);
+
+    // 5. Action Button
+    const actionBtn = document.createElement("button");
+    actionBtn.className = "export-action-btn";
+
+    const updateButtonText = () => {
+        const isImage = ["png", "jpeg"].includes(formatSelect.value);
+        actionBtn.textContent = isImage ? "Save Snapshot" : "Export Video";
+    };
+
+    formatSelect.addEventListener("change", updateButtonText);
+    updateButtonText();
+
+    actionBtn.onclick = () => {
+        this.startExportFromMenu({
+            filename: filenameInput.value || "video",
+            format: formatSelect.value,
+            scale: parseFloat(scaleSelect.value),
+            includeCaptions: captionsCheckbox.checked
+        });
+    };
+
+    this.exportMenu.appendChild(actionBtn);
+  }
+
+  private async startExportFromMenu(options: { filename: string, format: string, scale: number, includeCaptions: boolean }) {
+      this.closeExportMenu();
+
+      // Calculate dimensions
+      const w = this.videoWidth || 1920;
+      const h = this.videoHeight || 1080;
+      const width = Math.round(w * options.scale);
+      const height = Math.round(h * options.scale);
+
+      // Setup AbortController
+      this.abortController = new AbortController();
+      this.exportBtn.textContent = "Cancel"; // Should show cancel immediately
+
+      try {
+          await this.export({
+              filename: options.filename,
+              format: options.format as any,
+              width,
+              height,
+              includeCaptions: options.includeCaptions,
+              signal: this.abortController.signal,
+              onProgress: (p) => {
+                  const percent = Math.round(p * 100);
+                  if (options.format === 'png' || options.format === 'jpeg') {
+                      this.exportBtn.textContent = "Saving...";
+                  } else {
+                      this.exportBtn.textContent = `Cancel (${percent}%)`;
+                  }
+              }
+          });
+      } catch (e: any) {
+          if (e.message !== "Export aborted") {
+            this.showStatus("Export Failed: " + e.message, true, {
+              label: "Dismiss",
+              handler: () => this.hideStatus()
+            });
+          }
+          console.error("Export failed or aborted", e);
+      } finally {
+          this.exportBtn.textContent = "Export";
+          this.exportBtn.disabled = false;
+          this.abortController = null;
+      }
   }
 
   private renderSettingsMenu() {
@@ -1782,7 +2026,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     this.scrubber.addEventListener("touchcancel", this.handleScrubEnd);
     this.scrubberWrapper.addEventListener("mousemove", this.handleScrubberHover);
     this.scrubberWrapper.addEventListener("mouseleave", this.handleScrubberLeave);
-    this.exportBtn.addEventListener("click", this.renderClientSide);
+    this.exportBtn.addEventListener("click", this.handleExportClick);
     this.fullscreenBtn.addEventListener("click", this.toggleFullscreen);
     this.pipBtn.addEventListener("click", () => this.togglePip());
     this.ccBtn.addEventListener("click", this.toggleCaptions);
@@ -1850,7 +2094,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     this.scrubber.removeEventListener("touchcancel", this.handleScrubEnd);
     this.scrubberWrapper.removeEventListener("mousemove", this.handleScrubberHover);
     this.scrubberWrapper.removeEventListener("mouseleave", this.handleScrubberLeave);
-    this.exportBtn.removeEventListener("click", this.renderClientSide);
+    this.exportBtn.removeEventListener("click", this.handleExportClick);
     this.fullscreenBtn.removeEventListener("click", this.toggleFullscreen);
     this.ccBtn.removeEventListener("click", this.toggleCaptions);
     this.bigPlayBtn.removeEventListener("click", this.handleBigPlayClick);
@@ -2394,6 +2638,11 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
           this.closeSettingsMenu();
           this.settingsBtn.focus();
       }
+      if (!this.exportMenu.classList.contains("hidden")) {
+          e.stopPropagation();
+          this.closeExportMenu();
+          this.exportBtn.focus();
+      }
       if (!this.shortcutsOverlay.classList.contains("hidden")) {
           e.stopPropagation();
           this.toggleShortcutsOverlay();
@@ -2877,13 +3126,11 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     this.load();
   }
 
-  private renderClientSide = async () => {
+  private handleExportClick = (e: MouseEvent) => {
     // If we are already exporting, this is a cancel request
     if (this.abortController) {
       this.abortController.abort();
-      this.abortController = null;
-      this.exportBtn.textContent = "Export";
-      this.exportBtn.disabled = false;
+      // Cleanup is handled in startExportFromMenu finally block
       return;
     }
 
@@ -2893,29 +3140,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
         return;
     }
 
-    this.abortController = new AbortController();
-    this.exportBtn.textContent = "Cancel";
-
-    try {
-        await this.export({
-            signal: this.abortController.signal,
-            onProgress: (p) => {
-                this.exportBtn.textContent = `Cancel (${Math.round(p * 100)}%)`;
-            }
-        });
-    } catch (e: any) {
-        if (e.message !== "Export aborted") {
-          this.showStatus("Export Failed: " + e.message, true, {
-            label: "Dismiss",
-            handler: () => this.hideStatus()
-          });
-        }
-        console.error("Export failed or aborted", e);
-    } finally {
-        this.exportBtn.textContent = "Export";
-        this.exportBtn.disabled = false;
-        this.abortController = null;
-    }
+    this.toggleExportMenu(e);
   };
 }
 


### PR DESCRIPTION
Implemented an Export Menu in `<helios-player>` to improve client-side export usability.

**Changes:**
- **UI:** Added a new popup menu triggered by the "Export" button.
- **Features:**
    - **Filename:** Customizable output filename.
    - **Format:** Selection between Video (MP4, WebM) and Image (PNG, JPEG) formats.
    - **Resolution:** Option to scale export (Original vs Half).
    - **Captions:** Toggle for burning in captions (or saving as snapshot overlay).
    - **Snapshot:** "Save Snapshot" button when an image format is selected.
- **Logic:** Refactored the export button click handler to show the menu instead of immediately starting an export (unless an export is already in progress, in which case it still acts as Cancel).

---
*PR created automatically by Jules for task [16168326769771070873](https://jules.google.com/task/16168326769771070873) started by @BintzGavin*