### PR TITLE
feat(studio): Implement folder management in Assets Panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10186,7 +10186,7 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.27.0",
+      "version": "0.28.1",
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/packages/studio/src/components/AssetsPanel/AssetsPanel.tsx
+++ b/packages/studio/src/components/AssetsPanel/AssetsPanel.tsx
@@ -5,7 +5,7 @@ import { FolderItem } from './FolderItem';
 import './AssetsPanel.css';
 
 export const AssetsPanel: React.FC = () => {
-  const { assets, uploadAsset } = useStudio();
+  const { assets, uploadAsset, createFolder } = useStudio();
   const [isDragging, setIsDragging] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [filterType, setFilterType] = useState<Asset['type'] | 'all'>('all');
@@ -40,6 +40,13 @@ export const AssetsPanel: React.FC = () => {
 
   const handleUploadClick = () => {
       fileInputRef.current?.click();
+  };
+
+  const handleCreateFolder = async () => {
+      const name = window.prompt('Enter folder name:');
+      if (name) {
+          await createFolder(name, currentPath);
+      }
   };
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -81,10 +88,14 @@ export const AssetsPanel: React.FC = () => {
         if (parts.length > 1) {
             // It's in a subfolder
             folders.add(parts[0]);
-        } else {
-            // It's a file in this folder
-            if (filterType === 'all' || asset.type === filterType) {
-                files.push(asset);
+        } else if (parts.length === 1 && parts[0] !== '') {
+            if (asset.type === 'folder') {
+                folders.add(parts[0]);
+            } else {
+                // It's a file in this folder
+                if (filterType === 'all' || asset.type === filterType) {
+                    files.push(asset);
+                }
             }
         }
     });
@@ -131,7 +142,14 @@ export const AssetsPanel: React.FC = () => {
                 className="assets-upload-btn"
                 onClick={handleUploadClick}
              >
-                Upload to {currentPath ? currentPath : 'Root'}
+                Upload
+             </button>
+             <button
+                className="assets-upload-btn"
+                onClick={handleCreateFolder}
+                style={{ marginLeft: '8px' }}
+             >
+                New Folder
              </button>
          </div>
 

--- a/packages/studio/src/server/plugin.ts
+++ b/packages/studio/src/server/plugin.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { createMcpServer } from './mcp';
-import { findCompositions, findAssets, getProjectRoot, createComposition, deleteComposition, updateCompositionMetadata, duplicateComposition, renameComposition, renameAsset } from './discovery';
+import { findCompositions, findAssets, getProjectRoot, createComposition, deleteComposition, updateCompositionMetadata, duplicateComposition, renameComposition, renameAsset, createDirectory } from './discovery';
 import { templates } from './templates';
 import { findDocumentation, resolveDocumentationPath } from './documentation';
 import { startRender, getRenderJobSpec, getJob, getJobs, cancelJob, deleteJob, diagnoseServer } from './render-manager';
@@ -617,6 +617,29 @@ function configureMiddlewares(server: ViteDevServer | PreviewServer, isPreview: 
             }
             return;
           }
+        }
+
+        // POST: Create Directory
+        if (req.url === '/mkdir' && req.method === 'POST') {
+           try {
+             const body = await getBody(req);
+             const { path: dirPath } = body;
+
+             if (!dirPath) {
+               res.statusCode = 400;
+               res.end(JSON.stringify({ error: 'Path is required' }));
+               return;
+             }
+
+             const newDir = createDirectory(process.cwd(), dirPath);
+             res.setHeader('Content-Type', 'application/json');
+             res.end(JSON.stringify(newDir));
+           } catch (e: any) {
+             console.error(e);
+             res.statusCode = 500;
+             res.end(JSON.stringify({ error: e.message }));
+           }
+           return;
         }
 
         // POST: Upload asset


### PR DESCRIPTION
Implemented functionality to create and view folders in the Studio Assets Panel. This includes backend changes to discovery.ts to scan and create directories, a new /api/assets/mkdir endpoint, and UI updates to display empty folders and a "New Folder" button.Verified with backend script and Playwright frontend test.

---
*PR created automatically by Jules for task [13625516269094035377](https://jules.google.com/task/13625516269094035377) started by @BintzGavin*