### PR TITLE
✨ PLAYER: Fix tests and sync version

### DIFF
--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -60,6 +60,7 @@
 - **Export API**: Exposes public `export()` method for programmatic control over client-side exports, supporting Video (MP4/WebM) and Snapshot (PNG/JPEG) formats.
 - **Export Menu**: Implements a dedicated Export Menu in the player UI (replacing the direct export button action) to allow configuring format, resolution, filename, and captions before exporting or taking a snapshot.
 
+[v0.72.1] ✅ Verified: Test Suite Fixes - Updated tests to use `export()` instead of removed `renderClientSide()` and cleaned up duplicate keys in mock controllers. All 300 tests passed.
 [v0.72.1] ✅ Completed: Api Parity - Implemented `width`, `height`, `playsInline` properties and `fastSeek` method on `HeliosPlayer` to improve compatibility with standard `HTMLVideoElement` API.
 [v0.72.0] ✅ Completed: Export Menu - Implemented a dedicated Export Menu UI to allow users to configure export options (format, resolution, filename, captions) and take snapshots directly from the player.
 [v0.71.0] ✅ Completed: Synchronize Caption Styling - Implemented responsive caption sizing and configurable styling via CSS variables, ensuring visual parity between player preview and client-side export.

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.71.0",
+  "version": "0.72.1",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -67,14 +67,19 @@ describe('HeliosPlayer', () => {
         seek: vi.fn(),
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(), setCaptions: vi.fn(),
+        dispose: vi.fn(),
+        setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
-        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+        setAudioVolume: vi.fn(),
+        startAudioMetering: vi.fn(),
+        stopAudioMetering: vi.fn(),
+        onAudioMetering: vi.fn().mockReturnValue(() => {}),
+        diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+        clearPlaybackRange: vi.fn()
     };
 
     // Inject controller (using private access workaround)
@@ -113,14 +118,19 @@ describe('HeliosPlayer', () => {
         seek: vi.fn(),
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(), setCaptions: vi.fn(),
+        dispose: vi.fn(),
+        setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
-        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+        setAudioVolume: vi.fn(),
+        startAudioMetering: vi.fn(),
+        stopAudioMetering: vi.fn(),
+        onAudioMetering: vi.fn().mockReturnValue(() => {}),
+        diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+        clearPlaybackRange: vi.fn()
     };
 
     // Inject controller (using private access workaround)
@@ -203,11 +213,16 @@ describe('HeliosPlayer', () => {
         seek: vi.fn(),
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(), setCaptions: vi.fn(),
+        dispose: vi.fn(),
+        setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
-        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+        clearPlaybackRange: vi.fn(),
+        startAudioMetering: vi.fn(),
+        stopAudioMetering: vi.fn(),
+        onAudioMetering: vi.fn().mockReturnValue(() => {}),
+        diagnose: vi.fn(),
+        setAudioVolume: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn()
@@ -275,14 +290,19 @@ describe('HeliosPlayer', () => {
         seek: vi.fn(),
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(), setCaptions: vi.fn(),
+        dispose: vi.fn(),
+        setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
-        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+        setAudioVolume: vi.fn(),
+        startAudioMetering: vi.fn(),
+        stopAudioMetering: vi.fn(),
+        onAudioMetering: vi.fn().mockReturnValue(() => {}),
+        diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+        clearPlaybackRange: vi.fn()
     };
     (player as any).setController(mockController);
 
@@ -354,14 +374,19 @@ describe('HeliosPlayer', () => {
       seek: vi.fn(),
       subscribe: vi.fn().mockReturnValue(() => {}),
       onError: vi.fn().mockReturnValue(() => {}),
-      dispose: vi.fn(), setCaptions: vi.fn(),
+      dispose: vi.fn(),
+      setCaptions: vi.fn(),
       setPlaybackRate: vi.fn(),
-      setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+      setAudioVolume: vi.fn(),
+      startAudioMetering: vi.fn(),
+      stopAudioMetering: vi.fn(),
+      onAudioMetering: vi.fn().mockReturnValue(() => {}),
+      diagnose: vi.fn(),
       setAudioMuted: vi.fn(),
       setInputProps: vi.fn(),
       setLoop: vi.fn(),
       setPlaybackRange: vi.fn(),
-      clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+      clearPlaybackRange: vi.fn()
     };
     (player as any).setController(mockController);
 
@@ -407,14 +432,19 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -530,14 +560,19 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
-        setAudioMuted: vi.fn(),
-        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
-        setLoop: vi.fn(),
-        setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            setAudioMuted: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
+            setLoop: vi.fn(),
+            setPlaybackRange: vi.fn(),
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -622,14 +657,19 @@ describe('HeliosPlayer', () => {
         seek: vi.fn(),
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(), setCaptions: vi.fn(),
+        dispose: vi.fn(),
+        setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
-        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+        setAudioVolume: vi.fn(),
+        startAudioMetering: vi.fn(),
+        stopAudioMetering: vi.fn(),
+        onAudioMetering: vi.fn().mockReturnValue(() => {}),
+        diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+        clearPlaybackRange: vi.fn()
       };
       (player as any).setController(mockController);
 
@@ -656,14 +696,19 @@ describe('HeliosPlayer', () => {
         seek: vi.fn(),
         subscribe: vi.fn().mockReturnValue(() => {}),
         onError: vi.fn().mockReturnValue(() => {}),
-        dispose: vi.fn(), setCaptions: vi.fn(),
+        dispose: vi.fn(),
+        setCaptions: vi.fn(),
         setPlaybackRate: vi.fn(),
-        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+        setAudioVolume: vi.fn(),
+        startAudioMetering: vi.fn(),
+        stopAudioMetering: vi.fn(),
+        onAudioMetering: vi.fn().mockReturnValue(() => {}),
+        diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setInputProps: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+        clearPlaybackRange: vi.fn()
       };
       (player as any).setController(mockController);
 
@@ -691,14 +736,19 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
 
@@ -709,8 +759,16 @@ describe('HeliosPlayer', () => {
           return { export: mockExport };
         });
 
-        // Trigger export via private method to await it
-        await (player as any).renderClientSide();
+        // Trigger export via UI
+        const exportBtn = player.shadowRoot!.querySelector('.export-btn') as HTMLButtonElement;
+        exportBtn.disabled = false; // Enable button as we bypassed connection logic
+        exportBtn.click(); // Opens menu
+
+        const actionBtn = player.shadowRoot!.querySelector('.export-action-btn') as HTMLButtonElement;
+        actionBtn.click(); // Triggers export
+
+        // Wait for async operations
+        await new Promise(resolve => setTimeout(resolve, 0));
 
         // Verify Status Overlay
         const overlay = player.shadowRoot!.querySelector('.status-overlay') as HTMLElement;
@@ -735,14 +793,19 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
 
@@ -757,8 +820,16 @@ describe('HeliosPlayer', () => {
         const overlay = player.shadowRoot!.querySelector('.status-overlay') as HTMLElement;
         overlay.classList.add('hidden');
 
-        // Trigger export
-        await (player as any).renderClientSide();
+        // Trigger export via UI
+        const exportBtn = player.shadowRoot!.querySelector('.export-btn') as HTMLButtonElement;
+        exportBtn.disabled = false; // Enable button as we bypassed connection logic
+        exportBtn.click(); // Opens menu
+
+        const actionBtn = player.shadowRoot!.querySelector('.export-action-btn') as HTMLButtonElement;
+        actionBtn.click(); // Triggers export
+
+        // Wait for async operations
+        await new Promise(resolve => setTimeout(resolve, 0));
 
         // Should still be hidden (or at least not showing failure)
         expect(overlay.classList.contains('hidden')).toBe(true);
@@ -776,13 +847,18 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
-            getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            getAudioTracks: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -868,15 +944,20 @@ describe('HeliosPlayer', () => {
             play: vi.fn(),
             pause: vi.fn(),
             seek: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
-            getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            getAudioTracks: vi.fn()
         };
         (player as any).setController(mockController);
         (player as any).isLoaded = true;
@@ -1050,15 +1131,20 @@ describe('HeliosPlayer', () => {
             play: vi.fn(),
             pause: vi.fn(),
             seek: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
-            getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            getAudioTracks: vi.fn()
         };
         // Reset player pending props
         player.inputProps = null;
@@ -1120,14 +1206,19 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
         setInputProps: vi.fn(),
-        setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+        setAudioVolume: vi.fn(),
+        startAudioMetering: vi.fn(),
+        stopAudioMetering: vi.fn(),
+        onAudioMetering: vi.fn().mockReturnValue(() => {}),
+        diagnose: vi.fn(),
         setAudioMuted: vi.fn(),
         setLoop: vi.fn(),
         setPlaybackRange: vi.fn(),
-        clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+        clearPlaybackRange: vi.fn()
         };
     });
 
@@ -1260,15 +1351,20 @@ describe('HeliosPlayer', () => {
             play: vi.fn(),
             pause: vi.fn(),
             seek: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             captureFrame: vi.fn(),
-            getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            getAudioTracks: vi.fn()
         };
     });
 
@@ -1309,16 +1405,21 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            clearPlaybackRange: vi.fn(),
             captureFrame: vi.fn(),
-            getAudioTracks: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            getAudioTracks: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -1349,7 +1450,7 @@ describe('HeliosPlayer', () => {
         });
 
         // Trigger export
-        await (player as any).renderClientSide();
+        await (player as any).export();
 
         // Expect saveCaptionsAsSRT to be called with "my-movie.srt"
         expect(saveCaptionsSpy).toHaveBeenCalledWith(expect.anything(), 'my-movie.srt');
@@ -1374,7 +1475,7 @@ describe('HeliosPlayer', () => {
           };
         });
 
-        await (player as any).renderClientSide();
+        await (player as any).export();
 
         expect(saveCaptionsSpy).toHaveBeenCalledWith(expect.anything(), 'video.srt');
     });
@@ -1391,14 +1492,19 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            clearPlaybackRange: vi.fn()
         };
     });
 
@@ -1537,14 +1643,19 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -1615,14 +1726,19 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
     });
