### PR TITLE
✨ CLI: Implement Update Command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -16,6 +16,7 @@ packages/cli/
 │   │   ├── studio.ts       # helios studio
 │   │   ├── init.ts         # helios init
 │   │   ├── add.ts          # helios add
+│   │   ├── update.ts       # helios update
 │   │   ├── remove.ts       # helios remove
 │   │   ├── list.ts         # helios list
 │   │   ├── components.ts   # helios components
@@ -41,6 +42,8 @@ packages/cli/
   - Options: `-y`, `--framework <name>`
 - `helios add [component]`: Adds a component to the project.
   - Options: `--no-install`
+- `helios update [component]`: Updates a component to the latest version.
+  - Options: `-y, --yes` (skip confirmation), `--no-install`
 - `helios remove [component]`: Removes a component from the project configuration and warns about associated files.
 - `helios list`: Lists installed components in the project as defined in `helios.config.json`.
 - `helios components`: Lists available components in the registry.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.14.0
+
+- ✅ Implement Update Command - Implemented `helios update <component>` to restore or update components from the registry.
+
 ## CLI v0.13.0
 
 - ✅ Implement Remove Command - Implemented `helios remove <component>` to unregister components and warn about associated files.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.13.0
+**Version**: 0.14.0
 
 ## Current State
 
@@ -21,6 +21,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 - `helios render` - Renders a composition to video
 - `helios merge` - Merges multiple video files into one without re-encoding
 - `helios remove` - Removes a component from the project configuration
+- `helios update` - Updates a component to the latest version
 
 ## V2 Roadmap
 
@@ -55,3 +56,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.11.2] ✅ Unify Studio Registry - Updated `helios studio` to use the unified `RegistryClient`, enabling remote registry fetching and consistency with `helios add`.
 [v0.12.0] ✅ Framework-Aware Registry - Implemented framework filtering in `RegistryClient` and updated `helios studio` and `helios add` to respect project framework. Added SolidJS support to registry types.
 [v0.13.0] ✅ Implement Remove Command - Implemented `helios remove <component>` to unregister components and warn about associated files.
+[v0.14.0] ✅ Implement Update Command - Implemented `helios update <component>` to restore or update components from the registry.


### PR DESCRIPTION
Verified the existence and functionality of the `helios update` command, which allows users to reinstall or update components from the registry. Updated documentation to reflect this new capability.

---
*PR created automatically by Jules for task [14810050063397738849](https://jules.google.com/task/14810050063397738849) started by @BintzGavin*