### PR TITLE
📚 STUDIO: Enhance README Quickstart

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -58,7 +58,8 @@ The Studio is launched via the `helios` CLI (from `@helios-project/cli`).
 - **Renderer**: Uses `RenderOrchestrator` for planning and executing renders.
 - **CLI**: The Studio backend exposes endpoints that the CLI can leverage (e.g., for `helios render` with HMR support, though currently CLI uses Renderer directly).
 
-## F. Recent Changes (v0.108.1)
+## F. Recent Changes (v0.108.2)
+- **Completed: Enhance README Quickstart**: Updated `packages/studio/README.md` to recommend `npx helios init` for new projects, providing a clearer "Getting Started" guide.
 - **Verified: CLI Component Removal**: Verified `helios remove` command supports interactive file deletion, `--yes` flag, and `--keep-files` flag.
 - **MCP Server Enhancement**: Implemented MCP resources (documentation, assets, components) and tools (install/update/uninstall components) for agent integration.
 - **Documentation Maintenance**: Updated Studio documentation to document `helios preview` command usage.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### STUDIO v0.108.2
+- ✅ Completed: Enhance README Quickstart - Updated `packages/studio/README.md` to recommend `npx helios init` for new projects, providing a clearer "Getting Started" guide.
+
 ### CLI v0.24.0
 - ✅ Completed: Configurable Registry - Refactored `RegistryClient` to support configuration via `helios.config.json`'s `registry` property, enabling private registries.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.108.1
+**Version**: 0.108.2
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,6 +9,7 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.108.2] ✅ Completed: Enhance README Quickstart - Updated `packages/studio/README.md` to recommend `npx helios init` for new projects, providing a clearer "Getting Started" guide.
 - [v0.108.1] ✅ Verified: CLI Component Removal - Verified `helios remove` command supports interactive file deletion, `--yes` flag, and `--keep-files` flag.
 - [v0.108.0] ✅ Completed: Enhance MCP Server - Implemented MCP resources (documentation, assets, components) and tools (install/update/uninstall components) for agent integration.
 - [v0.107.3] ✅ Completed: Documentation Maintenance - Updated Studio documentation to document `helios preview` command usage.

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -14,6 +14,37 @@ Helios Studio is a visual interface for composing, previewing, and debugging Hel
 - **Diagnostics**: Inspect environment capabilities and system status.
 - **Client-Side Export**: Export MP4/WebM directly from the browser using WebCodecs.
 
+## Getting Started
+
+The recommended way to use Helios Studio is by initializing a new project with the Helios CLI.
+
+### 1. Create a New Project
+
+Use the `init` command to scaffold a project with your preferred framework (React, Vue, Svelte, Solid, or Vanilla):
+
+```bash
+npx helios init my-project
+```
+
+### 2. Install Dependencies
+
+Navigate to your project directory and install the necessary packages:
+
+```bash
+cd my-project
+npm install
+```
+
+### 3. Start the Studio
+
+Run the development server, which launches Helios Studio:
+
+```bash
+npm run dev
+```
+
+This will typically open the Studio at `http://localhost:5173`.
+
 ## Architecture
 
 Studio acts as a host environment for the Helios Player.
@@ -24,20 +55,24 @@ Studio acts as a host environment for the Helios Player.
 
 ## Usage
 
-### Installation
+### Commands
 
-Studio can be installed and run in two ways:
-
-**Option 1: Via Main CLI** (Recommended)
+**Start Development Server**
 ```bash
-# Start development server
 npx helios studio
+```
+Launches the Studio UI for the current directory. This is what `npm run dev` typically executes.
 
-# Preview production build
+**Preview Production Build**
+```bash
 npx helios preview
 ```
+Serves the static build output using `vite preview`, providing a production-like environment for verifying your composition before deployment.
 
-**Option 2: Direct Installation** (Standalone)
+### Standalone Usage
+
+You can also install the Studio package directly:
+
 ```bash
 # Install globally
 npm install -g @helios-project/studio
@@ -45,13 +80,6 @@ npm install -g @helios-project/studio
 # Run from any directory
 helios-studio
 ```
-
-Or use with npx:
-```bash
-npx @helios-project/studio
-```
-
-The `helios preview` command serves the static build output using `vite preview`, providing a production-like environment for verifying your composition before deployment.
 
 For a comprehensive guide on getting started, see the [Quickstart Guide](../../docs/site/getting-started/quickstart.md).
 
@@ -71,7 +99,7 @@ For a comprehensive guide on getting started, see the [Quickstart Guide](../../d
 
 ## Development
 
-To run the Studio package locally for development:
+To run the Studio package locally for development (contributing):
 
 1. Install dependencies:
    ```bash


### PR DESCRIPTION
💡 **What**: Updated `packages/studio/README.md` to provide a clearer "Getting Started" guide that recommends using `npx helios init` to scaffold new projects, instead of manual installation or cloning.

🎯 **Why**: The previous documentation focused on manual installation or cloning the repo, which is not the recommended workflow for end-users. The new guide aligns with the `helios init` command introduced in V2.

📊 **Impact**: Improves the onboarding experience for new users by providing a simple, standard workflow.

🔬 **Verification**: Verified the markdown content in `packages/studio/README.md`.

---
*PR created automatically by Jules for task [3737714352210829135](https://jules.google.com/task/3737714352210829135) started by @BintzGavin*