### PR TITLE
✨ CLI: Registry Auth & Tests

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -34,6 +34,7 @@ packages/cli/
 │   │   ├── studio.ts       # Starts Studio server
 │   │   └── update.ts       # Updates components
 │   ├── registry/
+│   │   ├── __tests__/      # Registry tests
 │   │   ├── client.ts       # Registry API client
 │   │   └── types.ts        # Registry types
 │   ├── templates/          # Project templates
@@ -43,7 +44,8 @@ packages/cli/
 │       ├── examples.ts     # Example fetching
 │       ├── install.ts      # Installation logic
 │       └── uninstall.ts    # Uninstallation logic
-└── package.json
+├── package.json
+└── vitest.config.ts        # Test configuration
 ```
 
 ## C. Commands
@@ -89,6 +91,8 @@ interface HeliosConfig {
 
 ## E. Integration
 
-- **Registry**: The CLI uses `RegistryClient` to fetch components. It supports a custom registry URL via `helios.config.json` or `HELIOS_REGISTRY_URL` env var.
+- **Registry**: The CLI uses `RegistryClient` to fetch components. It supports:
+  - Custom registry URL via `helios.config.json` or `HELIOS_REGISTRY_URL` env var.
+  - Authentication via `HELIOS_REGISTRY_TOKEN` env var or constructor injection (Bearer token).
 - **Studio**: The `studio` command launches a Vite server with `studioApiPlugin`, allowing the Studio UI to trigger CLI actions (install/remove components) via the server.
 - **Renderer**: The `render` command orchestrates rendering using `@helios-project/renderer`.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.26.0
+
+- ✅ Registry Auth & Tests - Implemented authentication support for private registries using Bearer tokens and established Vitest-based testing infrastructure for the CLI package.
+
 ## CLI v0.25.0
 
 - ✅ Diff Command - Implemented `helios diff <component>` to compare local component files with the registry version, showing colorized diffs.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### CLI v0.26.0
+- ✅ Completed: Registry Auth & Tests - Implemented authentication support for private registries using Bearer tokens and established Vitest-based testing infrastructure for the CLI package.
+
 ### STUDIO v0.109.0
 - ✅ Verified: CLI Diff Command - Verified implementation of `helios diff` command and updated documentation in Studio README.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.25.0
+**Version**: 0.26.0
 
 ## Current State
 
@@ -75,3 +75,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.23.0] ✅ Refine Component Removal - Enhanced `helios remove` to support interactive file deletion, `--yes` flag for automation, and `--keep-files` to preserve files.
 [v0.24.0] ✅ Configurable Registry - Refactored `RegistryClient` to support configuration via `helios.config.json`'s `registry` property, enabling private registries.
 [v0.25.0] ✅ Diff Command - Implemented `helios diff <component>` to compare local component files with the registry version, showing colorized diffs.
+[v0.26.0] ✅ Registry Auth & Tests - Implemented authentication support for private registries using Bearer tokens and established Vitest-based testing infrastructure for the CLI package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10206,7 +10206,8 @@
         "@types/degit": "^2.8.6",
         "@types/diff": "^7.0.2",
         "@types/prompts": "^2.4.9",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^4.0.18"
       }
     },
     "packages/cli/node_modules/commander": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc && node scripts/bundle-skills.js",
     "dev": "tsc -w",
+    "test": "vitest",
     "prepublishOnly": "npm run build"
   },
   "keywords": [
@@ -51,6 +52,7 @@
     "@types/degit": "^2.8.6",
     "@types/diff": "^7.0.2",
     "@types/prompts": "^2.4.9",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/cli/src/registry/__tests__/client.test.ts
+++ b/packages/cli/src/registry/__tests__/client.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RegistryClient } from '../client';
+
+describe('RegistryClient', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it('should use token provided in constructor', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new RegistryClient('http://test.registry', 'test-token');
+    await client.getComponents();
+
+    expect(fetchMock).toHaveBeenCalledWith('http://test.registry', expect.objectContaining({
+      headers: expect.objectContaining({
+        'Authorization': 'Bearer test-token',
+      }),
+    }));
+  });
+
+  it('should use token from environment variable', async () => {
+    process.env.HELIOS_REGISTRY_TOKEN = 'env-token';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new RegistryClient('http://test.registry');
+    await client.getComponents();
+
+    expect(fetchMock).toHaveBeenCalledWith('http://test.registry', expect.objectContaining({
+      headers: expect.objectContaining({
+        'Authorization': 'Bearer env-token',
+      }),
+    }));
+  });
+
+  it('should not send authorization header if no token is present', async () => {
+    delete process.env.HELIOS_REGISTRY_TOKEN;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new RegistryClient('http://test.registry');
+    await client.getComponents();
+
+    const calls = fetchMock.mock.calls;
+    const options = calls[0][1];
+    expect(options.headers).toEqual({});
+  });
+});

--- a/packages/cli/src/registry/client.ts
+++ b/packages/cli/src/registry/client.ts
@@ -3,10 +3,12 @@ import { ComponentDefinition } from './types.js';
 
 export class RegistryClient {
   private url: string | undefined;
+  private token: string | undefined;
   private cache: ComponentDefinition[] | null = null;
 
-  constructor(url?: string) {
+  constructor(url?: string, token?: string) {
     this.url = url || process.env.HELIOS_REGISTRY_URL;
+    this.token = token || process.env.HELIOS_REGISTRY_TOKEN;
   }
 
   async getComponents(framework?: string): Promise<ComponentDefinition[]> {
@@ -25,7 +27,15 @@ export class RegistryClient {
         const timeoutId = setTimeout(() => controller.abort(), 5000);
 
         try {
-          const res = await fetch(this.url, { signal: controller.signal });
+          const headers: HeadersInit = {};
+          if (this.token) {
+            headers['Authorization'] = `Bearer ${this.token}`;
+          }
+
+          const res = await fetch(this.url, {
+            signal: controller.signal,
+            headers,
+          });
           if (res.ok) {
             const data = await res.json();
             if (Array.isArray(data)) {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Implemented authentication support for private registries using Bearer tokens and established Vitest-based testing infrastructure for the CLI package.

Key changes:
- Added `vitest` to `packages/cli` devDependencies.
- Created `packages/cli/vitest.config.ts`.
- Updated `RegistryClient` to accept `token` and inject `Authorization: Bearer` header.
- Added unit tests in `packages/cli/src/registry/__tests__/client.test.ts`.
- Updated documentation (Status, Progress, Context).

---
*PR created automatically by Jules for task [7358229173048795068](https://jules.google.com/task/7358229173048795068) started by @BintzGavin*