### PR TITLE
✨ CLI: Sync Version to 0.25.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/cli",
-  "version": "0.18.0",
+  "version": "0.25.0",
   "description": "CLI for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,7 +19,7 @@ const program = new Command();
 program
   .name('helios')
   .description('Helios CLI')
-  .version('0.18.0');
+  .version('0.25.0');
 
 registerStudioCommand(program);
 registerInitCommand(program);


### PR DESCRIPTION
💡 **What**: Updated `packages/cli/package.json` and `packages/cli/src/index.ts` from version `0.18.0` to `0.25.0`.
🎯 **Why**: The `diff` command (and several other features like `preview`, `job`, `registry` configuration) were implemented and documented in `docs/status/CLI.md` as v0.25.0, but the package version was not updated in the code. This caused a discrepancy between the documentation/status and the actual runtime version.
📊 **Impact**: The CLI now correctly reports version `0.25.0` when running `helios --version`, matching the documentation and the set of available features.
🔬 **Verification**: Ran `npx tsx packages/cli/src/index.ts --version` which output `0.25.0`. Verified `diff` command functionality manually.

---
*PR created automatically by Jules for task [13206828302547887059](https://jules.google.com/task/13206828302547887059) started by @BintzGavin*