### PR TITLE
✨ CLI: Implement remove command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -16,6 +16,7 @@ packages/cli/
 │   │   ├── studio.ts       # helios studio
 │   │   ├── init.ts         # helios init
 │   │   ├── add.ts          # helios add
+│   │   ├── remove.ts       # helios remove
 │   │   ├── list.ts         # helios list
 │   │   ├── components.ts   # helios components
 │   │   ├── render.ts       # helios render
@@ -27,7 +28,8 @@ packages/cli/
 │   ├── utils/
 │   │   ├── config.ts       # Configuration management
 │   │   ├── logger.ts       # Logging utilities
-│   │   └── install.ts      # Component installation logic
+│   │   ├── install.ts      # Component installation logic
+│   │   └── uninstall.ts    # Component uninstallation logic
 │   └── types/
 │       └── index.ts        # Shared types
 ```
@@ -39,6 +41,7 @@ packages/cli/
   - Options: `-y`, `--framework <name>`
 - `helios add [component]`: Adds a component to the project.
   - Options: `--no-install`
+- `helios remove [component]`: Removes a component from the project configuration and warns about associated files.
 - `helios list`: Lists installed components in the project as defined in `helios.config.json`.
 - `helios components`: Lists available components in the registry.
 - `helios render [file]`: Renders a composition to video.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.13.0
+
+- ✅ Implement Remove Command - Implemented `helios remove <component>` to unregister components and warn about associated files.
+
 ## CLI v0.12.0
 
 - ✅ Framework-Aware Registry - Implemented framework filtering in `RegistryClient` and updated `helios studio` and `helios add` to respect project framework. Added SolidJS support to registry types.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.12.0
+**Version**: 0.13.0
 
 ## Current State
 
@@ -20,6 +20,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 - `helios components` - Lists available components in the registry
 - `helios render` - Renders a composition to video
 - `helios merge` - Merges multiple video files into one without re-encoding
+- `helios remove` - Removes a component from the project configuration
 
 ## V2 Roadmap
 
@@ -53,3 +54,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.11.1] ✅ Update Context & Verify - Updated context documentation for list command and re-verified functionality.
 [v0.11.2] ✅ Unify Studio Registry - Updated `helios studio` to use the unified `RegistryClient`, enabling remote registry fetching and consistency with `helios add`.
 [v0.12.0] ✅ Framework-Aware Registry - Implemented framework filtering in `RegistryClient` and updated `helios studio` and `helios add` to respect project framework. Added SolidJS support to registry types.
+[v0.13.0] ✅ Implement Remove Command - Implemented `helios remove <component>` to unregister components and warn about associated files.

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -1,0 +1,17 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { uninstallComponent } from '../utils/uninstall.js';
+
+export function registerRemoveCommand(program: Command) {
+  program
+    .command('remove <component>')
+    .description('Remove a component from your project configuration')
+    .action(async (component) => {
+      try {
+        await uninstallComponent(process.cwd(), component);
+      } catch (error) {
+        console.error(chalk.red((error as Error).message));
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { registerComponentsCommand } from './commands/components.js';
 import { registerRenderCommand } from './commands/render.js';
 import { registerMergeCommand } from './commands/merge.js';
 import { registerListCommand } from './commands/list.js';
+import { registerRemoveCommand } from './commands/remove.js';
 
 const program = new Command();
 
@@ -21,5 +22,6 @@ registerComponentsCommand(program);
 registerRenderCommand(program);
 registerMergeCommand(program);
 registerListCommand(program);
+registerRemoveCommand(program);
 
 program.parse(process.argv);

--- a/packages/cli/src/utils/uninstall.ts
+++ b/packages/cli/src/utils/uninstall.ts
@@ -1,0 +1,43 @@
+import path from 'path';
+import chalk from 'chalk';
+import { loadConfig, saveConfig } from './config.js';
+import { defaultClient } from '../registry/client.js';
+
+export async function uninstallComponent(rootDir: string, componentName: string): Promise<void> {
+  const config = loadConfig(rootDir);
+
+  if (!config) {
+    throw new Error('No helios.config.json found. Please run this command from the root of your project.');
+  }
+
+  if (!config.components.includes(componentName)) {
+    throw new Error(`Component "${componentName}" is not installed.`);
+  }
+
+  // Remove component from config
+  config.components = config.components.filter(c => c !== componentName);
+  saveConfig(config, rootDir);
+
+  console.log(chalk.green(`✓ Removed "${componentName}" from configuration.`));
+
+  try {
+    // Attempt to find files to warn user
+    const component = await defaultClient.findComponent(componentName, config.framework);
+
+    if (component) {
+      const componentsDir = path.resolve(rootDir, config.directories.components);
+      console.log(chalk.yellow('\nThe following files are no longer tracked and can be safely deleted:'));
+
+      for (const file of component.files) {
+        // Just show relative path to be cleaner for user
+        const relPath = path.join(config.directories.components, file.name);
+        console.log(chalk.dim(`- ${relPath}`));
+      }
+      console.log('');
+    } else {
+       console.log(chalk.yellow(`\nCould not find component "${componentName}" in registry to verify files.`));
+    }
+  } catch (error) {
+    console.log(chalk.yellow(`\nCould not verify associated files: ${(error as Error).message}`));
+  }
+}


### PR DESCRIPTION
Implemented the `helios remove <component>` command to allow users to unregister components from their project configuration. This command removes the component from `helios.config.json` and queries the registry to identify and list associated files that can be safely deleted. This non-destructive approach prevents accidental data loss while helping users maintain a clean codebase. Updated CLI documentation and status files to reflect the new command.

---
*PR created automatically by Jules for task [5267796520087072465](https://jules.google.com/task/5267796520087072465) started by @BintzGavin*