### PR TITLE
✨ RENDERER: Fix Skill Documentation

### DIFF
--- a/.agents/skills/helios/renderer/SKILL.md
+++ b/.agents/skills/helios/renderer/SKILL.md
@@ -71,6 +71,7 @@ interface RendererOptions {
   // Intermediate Capture (Canvas Mode)
   intermediateVideoCodec?: string; // 'vp8' (default), 'vp9', 'av1'
   keyFrameInterval?: number;       // Keyframe interval in frames (default: fps * 2)
+  hwAccel?: string;                // Hardware acceleration (e.g., 'cuda', 'vaapi', 'auto')
 
   // Intermediate Capture (DOM Mode)
   intermediateImageFormat?: 'png' | 'jpeg'; // Default: 'png'
@@ -87,6 +88,7 @@ interface RendererOptions {
 
 interface AudioTrackConfig {
   path: string;
+  buffer?: Buffer; // Buffer containing audio data (alternative to path)
   volume?: number; // 0.0 to 1.0
   offset?: number; // Start time in composition (seconds)
   seek?: number;   // Start time in source file (seconds)

--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -1,3 +1,15 @@
 ## [2026-09-15] - WebCodecs Determinism Gap
 **Learning:** `CanvasStrategy` strictly prioritizes hardware encoding (if available) via `VideoEncoder`. This introduces potential non-determinism across different GPUs, violating the project's goal of bit-exact rendering for regression testing.
 **Action:** Created plan `2026-09-15-RENDERER-WebCodecs-Preference.md` to introduce `webCodecsPreference` option, allowing users to force software encoding or disable WebCodecs entirely.
+
+## [1.79.1] - Missing Web Audio Support
+**Learning:** `CanvasStrategy` lacks `AudioEncoder` integration, preventing capture of procedural audio generated via Web Audio API.
+**Action:** Documented as a known limitation; future work should explore `AudioContext` capture.
+
+## [1.79.1] - Codec/PixelFormat Mismatch
+**Learning:** No validation exists for incompatible combinations like `libx264` + `yuva420p` (alpha channel), which causes FFmpeg to fail silently or produce corrupted output.
+**Action:** Future task should implement strict validation in `FFmpegBuilder` to warn or fail fast on invalid combinations.
+
+## [1.79.1] - GSAP Fragility
+**Learning:** `SeekTimeDriver` relies on the `window.__helios_gsap_timeline__` global for synchronization, which is fragile if the user doesn't expose it correctly or uses multiple timelines.
+**Action:** Future task should consider more robust discovery mechanisms or an explicit registration API.

--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -51,7 +51,7 @@ interface RendererOptions {
   mode?: 'canvas' | 'dom';
   videoCodec?: 'libx264' | 'libvpx-vp9' | 'copy';
   audioFilePath?: string;
-  audioTracks?: AudioTrackConfig[];
+  audioTracks?: (string | AudioTrackConfig)[]; // Path or config object (supports buffer)
   subtitles?: string; // Path to SRT file
   inputProps?: Record<string, any>;
   concurrency?: number; // For distributed rendering

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### RENDERER v1.79.1
+- ✅ Completed: Fix Skill Documentation - Added missing `hwAccel` and `buffer` properties to `SKILL.md` and updated journal with architectural learnings.
+
 ### STUDIO v0.107.0
 - ✅ Completed: Export Job Spec - Implemented "Export Job Spec" functionality in Renders Panel to generate distributed render job JSON files for cloud execution.
 

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,10 +1,11 @@
-**Version**: 1.79.0
+**Version**: 1.79.1
 
 **Posture**: MAINTENANCE WITH V2 EXPANSION
 
 # Renderer Agent Status
 
 ## Progress Log
+- [1.79.1] ✅ Completed: Fix Skill Documentation - Added missing `hwAccel` and `buffer` properties to `SKILL.md` and updated journal with architectural learnings.
 - [1.79.0] ✅ Completed: Validate HW Accel - Implemented validation in `Renderer.render()` to check requested `hwAccel` against available FFmpeg hardware accelerations and log warnings for mismatches. Verified with `verify-hwaccel-validation.ts`.
 - [1.78.0] ✅ Completed: Orchestrator Plan - Implemented `RenderOrchestrator.plan()` static method to decouple job planning from execution, returning a serializable `RenderPlan`. Refactored `render()` to use this plan. Verified with `verify-orchestrator-plan.ts`.
 - [1.77.4] ✅ Completed: Refactor Media Sync Logic - Consolidated duplicated media attribute parsing and synchronization logic from `SeekTimeDriver`, `CdpTimeDriver`, and `dom-scanner` into shared utilities in `dom-scripts.ts`, ensuring consistency and maintainability. Verified with `verify-media-sync.ts`.


### PR DESCRIPTION
Updated `.agents/skills/helios/renderer/SKILL.md` to include missing `hwAccel` and `buffer` properties, ensuring parity with `packages/renderer/src/types.ts`. Added critical architectural learnings to `.jules/RENDERER.md` regarding Web Audio limitations, codec mismatches, and GSAP fragility. Updated status and progress documentation.

---
*PR created automatically by Jules for task [9388651977242462277](https://jules.google.com/task/9388651977242462277) started by @BintzGavin*