### PR TITLE
CLI: Configurable Example Registry

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -44,7 +44,7 @@ packages/cli/
 ## C. Commands
 
 - `helios studio`: Launches the Helios Studio dev server.
-- `helios init [target]`: Initializes a new Helios project configuration and scaffolds project structure. Supports `--example <name>` to scaffold from GitHub examples.
+- `helios init [target]`: Initializes a new Helios project configuration and scaffolds project structure. Supports `--example <name>` to scaffold from GitHub examples, and `--repo <repo>` to specify a custom repository.
 - `helios add [component]`: Adds a component to the project.
 - `helios list`: Lists installed components in the project.
 - `helios components`: Lists available components in the registry.
@@ -67,4 +67,4 @@ This file tracks installed components and project settings.
 - **Registry**: `RegistryClient` fetches components from `HELIOS_REGISTRY_URL` or falls back to local registry.
 - **Renderer**: `helios render` uses `@helios-project/renderer` to execute rendering strategies (Canvas/DOM).
 - **Studio**: `helios studio` wraps the Studio dev server.
-- **Examples**: `helios init` fetches examples from the GitHub repository (`BintzGavin/helios/examples`).
+- **Examples**: `helios init` fetches examples from the GitHub repository (default: `BintzGavin/helios/examples`, configurable via `--repo`).

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -29,7 +29,7 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] **CLI**: Implement registry commands.
 - [x] **CLI**: Implement render command.
 - [x] **CLI**: Implement example init (`helios init --example`).
-- [ ] **CLI**: Make example registry configurable (remove hardcoded URL).
+- [x] **CLI**: Make example registry configurable (remove hardcoded URL).
 - [ ] **Examples**: Create examples demonstrating distributed rendering workflows.
 - [ ] **Examples**: Create examples demonstrating component usage.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -193,3 +193,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ## STUDIO v0.105.0
 - ✅ Completed: Component Management - Implemented ability to remove and update components from the Studio UI, adding corresponding CLI hooks and backend API endpoints.
+
+### CLI v0.21.0
+- ✅ Completed: Configurable Example Registry - Implemented --repo option for helios init to use custom GitHub repositories for example templates, supporting subdirectories and branches.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.20.0
+**Version**: 0.21.0
 
 ## Current State
 
@@ -68,3 +68,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.18.0] ✅ Implement Skills Command - Implemented `helios skills install` to distribute AI agent skills to user projects.
 [v0.19.0] ✅ Implement Preview Command - Implemented `helios preview` to serve the production build locally using Vite.
 [v0.20.0] ✅ Implement Example Init - Implemented `helios init --example` to fetch, download, and transform examples from GitHub, and improved interactivity with `prompts`.
+[v0.21.0] ✅ Configurable Example Registry - Implemented `--repo` option for `helios init` to use custom GitHub repositories for example templates, supporting subdirectories and branches.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/cli",
-  "version": "0.18.0",
+  "version": "0.21.0",
   "description": "CLI for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -28,6 +28,7 @@ export function registerInitCommand(program: Command) {
     .option('-y, --yes', 'Skip prompts and use defaults (React)')
     .option('-f, --framework <framework>', 'Specify framework (react, vue, svelte, solid, vanilla)')
     .option('--example <name>', 'Initialize from an example')
+    .option('--repo <repo>', 'Example repository (user/repo or user/repo/path)', 'BintzGavin/helios/examples')
     .action(async (target, options) => {
       const targetDir = target ? path.resolve(process.cwd(), target) : process.cwd();
       const configPath = path.resolve(targetDir, 'helios.config.json');
@@ -60,7 +61,7 @@ export function registerInitCommand(program: Command) {
         mode = 'example';
         console.log(chalk.cyan(`Downloading example '${options.example}'...`));
         try {
-          await downloadExample(options.example, targetDir);
+          await downloadExample(options.example, targetDir, options.repo);
           console.log(chalk.green('Downloaded example. Transforming files...'));
           transformProject(targetDir);
           console.log(chalk.green('Project initialized from example.'));
@@ -93,7 +94,7 @@ export function registerInitCommand(program: Command) {
 
         if (mode === 'example') {
             console.log(chalk.gray('Fetching examples...'));
-            const examples = await fetchExamples();
+            const examples = await fetchExamples(options.repo);
 
             if (examples.length === 0) {
               console.log(chalk.yellow('No examples found or failed to fetch. Falling back to templates.'));
@@ -110,7 +111,7 @@ export function registerInitCommand(program: Command) {
 
               console.log(chalk.cyan(`Downloading example '${response.example}'...`));
               try {
-                await downloadExample(response.example, targetDir);
+                await downloadExample(response.example, targetDir, options.repo);
                 transformProject(targetDir);
                 isScaffolded = true;
               } catch (error) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,7 +18,7 @@ const program = new Command();
 program
   .name('helios')
   .description('Helios CLI')
-  .version('0.18.0');
+  .version('0.21.0');
 
 registerStudioCommand(program);
 registerInitCommand(program);


### PR DESCRIPTION
Implemented `--repo` flag for `helios init` to allow specifying a custom example repository.
Updated `fetchExamples` and `downloadExample` to support dynamic repository paths and branches.
Updated documentation and synced version to 0.21.0.

---
*PR created automatically by Jules for task [15988271030360299606](https://jules.google.com/task/15988271030360299606) started by @BintzGavin*