### PR TITLE
RENDERER: Report Blocked Verification

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -39,3 +39,4 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
   - **Verification**: `examples/promo-video` must render correctly with all scenes visible.
 
 - [ ] **Documentation**: Add Quickstart guide.
+- [ ] ⛔ Renderer Verification Blocked: packages/studio dependency mismatch

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -129,3 +129,6 @@
 - [1.5.0] ✅ Completed: Implement Range Rendering - Added `startFrame` to `RendererOptions`, enabling rendering of partial animation ranges (distributed rendering support).
 - [1.5.1] ✅ Completed: Strict Error Propagation - Implemented "Fail Fast" mechanism to catch page errors, crashes, and WebCodecs failures immediately, and ensure proper FFmpeg process cleanup.
 - [1.5.2] ✅ Completed: Fix Audio Duration Logic - Replaced `-shortest` with `-t duration` to prevent video truncation when audio is short.
+
+## Blocked Items
+- [Verification] ⛔ Blocked: Unable to verify environment due to broken dependency in packages/studio (@helios-project/player version mismatch causing ETARGET).


### PR DESCRIPTION
Updated status and backlog to report a blocking dependency issue in `packages/studio` that prevents `packages/renderer` verification.

---
*PR created automatically by Jules for task [15178394599694885197](https://jules.google.com/task/15178394599694885197) started by @BintzGavin*