### PR TITLE
✨ CLI: Implement preview command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -27,6 +27,7 @@ packages/cli/
 │   │   ├── job.ts
 │   │   ├── list.ts
 │   │   ├── merge.ts
+│   │   ├── preview.ts
 │   │   ├── remove.ts
 │   │   ├── render.ts
 │   │   ├── skills.ts
@@ -51,6 +52,7 @@ packages/cli/
 - `helios remove <component>`: Removes a component from the project configuration.
 - `helios update <component>`: Updates a component to the latest version.
 - `helios build`: Builds the project for production using Vite.
+- `helios preview [dir]`: Previews the production build locally using Vite.
 - `helios job run <file>`: Execute a distributed render job from a JSON spec.
 - `helios skills install`: Installs AI agent skills into the project.
 

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,18 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.19.0
+
+- ✅ Implement Preview Command - Implemented `helios preview` to serve the production build locally using Vite.
+
+## CLI v0.18.0
+
+- ✅ Implement Skills Command - Implemented `helios skills install` to distribute AI agent skills to user projects.
+
+## CLI v0.17.0
+
+- ✅ Implement Job Command - Implemented `helios job run` to execute distributed rendering jobs from JSON specifications, supporting concurrency and selective chunk execution.
+
 ## CLI v0.16.0
 
 - ✅ Distributed Job Export - Implemented `--emit-job`, `--audio-codec`, and `--video-codec` options in `helios render` to generate distributed rendering job specifications.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.18.0
+**Version**: 0.19.0
 
 ## Current State
 
@@ -25,6 +25,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 - `helios build` - Builds the project for production
 - `helios job` - Manages distributed rendering jobs
 - `helios skills` - Manages AI agent skills installation
+- `helios preview` - Previews the production build locally
 
 ## V2 Roadmap
 
@@ -65,3 +66,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.16.0] ✅ Distributed Job Export - Implemented `--emit-job`, `--audio-codec`, and `--video-codec` options in `helios render` to generate distributed rendering job specifications.
 [v0.17.0] ✅ Implement Job Command - Implemented `helios job run` to execute distributed rendering jobs from JSON specifications, supporting concurrency and selective chunk execution.
 [v0.18.0] ✅ Implement Skills Command - Implemented `helios skills install` to distribute AI agent skills to user projects.
+[v0.19.0] ✅ Implement Preview Command - Implemented `helios preview` to serve the production build locally using Vite.

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -1,0 +1,38 @@
+import { Command } from 'commander';
+import { preview } from 'vite';
+import chalk from 'chalk';
+import path from 'path';
+import fs from 'fs';
+
+export function registerPreviewCommand(program: Command) {
+  program
+    .command('preview [dir]')
+    .description('Preview the production build locally')
+    .option('-o, --out-dir <dir>', 'Output directory', 'dist')
+    .option('-p, --port <number>', 'Port to listen on', '4173')
+    .action(async (dir = '.', options) => {
+      const rootDir = path.resolve(process.cwd(), dir);
+      const outDir = path.resolve(rootDir, options.outDir);
+
+      if (!fs.existsSync(outDir)) {
+        console.error(chalk.red(`Error: Build directory not found at ${outDir}`));
+        console.error(chalk.yellow(`Run 'helios build' first.`));
+        process.exit(1);
+      }
+
+      try {
+        const port = parseInt(options.port, 10);
+        const server = await preview({
+          root: rootDir,
+          build: { outDir: options.outDir },
+          preview: { port }
+        });
+
+        server.printUrls();
+        // Keep process alive
+      } catch (e) {
+        console.error(chalk.red('Failed to start preview server:'), e);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import { registerListCommand } from './commands/list.js';
 import { registerRemoveCommand } from './commands/remove.js';
 import { registerUpdateCommand } from './commands/update.js';
 import { registerBuildCommand } from './commands/build.js';
+import { registerPreviewCommand } from './commands/preview.js';
 import { registerJobCommand } from './commands/job.js';
 import { registerSkillsCommand } from './commands/skills.js';
 
@@ -29,6 +30,7 @@ registerListCommand(program);
 registerRemoveCommand(program);
 registerUpdateCommand(program);
 registerBuildCommand(program);
+registerPreviewCommand(program);
 registerJobCommand(program);
 registerSkillsCommand(program);
 


### PR DESCRIPTION
Implemented `helios preview` command to serve production builds locally using Vite. This command supports specifying the output directory and port. It was verified manually by serving a test directory. The implementation resides in `packages/cli/src/commands/preview.ts` and is registered in `packages/cli/src/index.ts`.

---
*PR created automatically by Jules for task [1048905530487189912](https://jules.google.com/task/1048905530487189912) started by @BintzGavin*