### PR TITLE
✨ PLAYER: Implement Standard Event Handlers

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -34,6 +34,7 @@ The Shadow DOM contains:
 - `audiometering`: Fired with `AudioLevels` data (stereo RMS/Peak).
 - `enterpictureinpicture`: Entered PiP mode.
 - `leavepictureinpicture`: Left PiP mode.
+- `resize`: Player dimensions changed.
 
 ## C. Observed Attributes
 - `src`: URL of the composition.
@@ -76,7 +77,8 @@ The Shadow DOM contains:
 - `inputProps` (get/set): Object for composition properties.
 - `sandbox` (get/set): Security flags.
 - `disablePictureInPicture` (get/set): PiP availability.
-- `seeking` (get): Whether the player is currently seeking (scrubbing or waiting for async seek).
+- `seeking` (get): Whether the player is currently seeking.
+- **Event Handlers**: `onplay`, `onpause`, `onended`, `ontimeupdate`, `onvolumechange`, `onratechange`, `ondurationchange`, `onseeking`, `onseeked`, `onresize`, `onloadstart`, `onloadedmetadata`, `onloadeddata`, `oncanplay`, `oncanplaythrough`, `onerror`, `onenterpictureinpicture`, `onleavepictureinpicture`.
 
 ## E. Public Methods
 - `play(): Promise<void>`: Start playback.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -205,3 +205,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ## STUDIO v0.105.0
 - ✅ Completed: Component Management - Implemented ability to remove and update components from the Studio UI, adding corresponding CLI hooks and backend API endpoints.
+
+## PLAYER v0.75.0
+- ✅ Completed: Implement Standard Event Handlers - Implemented standard HTMLMediaElement event handler properties (onplay, onpause, etc.) on HeliosPlayer for improved API parity.
+
+## PLAYER v0.75.0
+- ✅ Completed: Implement Standard Event Handlers - Implemented standard HTMLMediaElement event handler properties (onplay, onpause, etc.) on HeliosPlayer for improved API parity.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.74.4
+**Version**: v0.75.0
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -188,3 +188,5 @@
 [v0.6.0] ✅ Completed: Keyboard & Fullscreen Support - Implemented standard keyboard shortcuts (Space, F, Arrows) and Fullscreen UI/logic.
 [v0.5.2] ✅ Completed: Scaffold Tests - Added unit test suite for controllers and exporter using Vitest.
 [v0.5.1] ✅ Completed: Standard Attributes - Implemented `autoplay`, `loop`, and `controls` attributes. Synced version and artifacts.
+[v0.75.0] ✅ Completed: Implement Standard Event Handlers - Implemented standard HTMLMediaElement event handler properties (onplay, onpause, etc.) on HeliosPlayer for improved API parity.
+[v0.75.0] ✅ Completed: Implement Standard Event Handlers - Implemented standard HTMLMediaElement event handler properties (onplay, onpause, etc.) on HeliosPlayer for improved API parity.

