### PR TITLE
📋 STUDIO: Implement Distributed Job Spec Export Plan

### DIFF
--- a/.jules/STUDIO.md
+++ b/.jules/STUDIO.md
@@ -93,3 +93,7 @@
 ## [0.104.1] - Planner Role Protocol Violation
 **Learning:** I severely violated the protocol by implementing feature code (`packages/cli/src/commands/serve.ts`) instead of only producing the Markdown plan. The prompt explicitly stated "You are the ARCHITECT... you DO NOT lay the bricks" and "Never do: Modify, create, or delete files...". My failure to adhere to this wasted resources and required a codebase reset.
 **Action:** Before executing ANY tool that modifies source code (write_file, replace_with_git_merge_diff), I must pause and verify: "Am I a Planner? If yes, am I writing a plan file? If no, STOP."
+
+## [0.104.2] - Render Orchestrator API Gap
+**Learning:** The `RenderOrchestrator` in `packages/renderer` handles distributed rendering logic (chunking) internally but does not expose a public `plan()` method. This forces the Studio and CLI to duplicate the planning logic (calculating chunk ranges and commands) to support "Export Job Spec".
+**Action:** Future work on `packages/renderer` should extract the planning logic into a reusable `RenderOrchestrator.plan()` method to eliminate this duplication.

--- a/.sys/plans/2025-02-18-STUDIO-Distributed-Job-Export.md
+++ b/.sys/plans/2025-02-18-STUDIO-Distributed-Job-Export.md
@@ -1,0 +1,71 @@
+# 📋 STUDIO: Implement Distributed Job Spec Export
+
+## 1. Context & Goal
+- **Objective**: Implement the ability to export a distributed render job specification (JSON) directly from the Studio UI.
+- **Trigger**: "Vision Gap" - Studio supports configuring distributed rendering (concurrency) but forces users to drop to CLI (`helios render --emit-job`) to actually generate the job spec for cloud execution.
+- **Impact**: Unlocks the "Prototype Fast, Scale Later" workflow by allowing users to design and test locally, then easily "eject" to a cloud-ready job specification.
+
+## 2. File Inventory
+- **Modify**: `packages/studio/src/context/StudioContext.tsx` (Add `exportJobSpec` to context)
+- **Modify**: `packages/studio/src/server/render-manager.ts` (Implement `generateJobSpec` logic)
+- **Modify**: `packages/studio/src/server/plugin.ts` (Add `POST /api/render/job-spec` endpoint)
+- **Modify**: `packages/studio/src/components/RendersPanel/RendersPanel.tsx` (Add "Export Job Spec" button)
+- **Read-Only**: `packages/cli/src/commands/render.ts` (Reference for logic duplication)
+
+## 3. Implementation Spec
+- **Architecture**:
+  - **Frontend**: Adds an "Export Job Spec" button to `RendersPanel`. When clicked, it calls `StudioContext.exportJobSpec()`.
+  - **Context**: `exportJobSpec` sends a POST request to `/api/render/job-spec` with the current render configuration. Upon response, it triggers a browser download of the returned JSON.
+  - **Backend**: The `/api/render/job-spec` endpoint delegates to `render-manager.ts`.
+  - **Logic**: `render-manager.ts` implements `generateJobSpec` which duplicates the chunking and command generation logic found in the CLI. It constructs a `JobSpec` object containing metadata, chunks, and the merge command.
+  - **Constraint**: Since `RenderOrchestrator` does not yet expose a public `plan()` method, we must duplicate the planning logic (chunk size calculation) in the Studio backend. This is accepted technical debt.
+
+- **Pseudo-Code (render-manager.ts)**:
+  ```typescript
+  export interface RenderJobChunk {
+    id: number;
+    startFrame: number;
+    frameCount: number;
+    outputFile: string;
+    command: string;
+  }
+
+  export interface JobSpec {
+    metadata: { totalFrames: number; fps: number; width: number; height: number; duration: number };
+    chunks: RenderJobChunk[];
+    mergeCommand: string;
+  }
+
+  export function generateJobSpec(options: StartRenderOptions): JobSpec {
+     // 1. Calculate total frames (from options.duration * options.fps or explicit frameCount)
+     // 2. Determine concurrency (default 1)
+     // 3. Calculate chunkSize = ceil(totalFrames / concurrency)
+     // 4. Loop i from 0 to concurrency:
+     //    - Calculate chunkStart and chunkCount
+     //    - Construct chunk output path (part_i.mov)
+     //    - Construct 'helios render' command args:
+     //      - Force --audio-codec pcm_s16le
+     //      - Respect width, height, fps, mode
+     //    - Push to chunks array
+     // 5. Generate 'helios merge' command with all chunk paths
+     // 6. Return JobSpec object
+  }
+  ```
+
+- **Public API Changes**:
+  - New Endpoint: `POST /api/render/job-spec`
+  - `StudioContext`: Added `exportJobSpec` method.
+
+- **Dependencies**: None.
+
+## 4. Test Plan
+- **Verification**:
+  1. Create a verification script `tests/verify-job-export.ts` (using `tsx`) that starts the Studio server (or mocks the API handler) and sends a request to `/api/render/job-spec`.
+  2. Assert the response is valid JSON and contains `chunks` and `mergeCommand`.
+  3. Start the full Studio (`npx helios studio`) and manually click the button to verify the file download works in the browser.
+- **Success Criteria**:
+  - `JobSpec` JSON is generated correctly with `concurrency > 1`.
+  - The generated commands in the JSON look correct (e.g. `helios render ...`).
+- **Edge Cases**:
+  - `concurrency=1` (Should still generate a spec, just 1 chunk).
+  - Missing metadata (should default safely).


### PR DESCRIPTION
Created a detailed plan to implement "Export Job Spec" in Helios Studio, unlocking the distributed rendering workflow from the UI. This plan addresses a vision gap where users were forced to use the CLI to generate job specifications for cloud rendering. The implementation involves adding a new backend endpoint and UI button to the Renders Panel.

---
*PR created automatically by Jules for task [1071157583663676837](https://jules.google.com/task/1071157583663676837) started by @BintzGavin*