### PR TITLE
✨ RENDERER: FFmpeg Hardware Acceleration

### DIFF
--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -246,6 +246,13 @@ export interface RendererOptions {
    * Only applicable when `intermediateVideoCodec` is used or inferred.
    */
   keyFrameInterval?: number;
+
+  /**
+   * Hardware acceleration method to use for FFmpeg.
+   * Examples: 'cuda', 'vaapi', 'qsv', 'videotoolbox', 'auto'.
+   * If provided, adds the `-hwaccel` flag to the FFmpeg command.
+   */
+  hwAccel?: string;
 }
 
 export interface RenderJobOptions {

--- a/packages/renderer/src/utils/FFmpegBuilder.ts
+++ b/packages/renderer/src/utils/FFmpegBuilder.ts
@@ -224,7 +224,13 @@ export class FFmpegBuilder {
     }
 
     // 5. Construct Final Arguments
-    const finalArgs: string[] = ['-y', ...videoInputArgs, ...audioInputArgs];
+    const finalArgs: string[] = ['-y'];
+
+    if (options.hwAccel) {
+      finalArgs.push('-hwaccel', options.hwAccel);
+    }
+
+    finalArgs.push(...videoInputArgs, ...audioInputArgs);
 
     // Combine filters
     const complexFilters: string[] = [];

--- a/packages/renderer/src/utils/FFmpegInspector.ts
+++ b/packages/renderer/src/utils/FFmpegInspector.ts
@@ -6,6 +6,7 @@ export interface FFmpegDiagnostics {
   version?: string;
   encoders: string[];
   filters: string[];
+  hwaccels: string[];
   error?: string;
 }
 
@@ -16,6 +17,7 @@ export class FFmpegInspector {
       present: false,
       encoders: [],
       filters: [],
+      hwaccels: [],
     };
 
     try {
@@ -70,6 +72,23 @@ export class FFmpegInspector {
             if (match) {
                 result.filters.push(match[1]);
             }
+        }
+      }
+
+      // Check Hardware Accelerations
+      const hwaccelsProc = spawnSync(ffmpegPath, ['-hwaccels'], { encoding: 'utf-8' });
+      if (!hwaccelsProc.error && hwaccelsProc.status === 0) {
+        const lines = hwaccelsProc.stdout.split('\n');
+        // Output format:
+        // Hardware acceleration methods:
+        // vdpau
+        // vaapi
+        // ...
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i].trim();
+          if (line && line !== 'Hardware acceleration methods:') {
+            result.hwaccels.push(line);
+          }
         }
       }
 

--- a/packages/renderer/tests/verify-diagnose-ffmpeg.ts
+++ b/packages/renderer/tests/verify-diagnose-ffmpeg.ts
@@ -26,6 +26,7 @@ import * as assert from 'assert';
     assert.ok(diagnostics.ffmpeg.version, 'Version should be present');
     assert.ok(Array.isArray(diagnostics.ffmpeg.encoders), 'Encoders should be an array');
     assert.ok(Array.isArray(diagnostics.ffmpeg.filters), 'Filters should be an array');
+    assert.ok(Array.isArray(diagnostics.ffmpeg.hwaccels), 'Hardware accelerators should be an array');
 
     // Check for common encoder (libx264)
     const hasH264 = diagnostics.ffmpeg.encoders.includes('libx264');

--- a/packages/renderer/tests/verify-hwaccel-args.ts
+++ b/packages/renderer/tests/verify-hwaccel-args.ts
@@ -1,0 +1,35 @@
+import { FFmpegBuilder } from '../src/utils/FFmpegBuilder.js';
+import { RendererOptions } from '../src/types.js';
+import * as assert from 'assert';
+
+console.log('Verifying FFmpeg Hardware Acceleration Arguments...');
+
+const options: RendererOptions = {
+  width: 1920,
+  height: 1080,
+  fps: 30,
+  durationInSeconds: 10,
+  hwAccel: 'cuda',
+  ffmpegPath: '/usr/bin/ffmpeg', // Dummy path
+};
+
+const outputPath = 'output.mp4';
+const videoInputArgs = ['-i', 'pipe:0'];
+
+const { args } = FFmpegBuilder.getArgs(options, outputPath, videoInputArgs);
+
+console.log('Generated Args:', args);
+
+// Assert -hwaccel cuda is present
+const hwAccelIndex = args.indexOf('-hwaccel');
+assert.notStrictEqual(hwAccelIndex, -1, '-hwaccel flag should be present');
+assert.strictEqual(args[hwAccelIndex + 1], 'cuda', '-hwaccel value should be "cuda"');
+
+// Assert -hwaccel is before -i (video input)
+const inputIndex = args.indexOf('-i');
+// Note: videoInputArgs contains ['-i', 'pipe:0'], so -i is in the final args.
+// However, FFmpegBuilder puts -y then hwaccel then videoInputArgs.
+// So -hwaccel should be at index 1 (after -y) and -i at index 3 or later.
+assert.ok(inputIndex > hwAccelIndex, '-hwaccel should be before -i');
+
+console.log('✅ FFmpeg Hardware Acceleration Args Verified!');


### PR DESCRIPTION
💡 **What**: Added `hwAccel` option to `RendererOptions` and updated `FFmpegBuilder` to inject the `-hwaccel` flag. Also enhanced `FFmpegInspector` to detect available hardware acceleration methods.
🎯 **Why**: To enable users to leverage GPU acceleration for faster rendering, especially in distributed workflows, and to provide visibility into available accelerators via diagnostics.
📊 **Impact**: Faster rendering on supported hardware (e.g., CUDA, VAAPI, VideoToolbox).
🔬 **Verification**:
- Verified `diagnose()` detects accelerators using `verify-diagnose-ffmpeg.ts`.
- Verified `getArgs()` generates correct flags using `verify-hwaccel-args.ts`.

---
*PR created automatically by Jules for task [1026429094464071610](https://jules.google.com/task/1026429094464071610) started by @BintzGavin*