### PR TITLE
✨ RENDERER: Fix Verification Script Regression

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -16,6 +16,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### CLI v0.18.0
 - ✅ Completed: Implement Skills Command - Implemented `helios skills install` to distribute AI agent skills to user projects.
 
+### RENDERER v1.77.2
+- ✅ Completed: Fix Verification Script Regression - Updated `verify-asset-timeout.ts` to check for the correct log prefixes (`[Helios Preload]`, `[DomScanner]`) instead of `[DomStrategy]`, fixing a regression caused by the v1.77.1 DOM traversal refactor. Verified with `verify-asset-timeout.ts`.
+
 ### RENDERER v1.77.1
 - ✅ Completed: Refactor DOM Traversal - Consolidated duplicated DOM traversal logic (`findAllImages`, `findAllScopes`, `findAllElements`) into `dom-scripts.ts` and updated `DomStrategy` (preload) and `SeekTimeDriver` to use shared constants. Verified with `verify-enhanced-dom-preload.ts`.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,10 +1,11 @@
-**Version**: 1.77.1
+**Version**: 1.77.2
 
 **Posture**: MAINTENANCE WITH V2 EXPANSION
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.77.2] ✅ Completed: Fix Verification Script Regression - Updated `verify-asset-timeout.ts` to check for the correct log prefixes (`[Helios Preload]`, `[DomScanner]`) instead of `[DomStrategy]`, fixing a regression caused by the v1.77.1 DOM traversal refactor. Verified with `verify-asset-timeout.ts`.
 - [1.77.1] ✅ Completed: Refactor DOM Traversal - Consolidated duplicated DOM traversal logic (`findAllImages`, `findAllScopes`, `findAllElements`) into `dom-scripts.ts` and updated `DomStrategy` (preload) and `SeekTimeDriver` to use shared constants. Verified with `verify-enhanced-dom-preload.ts`.
 - [1.77.0] ✅ Completed: Abstraction for Pluggable Execution - Decoupled `RenderOrchestrator` from concrete `Renderer` implementation by introducing `RenderExecutor` interface and `LocalExecutor` strategy. Verified with `verify-orchestrator-executor.ts`.
 - [1.76.1] ✅ Completed: Restore Development Environment - Restored dependencies (`npm install`, `npx playwright install`) and fixed regressions in verification scripts (`verify-dom-preload.ts`, `verify-transparency.ts`), ensuring full test suite integrity.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10104,7 +10104,7 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.15.0",
+      "version": "0.18.0",
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/packages/renderer/tests/verify-asset-timeout.ts
+++ b/packages/renderer/tests/verify-asset-timeout.ts
@@ -66,7 +66,11 @@ async function verify() {
 
   // Verify warning log
   console.log('All Logs:', consoleLogs);
-  const timeoutLog = consoleLogs.find(l => l.includes('[DomStrategy] Timeout waiting for'));
+  const timeoutLog = consoleLogs.find(l =>
+    l.includes('[DomStrategy] Timeout waiting for') ||
+    l.includes('[Helios Preload] Timeout waiting for') ||
+    l.includes('[DomScanner] Timeout waiting for')
+  );
   if (!timeoutLog) {
     console.error('❌ Failed: Expected timeout warning log not found.');
     success = false;


### PR DESCRIPTION
This change fixes a regression in `packages/renderer/tests/verify-asset-timeout.ts` where the test was failing to detect timeout warnings due to changed log prefixes in the underlying implementation (v1.77.1 refactor). The test now correctly identifies logs from `dom-preload.ts` and `dom-scanner.ts`.

Verification:
- Run `npx tsx packages/renderer/tests/verify-asset-timeout.ts` -> Passes.

---
*PR created automatically by Jules for task [2118962371050181844](https://jules.google.com/task/2118962371050181844) started by @BintzGavin*