### PR TITLE
📋 PLAYER: Plan for Video Audio Export Support

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -33,3 +33,7 @@
 ## [v0.76.4] - Strict Role Adherence
 **Learning:** Attempting to implement code as a Planner is a violation of protocol and leads to rejection. The Planner must strictly produce spec files (`.md`) and never modify source code (`.ts`).
 **Action:** Always verify the "Identity" and "Protocol" section of the prompt before starting any file modifications. If the goal is a "Plan", the output must be a Markdown file in `/.sys/plans/`.
+
+## [v0.76.6] - Comprehensive Asset Discovery
+**Learning:** `getAudioAssets` only scanned for `<audio>` elements, causing `<video>` audio to be missing from client-side export and audio controls. This gap persisted despite previous partial fixes.
+**Action:** When implementing asset discovery for media features, always include both `audio` and `video` tags unless explicitly restricted.

--- a/.sys/plans/2026-02-16-PLAYER-VideoAudioExport.md
+++ b/.sys/plans/2026-02-16-PLAYER-VideoAudioExport.md
@@ -1,0 +1,34 @@
+# 2026-02-16-PLAYER-VideoAudioExport.md
+
+#### 1. Context & Goal
+- **Objective**: Update `getAudioAssets` to include `<video>` elements in audio asset discovery, enabling audio control and export for video sources.
+- **Trigger**: Vision Gap - `<video>` elements are currently ignored by the audio asset discovery logic, causing missing audio in client-side exports and missing controls in the Audio Menu.
+- **Impact**: Enables users to export compositions with video sound and control individual video track volumes via the player UI.
+
+#### 2. File Inventory
+- **Modify**:
+  - `packages/player/src/features/audio-utils.ts`: Update `getAudioAssets` query selector to include `video`.
+  - `packages/player/src/features/audio-utils.test.ts`: Add test cases for `<video>` element discovery.
+- **Read-Only**: `packages/player/src/features/exporter.ts` (consumer), `packages/player/src/features/audio-fader.ts` (reference).
+
+#### 3. Implementation Spec
+- **Architecture**: Extend the existing DOM query in `getAudioAssets` to select `audio, video` instead of just `audio`.
+- **Pseudo-Code**:
+  ```typescript
+  // In getAudioAssets
+  const elements = Array.from(doc.querySelectorAll('audio, video'));
+  // Iterate and extract attributes (src, volume, muted, loop, etc.)
+  // Reuse existing logic for ID generation and state merging
+  ```
+- **Public API Changes**: None (internal logic update).
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: Run `npm run test -w packages/player` to ensure `getAudioAssets` tests pass, including new video test cases.
+- **Success Criteria**:
+  - `getAudioAssets` returns assets for `<video>` elements.
+  - Video assets respect `data-helios-track-id`, `volume`, `muted`, and other attributes.
+- **Edge Cases**:
+  - Video without `src`.
+  - Video with `muted` attribute (should result in `muted: true`).
+  - Video with `volume` attribute vs property.


### PR DESCRIPTION
Created `.sys/plans/2026-02-16-PLAYER-VideoAudioExport.md` detailing the implementation of video element support in `getAudioAssets`.
This plan aims to fix the issue where client-side exports lack audio from video elements, and video tracks are missing from the player's audio menu.

---
*PR created automatically by Jules for task [7655104935384129485](https://jules.google.com/task/7655104935384129485) started by @BintzGavin*