### PR TITLE
📋 RENDERER: FFmpeg Hardware Acceleration Visibility Gap

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -41,3 +41,7 @@
 ## [1.76.0] - Role Adherence Failure
 **Learning:** I mistakenly acted as an Executor, implementing code (`dom-preload.ts`) instead of creating a Spec File. This violated the "Vision-Driven Planner" protocol and the "Never modify packages" rule.
 **Action:** Strictly adhere to the "Spec File Only" output. Verify role definition before starting.
+
+## [2026-09-13] - FFmpeg Hardware Acceleration Visibility Gap
+**Learning:** `FFmpegInspector` reports codec support but misses hardware acceleration capabilities (`-hwaccels`), leaving users blind to GPU availability in distributed environments. This violates the "GPU Acceleration" vision pillar for diagnostics.
+**Action:** Created plan `2026-09-13-RENDERER-FFmpeg-Hardware-Acceleration.md` to implement `-hwaccels` detection.

--- a/.sys/plans/2026-09-13-RENDERER-FFmpeg-Hardware-Acceleration.md
+++ b/.sys/plans/2026-09-13-RENDERER-FFmpeg-Hardware-Acceleration.md
@@ -1,0 +1,36 @@
+# Spec: FFmpeg Hardware Acceleration Discovery
+
+## 1. Context & Goal
+- **Objective:** Enable `FFmpegInspector` to detect and report supported hardware acceleration methods (e.g., `cuda`, `videotoolbox`, `vaapi`) by parsing `ffmpeg -hwaccels` output.
+- **Trigger:** Vision Gap "GPU Acceleration" visibility. The current diagnostics miss critical information for performance tuning on GPU infrastructure.
+- **Impact:** Allows users and the engine to verify GPU availability, facilitating the use of high-performance codecs like `h264_nvenc`.
+
+## 2. File Inventory
+- **Modify:** `packages/renderer/src/utils/FFmpegInspector.ts` (Implement `-hwaccels` check)
+- **Modify:** `packages/renderer/tests/verify-diagnose-ffmpeg.ts` (Add verification assertions)
+- **Read-Only:** `packages/renderer/src/types.ts`
+
+## 3. Implementation Spec
+- **Architecture:** Extend `FFmpegInspector.inspect` to spawn a synchronous `ffmpeg` process with the `-hwaccels` flag. Parse the output line-by-line to extract acceleration method names.
+- **Pseudo-Code:**
+  ```typescript
+  // In FFmpegInspector.inspect:
+  // 1. Spawn `ffmpeg -hwaccels`
+  // 2. Parse stdout:
+  //    - Skip header "Hardware acceleration methods:"
+  //    - Collect non-empty lines as methods
+  // 3. Add `hwaccels: string[]` to result object
+  ```
+- **Public API Changes:**
+  - Update `FFmpegDiagnostics` interface in `FFmpegInspector.ts` to include `hwaccels: string[]`.
+- **Dependencies:** None.
+
+## 4. Test Plan
+- **Verification:** Run `npx tsx packages/renderer/tests/verify-diagnose-ffmpeg.ts`.
+- **Success Criteria:**
+  - The script outputs the diagnostics JSON containing a `hwaccels` array.
+  - The array contains strings (even if empty, it should be an array).
+  - If running on a machine with GPU (e.g., Mac), it might show `videotoolbox`.
+- **Edge Cases:**
+  - FFmpeg version doesn't support `-hwaccels` (older versions). Handle error/empty output gracefully.
+  - Output format changes.


### PR DESCRIPTION
Identified a gap in FFmpeg diagnostics where hardware acceleration capabilities (`-hwaccels`) were not being reported. Created a detailed implementation plan to add this feature to `FFmpegInspector`, enabling users to verify GPU availability for high-performance rendering. Also updated the domain journal with this learning.

---
*PR created automatically by Jules for task [6182044510029770484](https://jules.google.com/task/6182044510029770484) started by @BintzGavin*