### PR TITLE
✨ RENDERER: Orchestrator Plan

### DIFF
--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,10 +1,11 @@
-**Version**: 1.77.4
+**Version**: 1.78.0
 
 **Posture**: MAINTENANCE WITH V2 EXPANSION
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.78.0] ✅ Completed: Orchestrator Plan - Implemented `RenderOrchestrator.plan()` static method to decouple job planning from execution, returning a serializable `RenderPlan`. Refactored `render()` to use this plan. Verified with `verify-orchestrator-plan.ts`.
 - [1.77.4] ✅ Completed: Refactor Media Sync Logic - Consolidated duplicated media attribute parsing and synchronization logic from `SeekTimeDriver`, `CdpTimeDriver`, and `dom-scanner` into shared utilities in `dom-scripts.ts`, ensuring consistency and maintainability. Verified with `verify-media-sync.ts`.
 - [1.77.3] ✅ Completed: Update Skill Documentation - Updated `.agents/skills/helios/renderer/SKILL.md` to match the actual `RendererOptions` and `AudioTrackConfig` interfaces in `packages/renderer/src/types.ts` (adding `subtitles` as string, `fadeInDuration`, `fadeOutDuration`, etc.), ensuring agents generate correct code. Verified by manual inspection.
 - [1.77.2] ✅ Completed: Fix Verification Script Regression - Updated `verify-asset-timeout.ts` to check for the correct log prefixes (`[Helios Preload]`, `[DomScanner]`) instead of `[DomStrategy]`, fixing a regression caused by the v1.77.1 DOM traversal refactor. Verified with `verify-asset-timeout.ts`.

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/renderer",
-  "version": "1.77.4",
+  "version": "1.78.0",
   "description": "Renderer for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/renderer/src/Orchestrator.ts
+++ b/packages/renderer/src/Orchestrator.ts
@@ -4,7 +4,7 @@ import * as os from 'os';
 import { spawn } from 'child_process';
 import ffmpeg from '@ffmpeg-installer/ffmpeg';
 import { Renderer } from './Renderer.js';
-import { RendererOptions, RenderJobOptions } from './types.js';
+import { RendererOptions, RenderJobOptions, RenderPlan, RenderChunk } from './types.js';
 import { concatenateVideos } from './concat.js';
 import { FFmpegBuilder } from './utils/FFmpegBuilder.js';
 import { RenderExecutor } from './executors/RenderExecutor.js';
