### PR TITLE
CLI: Add install tests

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -35,11 +35,14 @@ packages/cli/
 │   │   └── update.ts       # Updates components
 │   ├── registry/
 │   │   ├── __tests__/      # Registry tests
+│   │   │   └── client.test.ts
 │   │   ├── client.ts       # Registry API client
 │   │   └── types.ts        # Registry types
 │   ├── templates/          # Project templates
 │   ├── types/              # Shared types
 │   └── utils/
+│       ├── __tests__/      # Utility tests
+│       │   └── install.test.ts
 │       ├── config.ts       # Config management
 │       ├── examples.ts     # Example fetching
 │       ├── install.ts      # Installation logic

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.26.1
+
+- ✅ Add Install Tests - Added comprehensive unit tests for `installComponent` to verify dependency resolution, file operations, and config updates.
+
 ## CLI v0.26.0
 
 - ✅ Registry Auth & Tests - Implemented authentication support for private registries using Bearer tokens and established Vitest-based testing infrastructure for the CLI package.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.26.0
+**Version**: 0.26.1
 
 ## Current State
 
@@ -76,3 +76,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.24.0] ✅ Configurable Registry - Refactored `RegistryClient` to support configuration via `helios.config.json`'s `registry` property, enabling private registries.
 [v0.25.0] ✅ Diff Command - Implemented `helios diff <component>` to compare local component files with the registry version, showing colorized diffs.
 [v0.26.0] ✅ Registry Auth & Tests - Implemented authentication support for private registries using Bearer tokens and established Vitest-based testing infrastructure for the CLI package.
+[v0.26.1] ✅ Add Install Tests - Added comprehensive unit tests for `installComponent` to verify dependency resolution, file operations, and config updates.

