### PR TITLE
✨ PLAYER: Fix Async Seek State

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -76,6 +76,7 @@ The Shadow DOM contains:
 - `inputProps` (get/set): Object for composition properties.
 - `sandbox` (get/set): Security flags.
 - `disablePictureInPicture` (get/set): PiP availability.
+- `seeking` (get): Whether the player is currently seeking (scrubbing or waiting for async seek).
 
 ## E. Public Methods
 - `play(): Promise<void>`: Start playback.

--- a/.sys/plans/2026-10-17-PLAYER-Fix-Async-Seek-State.md
+++ b/.sys/plans/2026-10-17-PLAYER-Fix-Async-Seek-State.md
@@ -1,0 +1,30 @@
+# 2026-10-17-PLAYER-Fix-Async-Seek-State.md
+
+#### 1. Context & Goal
+- **Objective**: Fix the `seeking` property implementation in `HeliosPlayer` to correctly reflect the asynchronous seek state during programmatic seeks (setting `currentTime` or `currentFrame`), ensuring compliance with the Standard Media API.
+- **Trigger**: The previous implementation of Async Seek (`v0.73.0`) failed to update the `seeking` property during programmatic seeks; it only reflected UI scrubbing state.
+- **Impact**: Ensures that `player.seeking` is `true` while an async seek is in progress, allowing external tools (like exporters or tests) to correctly wait for seeking to complete.
+
+#### 2. File Inventory
+- **Modify**: `packages/player/src/index.ts` (Update `HeliosPlayer` class: add `_isSeeking` flag, update `seeking` getter, update `currentTime` setter).
+- **Verify**: `packages/player/src/api_parity.test.ts` (Add verification test).
+
+#### 3. Implementation Spec
+- **HeliosPlayer**:
+    - Add `private _isSeeking: boolean = false;`.
+    - Update `get seeking()`: Return `this.isScrubbing || this._isSeeking`.
+    - Update `set currentTime(val)` and `set currentFrame(val)`:
+        1. Set `this._isSeeking = true`.
+        2. Dispatch `seeking` event.
+        3. Call `await this.controller.seek(...)`.
+        4. Set `this._isSeeking = false`.
+        5. Dispatch `seeked` event.
+    - Ensure `fastSeek` also triggers this logic (it currently delegates to `currentTime` setter, so it should be fine).
+
+#### 4. Test Plan
+- **Verification**: `npm run test -w packages/player`.
+- **New Test**: Add a test case in `src/api_parity.test.ts` or a new test file:
+    - Set `player.currentTime = 10`.
+    - Assert `player.seeking` is `true` immediately.
+    - Wait for `seeked` event.
+    - Assert `player.seeking` is `false`.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -48,6 +48,9 @@ Each agent should update **their own dedicated progress file** instead of this f
   - Created workflow skill for `declarative-timeline` (Timeline & Active Clips)
   - Updated API skills for `core`, `renderer`, `player`, and `cli`.
 
+### PLAYER v0.74.3
+- ✅ Completed: Fix Async Seek State - Fixed `seeking` property implementation to correctly return `true` during programmatic asynchronous seeks (e.g. via `currentTime` setter), ensuring Standard Media API compliance.
+
 ### CLI v0.15.0
 - ✅ Completed: Implement Build Command - Implemented `helios build` wrapping Vite for production builds.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.74.2
+**Version**: v0.74.3
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -60,6 +60,7 @@
 - **Export API**: Exposes public `export()` method for programmatic control over client-side exports, supporting Video (MP4/WebM) and Snapshot (PNG/JPEG) formats.
 - **Export Menu**: Implements a dedicated Export Menu in the player UI (replacing the direct export button action) to allow configuring format, resolution, filename, and captions before exporting or taking a snapshot.
 
+[v0.74.3] ✅ Completed: Fix Async Seek State - Fixed `seeking` property implementation to correctly return `true` during programmatic asynchronous seeks (e.g. via `currentTime` setter), ensuring Standard Media API compliance.
 [v0.74.2] ✅ Completed: Api Parity Improvements - Fixed logic for `width`/`height` getters to handle invalid input gracefully, added missing test coverage, and updated documentation for Standard Media API parity.
 [v0.74.1] ✅ Completed: Implement SVG Icons - Replaced text-based control icons with inline SVGs for consistent visual styling.
 [v0.74.0] ✅ Completed: CSS Parts - Implemented CSS Shadow Parts (`part` attribute) for key UI elements (`controls`, `volume-control`, `scrubber-wrapper`, `poster-image`, `big-play-button`, etc.), enabling full styling customization.

