### PR TITLE
✨ CLI: Implement build command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -1,74 +1,130 @@
-# CLI Context
+# Helios CLI Context
 
 ## A. Architecture
-The Helios CLI is built using `commander.js`. The entry point is `bin/helios.js`, which imports the built `dist/index.js`.
-Commands are registered in `src/index.ts` using a `register[CommandName]Command(program)` pattern.
-Each command is isolated in its own file under `src/commands/`.
+
+The Helios CLI is built using `commander` and provides the primary interface for creating, managing, and rendering Helios projects. It follows a subcommand pattern where each command is isolated in its own file and registered in the main entry point.
+
+**Entry Point**: `bin/helios.js` (Shebang wrapper around `dist/index.js`)
+**Registration**: `src/index.ts` imports and registers all commands.
 
 ## B. File Tree
+
 ```
 packages/cli/
 ├── bin/
-│   └── helios.js           # Entry point
+│   └── helios.js           # Executable entry point
 ├── src/
-│   ├── index.ts            # Main CLI setup, command registration
+│   ├── index.ts            # Main CLI setup
 │   ├── commands/
 │   │   ├── studio.ts       # helios studio
 │   │   ├── init.ts         # helios init
 │   │   ├── add.ts          # helios add
-│   │   ├── update.ts       # helios update
-│   │   ├── remove.ts       # helios remove
-│   │   ├── list.ts         # helios list
 │   │   ├── components.ts   # helios components
 │   │   ├── render.ts       # helios render
-│   │   └── merge.ts        # helios merge
-│   ├── registry/
-│   │   ├── client.ts       # Registry client
-│   │   ├── manifest.ts     # Local registry manifest
-│   │   └── types.ts        # Registry types
-│   ├── utils/
-│   │   ├── config.ts       # Configuration management
-│   │   ├── logger.ts       # Logging utilities
-│   │   ├── install.ts      # Component installation logic
-│   │   └── uninstall.ts    # Component uninstallation logic
-│   └── types/
-│       └── index.ts        # Shared types
+│   │   ├── merge.ts        # helios merge
+│   │   ├── list.ts         # helios list
+│   │   ├── remove.ts       # helios remove
+│   │   ├── update.ts       # helios update
+│   │   └── build.ts        # helios build
+│   ├── registry/           # Registry client logic
+│   ├── templates/          # Project scaffolding templates
+│   └── utils/              # Shared utilities (config, logger)
+├── package.json
+└── tsconfig.json
 ```
 
 ## C. Commands
-- `helios studio [options]`: Launches the Studio development server.
-  - Options: `--port <number>`
-- `helios init [options]`: Initializes a new project.
-  - Options: `-y`, `--framework <name>`
-- `helios add [component]`: Adds a component to the project.
-  - Options: `--no-install`
-- `helios update [component]`: Updates a component to the latest version.
-  - Options: `-y, --yes` (skip confirmation), `--no-install`
-- `helios remove [component]`: Removes a component from the project configuration and warns about associated files.
-- `helios list`: Lists installed components in the project as defined in `helios.config.json`.
-- `helios components`: Lists available components in the registry.
-- `helios render [file]`: Renders a composition to video.
-  - Options: `--concurrency`, `--start-frame`, `--frame-count`
-- `helios merge [files...]`: Merges video files.
-  - Options: `-o, --output <file>`
+
+### `helios studio`
+Launches the Studio development server.
+```typescript
+function registerStudioCommand(program: Command): void;
+```
+
+### `helios init`
+Initializes a new Helios project configuration and scaffolds structure.
+Options:
+- `-y, --yes`: Skip prompts and use defaults.
+- `-f, --framework <framework>`: Specify framework (react, vue, svelte, solid, vanilla).
+```typescript
+function registerInitCommand(program: Command): void;
+```
+
+### `helios add [component]`
+Adds a component from the registry to the project.
+Options:
+- `--no-install`: Skip dependency installation.
+```typescript
+function registerAddCommand(program: Command): void;
+```
+
+### `helios components`
+Lists available components in the registry.
+```typescript
+function registerComponentsCommand(program: Command): void;
+```
+
+### `helios render`
+Renders a composition to video.
+Options:
+- `--start-frame <frame>`
+- `--frame-count <count>`
+```typescript
+function registerRenderCommand(program: Command): void;
+```
+
+### `helios merge`
+Merges multiple video files into one.
+```typescript
+function registerMergeCommand(program: Command): void;
+```
+
+### `helios list`
+Lists installed components.
+```typescript
+function registerListCommand(program: Command): void;
+```
+
+### `helios remove <component>`
+Removes a component from the project configuration.
+```typescript
+function registerRemoveCommand(program: Command): void;
+```
+
+### `helios update <component>`
+Updates or restores a component from the registry.
+```typescript
+function registerUpdateCommand(program: Command): void;
+```
+
+### `helios build`
+Builds the project for production using Vite.
+Options:
+- `-o, --out-dir <dir>`: Output directory (default: dist)
+```typescript
+function registerBuildCommand(program: Command): void;
+```
 
 ## D. Configuration
