### PR TITLE
CLI: Implement Example Init

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -36,6 +36,7 @@ packages/cli/
 │   ├── types/
 │   │   └── job.ts
 │   └── utils/
+│       └── examples.ts
 ├── package.json
 └── tsconfig.json
 ```
@@ -43,7 +44,7 @@ packages/cli/
 ## C. Commands
 
 - `helios studio`: Launches the Helios Studio dev server.
-- `helios init`: Initializes a new Helios project configuration and scaffolds project structure.
+- `helios init [target]`: Initializes a new Helios project configuration and scaffolds project structure. Supports `--example <name>` to scaffold from GitHub examples.
 - `helios add [component]`: Adds a component to the project.
 - `helios list`: Lists installed components in the project.
 - `helios components`: Lists available components in the registry.
@@ -66,3 +67,4 @@ This file tracks installed components and project settings.
 - **Registry**: `RegistryClient` fetches components from `HELIOS_REGISTRY_URL` or falls back to local registry.
 - **Renderer**: `helios render` uses `@helios-project/renderer` to execute rendering strategies (Canvas/DOM).
 - **Studio**: `helios studio` wraps the Studio dev server.
+- **Examples**: `helios init` fetches examples from the GitHub repository (`BintzGavin/helios/examples`).

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -28,6 +28,8 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] **CLI**: Implement init command.
 - [x] **CLI**: Implement registry commands.
 - [x] **CLI**: Implement render command.
+- [x] **CLI**: Implement example init (`helios init --example`).
+- [ ] **CLI**: Make example registry configurable (remove hardcoded URL).
 - [ ] **Examples**: Create examples demonstrating distributed rendering workflows.
 - [ ] **Examples**: Create examples demonstrating component usage.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### CLI v0.20.0
+- ✅ Completed: Implement Example Init - Implemented `helios init --example` to fetch, download, and transform examples from GitHub, and improved interactivity with `prompts`.
+
 ### RENDERER v1.77.3
 - ✅ Completed: Update Skill Documentation - Updated `.agents/skills/helios/renderer/SKILL.md` to match the actual `RendererOptions` and `AudioTrackConfig` interfaces in `packages/renderer/src/types.ts` (adding `subtitles` as string, `fadeInDuration`, `fadeOutDuration`, etc.), ensuring agents generate correct code. Verified by manual inspection.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.19.0
+**Version**: 0.20.0
 
 ## Current State
 
@@ -67,3 +67,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.17.0] ✅ Implement Job Command - Implemented `helios job run` to execute distributed rendering jobs from JSON specifications, supporting concurrency and selective chunk execution.
 [v0.18.0] ✅ Implement Skills Command - Implemented `helios skills install` to distribute AI agent skills to user projects.
 [v0.19.0] ✅ Implement Preview Command - Implemented `helios preview` to serve the production build locally using Vite.
+[v0.20.0] ✅ Implement Example Init - Implemented `helios init --example` to fetch, download, and transform examples from GitHub, and improved interactivity with `prompts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2986,6 +2986,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/degit": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@types/degit/-/degit-2.8.6.tgz",
+      "integrity": "sha512-y0M7sqzsnHB6cvAeTCBPrCQNQiZe8U4qdzf8uBVmOWYap5MMTN/gB2iEqrIqFiYcsyvP74GnGD5tgsHttielFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/dom-mediacapture-transform": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.11.tgz",
@@ -3061,7 +3068,6 @@
       "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3079,6 +3085,27 @@
       "integrity": "sha512-WFuP7jqc5CkkMtCK/NphgvMnJz1Qi9CMuK7t6xLu/tuXkRdGQA4q4AD0dUYcChC0Oibe8PE8gbKSFPNF0BqVNw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/prompts": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
+      "integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "kleur": "^3.0.3"
+      }
+    },
+    "node_modules/@types/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.13",
@@ -4916,6 +4943,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/degit": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.4.tgz",
+      "integrity": "sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng==",
+      "license": "MIT",
+      "bin": {
+        "degit": "degit"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/delaunator": {
@@ -7892,6 +7931,28 @@
         "lie": "^3.0.2"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -8597,6 +8658,12 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/sliced": {
       "version": "1.0.1",
@@ -9383,8 +9450,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unist-util-stringify-position": {
       "version": "3.0.3",
@@ -10108,16 +10174,20 @@
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@helios-project/renderer": "^0.0.2",
+        "@helios-project/renderer": "^1.77.4",
         "@helios-project/studio": "^0.104.1",
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
+        "degit": "^2.8.4",
+        "prompts": "^2.4.2",
         "vite": "^7.1.2"
       },
       "bin": {
         "helios": "bin/helios.js"
       },
       "devDependencies": {
+        "@types/degit": "^2.8.6",
+        "@types/prompts": "^2.4.9",
         "typescript": "^5.0.0"
       }
     },
