### PR TITLE
✨ CLI: Configurable Registry

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -1,97 +1,92 @@
 # CLI Context
 
-## Section A: Architecture
-The Helios CLI (`packages/cli`) is the primary interface for users. It is built using `commander.js`.
-- **Entry Point**: `bin/helios.js` (shebang) -> `dist/index.js` (compiled).
-- **Command Registration**: Commands are defined in `src/commands/` and registered in `src/index.ts` using `register[Command]Command(program)`.
-- **Registry**: Uses `RegistryClient` (`src/registry/client.ts`) to fetch components from a remote URL or fallback to a local manifest (`src/registry/manifest.ts`). Supports recursive installation via `registryDependencies`.
-- **Configuration**: Reads/writes `helios.config.json` in the project root.
+## A. Architecture
 
-## Section B: File Tree
+The Helios CLI is built using `commander` and serves as the primary interface for managing Helios projects. It handles:
+- Project initialization and scaffolding (`init`)
+- Component management (`add`, `remove`, `update`, `components`)
+- Development server (`studio`)
+- Rendering (`render`, `job`, `merge`)
+- Deployment (`build`, `preview`)
+
+Commands are registered in `src/index.ts` and implemented in individual files within `src/commands/`.
+
+## B. File Tree
+
 ```
 packages/cli/
 ├── bin/
-│   └── helios.js
+│   └── helios.js           # Entry point
 ├── src/
 │   ├── commands/
-│   │   ├── add.ts
-│   │   ├── build.ts
-│   │   ├── components.ts
-│   │   ├── init.ts
-│   │   ├── job.ts
-│   │   ├── list.ts
-│   │   ├── merge.ts
-│   │   ├── preview.ts
-│   │   ├── remove.ts
-│   │   ├── render.ts
-│   │   ├── skills.ts
-│   │   ├── studio.ts
-│   │   └── update.ts
+│   │   ├── add.ts          # Adds components
+│   │   ├── build.ts        # Builds for production
+│   │   ├── components.ts   # Lists registry components
+│   │   ├── init.ts         # Initializes project
+│   │   ├── job.ts          # Manages render jobs
+│   │   ├── list.ts         # Lists installed components
+│   │   ├── merge.ts        # Merges video files
+│   │   ├── preview.ts      # Previews build
+│   │   ├── remove.ts       # Removes components
+│   │   ├── render.ts       # Renders composition
+│   │   ├── skills.ts       # Installs agent skills
+│   │   ├── studio.ts       # Starts Studio server
+│   │   └── update.ts       # Updates components
 │   ├── registry/
-│   │   ├── client.ts
-│   │   ├── manifest.ts
-│   │   └── types.ts
-│   ├── templates/
-│   ├── utils/
-│   │   ├── config.ts
-│   │   ├── examples.ts
-│   │   ├── ffmpeg.ts
-│   │   ├── install.ts
-│   │   ├── logger.ts
-│   │   ├── package-manager.ts
-│   │   └── uninstall.ts
-│   └── index.ts
-├── package.json
-└── tsconfig.json
+│   │   ├── client.ts       # Registry API client
+│   │   └── types.ts        # Registry types
+│   ├── templates/          # Project templates
+│   ├── types/              # Shared types
+│   └── utils/
+│       ├── config.ts       # Config management
+│       ├── examples.ts     # Example fetching
+│       ├── install.ts      # Installation logic
+│       └── uninstall.ts    # Uninstallation logic
+└── package.json
 ```
 
-## Section C: Commands
-- `helios init [name]` - Initialize a new project.
-  - `--example <name>` - Scaffold from an example.
-  - `--repo <url>` - Scaffold from a git repo.
-  - `--yes` - Skip prompts.
-- `helios studio` - Start the Studio dev server.
-  - `--port <number>` - Specify port.
-  - `--open` - Open browser.
-- `helios add <component>` - Add a component to the project.
-  - `--no-install` - Skip npm dependency installation.
-  - Installs recursively (e.g., `timer` installs `use-video-frame`).
-- `helios remove <component>` - Remove a component.
-  - `--yes` - Skip confirmation.
-  - `--keep-files` - Keep component files on disk.
-- `helios update <component>` - Update a component from registry.
-- `helios list` - List installed components.
-- `helios components` - List available registry components.
-- `helios render <composition>` - Render a composition to video.
-  - `--out <file>` - Output file.
-  - `--concurrency <n>` - Number of parallel workers.
-  - `--start-frame <n>` - Start frame.
-  - `--frame-count <n>` - Number of frames.
-  - `--emit-job <file>` - Generate a distributed job JSON.
-- `helios merge <files...>` - Merge video files.
-  - `--out <file>` - Output file.
-- `helios build` - Build the project for production.
-- `helios preview` - Preview the production build.
-- `helios job run <file>` - Execute a distributed job.
-  - `--concurrency <n>` - Parallel workers.
-  - `--chunk <index>` - Run specific chunk.
-- `helios skills install <skill>` - Install AI agent skills.
+## C. Commands
 