@@ -34,49 +34,20 @@ function hasAudioStream(filePath: string, ffmpegPath: string): Promise<boolean> 
 }
 
 export class RenderOrchestrator {
-  static async render(compositionUrl: string, outputPath: string, options: DistributedRenderOptions, jobOptions?: RenderJobOptions): Promise<void> {
+  static plan(compositionUrl: string, outputPath: string, options: DistributedRenderOptions): RenderPlan {
     const concurrency = options.concurrency || Math.max(1, os.cpus().length - 1);
-
-    // Determine total frames
     let totalFrames = options.frameCount;
     if (!totalFrames) {
-        totalFrames = Math.ceil(options.durationInSeconds * options.fps);
+      totalFrames = Math.ceil(options.durationInSeconds * options.fps);
     }
 
-    const executor = options.executor || new LocalExecutor();
-
-    // If concurrency is 1, just use standard Renderer
-    if (concurrency === 1) {
-      return executor.render(compositionUrl, outputPath, options, jobOptions);
-    }
-
-    console.log(`Starting distributed render with concurrency: ${concurrency}`);
-
-    const chunkSize = Math.ceil(totalFrames / concurrency);
-    const tempFiles: string[] = [];
-    const promises: Promise<void>[] = [];
-
-    // Ensure output directory exists (Renderer usually does this, but we need it for temp files)
     const outputDir = path.dirname(outputPath);
-    if (!fs.existsSync(outputDir)) {
-      await fs.promises.mkdir(outputDir, { recursive: true });
-    }
-
-    // Pipeline Strategy:
-    // 1. Render chunks with PCM audio (capturing implicit DOM audio) into .mov container
-    // 2. Concatenate chunks into a master PCM .mov file
-    // 3. Transcode/Mix to final output (adding explicit audio)
-
-    // We always perform the final step to ensure consistent transcoding and mixing
-    const finalStepNeeded = true;
-
-    // The intermediate concatenation target is always a PCM .mov file
+    const tempPrefix = `temp_${Date.now()}_${Math.random().toString(36).substring(7)}`;
     const concatTarget = path.join(outputDir, `temp_concat_${Date.now()}${CHUNK_EXTENSION}`);
 
-    // Chunk Options:
+    // Chunk Base Options
     // - Remove explicit audio tracks (they are mixed in the final step)
     // - Force PCM audio codec (to capture implicit audio without artifacts)
-    // - Inherit video codec (or defaults from strategy)
     const chunkBaseOptions: RendererOptions = {
       ...options,
       audioTracks: [],
@@ -84,7 +55,73 @@ export class RenderOrchestrator {
       audioCodec: CHUNK_AUDIO_CODEC
     };
 
-    const tempPrefix = `temp_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+    const chunks: RenderChunk[] = [];
+    const chunkSize = Math.ceil(totalFrames / concurrency);
+    const tempFiles: string[] = [];
+
+    for (let i = 0; i < concurrency; i++) {
+      const start = i * chunkSize;
+      const count = Math.min(chunkSize, totalFrames - start);
+      if (count <= 0) break;
+
+      const tempFile = path.join(outputDir, `${tempPrefix}_part_${i}${CHUNK_EXTENSION}`);
+      tempFiles.push(tempFile);
+
+      const chunkOptions: RendererOptions = {
+        ...chunkBaseOptions,
+        startFrame: (options.startFrame || 0) + start,
+        frameCount: count,
+        durationInSeconds: count / options.fps
+      };
+
+      chunks.push({
+        id: i,
+        startFrame: chunkOptions.startFrame!,
+        frameCount: count,
+        outputFile: tempFile,
+        options: chunkOptions
+      });
+    }
+
+    const mixOptions: RendererOptions = {
+      ...options,
+      videoCodec: 'copy',
+      mixInputAudio: true, // Optimistically enable mix input audio, executor should verify
+      subtitles: undefined
+    };
+
+    const cleanupFiles = [...tempFiles, concatTarget];
+
+    return {
+      totalFrames,
+      chunks,
+      concatManifest: tempFiles,
+      concatOutputFile: concatTarget,
+      finalOutputFile: outputPath,
+      mixOptions,
+      cleanupFiles
+    };
+  }
+
+  static async render(compositionUrl: string, outputPath: string, options: DistributedRenderOptions, jobOptions?: RenderJobOptions): Promise<void> {
+    const executor = options.executor || new LocalExecutor();
+    const concurrency = options.concurrency || Math.max(1, os.cpus().length - 1);
+
+    // If concurrency is 1, just use standard Renderer directly (no planning needed)
+    if (concurrency === 1) {
+      return executor.render(compositionUrl, outputPath, options, jobOptions);
+    }
+
+    console.log(`Starting distributed render with concurrency: ${concurrency}`);
+
+    // Create the plan
+    const plan = this.plan(compositionUrl, outputPath, options);
+
+    // Ensure output directory exists (Renderer usually does this, but we need it for temp files)
+    const outputDir = path.dirname(outputPath);
+    if (!fs.existsSync(outputDir)) {
+      await fs.promises.mkdir(outputDir, { recursive: true });
+    }
 
     // Create an internal AbortController to manage worker cancellation
     const internalController = new AbortController();
@@ -99,33 +136,15 @@ export class RenderOrchestrator {
       }
     }
 
-    // Progress tracking
-    const workerProgress = new Array(concurrency).fill(0);
-    const workerWeights = new Array(concurrency).fill(0);
+    const promises: Promise<void>[] = [];
+    const workerProgress = new Array(plan.chunks.length).fill(0);
+    const workerWeights = new Array(plan.chunks.length).fill(0);
 
-    for (let i = 0; i < concurrency; i++) {
-      const start = i * chunkSize;
-      // Ensure we don't exceed totalFrames
-      const count = Math.min(chunkSize, totalFrames - start);
-
-      if (count <= 0) break;
+    for (let i = 0; i < plan.chunks.length; i++) {
+      const chunk = plan.chunks[i];
 
       // Calculate weight for this worker
-      workerWeights[i] = count / totalFrames;
-
-      // Use CHUNK_EXTENSION for temporary chunk files
-      const tempFile = path.join(outputDir, `${tempPrefix}_part_${i}${CHUNK_EXTENSION}`);
-      tempFiles.push(tempFile);
-
-      // Create options for this chunk
-      // We must preserve the original options but override startFrame and frameCount
-      const chunkOptions: RendererOptions = {
-        ...chunkBaseOptions,
-        startFrame: (options.startFrame || 0) + start,
-        frameCount: count,
-        // Calculate duration based on frame count to be consistent, though Renderer prioritizes frameCount
-        durationInSeconds: count / options.fps
-      };
+      workerWeights[i] = chunk.frameCount / plan.totalFrames;
 
       // Create job options for this worker with progress aggregation
       const workerJobOptions: RenderJobOptions = {
@@ -136,7 +155,7 @@ export class RenderOrchestrator {
 
           // Calculate global progress
           let globalProgress = 0;
-          for (let j = 0; j < concurrency; j++) {
+          for (let j = 0; j < plan.chunks.length; j++) {
             globalProgress += workerProgress[j] * workerWeights[j];
           }
 
@@ -146,10 +165,10 @@ export class RenderOrchestrator {
         }
       };
 
-      console.log(`[Worker ${i}] Rendering frames ${chunkOptions.startFrame} to ${chunkOptions.startFrame! + count} (${count} frames) to ${tempFile}`);
+      console.log(`[Worker ${i}] Rendering frames ${chunk.startFrame} to ${chunk.startFrame + chunk.frameCount} (${chunk.frameCount} frames) to ${chunk.outputFile}`);
 
       // Wrap the promise to abort other workers on failure
-      const promise = executor.render(compositionUrl, tempFile, chunkOptions, workerJobOptions)
+      const promise = executor.render(compositionUrl, chunk.outputFile, chunk.options, workerJobOptions)
         .catch(err => {
           // If one worker fails, abort the others immediately
           if (!internalController.signal.aborted) {
@@ -165,58 +184,53 @@ export class RenderOrchestrator {
     try {
       await Promise.all(promises);
       console.log('All chunks rendered. Concatenating...');
-      await concatenateVideos(tempFiles, concatTarget, { ffmpegPath: options.ffmpegPath });
+      await concatenateVideos(plan.concatManifest, plan.concatOutputFile, { ffmpegPath: options.ffmpegPath });
 
-      if (finalStepNeeded) {
-        console.log('Mixing audio into concatenated video...');
+      // Final mix step
+      console.log('Mixing audio into concatenated video...');
 
-        const ffmpegPath = options.ffmpegPath || ffmpeg.path;
+      const ffmpegPath = options.ffmpegPath || ffmpeg.path;
 
-        // Detect if the concatenated video has an audio stream (implicit audio)
-        const hasImplicitAudio = await hasAudioStream(concatTarget, ffmpegPath);
-        if (!hasImplicitAudio) {
-          console.log('No implicit audio stream detected in concatenated video.');
-        }
-
-        // Use FFmpegBuilder to generate args for the mixing pass
-        // We force 'copy' for video to avoid re-encoding
-        // We enable mixInputAudio to preserve the audio from the concatenated chunks (implicit audio)
-        // We explicitly disable subtitles because they are already burned into the chunks (if requested)
-        // and enabling them here with 'copy' codec would cause FFmpegBuilder to throw an error.
-        const mixOptions: RendererOptions = {
-          ...options,
-          videoCodec: 'copy',
-          mixInputAudio: hasImplicitAudio,
-          subtitles: undefined
-        };
-        const videoInputArgs = ['-i', concatTarget];
-
-        // FFmpegBuilder handles audio offsets/seeking based on options
-        const { args } = FFmpegBuilder.getArgs(mixOptions, outputPath, videoInputArgs);
-
-        console.log(`Spawning FFmpeg for audio mixing: ${ffmpegPath} ${args.join(' ')}`);
-
-        await new Promise<void>((resolve, reject) => {
-          const process = spawn(ffmpegPath, args);
-          let stderr = '';
-
-          process.stderr.on('data', (data) => {
-            stderr += data.toString();
-          });
-
-          process.on('close', (code) => {
-            if (code === 0) {
-              resolve();
-            } else {
-              reject(new Error(`FFmpeg audio mix failed with code ${code}: ${stderr}`));
-            }
-          });
-
-          process.on('error', (err) => {
-            reject(err);
-          });
-        });
+      // Detect if the concatenated video has an audio stream (implicit audio)
+      // This is a runtime check that overrides the plan's optimistic mixInputAudio
+      const hasImplicitAudio = await hasAudioStream(plan.concatOutputFile, ffmpegPath);
+      if (!hasImplicitAudio) {
+        console.log('No implicit audio stream detected in concatenated video.');
       }
+
+      // Use the plan's mix options but update mixInputAudio based on actual content
+      const mixOptions: RendererOptions = {
+        ...plan.mixOptions,
+        mixInputAudio: hasImplicitAudio && plan.mixOptions.mixInputAudio !== false
+      };
+
+      const videoInputArgs = ['-i', plan.concatOutputFile];
+
+      // FFmpegBuilder handles audio offsets/seeking based on options
+      const { args } = FFmpegBuilder.getArgs(mixOptions, outputPath, videoInputArgs);
+
+      console.log(`Spawning FFmpeg for audio mixing: ${ffmpegPath} ${args.join(' ')}`);
+
+      await new Promise<void>((resolve, reject) => {
+        const process = spawn(ffmpegPath, args);
+        let stderr = '';
+
+        process.stderr.on('data', (data) => {
+          stderr += data.toString();
+        });
+
+        process.on('close', (code) => {
+          if (code === 0) {
+            resolve();
+          } else {
+            reject(new Error(`FFmpeg audio mix failed with code ${code}: ${stderr}`));
+          }
+        });
+
+        process.on('error', (err) => {
+          reject(err);
+        });
+      });
 
     } finally {
       // Clean up event listener
@@ -226,12 +240,7 @@ export class RenderOrchestrator {
 
       console.log('Cleaning up temporary files...');
 
-      // Ensure the concatenated intermediate file is also cleaned up
-      if (concatTarget) {
-        tempFiles.push(concatTarget);
-      }
-
-      for (const file of tempFiles) {
+      for (const file of plan.cleanupFiles) {
         try {
           if (fs.existsSync(file)) {
             await fs.promises.unlink(file);

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -271,3 +271,21 @@ export interface FFmpegConfig {
   args: string[];
   inputBuffers: { index: number; buffer: Buffer }[];
 }
+
+export interface RenderChunk {
+  id: number;
+  startFrame: number;
+  frameCount: number;
+  outputFile: string;
+  options: RendererOptions;
+}
+
+export interface RenderPlan {
+  totalFrames: number;
+  chunks: RenderChunk[];
+  concatManifest: string[]; // List of chunk files to concatenate
+  concatOutputFile: string; // The intermediate PCM .mov file
+  finalOutputFile: string; // The final user-requested output
+  mixOptions: RendererOptions; // Options for the final audio mix/transcode pass
+  cleanupFiles: string[]; // List of temporary files to delete after success
+}

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -42,6 +42,7 @@ const tests = [
   'tests/verify-implicit-audio.ts',
   'tests/verify-keyframes.ts',
   'tests/verify-media-sync.ts',
+  'tests/verify-orchestrator-plan.ts',
   'tests/verify-pseudo-element-preload.ts',
   'tests/verify-range-render.ts',
   'tests/verify-seek-driver-determinism.ts',

--- a/packages/renderer/tests/verify-orchestrator-plan.ts
+++ b/packages/renderer/tests/verify-orchestrator-plan.ts
@@ -1,0 +1,102 @@
+
+import { RenderOrchestrator } from '../src/Orchestrator.js';
+import { DistributedRenderOptions } from '../src/Orchestrator.js';
+import * as path from 'path';
+
+async function main() {
+  console.log('Verifying RenderOrchestrator.plan()...');
+
+  const compositionUrl = 'http://localhost:3000/composition.html';
+  const outputPath = path.resolve('output.mp4');
+  const options: DistributedRenderOptions = {
+    width: 1920,
+    height: 1080,
+    fps: 30,
+    durationInSeconds: 10,
+    concurrency: 4,
+    videoCodec: 'libx264'
+  };
+
+  const plan = RenderOrchestrator.plan(compositionUrl, outputPath, options);
+
+  // Verify Total Frames
+  if (plan.totalFrames !== 300) {
+    throw new Error(`Expected totalFrames to be 300, got ${plan.totalFrames}`);
+  }
+
+  // Verify Chunks
+  if (plan.chunks.length !== 4) {
+    throw new Error(`Expected 4 chunks, got ${plan.chunks.length}`);
+  }
+
+  // Verify Chunk Details
+  const chunkSize = Math.ceil(300 / 4); // 75
+  let previousEnd = 0;
+
+  for (let i = 0; i < plan.chunks.length; i++) {
+    const chunk = plan.chunks[i];
+
+    // Check ID
+    if (chunk.id !== i) {
+      throw new Error(`Chunk ${i}: Expected id ${i}, got ${chunk.id}`);
+    }
+
+    // Check Start Frame
+    if (chunk.startFrame !== previousEnd) {
+      throw new Error(`Chunk ${i}: Expected startFrame ${previousEnd}, got ${chunk.startFrame}`);
+    }
+
+    // Check Frame Count
+    const expectedCount = Math.min(chunkSize, 300 - previousEnd);
+    if (chunk.frameCount !== expectedCount) {
+      throw new Error(`Chunk ${i}: Expected frameCount ${expectedCount}, got ${chunk.frameCount}`);
+    }
+
+    previousEnd += chunk.frameCount;
+
+    // Check Output File
+    if (!chunk.outputFile.includes(`_part_${i}.mov`)) {
+      throw new Error(`Chunk ${i}: Output file format incorrect: ${chunk.outputFile}`);
+    }
+
+    // Check Options
+    if (chunk.options.audioCodec !== 'pcm_s16le') {
+      throw new Error(`Chunk ${i}: Expected audioCodec 'pcm_s16le', got ${chunk.options.audioCodec}`);
+    }
+
+    if (chunk.options.audioTracks && chunk.options.audioTracks.length > 0) {
+      throw new Error(`Chunk ${i}: Expected audioTracks to be empty`);
+    }
+
+    if (chunk.options.videoCodec !== 'libx264') { // Should inherit from base options or defaults?
+        // In the implementation:
+        // const chunkBaseOptions = { ...options, ... }
+        // options has videoCodec: 'libx264'
+        // So chunkOptions should have it too.
+        if (chunk.options.videoCodec !== 'libx264') {
+             throw new Error(`Chunk ${i}: Expected videoCodec 'libx264', got ${chunk.options.videoCodec}`);
+        }
+    }
+  }
+
+  // Verify Mix Options
+  if (plan.mixOptions.videoCodec !== 'copy') {
+    throw new Error(`Expected mixOptions.videoCodec to be 'copy', got ${plan.mixOptions.videoCodec}`);
+  }
+
+  if (plan.mixOptions.mixInputAudio !== true) {
+      throw new Error(`Expected mixOptions.mixInputAudio to be true, got ${plan.mixOptions.mixInputAudio}`);
+  }
+
+  // Verify Cleanup Files
+  if (plan.cleanupFiles.length !== 5) { // 4 chunks + 1 concat target
+    throw new Error(`Expected 5 cleanup files, got ${plan.cleanupFiles.length}`);
+  }
+
+  console.log('✅ RenderOrchestrator.plan() verified successfully.');
+}
+
+main().catch(err => {
+  console.error('❌ Verification failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
💡 **What**: Decoupled `RenderOrchestrator` job planning from execution by introducing a static `plan()` method and `RenderPlan` interface.
🎯 **Why**: To enable CLI job generation (`--emit-job`) to share logic with the renderer, allow external execution of render plans, and improve inspectability of distributed jobs.
📊 **Impact**: Enables cleaner architecture for distributed rendering and reduces logic duplication in the CLI.
🔬 **Verification**: Added `tests/verify-orchestrator-plan.ts` to verify planning logic. Verified `tests/verify-distributed.ts` passes to ensure no regression in `render()` functionality.

---
*PR created automatically by Jules for task [3129997754652164014](https://jules.google.com/task/3129997754652164014) started by @BintzGavin*