@@ -10150,13 +10220,12 @@
       "devDependencies": {
         "jsdom": "^27.4.0",
         "typescript": "^5.0.0",
-        "vite": "^7.3.1",
         "vitest": "^4.0.17"
       }
     },
     "packages/renderer": {
       "name": "@helios-project/renderer",
-      "version": "0.0.2",
+      "version": "1.77.4",
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -10194,7 +10263,7 @@
       "dependencies": {
         "@helios-project/core": "^5.11.0",
         "@helios-project/player": "^0.74.0",
-        "@helios-project/renderer": "^0.0.2",
+        "@helios-project/renderer": "^1.77.4",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,13 +38,17 @@
   ],
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@helios-project/renderer": "^0.0.2",
+    "@helios-project/renderer": "^1.77.4",
     "@helios-project/studio": "^0.104.1",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
+    "degit": "^2.8.4",
+    "prompts": "^2.4.2",
     "vite": "^7.1.2"
   },
   "devDependencies": {
+    "@types/degit": "^2.8.6",
+    "@types/prompts": "^2.4.9",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,14 +1,15 @@
 import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
-import readline from 'readline';
 import chalk from 'chalk';
+import prompts from 'prompts';
 import { DEFAULT_CONFIG } from '../utils/config.js';
 import { REACT_TEMPLATE } from '../templates/react.js';
 import { VUE_TEMPLATE } from '../templates/vue.js';
 import { SVELTE_TEMPLATE } from '../templates/svelte.js';
 import { SOLID_TEMPLATE } from '../templates/solid.js';
 import { VANILLA_TEMPLATE } from '../templates/vanilla.js';
+import { fetchExamples, downloadExample, transformProject } from '../utils/examples.js';
 
 type Framework = 'react' | 'vue' | 'svelte' | 'solid' | 'vanilla';
 
@@ -22,64 +23,131 @@ const TEMPLATES: Record<Framework, Record<string, string>> = {
 
 export function registerInitCommand(program: Command) {
   program
-    .command('init')
+    .command('init [target]')
     .description('Initialize a new Helios project configuration')
     .option('-y, --yes', 'Skip prompts and use defaults (React)')
     .option('-f, --framework <framework>', 'Specify framework (react, vue, svelte, solid, vanilla)')
-    .action(async (options) => {
-      const configPath = path.resolve(process.cwd(), 'helios.config.json');
-      const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+    .option('--example <name>', 'Initialize from an example')
+    .action(async (target, options) => {
+      const targetDir = target ? path.resolve(process.cwd(), target) : process.cwd();
+      const configPath = path.resolve(targetDir, 'helios.config.json');
+      const packageJsonPath = path.resolve(targetDir, 'package.json');
       let isScaffolded = false;
       let selectedFramework: Framework = 'react';
+      let mode = 'template'; // 'template' | 'example'
 
-      if (options.framework) {
-        const normalized = options.framework.toLowerCase();
-        if (['react', 'vue', 'svelte', 'solid', 'vanilla'].includes(normalized)) {
-          selectedFramework = normalized as Framework;
-        } else {
-          console.error(chalk.red(`Invalid framework: ${options.framework}`));
+      // Create target directory if it doesn't exist
+      if (!fs.existsSync(targetDir)) {
+        fs.mkdirSync(targetDir, { recursive: true });
+      }
+
+      // Check if directory is empty
+      const isDirEmpty = (dir: string) => fs.readdirSync(dir).length === 0;
+      if (fs.existsSync(targetDir) && !isDirEmpty(targetDir)) {
+          if (!options.yes) {
+            const response = await prompts({
+              type: 'confirm',
+              name: 'continue',
+              message: `Target directory is not empty. Continue?`,
+              initial: false
+            });
+            if (!response.continue) process.exit(1);
+          }
+      }
+
+      // 1. Check for Example Usage via Flag
+      if (options.example) {
+        mode = 'example';
+        console.log(chalk.cyan(`Downloading example '${options.example}'...`));
+        try {
+          await downloadExample(options.example, targetDir);
+          console.log(chalk.green('Downloaded example. Transforming files...'));
+          transformProject(targetDir);
+          console.log(chalk.green('Project initialized from example.'));
+          isScaffolded = true;
+        } catch (error) {
+          console.error(chalk.red(`Failed to download example '${options.example}':`), error);
           process.exit(1);
         }
       }
-
-      const ask = (question: string, defaultValue?: string): Promise<string> => {
-        const rl = readline.createInterface({
-          input: process.stdin,
-          output: process.stdout,
-        });
-
-        return new Promise((resolve) => {
-          const suffix = defaultValue ? ` ${chalk.gray(`[${defaultValue}]`)}` : '';
-          rl.question(`${question}${suffix}: `, (answer) => {
-            rl.close();
-            resolve(answer.trim() || defaultValue || '');
-          });
-        });
-      };
-
-      if (!fs.existsSync(packageJsonPath)) {
-        let shouldScaffold = options.yes; // Default to yes if -y is passed
+      // 2. Normal Scaffolding Flow (Interactive)
+      else if (!fs.existsSync(packageJsonPath)) {
+        let shouldScaffold = options.yes;
 
         if (!options.yes) {
-          const answer = await ask(`No package.json found. Do you want to scaffold a new project? ${chalk.gray('(Y/n)')}`, 'y');
-          const normalized = answer.toLowerCase();
-          shouldScaffold = normalized === 'y' || normalized === 'yes';
+          const response = await prompts({
+            type: 'select',
+            name: 'mode',
+            message: 'How do you want to start?',
+            choices: [
+              { title: 'Scaffold a new project (from template)', value: 'template' },
+              { title: 'Download an example', value: 'example' },
+            ],
+            initial: 0
+          });
+
+          if (!response.mode) process.exit(0);
+          mode = response.mode;
+          shouldScaffold = true;
         }
 
-        if (shouldScaffold) {
-          if (!options.yes && !options.framework) {
-            const frameworkInput = await ask(`Select framework (${chalk.cyan('react')}, vue, svelte, solid, vanilla)`, 'react');
-            const normalized = frameworkInput.toLowerCase();
-            if (['react', 'vue', 'svelte', 'solid', 'vanilla'].includes(normalized)) {
-              selectedFramework = normalized as Framework;
+        if (mode === 'example') {
+            console.log(chalk.gray('Fetching examples...'));
+            const examples = await fetchExamples();
+
+            if (examples.length === 0) {
+              console.log(chalk.yellow('No examples found or failed to fetch. Falling back to templates.'));
+              mode = 'template';
+            } else {
+              const response = await prompts({
+                type: 'autocomplete',
+                name: 'example',
+                message: 'Select an example:',
+                choices: examples.map(ex => ({ title: ex, value: ex })),
+              });
+
+              if (!response.example) process.exit(0);
+
+              console.log(chalk.cyan(`Downloading example '${response.example}'...`));
+              try {
+                await downloadExample(response.example, targetDir);
+                transformProject(targetDir);
+                isScaffolded = true;
+              } catch (error) {
+                console.error(chalk.red('Failed to download example:'), error);
+                process.exit(1);
+              }
             }
+        }
+
+        if (mode === 'template' && shouldScaffold && !isScaffolded) {
+          if (options.framework) {
+             const normalized = options.framework.toLowerCase();
+             if (['react', 'vue', 'svelte', 'solid', 'vanilla'].includes(normalized)) {
+                selectedFramework = normalized as Framework;
+             }
+          } else if (!options.yes) {
+             const response = await prompts({
+               type: 'select',
+               name: 'framework',
+               message: 'Select framework',
+               choices: [
+                 { title: 'React', value: 'react' },
+                 { title: 'Vue', value: 'vue' },
+                 { title: 'Svelte', value: 'svelte' },
+                 { title: 'Solid', value: 'solid' },
+                 { title: 'Vanilla', value: 'vanilla' },
+               ]
+             });
+             if (!response.framework) process.exit(0);
+             selectedFramework = response.framework as Framework;
           }
 
           console.log(chalk.cyan(`Scaffolding new Helios project (${selectedFramework})...`));
           try {
             const template = TEMPLATES[selectedFramework];
             for (const [filepath, content] of Object.entries(template)) {
-              const fullPath = path.resolve(process.cwd(), filepath);
+              const fullPath = path.resolve(targetDir, filepath);
               const dir = path.dirname(fullPath);
               if (!fs.existsSync(dir)) {
                 fs.mkdirSync(dir, { recursive: true });
@@ -96,60 +164,89 @@ export function registerInitCommand(program: Command) {
         }
       }
 
+      // Config generation
       if (fs.existsSync(configPath)) {
-        console.error(chalk.red('Configuration file already exists.'));
-        process.exit(1);
-      }
+        if (!isScaffolded && !options.yes) {
+             console.error(chalk.red('Configuration file already exists.'));
+             process.exit(1);
+        }
+      } else {
+          // Deep copy default
+          let config = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
 
-      // Deep copy to avoid mutating the exported constant
-      let config = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
+          if (isScaffolded) {
+             if (mode === 'template') {
+                config.framework = selectedFramework;
+             } else if (mode === 'example') {
+                // Try to detect framework from package.json
+                try {
+                  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+                  const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+                  if (deps.vue) config.framework = 'vue';
+                  else if (deps.svelte) config.framework = 'svelte';
+                  else if (deps['solid-js']) config.framework = 'solid';
+                  else if (deps.react) config.framework = 'react';
+                } catch (e) {
+                  // ignore
+                }
+             }
+          }
+
+          if (!options.yes && !isScaffolded) {
+             const response = await prompts([
+                {
+                    type: 'select',
+                    name: 'framework',
+                    message: 'Which framework are you using?',
+                    choices: [
+                        { title: 'React', value: 'react' },
+                        { title: 'Vue', value: 'vue' },
+                        { title: 'Svelte', value: 'svelte' },
+                        { title: 'Solid', value: 'solid' },
+                        { title: 'Vanilla', value: 'vanilla' },
+                    ],
+                    initial: 0
+                },
+                {
+                    type: 'text',
+                    name: 'components',
+                    message: 'Where would you like to install components?',
+                    initial: DEFAULT_CONFIG.directories.components
+                },
+                {
+                    type: 'text',
+                    name: 'lib',
+                    message: 'Where is your lib directory?',
+                    initial: DEFAULT_CONFIG.directories.lib
+                }
+             ]);
+
+             if (!response.framework) process.exit(0);
+
+             config.framework = response.framework;
+             config.directories.components = response.components;
+             config.directories.lib = response.lib;
+          } else if (options.framework) {
+             config.framework = options.framework.toLowerCase();
+          }
+
+          try {
+            fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+            console.log(chalk.green('Initialized helios.config.json'));
+          } catch (error) {
+             console.error(chalk.red('Failed to write configuration file:'), error);
+             process.exit(1);
+          }
+      }
 
       if (isScaffolded) {
-        config.framework = selectedFramework;
-      }
-
-      // Skip prompts if we just scaffolded (use defaults matching template) OR if -y passed
-      if (!options.yes && !isScaffolded) {
-        console.log(chalk.cyan('Initializing Helios configuration...'));
-
-        if (options.framework) {
-          config.framework = options.framework.toLowerCase();
-        } else {
-          const framework = await ask(
-            'Which framework are you using? (react, vue, svelte, solid, vanilla)',
-            'react'
-          );
-          if (['react', 'vue', 'svelte', 'solid', 'vanilla'].includes(framework.toLowerCase())) {
-            config.framework = framework.toLowerCase();
-          }
+        console.log(chalk.blue('\nProject ready! Run the following commands to get started:\n'));
+        if (target) {
+            console.log(chalk.cyan(`  cd ${target}`));
         }
-
-        const componentsDir = await ask(
-          'Where would you like to install components?',
-          DEFAULT_CONFIG.directories.components
-        );
-        const libDir = await ask(
-          'Where is your lib directory?',
-          DEFAULT_CONFIG.directories.lib
-        );
-
-        config.directories.components = componentsDir;
-        config.directories.lib = libDir;
-      }
-
-      try {
-        fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-        console.log(chalk.green('Initialized helios.config.json'));
-
-        if (isScaffolded) {
-          console.log(chalk.blue('\nProject ready! Run the following commands to get started:\n'));
-          console.log(chalk.cyan('  npm install'));
-          console.log(chalk.cyan('  npm run dev'));
-          console.log('');
-        }
-      } catch (error) {
-        console.error(chalk.red('Failed to write configuration file:'), error);
-        process.exit(1);
+        console.log(chalk.cyan('  npm install'));
+        console.log(chalk.cyan('  npm run dev'));
+        console.log('');
       }
     });
 }

--- a/packages/cli/src/utils/examples.ts
+++ b/packages/cli/src/utils/examples.ts
@@ -1,0 +1,119 @@
+import fs from 'fs';
+import path from 'path';
+import degit from 'degit';
+import chalk from 'chalk';
+
+export async function fetchExamples(): Promise<string[]> {
+  try {
+    const response = await fetch('https://api.github.com/repos/BintzGavin/helios/contents/examples');
+    if (!response.ok) {
+      throw new Error(`Failed to fetch examples: ${response.statusText}`);
+    }
+    const data = await response.json() as any[];
+    return data
+      .filter((item: any) => item.type === 'dir')
+      .map((item: any) => item.name);
+  } catch (error) {
+    console.warn(chalk.yellow('Failed to fetch examples list from GitHub.'));
+    return [];
+  }
+}
+
+export async function downloadExample(name: string, targetDir: string): Promise<void> {
+  const emitter = degit(`BintzGavin/helios/examples/${name}`, {
+    cache: false,
+    force: true,
+    verbose: false,
+  });
+
+  await emitter.clone(targetDir);
+}
+
+export function transformProject(targetDir: string) {
+  // 1. package.json
+  const pkgPath = path.join(targetDir, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkgContent = fs.readFileSync(pkgPath, 'utf-8');
+      const pkg = JSON.parse(pkgContent);
+
+      const processDeps = (deps: Record<string, string> = {}) => {
+        for (const [key, value] of Object.entries(deps)) {
+          if (value.startsWith('file:') && key.startsWith('@helios-project/')) {
+            deps[key] = 'latest';
+          }
+        }
+      };
+
+      if (pkg.dependencies) processDeps(pkg.dependencies);
+      if (pkg.devDependencies) processDeps(pkg.devDependencies);
+
+      fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+    } catch (e) {
+      console.warn(chalk.yellow('Failed to transform package.json'));
+    }
+  }
+
+  // 2. vite.config.ts
+  const vitePath = path.join(targetDir, 'vite.config.ts');
+  if (fs.existsSync(vitePath)) {
+    try {
+      let content = fs.readFileSync(vitePath, 'utf-8');
+
+      // Handle imports cleanup first
+      // Remove searchForWorkspaceRoot from imports if present with others
+      content = content.replace(/,\s*searchForWorkspaceRoot\b/g, '');
+      content = content.replace(/\bsearchForWorkspaceRoot\s*,\s*/g, '');
+      // Remove standalone import if it was the only one
+      content = content.replace(/import\s*\{\s*searchForWorkspaceRoot\s*\}\s*from\s*['"]vite['"];?\r?\n?/g, '');
+
+      // Split lines to filter out usages
+      const lines = content.split('\n');
+      const newLines = lines.filter(line => {
+        // Keep import lines (already cleaned up)
+        if (line.trim().startsWith('import')) return true;
+
+        // Remove lines using searchForWorkspaceRoot function
+        if (line.includes('searchForWorkspaceRoot(')) return false;
+
+        // Remove lines with aliases to @helios-project/core
+        if (line.includes("'@helios-project/core':")) return false;
+        if (line.includes('"@helios-project/core":')) return false;
+
+        return true;
+      });
+      content = newLines.join('\n');
+
+      fs.writeFileSync(vitePath, content);
+    } catch (e) {
+      console.warn(chalk.yellow('Failed to transform vite.config.ts'));
+    }
+  }
+
+  // 3. tsconfig.json
+  const tsconfigPath = path.join(targetDir, 'tsconfig.json');
+  if (fs.existsSync(tsconfigPath)) {
+    try {
+      let content = fs.readFileSync(tsconfigPath, 'utf-8');
+
+      // Line based removal for paths
+      const lines = content.split('\n');
+      const newLines = lines.filter(line => {
+         // Check for path mapping to core
+         if (line.includes('"@helios-project/core":')) return false;
+         return true;
+      });
+      content = newLines.join('\n');
+
+      fs.writeFileSync(tsconfigPath, content);
+    } catch (e) {
+      console.warn(chalk.yellow('Failed to transform tsconfig.json'));
+    }
+  }
+
+  // 4. postcss.config.cjs
+  const postcssPath = path.join(targetDir, 'postcss.config.cjs');
+  if (!fs.existsSync(postcssPath)) {
+    fs.writeFileSync(postcssPath, 'module.exports = {};\n');
+  }
+}

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@helios-project/core": "^5.11.0",
     "@helios-project/player": "^0.74.0",
-    "@helios-project/renderer": "^0.0.2",
+    "@helios-project/renderer": "^1.77.4",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",


### PR DESCRIPTION
💡 **What**: Implemented `helios init --example <name>` command and interactive flow to scaffold projects from existing examples.
🎯 **Why**: To allow users to easily start with a working example project without manual copy-pasting or monorepo setup issues.
📊 **Impact**: Improved DX for new users. Enables distribution of examples as standalone projects.
🔬 **Verification**: Verified by running `helios init test-init --example simple-animation` and inspecting the transformed `package.json`, `vite.config.ts`, and `tsconfig.json`. Confirmed build success for `cli` and `studio`.

---
*PR created automatically by Jules for task [13654119634294251206](https://jules.google.com/task/13654119634294251206) started by @BintzGavin*