### PR TITLE
Docs: Update Studio README with Preview Command

### DIFF
--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,9 @@
+## STUDIO v0.107.3
+- ✅ Completed: Documentation Maintenance - Updated Studio documentation to document `helios preview` command usage.
+
+## STUDIO v0.107.2
+- ✅ Verified: Renders Panel Tests - Implemented comprehensive unit tests for `RendersPanel`, covering interactions, states, and context integration.
+
 ## STUDIO v0.107.1
 - ✅ Completed: Portable Job Paths - Updated `getRenderJobSpec` to generate relative paths for input, output, and chunks, ensuring distributed render jobs are portable across environments.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.107.2
+**Version**: 0.107.3
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.107.3] ✅ Completed: Documentation Maintenance - Updated Studio documentation to document `helios preview` command usage.
 - [v0.107.2] ✅ Verified: Renders Panel Tests - Implemented comprehensive unit tests for `RendersPanel`, covering interactions, states, and context integration.
 - [v0.107.1] ✅ Completed: Portable Job Paths - Updated `getRenderJobSpec` to generate relative paths for input, output, and chunks, ensuring distributed render jobs are portable across environments.
 - [v0.107.0] ✅ Completed: Export Job Spec - Implemented "Export Job Spec" functionality in Renders Panel to generate distributed render job JSON files for cloud execution.

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -28,12 +28,16 @@ Studio acts as a host environment for the Helios Player.
 
 Studio can be installed and run in two ways:
 
-**Option 1: Via Main CLI** (Development Mode)
+**Option 1: Via Main CLI** (Recommended)
 ```bash
+# Start development server
 npx helios studio
+
+# Preview production build
+npx helios preview
 ```
 
-**Option 2: Direct Installation** (Production Mode)
+**Option 2: Direct Installation** (Standalone)
 ```bash
 # Install globally
 npm install -g @helios-project/studio
@@ -47,7 +51,7 @@ Or use with npx:
 npx @helios-project/studio
 ```
 
-The standalone CLI serves the built Studio UI using `vite preview`, automatically detecting your project root.
+The `helios preview` command serves the static build output using `vite preview`, providing a production-like environment for verifying your composition before deployment.
 
 For a comprehensive guide on getting started, see the [Quickstart Guide](../../docs/site/getting-started/quickstart.md).
 


### PR DESCRIPTION
Documented the `helios preview` command in `packages/studio/README.md` to improve clarity on how to serve production builds locally. Validated existing implementation of `packages/cli/src/commands/preview.ts`. Note: Build verification was skipped due to environment dependency issues, but code was verified via static analysis.

---
*PR created automatically by Jules for task [7958741262153540668](https://jules.google.com/task/7958741262153540668) started by @BintzGavin*