### PR TITLE
✨ STUDIO: Agent Skills Documentation

### DIFF
--- a/.jules/STUDIO.md
+++ b/.jules/STUDIO.md
@@ -73,3 +73,7 @@
 ## [0.98.0] - Planner Role Boundaries
 **Learning:** The "Vision-Driven Planner" role requires strict adherence to producing *only* the plan file and not executing it, even if the general system instructions suggest "working on changes". The Planner's output is the blueprint, not the building.
 **Action:** Explicitly check the role description ("DO NOT lay the bricks") before interpreting general tool instructions.
+
+## [0.102.0] - Documentation Verification
+**Learning:** Verification of backend-only logic like documentation discovery in Studio requires custom scripts (`npx tsx`) because the sandbox environment lacks `node_modules` within package directories, preventing standard test runners like `vitest` from working out of the box without potentially disruptive installs.
+**Action:** When implementing backend features, prioritize creating standalone verification scripts that import the source directly to verify logic without relying on the test runner environment.

--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -4,7 +4,7 @@
 
 The Studio is a browser-based development environment for Helios. It consists of:
 1.  **CLI**: Entry point (`helios studio`) that launches the dev server.
-2.  **Server**: A Vite-based dev server (`packages/studio/src/server`) that serves the UI and provides API endpoints for filesystem operations (compositions, assets, renders).
+2.  **Server**: A Vite-based dev server (`packages/studio/src/server`) that serves the UI and provides API endpoints for filesystem operations (compositions, assets, renders) and documentation discovery (READMEs, Agent Skills).
 3.  **UI**: A React-based Single Page Application (`packages/studio/src`) that provides the IDE interface.
 4.  **Integration**:
     -   **Core**: Consumed via `Helios` class for composition logic.
@@ -24,7 +24,7 @@ packages/studio/
 │   │   └── Timeline/   # Timeline area
 │   ├── context/        # React Context (StudioContext, ToastContext)
 │   ├── hooks/          # Custom hooks (usePersistentState)
-│   ├── server/         # Backend logic (discovery, render-manager, plugin)
+│   ├── server/         # Backend logic (discovery, render-manager, plugin, documentation)
 │   ├── utils/          # Utilities
 │   ├── App.tsx         # Main UI entry
 │   ├── main.tsx        # React root
@@ -74,3 +74,4 @@ Commands:
     -   `POST /api/render`: Submit a render job.
     -   `GET /api/jobs`: List render jobs.
     -   `GET /api/assets`: List assets.
+    -   `GET /api/documentation`: Returns documentation sections (READMEs and SKILLs).

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.102.0
+- ✅ Completed: Agent Skills Documentation - Updated Studio Assistant backend to index `SKILL.md` files from `.agents/skills/helios`, making agent-specific knowledge available in the documentation search.
+
 ## STUDIO v0.101.0
 - ✅ Completed: Open in Editor - Implemented "Open in Editor" buttons for assets and compositions, allowing users to open source files directly in their default editor.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.101.0
+**Version**: 0.102.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.102.0] ✅ Completed: Agent Skills Documentation - Updated Studio Assistant backend to index `SKILL.md` files from `.agents/skills/helios`, making agent-specific knowledge available in the documentation search.
 - [v0.101.0] ✅ Completed: Open in Editor - Implemented "Open in Editor" buttons for assets and compositions, allowing users to open source files directly in their default editor.
 - [v0.100.0] ✅ Completed: Resizable Layout - Implemented resizable Sidebar, Inspector, and Timeline panels with persistence using `localStorage` and CSS variables.
 - [v0.99.0] ✅ Completed: CLI List Command - Verified implementation of `helios list` command to display installed components from `helios.config.json`.


### PR DESCRIPTION
💡 **What**: Updated Studio Assistant backend to index `SKILL.md` files from `.agents/skills/helios`.
🎯 **Why**: To expose agent-specific knowledge (skills) in the Studio Assistant documentation search, bridging the gap between agent resources and user documentation.
📊 **Impact**: Users (and agents using the Studio) can now query "skills" documentation directly within the Studio interface.
🔬 **Verification**: Verified via custom script `packages/studio/verify-skills.ts` which confirmed `findDocumentation` correctly locates and includes content from `.agents/skills/helios`. Existing tests could not be run due to environment limitations but the change is isolated to a new backend utility function.

---
*PR created automatically by Jules for task [11031961647584893098](https://jules.google.com/task/11031961647584893098) started by @BintzGavin*