--- a/packages/cli/src/utils/__tests__/install.test.ts
+++ b/packages/cli/src/utils/__tests__/install.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+import { installComponent } from '../install';
+import { loadConfig, saveConfig } from '../config';
+import { installPackage } from '../package-manager';
+
+// Mock dependencies
+vi.mock('fs');
+vi.mock('../config');
+vi.mock('../package-manager');
+// We don't need to mock RegistryClient completely if we inject a mock object,
+// but installComponent imports it. However, the function accepts an optional client.
+// We will test by injecting a mock client.
+
+describe('installComponent', () => {
+  const mockRootDir = '/mock/root';
+  const mockConfig = {
+    version: '1.0.0',
+    directories: {
+      components: 'src/components/helios',
+      lib: 'src/lib',
+    },
+    components: [],
+    framework: 'react',
+  };
+
+  const mockComponent = {
+    name: 'test-component',
+    type: 'component',
+    files: [
+      { name: 'TestComponent.tsx', content: '// test content' },
+    ],
+    dependencies: {
+      'react': '^18.0.0',
+    },
+    registryDependencies: ['child-component'],
+  };
+
+  const mockChildComponent = {
+    name: 'child-component',
+    type: 'component',
+    files: [
+      { name: 'ChildComponent.tsx', content: '// child content' },
+    ],
+    dependencies: {},
+    registryDependencies: [],
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (loadConfig as any).mockReturnValue({ ...mockConfig });
+    // Default: directories exist, files don't
+    (fs.existsSync as any).mockImplementation((p: string) => {
+        if (p === mockRootDir) return true;
+        return false;
+    });
+    (fs.mkdirSync as any).mockImplementation(() => {});
+    (fs.writeFileSync as any).mockImplementation(() => {});
+    (fs.readFileSync as any).mockImplementation(() => '{}');
+    (installPackage as any).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should throw error if config is missing', async () => {
+    (loadConfig as any).mockReturnValue(null);
+    await expect(installComponent(mockRootDir, 'test-component'))
+      .rejects.toThrow('Configuration file not found');
+  });
+
+  it('should install component and update config', async () => {
+    const mockClient = {
+      findComponent: vi.fn().mockResolvedValue(mockComponent),
+    } as any;
+
+    await installComponent(mockRootDir, 'test-component', { install: true, client: mockClient });
+
+    // Verify component fetch
+    expect(mockClient.findComponent).toHaveBeenCalledWith('test-component', 'react');
+
+    // Verify file creation
+    const targetDir = path.resolve(mockRootDir, 'src/components/helios');
+    const filePath = path.join(targetDir, 'TestComponent.tsx');
+
+    // mkdirSync should be called for the component directory
+    expect(fs.mkdirSync).toHaveBeenCalledWith(targetDir, { recursive: true });
+    expect(fs.writeFileSync).toHaveBeenCalledWith(filePath, '// test content');
+
+    // Verify config update
+    expect(saveConfig).toHaveBeenCalledWith(expect.objectContaining({
+      components: expect.arrayContaining(['test-component']),
+    }), mockRootDir);
+  });
+
+  it('should recursively install dependencies', async () => {
+    const mockClient = {
+      findComponent: vi.fn().mockImplementation((name) => {
+        if (name === 'test-component') return Promise.resolve(mockComponent);
+        if (name === 'child-component') return Promise.resolve(mockChildComponent);
+        return Promise.resolve(null);
+      }),
+    } as any;
+
+    await installComponent(mockRootDir, 'test-component', { install: true, client: mockClient });
+
+    // Verify both components fetched
+    expect(mockClient.findComponent).toHaveBeenCalledWith('test-component', 'react');
+    expect(mockClient.findComponent).toHaveBeenCalledWith('child-component', 'react');
+
+    // Verify both files written
+    const targetDir = path.resolve(mockRootDir, 'src/components/helios');
+    expect(fs.writeFileSync).toHaveBeenCalledWith(path.join(targetDir, 'TestComponent.tsx'), expect.any(String));
+    expect(fs.writeFileSync).toHaveBeenCalledWith(path.join(targetDir, 'ChildComponent.tsx'), expect.any(String));
+
+    // Verify config update includes both
+    expect(saveConfig).toHaveBeenCalledWith(expect.objectContaining({
+      components: expect.arrayContaining(['child-component', 'test-component']),
+    }), mockRootDir);
+  });
+
+  it('should skip existing files if overwrite is false', async () => {
+     const mockClient = {
+      findComponent: vi.fn().mockResolvedValue(mockComponent),
+    } as any;
+
+    // Simulate file exists
+    (fs.existsSync as any).mockReturnValue(true);
+
+    await installComponent(mockRootDir, 'test-component', { install: true, overwrite: false, client: mockClient });
+
+    // Should verify it exists (mocked above) but NOT write
+    // Note: The implementation checks fs.existsSync(filePath).
+    // If it returns true and !overwrite, it skips write.
+    // However, mkdirSync might still be called, which is fine.
+
+    // We check that writeFileSync was NOT called for the component file
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should overwrite existing files if overwrite is true', async () => {
+     const mockClient = {
+      findComponent: vi.fn().mockResolvedValue(mockComponent),
+    } as any;
+
+    // Simulate file exists
+    (fs.existsSync as any).mockReturnValue(true);
+
+    await installComponent(mockRootDir, 'test-component', { install: true, overwrite: true, client: mockClient });
+
+    expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('should install npm dependencies', async () => {
+    const mockClient = {
+      findComponent: vi.fn().mockResolvedValue(mockComponent),
+    } as any;
+
+    // Mock package.json reading to return empty deps
+    (fs.readFileSync as any).mockReturnValue('{}');
+
+    await installComponent(mockRootDir, 'test-component', { install: true, client: mockClient });
+
+    expect(installPackage).toHaveBeenCalledWith(
+      mockRootDir,
+      ['react@^18.0.0']
+    );
+  });
+
+  it('should not install npm dependencies if options.install is false', async () => {
+    const mockClient = {
+      findComponent: vi.fn().mockResolvedValue(mockComponent),
+    } as any;
+
+    (fs.readFileSync as any).mockReturnValue('{}');
+
+    await installComponent(mockRootDir, 'test-component', { install: false, client: mockClient });
+
+    expect(installPackage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Implemented unit tests for `installComponent` in `packages/cli/src/utils/__tests__/install.test.ts`. 
Verified:
- Successful component installation (file writes, config updates).
- Recursive dependency resolution.
- File conflict handling (overwrite vs skip).
- NPM dependency installation.
- Error handling for missing config.

This addresses the need for increased test coverage in the CLI package following the implementation of registry authentication.

---
*PR created automatically by Jules for task [3731155888597330324](https://jules.google.com/task/3731155888597330324) started by @BintzGavin*