-The CLI uses `helios.config.json` in the project root.
-Managed via `src/utils/config.ts`.
+
+The CLI reads and writes `helios.config.json` in the project root.
 Structure:
-```typescript
-interface HeliosConfig {
-  version: string;
-  directories: {
-    components: string;
-    lib: string;
-  };
-  framework?: 'react' | 'vue' | 'svelte' | 'solid' | 'vanilla';
-  components: string[];
+```json
+{
+  "framework": "react",
+  "directories": {
+    "components": "src/components",
+    "lib": "src/lib"
+  },
+  "components": {
+    "MyComponent": { ... }
+  }
 }
 ```
 
 ## E. Integration
-- **Registry**: `src/registry/client.ts` fetches components from the remote registry (with local fallback). Supports framework-based filtering.
-- **Studio**: `helios studio` wraps the Studio dev server and injects the registry via `studioApiPlugin`. Filters registry based on `helios.config.json` framework.
-- **Renderer**: `helios render` invokes `@helios-project/renderer`.
+
+- **Registry**: Uses `RegistryClient` to fetch component metadata and code.
+- **Renderer**: Uses `@helios-project/renderer` for the `render` command.
+- **Studio**: Uses `@helios-project/studio` for the `studio` command.
+- **Vite**: Wraps `vite` for `build` command and dev server.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.15.0
+
+- ✅ Implement Build Command - Implemented `helios build` wrapping Vite for production builds.
+
 ## CLI v0.14.0
 
 - ✅ Implement Update Command - Implemented `helios update <component>` to restore or update components from the registry.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### CLI v0.15.0
+- ✅ Completed: Implement Build Command - Implemented `helios build` wrapping Vite for production builds.
+
 ### RENDERER v1.75.0
 - ✅ Completed: Distributed Progress Aggregation - Implemented weighted progress aggregation in RenderOrchestrator to ensure monotonic progress reporting during distributed rendering. Verified with `verify-distributed-progress.ts`.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.14.0
+**Version**: 0.15.0
 
 ## Current State
 
@@ -22,6 +22,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 - `helios merge` - Merges multiple video files into one without re-encoding
 - `helios remove` - Removes a component from the project configuration
 - `helios update` - Updates a component to the latest version
+- `helios build` - Builds the project for production
 
 ## V2 Roadmap
 
@@ -57,3 +58,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.12.0] ✅ Framework-Aware Registry - Implemented framework filtering in `RegistryClient` and updated `helios studio` and `helios add` to respect project framework. Added SolidJS support to registry types.
 [v0.13.0] ✅ Implement Remove Command - Implemented `helios remove <component>` to unregister components and warn about associated files.
 [v0.14.0] ✅ Implement Update Command - Implemented `helios update <component>` to restore or update components from the registry.
+[v0.15.0] ✅ Implement Build Command - Implemented `helios build` wrapping Vite for production builds.

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,0 +1,28 @@
+import { Command } from 'commander';
+import { build } from 'vite';
+import chalk from 'chalk';
+
+export function registerBuildCommand(program: Command) {
+  program
+    .command('build')
+    .description('Build the project for production')
+    .option('-o, --out-dir <dir>', 'Output directory', 'dist')
+    .action(async (options) => {
+      try {
+        console.log(chalk.cyan('Starting production build...'));
+
+        await build({
+          root: process.cwd(),
+          build: {
+            outDir: options.outDir,
+            emptyOutDir: true,
+          }
+        });
+
+        console.log(chalk.green(`Build complete. Output: ${options.outDir}`));
+      } catch (error) {
+        console.error(chalk.red('Build failed:'), error);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import { registerMergeCommand } from './commands/merge.js';
 import { registerListCommand } from './commands/list.js';
 import { registerRemoveCommand } from './commands/remove.js';
 import { registerUpdateCommand } from './commands/update.js';
+import { registerBuildCommand } from './commands/build.js';
 
 const program = new Command();
 
@@ -25,5 +26,6 @@ registerMergeCommand(program);
 registerListCommand(program);
 registerRemoveCommand(program);
 registerUpdateCommand(program);
+registerBuildCommand(program);
 
 program.parse(process.argv);


### PR DESCRIPTION
💡 **What**: Implemented `helios build` command wrapping Vite.
🎯 **Why**: To provide a standardized way to build Helios projects for production, facilitating deployment.
📊 **Impact**: Users can now run `helios build` to generate a production build in `dist/`.
🔬 **Verification**: Verified by creating a temporary project and running `helios build` and `helios build --out-dir`, confirming output files are generated.

---
*PR created automatically by Jules for task [3390238707126466776](https://jules.google.com/task/3390238707126466776) started by @BintzGavin*