### PR TITLE
✨ RENDERER: Enable Verification for Configurable Asset Timeout

### DIFF
--- a/docs/PROGRESS-RENDERER.md
+++ b/docs/PROGRESS-RENDERER.md
@@ -1,5 +1,8 @@
 # Renderer Progress Log
 
+## RENDERER v1.75.1
+- ✅ Completed: Verify Configurable Asset Timeout - Enabled `verify-asset-timeout.ts` in the main test suite to ensure `stabilityTimeout` logic in `DomStrategy` remains robust and prevents hangs.
+
 ## RENDERER v1.75.0
 - ✅ Completed: Distributed Progress Aggregation - Implemented weighted progress aggregation in RenderOrchestrator to ensure monotonic progress reporting during distributed rendering. Verified with `verify-distributed-progress.ts`.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,10 +1,11 @@
-**Version**: 1.75.0
+**Version**: 1.75.1
 
 **Posture**: MAINTENANCE WITH V2 EXPANSION
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.75.1] ✅ Completed: Verify Configurable Asset Timeout - Enabled `verify-asset-timeout.ts` in the main test suite to ensure `stabilityTimeout` logic in `DomStrategy` remains robust and prevents hangs.
 - [1.75.0] ✅ Completed: Distributed Progress Aggregation - Implemented weighted progress aggregation in RenderOrchestrator to ensure monotonic progress reporting during distributed rendering. Verified with `verify-distributed-progress.ts`.
 - [1.74.0] ✅ Completed: Configurable Asset Timeout - Implemented `stabilityTimeout` support in `DomStrategy` and `CanvasStrategy` to prevent indefinite hangs during asset preloading (fonts, images) and audio track scanning. Verified with `verify-asset-timeout.ts`.
 - [1.73.0] ✅ Completed: Configurable Random Seed - Added `randomSeed` to `RendererOptions` and updated `TimeDriver` to inject a seeded Mulberry32 PRNG script, ensuring deterministic `Math.random()` behavior for generative compositions. Verified with `tests/verify-random-seed.ts`.

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'child_process';
 import * as path from 'path';
 
 const tests = [
+  'tests/verify-asset-timeout.ts',
   'tests/verify-audio-codecs.ts',
   'tests/verify-audio-fades.ts',
   'tests/verify-audio-loop.ts',


### PR DESCRIPTION
This change enables the existing `verify-asset-timeout.ts` script in the main test runner `packages/renderer/tests/run-all.ts`. This ensures that the Configurable Asset Timeout feature (which prevents indefinite hangs during asset preloading) is actively verified in the test suite.

Documentation (`docs/status/RENDERER.md` and `docs/PROGRESS-RENDERER.md`) has been updated to reflect this enablement.


---
*PR created automatically by Jules for task [14910457015552264989](https://jules.google.com/task/14910457015552264989) started by @BintzGavin*