### PR TITLE
✨ STUDIO: CLI Build Command

### DIFF
--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.104.0
+- ✅ Completed: CLI Build Command - Implemented `helios build` command to generate a deployable player harness.
+
 ## STUDIO v0.103.2
 - ✅ Fixed: Dependency Mismatch - Updated `packages/studio/package.json` to align `core` dependency with workspace version (`^5.11.0`) and fixed verification pipeline.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.103.2
+**Version**: 0.104.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.104.0] ✅ Completed: CLI Build Command - Implemented `helios build` command to generate a deployable player harness.
 - [v0.103.2] ✅ Fixed: Dependency Mismatch - Updated `packages/studio/package.json` to align `core` dependency with workspace version (`^5.11.0`) and fixed verification pipeline.
 - [v0.103.1] ✅ Completed: Refine Agent Skills - Prepend "Agent Skill: " to skill titles in documentation to distinguish them from standard package docs.
 - [v0.103.0] ✅ Completed: CLI Update Command - Implemented `helios update` command in CLI to update/reinstall components with overwrite support, ensuring users can refresh component code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10140,7 +10140,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.71.0",
+      "version": "0.72.1",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^5.8.0",
@@ -10191,7 +10191,7 @@
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^5.11.0",
-        "@helios-project/player": "^0.71.0",
+        "@helios-project/player": "^0.72.1",
         "@helios-project/renderer": "^0.0.2",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "react": "^19.2.3",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,28 +1,80 @@
 import { Command } from 'commander';
 import { build } from 'vite';
 import chalk from 'chalk';
+import path from 'path';
+import fs from 'fs';
 
 export function registerBuildCommand(program: Command) {
   program
-    .command('build')
+    .command('build [dir]')
     .description('Build the project for production')
     .option('-o, --out-dir <dir>', 'Output directory', 'dist')
-    .action(async (options) => {
+    .action(async (dir = '.', options) => {
+      const rootDir = path.resolve(process.cwd(), dir);
+      const outDir = options.outDir;
+      const entryPath = path.join(rootDir, '.helios-build-entry.html');
+      const compositionPath = path.join(rootDir, 'composition.html');
+
+      if (!fs.existsSync(compositionPath)) {
+        console.error(chalk.red(`Error: composition.html not found in ${rootDir}`));
+        process.exit(1);
+      }
+
+      // Create temporary entry file
+      const entryContent = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Helios Player</title>
+  <style>
+    body { margin: 0; overflow: hidden; background: #000; height: 100vh; width: 100vw; }
+    helios-player { width: 100%; height: 100%; }
+  </style>
+</head>
+<body>
+  <helios-player src="./composition.html" auto-play controls></helios-player>
+  <script type="module">import '@helios-project/player'</script>
+</body>
+</html>`;
+
       try {
         console.log(chalk.cyan('Starting production build...'));
 
+        fs.writeFileSync(entryPath, entryContent);
+
         await build({
-          root: process.cwd(),
+          root: rootDir,
           build: {
-            outDir: options.outDir,
+            outDir: outDir,
             emptyOutDir: true,
+            rollupOptions: {
+              input: {
+                main: entryPath,
+                composition: compositionPath
+              }
+            }
           }
         });
 
-        console.log(chalk.green(`Build complete. Output: ${options.outDir}`));
+        // Rename output file
+        const distDir = path.resolve(rootDir, outDir);
+        const builtEntryPath = path.join(distDir, '.helios-build-entry.html');
+        const finalIndexPath = path.join(distDir, 'index.html');
+
+        if (fs.existsSync(builtEntryPath)) {
+            fs.renameSync(builtEntryPath, finalIndexPath);
+        }
+
+        console.log(chalk.green(`Build complete. Output: ${path.join(dir, outDir)}`));
       } catch (error) {
         console.error(chalk.red('Build failed:'), error);
-        process.exit(1);
+        process.exitCode = 1;
+      } finally {
+        // Cleanup
+        if (fs.existsSync(entryPath)) {
+            fs.unlinkSync(entryPath);
+        }
       }
     });
 }

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@helios-project/core": "^5.11.0",
-    "@helios-project/player": "^0.71.0",
+    "@helios-project/player": "^0.72.1",
     "@helios-project/renderer": "^0.0.2",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "react": "^19.2.3",


### PR DESCRIPTION
- Implemented `helios build` command in `packages/cli/src/commands/build.ts`.
- Command generates a temporary entry HTML file importing `@helios-project/player` and bundling it with Vite.
- Added error handling for missing `composition.html`.
- Fixed `@helios-project/player` dependency version in `packages/studio/package.json` to resolve build errors.
- Verified manually with `examples/simple-animation`.

---
*PR created automatically by Jules for task [11897203139462806190](https://jules.google.com/task/11897203139462806190) started by @BintzGavin*