### PR TITLE
✨ CLI: Implement `helios skills install` command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -15,6 +15,8 @@ Entry Points:
 packages/cli/
 ├── bin/
 │   └── helios.js
+├── scripts/
+│   └── bundle-skills.js
 ├── src/
 │   ├── index.ts
 │   ├── commands/
@@ -27,6 +29,7 @@ packages/cli/
 │   │   ├── merge.ts
 │   │   ├── remove.ts
 │   │   ├── render.ts
+│   │   ├── skills.ts
 │   │   ├── studio.ts
 │   │   └── update.ts
 │   ├── types/
@@ -49,6 +52,7 @@ packages/cli/
 - `helios update <component>`: Updates a component to the latest version.
 - `helios build`: Builds the project for production using Vite.
 - `helios job run <file>`: Execute a distributed render job from a JSON spec.
+- `helios skills install`: Installs AI agent skills into the project.
 
 ## D. Configuration
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### CLI v0.18.0
+- ✅ Completed: Implement Skills Command - Implemented `helios skills install` to distribute AI agent skills to user projects.
+
 ### RENDERER v1.77.1
 - ✅ Completed: Refactor DOM Traversal - Consolidated duplicated DOM traversal logic (`findAllImages`, `findAllScopes`, `findAllElements`) into `dom-scripts.ts` and updated `DomStrategy` (preload) and `SeekTimeDriver` to use shared constants. Verified with `verify-enhanced-dom-preload.ts`.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.17.0
+**Version**: 0.18.0
 
 ## Current State
 
@@ -24,6 +24,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 - `helios update` - Updates a component to the latest version
 - `helios build` - Builds the project for production
 - `helios job` - Manages distributed rendering jobs
+- `helios skills` - Manages AI agent skills installation
 
 ## V2 Roadmap
 
@@ -63,3 +64,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.15.0] ✅ Synced Version - Updated package.json and index.ts to match status file and verified functionality.
 [v0.16.0] ✅ Distributed Job Export - Implemented `--emit-job`, `--audio-codec`, and `--video-codec` options in `helios render` to generate distributed rendering job specifications.
 [v0.17.0] ✅ Implement Job Command - Implemented `helios job run` to execute distributed rendering jobs from JSON specifications, supporting concurrency and selective chunk execution.
+[v0.18.0] ✅ Implement Skills Command - Implemented `helios skills install` to distribute AI agent skills to user projects.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/cli",
-  "version": "0.15.0",
+  "version": "0.18.0",
   "description": "CLI for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",
@@ -24,7 +24,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/bundle-skills.js",
     "dev": "tsc -w",
     "prepublishOnly": "npm run build"
   },

--- a/packages/cli/scripts/bundle-skills.js
+++ b/packages/cli/scripts/bundle-skills.js
@@ -1,0 +1,30 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Resolving paths relative to this script file
+const sourceDir = path.resolve(__dirname, '../../../.agents/skills/helios');
+const destDir = path.resolve(__dirname, '../dist/skills');
+
+console.log(`Bundling skills from ${sourceDir} to ${destDir}...`);
+
+if (!fs.existsSync(sourceDir)) {
+  console.error(`Source directory not found: ${sourceDir}`);
+  process.exit(1);
+}
+
+// Clean destination
+if (fs.existsSync(destDir)) {
+    fs.rmSync(destDir, { recursive: true, force: true });
+}
+
+// Ensure destination exists
+fs.mkdirSync(destDir, { recursive: true });
+
+// Copy recursively
+fs.cpSync(sourceDir, destDir, { recursive: true });
+
+console.log('Skills bundled successfully.');

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,0 +1,45 @@
+import { Command } from 'commander';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import chalk from 'chalk';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export function registerSkillsCommand(program: Command) {
+  const skills = program.command('skills')
+    .description('Manage Helios agent skills');
+
+  skills.command('install')
+    .description('Install Helios skills into the current project')
+    .action(() => {
+      // Determine the location of the bundled skills directory
+      // When built, this file is in dist/commands/skills.js
+      // The skills are bundled into dist/skills
+      const skillsDir = path.resolve(__dirname, '../skills');
+      const targetDir = path.resolve(process.cwd(), '.agents/skills/helios');
+
+      console.log(chalk.blue(`Installing skills to ${targetDir}...`));
+
+      if (!fs.existsSync(skillsDir)) {
+        console.error(chalk.red(`Error: Skills directory not found at ${skillsDir}.`));
+        console.error(chalk.red('This installation of Helios CLI seems to be missing the bundled skills.'));
+        process.exit(1);
+      }
+
+      if (fs.existsSync(targetDir)) {
+          console.warn(chalk.yellow(`Target directory ${targetDir} already exists. Overwriting...`));
+          fs.rmSync(targetDir, { recursive: true, force: true });
+      }
+
+      try {
+        fs.mkdirSync(targetDir, { recursive: true });
+        fs.cpSync(skillsDir, targetDir, { recursive: true });
+        console.log(chalk.green('Skills installed successfully!'));
+      } catch (error) {
+        console.error(chalk.red('Failed to install skills:'), error);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,13 +10,14 @@ import { registerRemoveCommand } from './commands/remove.js';
 import { registerUpdateCommand } from './commands/update.js';
 import { registerBuildCommand } from './commands/build.js';
 import { registerJobCommand } from './commands/job.js';
+import { registerSkillsCommand } from './commands/skills.js';
 
 const program = new Command();
 
 program
   .name('helios')
   .description('Helios CLI')
-  .version('0.15.0');
+  .version('0.18.0');
 
 registerStudioCommand(program);
 registerInitCommand(program);
@@ -29,5 +30,6 @@ registerRemoveCommand(program);
 registerUpdateCommand(program);
 registerBuildCommand(program);
 registerJobCommand(program);
+registerSkillsCommand(program);
 
 program.parse(process.argv);


### PR DESCRIPTION
Implemented `helios skills install` command and a build-time script to bundle AI agent skills.
Updated `package.json` to run the bundling script on build.
Registered the new command in `src/index.ts`.
Updated documentation to reflect the new command.

---
*PR created automatically by Jules for task [11358100445054749869](https://jules.google.com/task/11358100445054749869) started by @BintzGavin*