### PR TITLE
RENDERER: Plan FFmpeg Hardware Acceleration

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -45,3 +45,7 @@
 ## [2026-09-13] - FFmpeg Hardware Acceleration Visibility Gap
 **Learning:** `FFmpegInspector` reports codec support but misses hardware acceleration capabilities (`-hwaccels`), leaving users blind to GPU availability in distributed environments. This violates the "GPU Acceleration" vision pillar for diagnostics.
 **Action:** Created plan `2026-09-13-RENDERER-FFmpeg-Hardware-Acceleration.md` to implement `-hwaccels` detection.
+
+## [2026-09-14] - FFmpeg Hardware Acceleration Implementation Gap
+**Learning:** The plan `2026-09-13-RENDERER-FFmpeg-Hardware-Acceleration.md` existed but the implementation was missing. Additionally, `FFmpegBuilder` lacked support for using the detected acceleration.
+**Action:** Created expanded plan `2026-09-14-RENDERER-FFmpeg-Hardware-Acceleration.md` to cover both detection and usage.

--- a/.sys/plans/2026-09-14-RENDERER-FFmpeg-Hardware-Acceleration.md
+++ b/.sys/plans/2026-09-14-RENDERER-FFmpeg-Hardware-Acceleration.md
@@ -1,0 +1,49 @@
+# 2026-09-14-RENDERER-FFmpeg-Hardware-Acceleration.md
+
+#### 1. Context & Goal
+- **Objective**: Implement hardware acceleration detection in `FFmpegInspector` AND support for configurable `-hwaccel` flag in `FFmpegBuilder`.
+- **Trigger**: Vision gap identified. The previous plan `2026-09-13` (Detection) was not implemented, and usage support (`FFmpegBuilder`) is missing.
+- **Impact**: Enables users to leverage GPU for faster rendering, especially in distributed workflows. Provides visibility via `renderer.diagnose()`.
+
+#### 2. File Inventory
+- **Modify**:
+  - `packages/renderer/src/utils/FFmpegInspector.ts`: Add `hwaccels` detection logic.
+  - `packages/renderer/src/types.ts`: Add `hwAccel` option to `RendererOptions`.
+  - `packages/renderer/src/utils/FFmpegBuilder.ts`: Inject `-hwaccel` flag based on options.
+  - `packages/renderer/tests/verify-diagnose-ffmpeg.ts`: Update to verify `hwaccels` detection.
+- **Create**:
+  - `packages/renderer/tests/verify-hwaccel-args.ts`: New test to verify correct argument generation.
+- **Read-Only**:
+  - `packages/renderer/src/Renderer.ts` (Reference for `diagnose` flow)
+
+#### 3. Implementation Spec
+- **Architecture**:
+  - Extend `FFmpegInspector` to spawn `ffmpeg -hwaccels` and parse the output.
+  - Update `RendererOptions` to include an optional `hwAccel` property.
+  - Update `FFmpegBuilder` to inject the `-hwaccel` flag before the input file (`-i`) when configured.
+- **Public API Changes**:
+  - `FFmpegDiagnostics` interface in `FFmpegInspector.ts`: Add `hwaccels: string[]`.
+  - `RendererOptions` interface in `types.ts`: Add `hwAccel?: 'auto' | 'cuda' | 'dr' | 'vaapi' | 'qsv' | 'videotoolbox' | string;`.
+- **Logic Flow**:
+  1. **Detection (`FFmpegInspector`)**:
+     - Spawn `ffmpeg -hwaccels`.
+     - Capture **stdout**.
+     - Parse output: Skip the first line ("Hardware acceleration methods:"), split by newline, trim, filter empty lines.
+     - Add resulting list to `result.hwaccels`.
+  2. **Configuration (`FFmpegBuilder`)**:
+     - In `getArgs`: Check `options.hwAccel`.
+     - If present, create `hwAccelArgs = ['-hwaccel', options.hwAccel]`.
+     - Prepend `hwAccelArgs` to `finalArgs` *before* `videoInputArgs` (which contains `-i`).
+     - Ensure correct order: `['-y', ...hwAccelArgs, ...videoInputArgs, ...audioInputArgs]`.
+
+#### 4. Test Plan
+- **Verification**:
+  - Run `npx tsx packages/renderer/tests/verify-diagnose-ffmpeg.ts` to confirm detection works with local FFmpeg (should list `vdpau`, `vaapi`).
+  - Run `npx tsx packages/renderer/tests/verify-hwaccel-args.ts` to confirm arguments are generated correctly.
+- **Success Criteria**:
+  - `verify-diagnose-ffmpeg.ts` passes and logs detected accelerators (assert `diagnostics.ffmpeg.hwaccels` is array).
+  - `verify-hwaccel-args.ts` confirms `-hwaccel cuda` (or other values) appears before `-i` in the argument list.
+- **Edge Cases**:
+  - Empty/Unsupported `hwaccels` output from FFmpeg (should return empty array).
+  - `hwAccel` option provided but empty string (should be ignored).
+  - FFmpeg version differences in `-hwaccels` output format (handle robustly).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10225,7 +10225,7 @@
     },
     "packages/renderer": {
       "name": "@helios-project/renderer",
-      "version": "1.77.4",
+      "version": "1.78.0",
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/stderr.txt
+++ b/stderr.txt
@@ -1,0 +1,11 @@
+ffmpeg version N-47683-g0e8eb07980-static https://johnvansickle.com/ffmpeg/  Copyright (c) 2000-2018 the FFmpeg developers
+  built with gcc 6.3.0 (Debian 6.3.0-18+deb9u1) 20170516
+  configuration: --enable-gpl --enable-version3 --enable-static --disable-debug --disable-ffplay --disable-indev=sndio --disable-outdev=sndio --cc=gcc-6 --enable-fontconfig --enable-frei0r --enable-gnutls --enable-gray --enable-libaom --enable-libfribidi --enable-libass --enable-libvmaf --enable-libfreetype --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-librubberband --enable-libsoxr --enable-libspeex --enable-libvorbis --enable-libopus --enable-libtheora --enable-libvidstab --enable-libvo-amrwbenc --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzimg
+  libavutil      56. 24.101 / 56. 24.101
+  libavcodec     58. 42.100 / 58. 42.100
+  libavformat    58. 24.100 / 58. 24.100
+  libavdevice    58.  6.101 / 58.  6.101
+  libavfilter     7. 46.101 /  7. 46.101
+  libswscale      5.  4.100 /  5.  4.100
+  libswresample   3.  4.100 /  3.  4.100
+  libpostproc    55.  4.100 / 55.  4.100

--- a/stdout.txt
+++ b/stdout.txt
@@ -1,0 +1,3 @@
+Hardware acceleration methods:
+vdpau
+vaapi


### PR DESCRIPTION
Created a detailed spec file for implementing FFmpeg hardware acceleration detection and usage.

- **Detection**: Update `FFmpegInspector` to parse `ffmpeg -hwaccels`.
- **Configuration**: Add `hwAccel` option to `RendererOptions`.
- **Usage**: Update `FFmpegBuilder` to inject `-hwaccel` flag.
- **Verification**: Added test plans for detection and argument generation.

This enables users to leverage GPU acceleration for faster rendering, aligning with the "GPU Acceleration" vision.

---
*PR created automatically by Jules for task [1378421585554386680](https://jules.google.com/task/1378421585554386680) started by @BintzGavin*