### PR TITLE
✨ CLI: Implement `diff` Command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -4,7 +4,7 @@
 
 The Helios CLI is built using `commander` and serves as the primary interface for managing Helios projects. It handles:
 - Project initialization and scaffolding (`init`)
-- Component management (`add`, `remove`, `update`, `components`)
+- Component management (`add`, `remove`, `update`, `components`, `diff`)
 - Development server (`studio`)
 - Rendering (`render`, `job`, `merge`)
 - Deployment (`build`, `preview`)
@@ -22,6 +22,7 @@ packages/cli/
 │   │   ├── add.ts          # Adds components
 │   │   ├── build.ts        # Builds for production
 │   │   ├── components.ts   # Lists registry components
+│   │   ├── diff.ts         # Diffs components
 │   │   ├── init.ts         # Initializes project
 │   │   ├── job.ts          # Manages render jobs
 │   │   ├── list.ts         # Lists installed components
@@ -59,6 +60,7 @@ packages/cli/
   - Options: `--yes`, `--no-install`
 - `helios components`: List available components in the registry.
 - `helios list`: List installed components.
+- `helios diff <component>`: Compare local component with registry version.
 - `helios render <input>`: Render a composition.
   - Options: `--output`, `--width`, `--height`, `--fps`, `--duration`, `--quality`, `--mode`, `--emit-job`
 - `helios job run <spec>`: Run a distributed render job.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,6 +27,7 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] **Studio**: Expand features to support distributed rendering configuration.
 - [x] **CLI**: Implement init command.
 - [x] **CLI**: Implement registry commands.
+- [x] **CLI**: Implement diff command.
 - [x] **CLI**: Implement render command.
 - [x] **CLI**: Implement example init (`helios init --example`).
 - [x] **CLI**: Make example registry configurable (remove hardcoded URL).

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,14 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.25.0
+
+- ✅ Diff Command - Implemented `helios diff <component>` to compare local component files with the registry version, showing colorized diffs.
+
+## CLI v0.24.0
+
+- ✅ Configurable Registry - Refactored `RegistryClient` to support configuration via `helios.config.json`'s `registry` property, enabling private registries.
+
 ## CLI v0.23.0
 
 - ✅ Refine Component Removal - Enhanced `helios remove` to support interactive file deletion, `--yes` flag for automation, and `--keep-files` to preserve files.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.24.0
+**Version**: 0.25.0
 
 ## Current State
 
@@ -26,6 +26,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 - `helios job` - Manages distributed rendering jobs
 - `helios skills` - Manages AI agent skills installation
 - `helios preview` - Previews the production build locally
+- `helios diff` - Compares local component code with the registry version
 
 ## V2 Roadmap
 
@@ -73,3 +74,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.22.0] ✅ Registry Dependencies - Implemented recursive component installation to support shared registry dependencies (e.g. `use-video-frame`).
 [v0.23.0] ✅ Refine Component Removal - Enhanced `helios remove` to support interactive file deletion, `--yes` flag for automation, and `--keep-files` to preserve files.
 [v0.24.0] ✅ Configurable Registry - Refactored `RegistryClient` to support configuration via `helios.config.json`'s `registry` property, enabling private registries.
+[v0.25.0] ✅ Diff Command - Implemented `helios diff <component>` to compare local component files with the registry version, showing colorized diffs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "diff": "^8.0.3"
+      },
       "devDependencies": {
         "@excalidraw/excalidraw": "^0.18.0",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -18,6 +21,7 @@
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
+        "@types/diff": "^7.0.2",
         "@types/leaflet": "^1.9.12",
         "@types/p5": "^1.7.7",
         "@vitejs/plugin-react": "^5.1.2",
@@ -2993,6 +2997,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/dom-mediacapture-transform": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.11.tgz",
@@ -5027,10 +5038,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "dev": true,
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -9337,6 +9347,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -10179,6 +10199,7 @@
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
         "degit": "^2.8.4",
+        "diff": "^8.0.3",
         "prompts": "^2.4.2",
         "vite": "^7.1.2"
       },
