### PR TITLE
Implement resize event in HeliosPlayer

### DIFF
--- a/.sys/plans/2025-02-12-PLAYER-ResizeEvent.md
+++ b/.sys/plans/2025-02-12-PLAYER-ResizeEvent.md
@@ -1,0 +1,30 @@
+# 2025-02-12-PLAYER-ResizeEvent
+
+#### 1. Context & Goal
+- **Objective**: Implement the standard `resize` event in `<helios-player>` to notify when the composition's intrinsic dimensions change.
+- **Trigger**: Standard Media API parity gap. `HTMLVideoElement` fires `resize` when `videoWidth`/`videoHeight` changes, but `<helios-player>` currently does not.
+- **Impact**: Enables host applications (like Studio) to reactively resize the player container or update UI layouts when the composition size changes dynamically.
+
+#### 2. File Inventory
+- **Modify**: `packages/player/src/index.ts` (Implement event dispatch logic in `updateUI`)
+- **Modify**: `packages/player/src/api_parity.test.ts` (Add verification test)
+
+#### 3. Implementation Spec
+- **Architecture**: Extend the `updateUI` method in `HeliosPlayer` to compare current `width`/`height` from state with `lastState`.
+- **Logic**:
+  ```typescript
+  // Inside updateUI(state), BEFORE `this.lastState = state;`
+  if (this.lastState) {
+    const widthChanged = state.width !== this.lastState.width;
+    const heightChanged = state.height !== this.lastState.height;
+    if (widthChanged || heightChanged) {
+      this.dispatchEvent(new Event("resize"));
+    }
+  }
+  ```
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: Run `npm test packages/player/src/api_parity.test.ts`
+- **Success Criteria**: New test case "should dispatch resize event when dimensions change" passes.
+- **Edge Cases**: Ensure event fires only when dimensions *actually* change (not on every frame update).

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -493,4 +493,46 @@ describe('HeliosPlayer API Parity', () => {
     expect(track.selected).toBe(false);
     expect(player.videoTracks.selectedIndex).toBe(-1);
   });
+
+  it('should dispatch resize event when dimensions change', () => {
+    const resizeSpy = vi.fn();
+    player.addEventListener('resize', resizeSpy);
+
+    const baseState = { width: 1920, height: 1080, duration: 10, fps: 30, currentFrame: 0, isPlaying: false };
+
+    const mockController = {
+      getState: () => baseState,
+      pause: vi.fn(),
+      dispose: vi.fn(),
+      subscribe: vi.fn((cb) => {
+        // Mock sending initial state then update
+        cb(baseState); // Initial state
+        return vi.fn();
+      }),
+      onError: vi.fn().mockReturnValue(() => {}),
+      onAudioMetering: vi.fn().mockReturnValue(() => {}),
+      setAudioVolume: vi.fn(),
+      setPlaybackRate: vi.fn(),
+      setAudioMuted: vi.fn(),
+      setInputProps: vi.fn(),
+      setLoop: vi.fn(),
+      play: vi.fn(),
+    };
+    (player as any).setController(mockController);
+
+    // Initial state set should not trigger resize as lastState was null
+    expect(resizeSpy).toHaveBeenCalledTimes(0);
+
+    // Update with new dimensions
+    (player as any).updateUI({ ...baseState, width: 1280, height: 720 });
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+
+    // Update with same dimensions
+    (player as any).updateUI({ ...baseState, width: 1280, height: 720 });
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+
+    // Update with new height
+    (player as any).updateUI({ ...baseState, width: 1280, height: 721 });
+    expect(resizeSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -2923,6 +2923,12 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
         if (state.duration !== this.lastState.duration) {
             this.dispatchEvent(new Event("durationchange"));
         }
+
+        const widthChanged = state.width !== this.lastState.width;
+        const heightChanged = state.height !== this.lastState.height;
+        if (widthChanged || heightChanged) {
+            this.dispatchEvent(new Event("resize"));
+        }
       }
 
       const isFinished = state.currentFrame >= state.duration * state.fps - 1;


### PR DESCRIPTION
Implemented `resize` event dispatching in `HeliosPlayer` when intrinsic dimensions change, filling a gap in Standard Media API parity. Verified with unit tests. Restored `dist` artifacts to ensure no regressions in build output.

---
*PR created automatically by Jules for task [14561100504720309619](https://jules.google.com/task/14561100504720309619) started by @BintzGavin*