### PR TITLE
Implement Audio Fades for Preview

### DIFF
--- a/packages/player/src/bridge.test.ts
+++ b/packages/player/src/bridge.test.ts
@@ -2,6 +2,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { connectToParent } from './bridge';
 
+// Mock AudioFader
+vi.mock('./features/audio-fader', () => ({
+    AudioFader: class {
+        connect = vi.fn();
+        enable = vi.fn();
+        disable = vi.fn();
+        dispose = vi.fn();
+    }
+}));
+
 // Mock Helios
 vi.mock('@helios-project/core', () => {
     return {

--- a/packages/player/src/bridge.ts
+++ b/packages/player/src/bridge.ts
@@ -2,10 +2,15 @@ import { Helios } from "@helios-project/core";
 import { captureDomToBitmap } from "./features/dom-capture";
 import { getAudioAssets } from "./features/audio-utils";
 import { AudioMeter } from "./features/audio-metering";
+import { AudioFader } from "./features/audio-fader";
 
 export function connectToParent(helios: Helios) {
   let audioMeter: AudioMeter | null = null;
   let audioMeterRaf: number | null = null;
+  const audioFader = new AudioFader();
+
+  // Connect fader immediately (scans document for audio elements)
+  audioFader.connect(document);
 
   // 1. Listen for messages from parent
   window.addEventListener('message', async (event) => {
@@ -155,6 +160,11 @@ export function connectToParent(helios: Helios) {
 
   // 3. Subscribe to Helios state changes and broadcast
   helios.subscribe((state: any) => {
+    if (state.isPlaying) {
+      audioFader.enable();
+    } else {
+      audioFader.disable();
+    }
     window.parent.postMessage({ type: 'HELIOS_STATE', state }, '*');
   });
 

--- a/packages/player/src/controllers.test.ts
+++ b/packages/player/src/controllers.test.ts
@@ -3,6 +3,16 @@ import { DirectController, BridgeController } from './controllers';
 import { Helios } from '@helios-project/core';
 import * as domCapture from './features/dom-capture';
 
+// Mock AudioFader
+vi.mock('./features/audio-fader', () => ({
+    AudioFader: class {
+        connect = vi.fn();
+        enable = vi.fn();
+        disable = vi.fn();
+        dispose = vi.fn();
+    }
+}));
+
 // Mock Helios
 vi.mock('@helios-project/core', () => {
     const MockHelios = vi.fn();

--- a/packages/player/src/features/audio-fader.test.ts
+++ b/packages/player/src/features/audio-fader.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AudioFader } from './audio-fader';
+import { SharedAudioContextManager } from './audio-context-manager';
+
+// Mock SharedAudioContextManager
+vi.mock('./audio-context-manager', () => {
+  const mockSharedSource = {
+    setFadeGain: vi.fn(),
+  };
+
+  const mockManager = {
+    context: {
+      state: 'running',
+      resume: vi.fn().mockResolvedValue(undefined),
+    },
+    getSharedSource: vi.fn().mockReturnValue(mockSharedSource),
+  };
+
+  return {
+    SharedAudioContextManager: {
+      getInstance: vi.fn().mockReturnValue(mockManager),
+    },
+    SharedAudioSource: vi.fn(),
+  };
+});
+
+describe('AudioFader', () => {
+  let fader: AudioFader;
+  let mockManager: any;
+  let mockSharedSource: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockManager = SharedAudioContextManager.getInstance();
+    mockSharedSource = mockManager.getSharedSource(document.createElement('audio')); // Use getSharedSource to get the mock source
+    vi.clearAllMocks(); // Clear calls from setup
+
+    fader = new AudioFader();
+
+    // Mock requestAnimationFrame
+    vi.stubGlobal('requestAnimationFrame', (cb: any) => setTimeout(cb, 0));
+    vi.stubGlobal('cancelAnimationFrame', (id: any) => clearTimeout(id));
+  });
+
+  afterEach(() => {
+    fader.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  it('should scan for audio elements with fade attributes', () => {
+    const doc = document.implementation.createHTMLDocument();
+    const audio1 = doc.createElement('audio');
+    audio1.setAttribute('data-helios-fade-in', '2');
+    doc.body.appendChild(audio1);
+
+    const audio2 = doc.createElement('audio'); // No fade
+    doc.body.appendChild(audio2);
+
+    fader.connect(doc);
+
+    expect(mockManager.getSharedSource).toHaveBeenCalledWith(audio1);
+    expect(mockManager.getSharedSource).not.toHaveBeenCalledWith(audio2);
+  });
+
+  it('should calculate fade-in gain correctly', async () => {
+    const doc = document.implementation.createHTMLDocument();
+    const audio = doc.createElement('audio');
+    audio.setAttribute('data-helios-fade-in', '2'); // 2s fade in
+    doc.body.appendChild(audio);
+
+    // Mock properties
+    Object.defineProperty(audio, 'duration', { value: 10, writable: true });
+    Object.defineProperty(audio, 'currentTime', { value: 1, writable: true }); // 50% fade in
+
+    fader.connect(doc);
+    fader.enable();
+
+    // Wait for RAF
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(mockSharedSource.setFadeGain).toHaveBeenCalledWith(0.5);
+  });
+
+  it('should calculate fade-out gain correctly', async () => {
+    const doc = document.implementation.createHTMLDocument();
+    const audio = doc.createElement('audio');
+    audio.setAttribute('data-helios-fade-out', '2'); // 2s fade out
+    doc.body.appendChild(audio);
+
+    // Mock properties
+    Object.defineProperty(audio, 'duration', { value: 10, writable: true });
+    Object.defineProperty(audio, 'currentTime', { value: 9, writable: true }); // 1s remaining (50% fade out)
+
+    fader.connect(doc);
+    fader.enable();
+
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(mockSharedSource.setFadeGain).toHaveBeenCalledWith(0.5);
+  });
+
+  it('should handle overlapping fade-in and fade-out', async () => {
+    const doc = document.implementation.createHTMLDocument();
+    const audio = doc.createElement('audio');
+    audio.setAttribute('data-helios-fade-in', '4');
+    audio.setAttribute('data-helios-fade-out', '4');
+    doc.body.appendChild(audio);
+
+    // Mock properties
+    Object.defineProperty(audio, 'duration', { value: 6, writable: true });
+    // Middle point (3s):
+    // Fade In: 3/4 = 0.75
+    // Fade Out: (6-3)/4 = 3/4 = 0.75
+    Object.defineProperty(audio, 'currentTime', { value: 3, writable: true });
+
+    fader.connect(doc);
+    fader.enable();
+
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(mockSharedSource.setFadeGain).toHaveBeenCalledWith(0.75);
+  });
+
+  it('should set gain to 1 when outside fade zones', async () => {
+    const doc = document.implementation.createHTMLDocument();
+    const audio = doc.createElement('audio');
+    audio.setAttribute('data-helios-fade-in', '1');
+    doc.body.appendChild(audio);
+
+    // Mock properties
+    Object.defineProperty(audio, 'duration', { value: 10, writable: true });
+    Object.defineProperty(audio, 'currentTime', { value: 5, writable: true });
+
+    fader.connect(doc);
+    fader.enable();
+
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(mockSharedSource.setFadeGain).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/player/src/features/audio-fader.ts
+++ b/packages/player/src/features/audio-fader.ts
@@ -1,0 +1,83 @@
+import { SharedAudioContextManager, SharedAudioSource } from './audio-context-manager';
+
+export class AudioFader {
+  private sources: Map<HTMLMediaElement, SharedAudioSource> = new Map();
+  private rafId: number | null = null;
+  private manager: SharedAudioContextManager;
+  private isEnabled: boolean = false;
+
+  constructor() {
+    this.manager = SharedAudioContextManager.getInstance();
+  }
+
+  connect(doc: Document) {
+    if (this.manager.context.state === 'suspended') {
+      this.manager.context.resume().catch(e => console.warn("AudioFader: Failed to resume context", e));
+    }
+
+    const elements = Array.from(doc.querySelectorAll('audio, video')) as HTMLMediaElement[];
+
+    elements.forEach(el => {
+      const fadeIn = parseFloat(el.getAttribute('data-helios-fade-in') || '0');
+      const fadeOut = parseFloat(el.getAttribute('data-helios-fade-out') || '0');
+
+      if (fadeIn > 0 || fadeOut > 0) {
+        if (!this.sources.has(el)) {
+          const source = this.manager.getSharedSource(el);
+          this.sources.set(el, source);
+        }
+      }
+    });
+  }
+
+  enable() {
+    if (this.isEnabled) return;
+    this.isEnabled = true;
+    this.loop();
+  }
+
+  disable() {
+    this.isEnabled = false;
+    if (this.rafId) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+  }
+
+  private loop = () => {
+    if (!this.isEnabled) return;
+
+    this.sources.forEach((source, el) => {
+      const fadeIn = parseFloat(el.getAttribute('data-helios-fade-in') || '0');
+      const fadeOut = parseFloat(el.getAttribute('data-helios-fade-out') || '0');
+      const duration = el.duration;
+      const currentTime = el.currentTime;
+
+      let gain = 1;
+
+      // Calculate Fade In
+      if (fadeIn > 0 && currentTime < fadeIn) {
+        gain = currentTime / fadeIn;
+      }
+
+      // Calculate Fade Out
+      if (fadeOut > 0 && duration > 0) {
+        const remaining = duration - currentTime;
+        if (remaining < fadeOut) {
+             const fadeOutGain = Math.max(0, remaining / fadeOut);
+             gain = Math.min(gain, fadeOutGain);
+        }
+      }
+
+      // Apply to source
+      source.setFadeGain(gain);
+    });
+
+    this.rafId = requestAnimationFrame(this.loop);
+  }
+
+  dispose() {
+    this.disable();
+    this.sources.clear();
+  }
+}


### PR DESCRIPTION
Implemented audio fading for in-browser previews to match client-side export behavior. The player now respects `data-helios-fade-in` and `data-helios-fade-out` attributes on audio elements by dynamically adjusting gain during playback. This ensures a "What You See Is What You Get" experience for audio effects.

---
*PR created automatically by Jules for task [7406009938610848065](https://jules.google.com/task/7406009938610848065) started by @BintzGavin*