@@ -10187,6 +10208,7 @@
       },
       "devDependencies": {
         "@types/degit": "^2.8.6",
+        "@types/diff": "^7.0.2",
         "@types/prompts": "^2.4.9",
         "typescript": "^5.0.0"
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,11 +43,13 @@
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
     "degit": "^2.8.4",
+    "diff": "^8.0.3",
     "prompts": "^2.4.2",
     "vite": "^7.1.2"
   },
   "devDependencies": {
     "@types/degit": "^2.8.6",
+    "@types/diff": "^7.0.2",
     "@types/prompts": "^2.4.9",
     "typescript": "^5.0.0"
   }

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -1,0 +1,71 @@
+import { Command } from 'commander';
+import { createTwoFilesPatch } from 'diff';
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import { loadConfig } from '../utils/config.js';
+import { RegistryClient } from '../registry/client.js';
+
+export function registerDiffCommand(program: Command) {
+  program
+    .command('diff <component>')
+    .description('Compare local component with registry version')
+    .action(async (componentName) => {
+      const config = loadConfig();
+      if (!config) {
+        console.error(chalk.red('No helios.config.json found.'));
+        process.exit(1);
+      }
+
+      const client = new RegistryClient(config.registry);
+      const remoteComponent = await client.findComponent(componentName, config.framework);
+
+      if (!remoteComponent) {
+        console.error(chalk.red(`Component "${componentName}" not found in registry.`));
+        process.exit(1);
+      }
+
+      const localBaseDir = path.resolve(process.cwd(), config.directories.components);
+      let hasDiff = false;
+
+      for (const file of remoteComponent.files) {
+        const localPath = path.join(localBaseDir, file.name);
+
+        if (fs.existsSync(localPath)) {
+          const localContent = fs.readFileSync(localPath, 'utf-8');
+          const remoteContent = file.content;
+
+          if (localContent.replace(/\r\n/g, '\n').trim() !== remoteContent.replace(/\r\n/g, '\n').trim()) {
+             const patch = createTwoFilesPatch(
+               file.name,
+               file.name,
+               remoteContent,
+               localContent,
+               'Registry',
+               'Local'
+             );
+
+             patch.split('\n').forEach(line => {
+               if (line.startsWith('+') && !line.startsWith('+++')) {
+                 console.log(chalk.green(line));
+               } else if (line.startsWith('-') && !line.startsWith('---')) {
+                 console.log(chalk.red(line));
+               } else if (line.startsWith('@')) {
+                 console.log(chalk.cyan(line));
+               } else {
+                 console.log(line);
+               }
+             });
+             hasDiff = true;
+          }
+        } else {
+          console.log(chalk.green(`New file in registry: ${file.name}`));
+          hasDiff = true;
+        }
+      }
+
+      if (!hasDiff) {
+        console.log(chalk.gray('No differences found.'));
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import { registerBuildCommand } from './commands/build.js';
 import { registerPreviewCommand } from './commands/preview.js';
 import { registerJobCommand } from './commands/job.js';
 import { registerSkillsCommand } from './commands/skills.js';
+import { registerDiffCommand } from './commands/diff.js';
 
 const program = new Command();
 
@@ -33,5 +34,6 @@ registerBuildCommand(program);
 registerPreviewCommand(program);
 registerJobCommand(program);
 registerSkillsCommand(program);
+registerDiffCommand(program);
 
 program.parse(process.argv);


### PR DESCRIPTION
Implemented `helios diff` command to compare local component files against the registry version.

- Added `diff` dependency to `packages/cli`.
- created `packages/cli/src/commands/diff.ts` with `registerDiffCommand`.
- Registered the command in `packages/cli/src/index.ts`.
- Command uses `diff` library to generate patches and `chalk` to colorize output (green for local additions, red for registry deletions/missing in local).
- Verified manually with test cases.
- Updated documentation and backlog.

---
*PR created automatically by Jules for task [11185146289139536339](https://jules.google.com/task/11185146289139536339) started by @BintzGavin*