### PR TITLE
Enable bundled agent skills in Studio

### DIFF
--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -4,6 +4,7 @@ import { studioApiPlugin } from '@helios-project/studio/cli';
 import { createRequire } from 'module';
 import path from 'path';
 import fs from 'fs';
+import { fileURLToPath } from 'url';
 import { defaultClient } from '../registry/client.js';
 import { installComponent } from '../utils/install.js';
 import { loadConfig } from '../utils/config.js';
@@ -31,7 +32,15 @@ export function registerStudioCommand(program: Command) {
         const studioRoot = path.resolve(path.dirname(studioCliPath), '../../');
         const studioDist = path.join(studioRoot, 'dist');
 
+        // Resolve bundled skills path relative to this CLI file
+        const __filename = fileURLToPath(import.meta.url);
+        const __dirname = path.dirname(__filename);
+        const skillsRoot = path.resolve(__dirname, '../skills');
+
         console.log(`Studio Root: ${studioRoot}`);
+        if (fs.existsSync(skillsRoot)) {
+            console.log(`Skills Root: ${skillsRoot}`);
+        }
 
         const server = await createServer({
           // configFile: false, // Removed to allow loading user config (crucial for framework plugins)
@@ -43,6 +52,7 @@ export function registerStudioCommand(program: Command) {
           plugins: [
             studioApiPlugin({
               studioRoot: studioDist,
+              skillsRoot: skillsRoot,
               components: components,
               onInstallComponent: async (name: string) => {
                 await installComponent(process.cwd(), name);

--- a/packages/studio/src/server/documentation.ts
+++ b/packages/studio/src/server/documentation.ts
@@ -112,12 +112,16 @@ function parseMarkdown(pkg: string, content: string, sections: DocSection[], tit
   flush();
 }
 
-function findSkills(cwd: string, sections: DocSection[]) {
+function findSkills(cwd: string, sections: DocSection[], skillsRootOverride?: string) {
   let skillsRoot: string | null = null;
   const possiblePaths = [
       path.resolve(cwd, '../../.agents/skills/helios'), // From packages/studio
       path.resolve(cwd, '.agents/skills/helios')        // From root
   ];
+
+  if (skillsRootOverride) {
+      possiblePaths.push(skillsRootOverride);
+  }
 
   for (const p of possiblePaths) {
       if (fs.existsSync(p)) {
@@ -142,7 +146,7 @@ function findSkills(cwd: string, sections: DocSection[]) {
   }
 }
 
-export function findDocumentation(cwd: string): DocSection[] {
+export function findDocumentation(cwd: string, skillsRoot?: string): DocSection[] {
   const sections: DocSection[] = [];
 
   const packages = ['core', 'studio', 'renderer', 'player', 'root'];
@@ -159,7 +163,7 @@ export function findDocumentation(cwd: string): DocSection[] {
       }
   }
 
-  findSkills(cwd, sections);
+  findSkills(cwd, sections, skillsRoot);
 
   return sections;
 }

--- a/packages/studio/src/server/plugin.ts
+++ b/packages/studio/src/server/plugin.ts
@@ -19,6 +19,7 @@ export interface StudioComponentDefinition {
 
 export interface StudioPluginOptions {
   studioRoot?: string;
+  skillsRoot?: string;
   components?: StudioComponentDefinition[];
   onInstallComponent?: (name: string) => Promise<void>;
   onCheckInstalled?: (name: string) => Promise<boolean>;
@@ -464,7 +465,7 @@ function configureMiddlewares(server: ViteDevServer | PreviewServer, isPreview: 
       server.middlewares.use('/api/documentation', async (req, res, next) => {
         if (req.url === '/' || req.url === '') {
           try {
-            const docs = findDocumentation(process.cwd());
+            const docs = findDocumentation(process.cwd(), options.skillsRoot);
             res.setHeader('Content-Type', 'application/json');
             res.end(JSON.stringify(docs));
           } catch (e: any) {

--- a/verification/verify-skills-loading.ts
+++ b/verification/verify-skills-loading.ts
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { findDocumentation } from '../packages/studio/src/server/documentation';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function runVerification() {
+  console.log('Verifying bundled skills loading...');
+
+  const mockSkillsRoot = path.join(__dirname, 'mock-skills');
+  const coreSkillDir = path.join(mockSkillsRoot, 'core');
+  const skillFile = path.join(coreSkillDir, 'SKILL.md');
+
+  const deepDir = path.join(__dirname, 'tmp', 'deep', 'dir');
+  const fakeCwd = path.join(deepDir, 'fake-cwd');
+
+  // Cleanup
+  if (fs.existsSync(mockSkillsRoot)) {
+    fs.rmSync(mockSkillsRoot, { recursive: true, force: true });
+  }
+  if (fs.existsSync(path.join(__dirname, 'tmp'))) {
+    fs.rmSync(path.join(__dirname, 'tmp'), { recursive: true, force: true });
+  }
+
+  try {
+    fs.mkdirSync(coreSkillDir, { recursive: true });
+
+    // The parser uses headers for titles
+    const uniqueTitle = 'Unique Mock Skill';
+    const fullExpectedTitle = 'Agent Skill: ' + uniqueTitle;
+
+    fs.writeFileSync(skillFile, `# ${uniqueTitle}\n\nUse this pattern.`);
+
+    fs.mkdirSync(fakeCwd, { recursive: true });
+
+    const docs = findDocumentation(fakeCwd, mockSkillsRoot);
+
+    const foundSkill = docs.find(d => d.title === fullExpectedTitle);
+
+    if (foundSkill) {
+      console.log('Success: Found bundled skill');
+      console.log('Content preview:', foundSkill.content.substring(0, 50));
+    } else {
+      console.error('Failure: Did not find bundled skill');
+
+      const foundTitles = docs.map(d => d.title);
+      console.log('Docs found:', foundTitles.length > 0 ? foundTitles : 'None');
+      console.log('Expected:', fullExpectedTitle);
+
+      process.exit(1);
+    }
+
+  } catch (e) {
+    console.error('Error during verification:', e);
+    process.exit(1);
+  } finally {
+    // Cleanup
+    if (fs.existsSync(mockSkillsRoot)) {
+      fs.rmSync(mockSkillsRoot, { recursive: true, force: true });
+    }
+    if (fs.existsSync(path.join(__dirname, 'tmp'))) {
+        fs.rmSync(path.join(__dirname, 'tmp'), { recursive: true, force: true });
+    }
+  }
+}
+
+runVerification();


### PR DESCRIPTION
Enables the Helios Studio Assistant to access bundled Agent Skills directly from the CLI package. This ensures the Assistant can provide best-practice guidance even in fresh projects where users haven't manually installed skills.

- Updated `packages/studio/src/server/documentation.ts` to accept `skillsRoot` as a fallback source.
- Updated `packages/studio/src/server/plugin.ts` to pass `skillsRoot` from options.
- Updated `packages/cli/src/commands/studio.ts` to resolve and pass the bundled `dist/skills` path.
- Added `verification/verify-skills-loading.ts` to verify the logic.

---
*PR created automatically by Jules for task [9540015394871955701](https://jules.google.com/task/9540015394871955701) started by @BintzGavin*