--- a/packages/player/dist/index.d.ts
+++ b/packages/player/dist/index.d.ts
@@ -86,6 +86,7 @@ export declare class HeliosPlayer extends HTMLElement implements TrackHost, Audi
     private abortController;
     private isExporting;
     private isScrubbing;
+    private _isSeeking;
     private wasPlayingBeforeScrub;
     private lastState;
     private pendingProps;
@@ -128,21 +129,25 @@ export declare class HeliosPlayer extends HTMLElement implements TrackHost, Audi
     /**
      * Gets the width attribute of the player.
      * Part of the Standard Media API parity.
+     * @returns {number} The width.
      */
     get width(): number;
     /**
      * Sets the width attribute of the player.
      * Part of the Standard Media API parity.
+     * @param {number} val The new width.
      */
     set width(val: number);
     /**
      * Gets the height attribute of the player.
      * Part of the Standard Media API parity.
+     * @returns {number} The height.
      */
     get height(): number;
     /**
      * Sets the height attribute of the player.
      * Part of the Standard Media API parity.
+     * @param {number} val The new height.
      */
     set height(val: number);
     get videoWidth(): number;
@@ -150,17 +155,20 @@ export declare class HeliosPlayer extends HTMLElement implements TrackHost, Audi
     /**
      * Gets whether the playsinline attribute is present.
      * Part of the Standard Media API parity.
+     * @returns {boolean} True if playsinline is present.
      */
     get playsInline(): boolean;
     /**
      * Sets the playsinline attribute.
      * Part of the Standard Media API parity.
+     * @param {boolean} val Whether playsinline should be present.
      */
     set playsInline(val: boolean);
     /**
      * Seeks to the specified time.
      * Part of the Standard Media API parity.
      * Note: In HeliosPlayer, this currently delegates to standard seek (currentTime setter).
+     * @param time The time to seek to.
      */
     fastSeek(time: number): void;
     get currentTime(): number;

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -866,6 +866,7 @@ export class HeliosPlayer extends HTMLElement {
     abortController = null;
     isExporting = false;
     isScrubbing = false;
+    _isSeeking = false;
     wasPlayingBeforeScrub = false;
     lastState = null;
     pendingProps = null;
@@ -951,7 +952,7 @@ export class HeliosPlayer extends HTMLElement {
     }
     get seeking() {
         // Return internal scrubbing state as seeking
-        return this.isScrubbing;
+        return this.isScrubbing || this._isSeeking;
     }
     get buffered() {
         return new StaticTimeRange(0, this.duration);
@@ -966,14 +967,16 @@ export class HeliosPlayer extends HTMLElement {
     /**
      * Gets the width attribute of the player.
      * Part of the Standard Media API parity.
+     * @returns {number} The width.
      */
     get width() {
         const val = this.getAttribute("width");
-        return val ? parseInt(val, 10) : 0;
+        return val ? (parseInt(val, 10) || 0) : 0;
     }
     /**
      * Sets the width attribute of the player.
      * Part of the Standard Media API parity.
+     * @param {number} val The new width.
      */
     set width(val) {
         this.setAttribute("width", String(val));
@@ -981,14 +984,16 @@ export class HeliosPlayer extends HTMLElement {
     /**
      * Gets the height attribute of the player.
      * Part of the Standard Media API parity.
+     * @returns {number} The height.
      */
     get height() {
         const val = this.getAttribute("height");
-        return val ? parseInt(val, 10) : 0;
+        return val ? (parseInt(val, 10) || 0) : 0;
     }
     /**
      * Sets the height attribute of the player.
      * Part of the Standard Media API parity.
+     * @param {number} val The new height.
      */
     set height(val) {
         this.setAttribute("height", String(val));
@@ -1012,6 +1017,7 @@ export class HeliosPlayer extends HTMLElement {
     /**
      * Gets whether the playsinline attribute is present.
      * Part of the Standard Media API parity.
+     * @returns {boolean} True if playsinline is present.
      */
     get playsInline() {
         return this.hasAttribute("playsinline");
@@ -1019,6 +1025,7 @@ export class HeliosPlayer extends HTMLElement {
     /**
      * Sets the playsinline attribute.
      * Part of the Standard Media API parity.
+     * @param {boolean} val Whether playsinline should be present.
      */
     set playsInline(val) {
         if (val) {
@@ -1032,6 +1039,7 @@ export class HeliosPlayer extends HTMLElement {
      * Seeks to the specified time.
      * Part of the Standard Media API parity.
      * Note: In HeliosPlayer, this currently delegates to standard seek (currentTime setter).
+     * @param time The time to seek to.
      */
     fastSeek(time) {
         this.currentTime = time;
@@ -1047,8 +1055,10 @@ export class HeliosPlayer extends HTMLElement {
             const s = this.controller.getState();
             if (s.fps) {
                 // Dispatch events to satisfy Standard Media API expectations
+                this._isSeeking = true;
                 this.dispatchEvent(new Event("seeking"));
                 this.controller.seek(Math.floor(val * s.fps)).then(() => {
+                    this._isSeeking = false;
                     this.dispatchEvent(new Event("seeked"));
                 });
             }
@@ -1060,8 +1070,10 @@ export class HeliosPlayer extends HTMLElement {
     set currentFrame(val) {
         if (this.controller) {
             // Dispatch events to satisfy Standard Media API expectations
+            this._isSeeking = true;
             this.dispatchEvent(new Event("seeking"));
             this.controller.seek(Math.floor(val)).then(() => {
+                this._isSeeking = false;
                 this.dispatchEvent(new Event("seeked"));
             });
         }

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -236,17 +236,21 @@ describe('HeliosPlayer API Parity', () => {
 
     player.currentTime = 5;
     expect(seekingSpy).toHaveBeenCalledTimes(1);
+    expect(player.seeking).toBe(true);
     expect(mockController.seek).toHaveBeenCalledWith(150); // 5 * 30
 
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(seekedSpy).toHaveBeenCalledTimes(1);
+    expect(player.seeking).toBe(false);
 
     player.currentFrame = 10;
     expect(seekingSpy).toHaveBeenCalledTimes(2);
+    expect(player.seeking).toBe(true);
     expect(mockController.seek).toHaveBeenCalledWith(10);
 
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(seekedSpy).toHaveBeenCalledTimes(2);
+    expect(player.seeking).toBe(false);
   });
 
   it('should support fastSeek method', () => {

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -904,6 +904,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   private abortController: AbortController | null = null;
   private isExporting: boolean = false;
   private isScrubbing: boolean = false;
+  private _isSeeking: boolean = false;
   private wasPlayingBeforeScrub: boolean = false;
   private lastState: any = null;
   private pendingProps: Record<string, any> | null = null;
@@ -1009,7 +1010,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
 
   public get seeking(): boolean {
     // Return internal scrubbing state as seeking
-    return this.isScrubbing;
+    return this.isScrubbing || this._isSeeking;
   }
 
   public get buffered(): TimeRanges {
@@ -1122,8 +1123,10 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
       const s = this.controller.getState();
       if (s.fps) {
         // Dispatch events to satisfy Standard Media API expectations
+        this._isSeeking = true;
         this.dispatchEvent(new Event("seeking"));
         this.controller.seek(Math.floor(val * s.fps)).then(() => {
+          this._isSeeking = false;
           this.dispatchEvent(new Event("seeked"));
         });
       }
@@ -1137,8 +1140,10 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   public set currentFrame(val: number) {
     if (this.controller) {
       // Dispatch events to satisfy Standard Media API expectations
+      this._isSeeking = true;
       this.dispatchEvent(new Event("seeking"));
       this.controller.seek(Math.floor(val)).then(() => {
+        this._isSeeking = false;
         this.dispatchEvent(new Event("seeked"));
       });
     }


### PR DESCRIPTION
💡 **What**: Fixed the `seeking` property in `HeliosPlayer` to correctly return `true` during programmatic asynchronous seeks (e.g., via `currentTime` or `currentFrame` setters).
🎯 **Why**: The previous implementation only reflected the UI scrubbing state in the `seeking` property, violating the Standard Media API contract during programmatic seeks.
📊 **Impact**: External tools and tests can now reliably wait for `seeking` to become `false` after a seek operation, improving synchronization and stability.
🔬 **Verification**: Added a regression test in `api_parity.test.ts` asserting `player.seeking` is `true` immediately after setting `currentTime`. Ran `npm run test -w packages/player` and verified all 309 tests passed.

---
*PR created automatically by Jules for task [6329926897973285898](https://jules.google.com/task/6329926897973285898) started by @BintzGavin*