@@ -1739,11 +1855,16 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn()
         };
     });
 
@@ -1938,13 +2059,18 @@ describe('HeliosPlayer', () => {
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
 
@@ -1969,13 +2095,18 @@ describe('HeliosPlayer', () => {
             setPlaybackRate: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setInputProps: vi.fn(),
             setAudioMuted: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn()
+            clearPlaybackRange: vi.fn()
         };
         (player as any).setController(mockController);
 
@@ -2003,14 +2134,19 @@ describe('HeliosPlayer', () => {
             seek: vi.fn(),
             subscribe: vi.fn().mockReturnValue(() => {}),
             onError: vi.fn().mockReturnValue(() => {}),
-            dispose: vi.fn(), setCaptions: vi.fn(),
+            dispose: vi.fn(),
+            setCaptions: vi.fn(),
             setPlaybackRate: vi.fn(),
-            setAudioVolume: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            setAudioVolume: vi.fn(),
+            startAudioMetering: vi.fn(),
+            stopAudioMetering: vi.fn(),
+            onAudioMetering: vi.fn().mockReturnValue(() => {}),
+            diagnose: vi.fn(),
             setAudioMuted: vi.fn(),
             setInputProps: vi.fn(),
             setLoop: vi.fn(),
             setPlaybackRange: vi.fn(),
-            clearPlaybackRange: vi.fn(), startAudioMetering: vi.fn(), stopAudioMetering: vi.fn(), onAudioMetering: vi.fn().mockReturnValue(() => {}), diagnose: vi.fn(),
+            clearPlaybackRange: vi.fn(),
             captureFrame: vi.fn(),
             getAudioTracks: vi.fn()
         };
@@ -2044,7 +2180,7 @@ describe('HeliosPlayer', () => {
           return { export: exportSpy };
         });
 
-        await (player as any).renderClientSide();
+        await (player as any).export();
 
         expect(exportSpy).toHaveBeenCalledWith(expect.objectContaining({
             captionStyle: {
@@ -2068,7 +2204,7 @@ describe('HeliosPlayer', () => {
           return { export: exportSpy };
         });
 
-        await (player as any).renderClientSide();
+        await (player as any).export();
 
         expect(exportSpy).toHaveBeenCalledWith(expect.objectContaining({
             captionStyle: {


### PR DESCRIPTION
💡 **What**:
- Updated `packages/player/src/index.test.ts` to use `export()` instead of the removed `renderClientSide()` method.
- Updated `packages/player/src/index.test.ts` to explicitly enable the export button before clicking it in tests, simulating correct connection state.
- Cleaned up duplicate keys in mock controller definitions in tests.
- Synced `packages/player/package.json` version to `0.72.1` to match `docs/status/PLAYER.md`.

🎯 **Why**:
- Tests were failing because they were calling a non-existent method `renderClientSide` which was superseded by `export`.
- `package.json` version was out of sync with the status file.

📊 **Impact**:
- `packages/player` tests now pass (300 passing).
- Package version is consistent.

🔬 **Verification**:
- Ran `npm test -w packages/player` and verified all tests pass.

---
*PR created automatically by Jules for task [8425220454814227027](https://jules.google.com/task/8425220454814227027) started by @BintzGavin*