--- a/packages/player/src/event_handlers.test.ts
+++ b/packages/player/src/event_handlers.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { HeliosPlayer } from './index';
+
+// Mock ResizeObserver
+global.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as any;
+
+describe('HeliosPlayer Event Handlers', () => {
+  let player: HeliosPlayer;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    player = new HeliosPlayer();
+    document.body.appendChild(player);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should call onplay handler when play event is dispatched', () => {
+    const handler = vi.fn();
+    player.onplay = handler;
+    player.dispatchEvent(new Event('play'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should remove old onplay handler when replaced', () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    player.onplay = handler1;
+    player.onplay = handler2;
+    player.dispatchEvent(new Event('play'));
+    expect(handler1).not.toHaveBeenCalled();
+    expect(handler2).toHaveBeenCalledTimes(1);
+  });
+
+  it('should remove onplay handler when set to null', () => {
+    const handler = vi.fn();
+    player.onplay = handler;
+    player.onplay = null;
+    player.dispatchEvent(new Event('play'));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('should support all standard event handlers', () => {
+    const events = [
+      'pause', 'ended', 'timeupdate', 'volumechange', 'ratechange',
+      'durationchange', 'seeking', 'seeked', 'resize', 'loadstart',
+      'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough',
+      'error', 'enterpictureinpicture', 'leavepictureinpicture'
+    ];
+
+    events.forEach(eventName => {
+      const handler = vi.fn();
+      const propName = 'on' + eventName;
+      // @ts-ignore
+      player[propName] = handler;
+
+      player.dispatchEvent(new Event(eventName));
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      // Cleanup
+      // @ts-ignore
+      player[propName] = null;
+      player.dispatchEvent(new Event(eventName));
+      expect(handler).toHaveBeenCalledTimes(1); // Should not increase
+    });
+  });
+});

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -947,6 +947,152 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     return this.src;
   }
 
+  // --- Standard Event Handlers ---
+
+  private _onplay: ((event: Event) => void) | null = null;
+  public get onplay() { return this._onplay; }
+  public set onplay(handler: ((event: Event) => void) | null) {
+    if (this._onplay) this.removeEventListener('play', this._onplay);
+    this._onplay = handler;
+    if (handler) this.addEventListener('play', handler);
+  }
+
+  private _onpause: ((event: Event) => void) | null = null;
+  public get onpause() { return this._onpause; }
+  public set onpause(handler: ((event: Event) => void) | null) {
+    if (this._onpause) this.removeEventListener('pause', this._onpause);
+    this._onpause = handler;
+    if (handler) this.addEventListener('pause', handler);
+  }
+
+  private _onended: ((event: Event) => void) | null = null;
+  public get onended() { return this._onended; }
+  public set onended(handler: ((event: Event) => void) | null) {
+    if (this._onended) this.removeEventListener('ended', this._onended);
+    this._onended = handler;
+    if (handler) this.addEventListener('ended', handler);
+  }
+
+  private _ontimeupdate: ((event: Event) => void) | null = null;
+  public get ontimeupdate() { return this._ontimeupdate; }
+  public set ontimeupdate(handler: ((event: Event) => void) | null) {
+    if (this._ontimeupdate) this.removeEventListener('timeupdate', this._ontimeupdate);
+    this._ontimeupdate = handler;
+    if (handler) this.addEventListener('timeupdate', handler);
+  }
+
+  private _onvolumechange: ((event: Event) => void) | null = null;
+  public get onvolumechange() { return this._onvolumechange; }
+  public set onvolumechange(handler: ((event: Event) => void) | null) {
+    if (this._onvolumechange) this.removeEventListener('volumechange', this._onvolumechange);
+    this._onvolumechange = handler;
+    if (handler) this.addEventListener('volumechange', handler);
+  }
+
+  private _onratechange: ((event: Event) => void) | null = null;
+  public get onratechange() { return this._onratechange; }
+  public set onratechange(handler: ((event: Event) => void) | null) {
+    if (this._onratechange) this.removeEventListener('ratechange', this._onratechange);
+    this._onratechange = handler;
+    if (handler) this.addEventListener('ratechange', handler);
+  }
+
+  private _ondurationchange: ((event: Event) => void) | null = null;
+  public get ondurationchange() { return this._ondurationchange; }
+  public set ondurationchange(handler: ((event: Event) => void) | null) {
+    if (this._ondurationchange) this.removeEventListener('durationchange', this._ondurationchange);
+    this._ondurationchange = handler;
+    if (handler) this.addEventListener('durationchange', handler);
+  }
+
+  private _onseeking: ((event: Event) => void) | null = null;
+  public get onseeking() { return this._onseeking; }
+  public set onseeking(handler: ((event: Event) => void) | null) {
+    if (this._onseeking) this.removeEventListener('seeking', this._onseeking);
+    this._onseeking = handler;
+    if (handler) this.addEventListener('seeking', handler);
+  }
+
+  private _onseeked: ((event: Event) => void) | null = null;
+  public get onseeked() { return this._onseeked; }
+  public set onseeked(handler: ((event: Event) => void) | null) {
+    if (this._onseeked) this.removeEventListener('seeked', this._onseeked);
+    this._onseeked = handler;
+    if (handler) this.addEventListener('seeked', handler);
+  }
+
+  private _onresize: ((event: Event) => void) | null = null;
+  public get onresize() { return this._onresize; }
+  public set onresize(handler: ((event: Event) => void) | null) {
+    if (this._onresize) this.removeEventListener('resize', this._onresize);
+    this._onresize = handler;
+    if (handler) this.addEventListener('resize', handler);
+  }
+
+  private _onloadstart: ((event: Event) => void) | null = null;
+  public get onloadstart() { return this._onloadstart; }
+  public set onloadstart(handler: ((event: Event) => void) | null) {
+    if (this._onloadstart) this.removeEventListener('loadstart', this._onloadstart);
+    this._onloadstart = handler;
+    if (handler) this.addEventListener('loadstart', handler);
+  }
+
+  private _onloadedmetadata: ((event: Event) => void) | null = null;
+  public get onloadedmetadata() { return this._onloadedmetadata; }
+  public set onloadedmetadata(handler: ((event: Event) => void) | null) {
+    if (this._onloadedmetadata) this.removeEventListener('loadedmetadata', this._onloadedmetadata);
+    this._onloadedmetadata = handler;
+    if (handler) this.addEventListener('loadedmetadata', handler);
+  }
+
+  private _onloadeddata: ((event: Event) => void) | null = null;
+  public get onloadeddata() { return this._onloadeddata; }
+  public set onloadeddata(handler: ((event: Event) => void) | null) {
+    if (this._onloadeddata) this.removeEventListener('loadeddata', this._onloadeddata);
+    this._onloadeddata = handler;
+    if (handler) this.addEventListener('loadeddata', handler);
+  }
+
+  private _oncanplay: ((event: Event) => void) | null = null;
+  public get oncanplay() { return this._oncanplay; }
+  public set oncanplay(handler: ((event: Event) => void) | null) {
+    if (this._oncanplay) this.removeEventListener('canplay', this._oncanplay);
+    this._oncanplay = handler;
+    if (handler) this.addEventListener('canplay', handler);
+  }
+
+  private _oncanplaythrough: ((event: Event) => void) | null = null;
+  public get oncanplaythrough() { return this._oncanplaythrough; }
+  public set oncanplaythrough(handler: ((event: Event) => void) | null) {
+    if (this._oncanplaythrough) this.removeEventListener('canplaythrough', this._oncanplaythrough);
+    this._oncanplaythrough = handler;
+    if (handler) this.addEventListener('canplaythrough', handler);
+  }
+
+  private _onerror: ((event: Event) => void) | null = null;
+  public get onerror() { return this._onerror; }
+  public set onerror(handler: ((event: Event) => void) | null) {
+    if (this._onerror) this.removeEventListener('error', this._onerror);
+    this._onerror = handler;
+    if (handler) this.addEventListener('error', handler);
+  }
+
+  private _onenterpictureinpicture: ((event: Event) => void) | null = null;
+  public get onenterpictureinpicture() { return this._onenterpictureinpicture; }
+  public set onenterpictureinpicture(handler: ((event: Event) => void) | null) {
+    if (this._onenterpictureinpicture) this.removeEventListener('enterpictureinpicture', this._onenterpictureinpicture);
+    this._onenterpictureinpicture = handler;
+    if (handler) this.addEventListener('enterpictureinpicture', handler);
+  }
+
+  private _onleavepictureinpicture: ((event: Event) => void) | null = null;
+  public get onleavepictureinpicture() { return this._onleavepictureinpicture; }
+  public set onleavepictureinpicture(handler: ((event: Event) => void) | null) {
+    if (this._onleavepictureinpicture) this.removeEventListener('leavepictureinpicture', this._onleavepictureinpicture);
+    this._onleavepictureinpicture = handler;
+    if (handler) this.addEventListener('leavepictureinpicture', handler);
+  }
+
   // --- Standard Media API ---
 
   public canPlayType(type: string): CanPlayTypeResult {


### PR DESCRIPTION
💡 **What**: Implemented standard `HTMLMediaElement` event handler properties (`onplay`, `onpause`, `onended`, etc.) on `HeliosPlayer` class.
🎯 **Why**: To achieve fuller parity with the Standard Media API and improve compatibility with third-party tools.
📊 **Impact**: Developers can now use property-based event binding (e.g. `player.onplay = func`) instead of just `addEventListener`.
🔬 **Verification**: Added `event_handlers.test.ts` verifying property assignment adds/removes listeners correctly. Fixed test environment by running `npm install`.

---
*PR created automatically by Jules for task [11061820144539050281](https://jules.google.com/task/11061820144539050281) started by @BintzGavin*