### PR TITLE
CLI Plan: Use RenderOrchestrator for Distributed Job Planning

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -65,3 +65,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.19.0] - Example Distributability
 **Learning:** The examples in the repository rely on local monorepo paths (`../../../packages/*`), making them impossible to distribute directly to users via `helios init`. The "Examples" product surface is blocked by this coupling.
 **Action:** Implement transformation logic in the CLI to rewrite imports and dependencies when scaffolding from an example, ensuring the user gets a standalone project.
+
+## [0.20.0] - Distributed Plan Consistency
+**Learning:** `helios render --emit-job` implemented manual chunking logic that diverged from `RenderOrchestrator.plan()`. This created a risk where distributed jobs would behave differently from local runs (e.g., audio mixing, frame ranges).
+**Action:** Always delegate logic to the core domain (Renderer) rather than reimplementing it in the interface (CLI). If the API is missing, expose it, but don't duplicate the math.

--- a/.sys/plans/2025-02-18-CLI-Use-RenderOrchestrator-Planning.md
+++ b/.sys/plans/2025-02-18-CLI-Use-RenderOrchestrator-Planning.md
@@ -1,0 +1,92 @@
+# 2025-02-18-CLI-Use-RenderOrchestrator-Planning
+
+#### 1. Context & Goal
+- **Objective**: Refactor `helios render --emit-job` to use `RenderOrchestrator.plan()` for generating distributed job specifications.
+- **Trigger**: Vision Gap - Distributed rendering logic currently duplicates and diverges from the core `RenderOrchestrator` logic, leading to potential inconsistencies in chunking and file handling.
+- **Impact**: Ensures that distributed jobs use the same planning logic (chunk size calculation, temp file naming, audio strategy) as local rendering, improving reliability and maintainability. This is a prerequisite for advanced distributed rendering features (like sophisticated audio mixing) to work correctly.
+
+#### 2. File Inventory
+- **Modify**: `packages/cli/src/commands/render.ts` (Replace manual chunking logic with `RenderOrchestrator.plan()`)
+- **Read-Only**: `packages/renderer/src/Orchestrator.ts` (Reference for `plan()` return type and logic)
+
+#### 3. Implementation Spec
+- **Architecture**:
+  - The CLI will delegate the calculation of render chunks to `RenderOrchestrator.plan()`.
+  - It will then map the returned `RenderPlan` (which contains `RenderChunk[]`) to the `JobSpec` (which requires `RenderJobChunk[]` with command strings).
+  - A helper function `rendererOptionsToFlags(options: RendererOptions): string` will be implemented to serialize `RendererOptions` back into CLI arguments for the worker commands.
+
+- **Pseudo-Code**:
+  ```typescript
+  // In render.ts action handler
+  const options = parseOptions(...);
+
+  if (emitJob) {
+    // Delegate planning to the core renderer
+    const plan = RenderOrchestrator.plan(url, outputPath, options);
+
+    // Helper to convert options back to CLI flags
+    const rendererOptionsToFlags = (opts: RendererOptions) => {
+      // Implement mapping:
+      // opts.width -> --width
+      // opts.height -> --height
+      // opts.fps -> --fps
+      // opts.audioCodec -> --audio-codec
+      // opts.videoCodec -> --video-codec
+      // opts.crf -> --quality
+      // opts.mode -> --mode
+      // opts.browserConfig.headless -> --no-headless (if false)
+      // etc.
+      // Returns string
+    };
+
+    // Map plan to job spec
+    const chunks = plan.chunks.map(chunk => ({
+      id: chunk.id,
+      startFrame: chunk.startFrame,
+      frameCount: chunk.frameCount,
+      outputFile: chunk.outputFile,
+      command: `helios render ${url} -o ${chunk.outputFile} --start-frame ${chunk.startFrame} --frame-count ${chunk.frameCount} ${rendererOptionsToFlags(chunk.options)}`
+    }));
+
+    // Construct merge command
+    // Use plan.concatManifest (list of temp files) as inputs
+    // Pass mixOptions (codecs/quality) to merge command
+    let mergeCmd = `helios merge ${outputPath} ${plan.concatManifest.join(' ')}`;
+    if (plan.mixOptions.videoCodec) mergeCmd += ` --video-codec ${plan.mixOptions.videoCodec}`;
+    if (plan.mixOptions.audioCodec) mergeCmd += ` --audio-codec ${plan.mixOptions.audioCodec}`;
+    if (plan.mixOptions.crf) mergeCmd += ` --quality ${plan.mixOptions.crf}`;
+
+    // Note: Implicit audio mixing logic from RenderOrchestrator is not fully captured by 'helios merge' yet,
+    // but basic concatenation and transcoding will work. This is acceptable for now.
+
+    const jobSpec: JobSpec = {
+      metadata: {
+        totalFrames: plan.totalFrames,
+        fps: options.fps,
+        width: options.width,
+        height: options.height,
+        duration: plan.totalFrames / options.fps
+      },
+      chunks,
+      mergeCommand: mergeCmd
+    };
+
+    writeJobSpec(emitJobPath, jobSpec);
+    return;
+  }
+  ```
+
+- **Dependencies**: None. `RenderOrchestrator` is already available in `@helios-project/renderer`.
+
+#### 4. Test Plan
+- **Verification**:
+  - Run `helios render examples/hello-world/composition.html --emit-job job.json --concurrency 2`
+  - Inspect `job.json`:
+    - Ensure `chunks` has 2 entries.
+    - Ensure `command` string in chunks contains correct flags (e.g., `--width`, `--height`).
+    - Ensure `outputFile` in chunks matches `RenderOrchestrator`'s temp file pattern (`temp_...` or similar).
+    - Ensure `mergeCommand` lists the correct temp files as inputs.
+- **Success Criteria**: Generated `job.json` is valid JSON and structurally consistent with `RenderOrchestrator`'s internal logic.
+- **Edge Cases**:
+  - Test with `concurrency=1`.
+  - Test with custom `start-frame` and `frame-count` (e.g., partial render).


### PR DESCRIPTION
Created `.sys/plans/2025-02-18-CLI-Use-RenderOrchestrator-Planning.md` specifying the refactor of `helios render --emit-job` to utilize the core `RenderOrchestrator.plan()` method. This alignment ensures that distributed jobs benefit from the same robust chunking, temporary file management, and audio planning logic as local renders, eliminating a key source of divergence and potential bugs. Also updated the CLI journal with learnings about distributed planning consistency.

---
*PR created automatically by Jules for task [15482442161640312317](https://jules.google.com/task/15482442161640312317) started by @BintzGavin*