### PR TITLE
Configurable Example Registry (CLI)

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -58,6 +58,17 @@ Options:
 - `--out-dir <dir>`: Output directory to serve (default: `dist`).
 - `--port <number>`: Port to listen on (default: 4173).
 
+```bash
+npx helios init [target] [options]
+```
+
+Options:
+- `[target]`: Target directory (default: current working directory).
+- `--repo <repo>`: Example repository (user/repo or user/repo/path).
+- `--example <name>`: Initialize from an example.
+- `--yes`: Skip prompts and use defaults.
+- `--framework <framework>`: Specify framework (react, vue, svelte, solid, vanilla).
+
 ## D. UI Components
 
 - **Sidebar**: Navigation between different panels (Assets, Renders, Settings).

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -29,7 +29,7 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] **CLI**: Implement registry commands.
 - [x] **CLI**: Implement render command.
 - [x] **CLI**: Implement example init (`helios init --example`).
-- [ ] **CLI**: Make example registry configurable (remove hardcoded URL).
+- [x] **CLI**: Make example registry configurable (remove hardcoded URL).
 - [ ] **Examples**: Create examples demonstrating distributed rendering workflows.
 - [ ] **Examples**: Create examples demonstrating component usage.
 

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,18 @@
+## STUDIO v0.106.0
+- ✅ Completed: Configurable Example Registry (CLI) - Implemented `--repo` flag for `helios init` command, enabling scaffolding from custom GitHub repositories.
+
+## STUDIO v0.105.1
+- ✅ Verified: Components Panel Tests - Implemented comprehensive unit tests for ComponentsPanel covering loading, listing, install, update, and remove flows.
+
+## STUDIO v0.105.0
+- ✅ Completed: Component Management - Implemented ability to remove and update components from the Studio UI, adding corresponding CLI hooks and backend API endpoints.
+
+## STUDIO v0.104.3
+- ✅ Completed: Preview Command - Implemented `helios preview` command to serve production builds locally for verification.
+
+## STUDIO v0.104.2
+- ✅ Completed: CompositionsPanel Tests - Implemented unit tests for CompositionsPanel covering CRUD and filtering.
+
 ## STUDIO v0.104.1
 - ✅ Verified: Agent Skills Tests - Added unit tests for agent skills documentation logic and synced package version.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### STUDIO v0.106.0
+- ✅ Completed: Configurable Example Registry (CLI) - Implemented `--repo` flag for `helios init` command, enabling scaffolding from custom GitHub repositories.
+
 ### CLI v0.20.0
 - ✅ Completed: Implement Example Init - Implemented `helios init --example` to fetch, download, and transform examples from GitHub, and improved interactivity with `prompts`.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.105.1
+**Version**: 0.106.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.106.0] ✅ Completed: Configurable Example Registry (CLI) - Implemented `--repo` flag for `helios init` command, enabling scaffolding from custom GitHub repositories.
 - [v0.105.1] ✅ Verified: Components Panel Tests - Implemented comprehensive unit tests for ComponentsPanel covering loading, listing, install, update, and remove flows.
 - [v0.105.0] ✅ Completed: Component Management - Implemented ability to remove and update components from the Studio UI, adding corresponding CLI hooks and backend API endpoints.
 - [v0.104.3] ✅ Completed: Preview Command - Implemented `helios preview` command to serve production builds locally for verification.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -28,6 +28,7 @@ export function registerInitCommand(program: Command) {
     .option('-y, --yes', 'Skip prompts and use defaults (React)')
     .option('-f, --framework <framework>', 'Specify framework (react, vue, svelte, solid, vanilla)')
     .option('--example <name>', 'Initialize from an example')
+    .option('--repo <repo>', 'Example repository (user/repo or user/repo/path)', 'BintzGavin/helios/examples')
     .action(async (target, options) => {
       const targetDir = target ? path.resolve(process.cwd(), target) : process.cwd();
       const configPath = path.resolve(targetDir, 'helios.config.json');
@@ -58,9 +59,9 @@ export function registerInitCommand(program: Command) {
       // 1. Check for Example Usage via Flag
       if (options.example) {
         mode = 'example';
-        console.log(chalk.cyan(`Downloading example '${options.example}'...`));
+        console.log(chalk.cyan(`Downloading example '${options.example}' from '${options.repo}'...`));
         try {
-          await downloadExample(options.example, targetDir);
+          await downloadExample(options.example, targetDir, options.repo);
           console.log(chalk.green('Downloaded example. Transforming files...'));
           transformProject(targetDir);
           console.log(chalk.green('Project initialized from example.'));
@@ -92,8 +93,8 @@ export function registerInitCommand(program: Command) {
         }
 
         if (mode === 'example') {
-            console.log(chalk.gray('Fetching examples...'));
-            const examples = await fetchExamples();
+            console.log(chalk.gray(`Fetching examples from ${options.repo}...`));
+            const examples = await fetchExamples(options.repo);
 
             if (examples.length === 0) {
               console.log(chalk.yellow('No examples found or failed to fetch. Falling back to templates.'));
@@ -110,7 +111,7 @@ export function registerInitCommand(program: Command) {
 
               console.log(chalk.cyan(`Downloading example '${response.example}'...`));
               try {
-                await downloadExample(response.example, targetDir);
+                await downloadExample(response.example, targetDir, options.repo);
                 transformProject(targetDir);
                 isScaffolded = true;
               } catch (error) {


### PR DESCRIPTION
Implemented --repo flag for helios init command to support custom GitHub repositories for examples. Updated fetchExamples and downloadExample utilities to handle dynamic repository paths. Verified with automated script.

---
*PR created automatically by Jules for task [16201739289984762096](https://jules.google.com/task/16201739289984762096) started by @BintzGavin*