-## Section D: Configuration
-**`helios.config.json`**:
-```json
-{
-  "version": "1.0.0",
-  "directories": {
-    "components": "src/components/helios",
-    "lib": "src/lib"
-  },
-  "components": ["timer", "use-video-frame"],
-  "framework": "react" | "vue" | "svelte" | "solid" | "vanilla"
+- `helios init [target]`: Initialize a new project.
+  - Options: `--yes`, `--framework <name>`, `--example <name>`, `--repo <url>`
+- `helios studio`: Start the Studio development server.
+  - Options: `--port <number>`
+- `helios add <component>`: Add a component from the registry.
+  - Options: `--no-install`
+- `helios remove <component>`: Remove a component.
+  - Options: `--yes`, `--keep-files`
+- `helios update <component>`: Update a component.
+  - Options: `--yes`, `--no-install`
+- `helios components`: List available components in the registry.
+- `helios list`: List installed components.
+- `helios render <input>`: Render a composition.
+  - Options: `--output`, `--width`, `--height`, `--fps`, `--duration`, `--quality`, `--mode`, `--emit-job`
+- `helios job run <spec>`: Run a distributed render job.
+  - Options: `--concurrency`, `--chunks`
+- `helios merge <output> <inputs...>`: Merge video files.
+- `helios build`: Build the project for production.
+- `helios preview`: Preview the production build.
+- `helios skills install`: Install agent skills.
+
+## D. Configuration
+
+The CLI reads `helios.config.json` in the project root.
+
+```typescript
+interface HeliosConfig {
+  version: string;
+  registry?: string; // Custom registry URL
+  directories: {
+    components: string;
+    lib: string;
+  };
+  framework?: 'react' | 'vue' | 'svelte' | 'solid' | 'vanilla';
+  components: string[];
 }
 ```
 
-## Section E: Integration
-- **Registry**: `RegistryClient` caches results and handles fallback. `installComponent` resolves dependency trees recursively.
-- **Renderer**: `helios render` uses `RenderOrchestrator` from `@helios-project/renderer` for local and distributed rendering.
-- **Studio**: `helios studio` uses `@helios-project/studio` to serve the UI, injecting project root context.
+## E. Integration
+
+- **Registry**: The CLI uses `RegistryClient` to fetch components. It supports a custom registry URL via `helios.config.json` or `HELIOS_REGISTRY_URL` env var.
+- **Studio**: The `studio` command launches a Vite server with `studioApiPlugin`, allowing the Studio UI to trigger CLI actions (install/remove components) via the server.
+- **Renderer**: The `render` command orchestrates rendering using `@helios-project/renderer`.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### CLI v0.24.0
+- ✅ Completed: Configurable Registry - Refactored `RegistryClient` to support configuration via `helios.config.json`'s `registry` property, enabling private registries.
+
 ### PLAYER v0.76.2
 - ✅ Completed: Sync Dependencies - Updated @helios-project/core and mediabunny dependencies to match workspace versions.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.23.0
+**Version**: 0.24.0
 
 ## Current State
 
@@ -72,3 +72,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.21.0] ✅ Portable Job Paths - Implemented relative path generation in `helios render --emit-job` and relative execution in `helios job run`.
 [v0.22.0] ✅ Registry Dependencies - Implemented recursive component installation to support shared registry dependencies (e.g. `use-video-frame`).
 [v0.23.0] ✅ Refine Component Removal - Enhanced `helios remove` to support interactive file deletion, `--yes` flag for automation, and `--keep-files` to preserve files.
+[v0.24.0] ✅ Configurable Registry - Refactored `RegistryClient` to support configuration via `helios.config.json`'s `registry` property, enabling private registries.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,5 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
+import { loadConfig } from '../utils/config.js';
+import { RegistryClient } from '../registry/client.js';
 import { installComponent } from '../utils/install.js';
 
 export function registerAddCommand(program: Command) {
@@ -9,7 +11,9 @@ export function registerAddCommand(program: Command) {
     .option('--no-install', 'Skip dependency installation')
     .action(async (componentName, options) => {
       try {
-        await installComponent(process.cwd(), componentName, { install: options.install });
+        const config = loadConfig(process.cwd());
+        const client = new RegistryClient(config?.registry);
+        await installComponent(process.cwd(), componentName, { install: options.install, client });
       } catch (e: any) {
         console.error(chalk.red(e.message));
         process.exit(1);

--- a/packages/cli/src/commands/components.ts
+++ b/packages/cli/src/commands/components.ts
@@ -1,13 +1,16 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { defaultClient } from '../registry/client.js';
+import { loadConfig } from '../utils/config.js';
+import { RegistryClient } from '../registry/client.js';
 
 export function registerComponentsCommand(program: Command) {
   program
     .command('components')
     .description('List available components')
     .action(async () => {
-      const components = await defaultClient.getComponents();
+      const config = loadConfig(process.cwd());
+      const client = new RegistryClient(config?.registry);
+      const components = await client.getComponents(config?.framework);
 
       if (components.length === 0) {
         console.log(chalk.yellow('No components found in registry.'));

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -5,7 +5,7 @@ import { createRequire } from 'module';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import { defaultClient } from '../registry/client.js';
+import { RegistryClient } from '../registry/client.js';
 import { installComponent } from '../utils/install.js';
 import { uninstallComponent } from '../utils/uninstall.js';
 import { loadConfig } from '../utils/config.js';
@@ -23,7 +23,8 @@ export function registerStudioCommand(program: Command) {
         const config = loadConfig(process.cwd());
         console.log(chalk.dim(`Fetching component registry${config?.framework ? ` (${config.framework})` : ''}...`));
 
-        const components = await defaultClient.getComponents(config?.framework);
+        const client = new RegistryClient(config?.registry);
+        const components = await client.getComponents(config?.framework);
 
         const require = createRequire(import.meta.url);
 
@@ -56,13 +57,13 @@ export function registerStudioCommand(program: Command) {
               skillsRoot: skillsRoot,
               components: components,
               onInstallComponent: async (name: string) => {
-                await installComponent(process.cwd(), name);
+                await installComponent(process.cwd(), name, { install: true, client });
               },
               onRemoveComponent: async (name: string) => {
-                await uninstallComponent(process.cwd(), name, { removeFiles: true });
+                await uninstallComponent(process.cwd(), name, { removeFiles: true, client });
               },
               onUpdateComponent: async (name: string) => {
-                await installComponent(process.cwd(), name, { install: true, overwrite: true });
+                await installComponent(process.cwd(), name, { install: true, overwrite: true, client });
               },
               onCheckInstalled: async (name: string) => {
                 const config = loadConfig(process.cwd());

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import readline from 'readline';
 import { loadConfig } from '../utils/config.js';
+import { RegistryClient } from '../registry/client.js';
 import { installComponent } from '../utils/install.js';
 
 export function registerUpdateCommand(program: Command) {
@@ -12,6 +13,7 @@ export function registerUpdateCommand(program: Command) {
     .option('--no-install', 'Skip dependency installation')
     .action(async (component, options) => {
       const config = loadConfig();
+      const client = new RegistryClient(config?.registry);
 
       if (!config) {
         console.error(chalk.red('Configuration file not found. Run "helios init" first.'));
@@ -50,6 +52,7 @@ export function registerUpdateCommand(program: Command) {
         await installComponent(process.cwd(), component, {
           install: options.install,
           overwrite: true,
+          client,
         });
         console.log(chalk.green(`\nSuccessfully updated ${component}!`));
       } catch (error) {

--- a/packages/cli/src/registry/client.ts
+++ b/packages/cli/src/registry/client.ts
@@ -56,4 +56,3 @@ export class RegistryClient {
   }
 }
 
-export const defaultClient = new RegistryClient();

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 export interface HeliosConfig {
   version: string;
+  registry?: string;
   directories: {
     components: string;
     lib: string;

--- a/packages/cli/src/utils/uninstall.ts
+++ b/packages/cli/src/utils/uninstall.ts
@@ -2,10 +2,11 @@ import path from 'path';
 import fs from 'fs';
 import chalk from 'chalk';
 import { loadConfig, saveConfig } from './config.js';
-import { defaultClient } from '../registry/client.js';
+import { RegistryClient } from '../registry/client.js';
 
 export interface UninstallOptions {
   removeFiles?: boolean;
+  client?: RegistryClient;
 }
 
 export async function uninstallComponent(rootDir: string, componentName: string, options: UninstallOptions = {}): Promise<void> {
@@ -26,8 +27,10 @@ export async function uninstallComponent(rootDir: string, componentName: string,
   console.log(chalk.green(`✓ Removed "${componentName}" from configuration.`));
 
   try {
+    const client = options.client || new RegistryClient(config.registry);
+
     // Attempt to find files to warn user or delete them
-    const component = await defaultClient.findComponent(componentName, config.framework);
+    const component = await client.findComponent(componentName, config.framework);
 
     if (component) {
       const componentsDir = path.resolve(rootDir, config.directories.components);


### PR DESCRIPTION
This PR introduces support for configuring the component registry URL via `helios.config.json`.

Changes:
- **Modified `HeliosConfig`**: Added optional `registry` property.
- **Refactored `RegistryClient`**: Removed `defaultClient` singleton export. The client is now instantiated per-command with the configured URL.
- **Updated Utilities**: `installComponent` and `uninstallComponent` now accept a `RegistryClient` instance.
- **Updated Commands**: `add`, `studio`, `components`, `update`, and `remove` commands now load the config and instantiate `RegistryClient` with the custom URL if present.

This ensures that all registry interactions respect the project-level configuration, while falling back to `HELIOS_REGISTRY_URL` or the default if no config is present.

---
*PR created automatically by Jules for task [8279296544103611533](https://jules.google.com/task/8279296544103611533) started by @BintzGavin*