### PR TITLE
CLI: Replace degit with giget for example initialization

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -39,6 +39,7 @@ packages/studio/
 The Studio is launched via the `helios` CLI (from `@helios-project/cli`).
 
 - `helios studio [dir]`: Opens the Studio UI for the specified directory (defaults to CWD).
+- `helios init --example [name]`: Scaffolds a project from an example repository using `giget` (replacing `degit`).
 - `helios build`: Builds a production-ready player harness.
 - `helios preview`: Serves the production build locally.
 - `helios remove`: Removes a component from the project configuration and deletes associated files (interactive).
@@ -63,8 +64,9 @@ The Studio is launched via the `helios` CLI (from `@helios-project/cli`).
 - **Renderer**: Uses `RenderOrchestrator` for planning and executing renders.
 - **CLI**: The Studio backend exposes endpoints that the CLI can leverage (e.g., for `helios render` with HMR support, though currently CLI uses Renderer directly).
 
-## F. Recent Changes (v0.112.0)
+## F. Recent Changes (v0.113.1)
+- **Completed: CLI Init Examples Fix**: Replaced `degit` with `giget` in `helios init --example` to ensure reliable template downloading and added comprehensive tests.
+- **Completed: CLI Components Command Enhanced**: Verified implementation of `helios components` command with comprehensive unit tests and updated Studio documentation.
 - **Completed: CLI Registry Filtering**: Updated `RegistryClient` to support cross-framework component sharing by allowing `vanilla` components to be discovered and installed in framework-specific projects.
 - **Completed: CLI Registry Auth**: Enabled authentication for private component registries via environment variable `HELIOS_REGISTRY_TOKEN`.
 - **Completed: Distributed Rendering Example**: Created `examples/distributed-rendering` demonstrating the workflow for generating and executing distributed render jobs.
-- **Verified: CLI Diff Command**: Verified implementation of `helios diff` command and updated documentation in Studio README.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,15 @@
+## STUDIO v0.113.1
+- ✅ Completed: CLI Init Examples Fix - Replaced `degit` with `giget` in `helios init --example` to ensure reliable template downloading and added comprehensive tests.
+
+## STUDIO v0.113.0
+- ✅ Completed: CLI Components Command Enhanced - Verified implementation of `helios components` command with comprehensive unit tests and updated Studio documentation.
+
+## STUDIO v0.112.0
+- ✅ Completed: CLI Registry Filtering - Updated `RegistryClient` to support cross-framework component sharing by allowing `vanilla` components to be discovered and installed in framework-specific projects.
+
+## STUDIO v0.111.0
+- ✅ Completed: CLI Registry Auth - Enabled authentication for private component registries via environment variable `HELIOS_REGISTRY_TOKEN`.
+
 ## STUDIO v0.110.0
 - ✅ Completed: Distributed Rendering Example - Created `examples/distributed-rendering` demonstrating the workflow for generating and executing distributed render jobs.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.28.2
+**Version**: 0.28.3
 
 ## Current State
 
@@ -81,3 +81,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.28.0] ✅ Enhance Components Command - Updated `helios components` to support search queries and framework/all filtering, displaying component descriptions in the output.
 [v0.28.1] ✅ Verify Components Command - Verified implementation of enhanced `helios components` command with search queries and framework filtering, confirming functionality matches documentation.
 [v0.28.2] ✅ Registry Filtering - Verified `RegistryClient` cross-framework component sharing logic and consolidated test files.
+[v0.28.3] ✅ Init Examples Fix - Replaced `degit` with `giget` in `helios init --example` to ensure reliable template downloading.

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.113.0
+**Version**: 0.113.1
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -9,8 +9,8 @@
 **Focus**: UI Implementation & CLI
 
 ## Recent Updates
+- [v0.113.1] ✅ Completed: CLI Init Examples Fix - Replaced `degit` with `giget` in `helios init --example` to ensure reliable template downloading and added comprehensive tests.
 - [v0.113.0] ✅ Completed: CLI Components Command Enhanced - Verified implementation of `helios components` command with comprehensive unit tests and updated Studio documentation.
-- [v0.112.0] ✅ Completed: CLI Registry Filtering - Updated `RegistryClient` to support cross-framework component sharing by allowing `vanilla` components to be discovered and installed in framework-specific projects.
 - [v0.111.0] ✅ Completed: CLI Registry Auth - Enabled authentication for private component registries via environment variable `HELIOS_REGISTRY_TOKEN`.
 - [v0.110.0] ✅ Completed: Distributed Rendering Example - Created `examples/distributed-rendering` demonstrating the workflow for generating and executing distributed render jobs.
 - [v0.109.0] ✅ Verified: CLI Diff Command - Verified implementation of `helios diff` command and updated documentation in Studio README.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2986,13 +2986,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/degit": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/@types/degit/-/degit-2.8.6.tgz",
-      "integrity": "sha512-y0M7sqzsnHB6cvAeTCBPrCQNQiZe8U4qdzf8uBVmOWYap5MMTN/gB2iEqrIqFiYcsyvP74GnGD5tgsHttielFw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/diff": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
@@ -4952,18 +4945,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/degit": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.4.tgz",
-      "integrity": "sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng==",
-      "license": "MIT",
-      "bin": {
-        "degit": "degit"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -5767,6 +5748,15 @@
       "license": "MIT",
       "dependencies": {
         "js-binary-schema-parser": "^2.0.3"
+      }
+    },
+    "node_modules/giget": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.1.2.tgz",
+      "integrity": "sha512-T2qUpKBHeUTwHcIhydgnJzhL0Hj785ms+JkxaaWQH9SDM/llXeewnOkfJcFShAHjWI+26hOChwUfCoupaXLm8g==",
+      "license": "MIT",
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/glob-parent": {
@@ -10186,7 +10176,7 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -10194,8 +10184,8 @@
         "@helios-project/studio": "^0.107.1",
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
-        "degit": "^2.8.4",
         "diff": "^8.0.3",
+        "giget": "^3.1.2",
         "prompts": "^2.4.2",
         "vite": "^7.1.2"
       },
@@ -10203,7 +10193,6 @@
         "helios": "bin/helios.js"
       },
       "devDependencies": {
-        "@types/degit": "^2.8.6",
         "@types/diff": "^7.0.2",
         "@types/prompts": "^2.4.9",
         "typescript": "^5.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/cli",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "CLI for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",
@@ -43,13 +43,12 @@
     "@helios-project/studio": "^0.107.1",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
-    "degit": "^2.8.4",
     "diff": "^8.0.3",
+    "giget": "^3.1.2",
     "prompts": "^2.4.2",
     "vite": "^7.1.2"
   },
   "devDependencies": {
-    "@types/degit": "^2.8.6",
     "@types/diff": "^7.0.2",
     "@types/prompts": "^2.4.9",
     "typescript": "^5.0.0",

--- a/packages/cli/src/utils/__tests__/examples.test.ts
+++ b/packages/cli/src/utils/__tests__/examples.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+import { fetchExamples, downloadExample, transformProject } from '../examples';
+import { downloadTemplate } from 'giget';
+
+// Mock giget
+vi.mock('giget', () => ({
+  downloadTemplate: vi.fn(),
+}));
+
+// Mock fs
+vi.mock('fs');
+
+describe('fetchExamples', () => {
+  const repoPath = 'owner/repo/examples';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should return list of example names', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => [
+        { name: 'example1', type: 'dir' },
+        { name: 'example2', type: 'dir' },
+        { name: 'file1', type: 'file' },
+      ],
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+    const result = await fetchExamples(repoPath);
+    expect(result).toEqual(['example1', 'example2']);
+    expect(fetch).toHaveBeenCalledWith('https://api.github.com/repos/owner/repo/contents/examples');
+  });
+
+  it('should return empty list on fetch error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+    const result = await fetchExamples(repoPath);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty list on non-ok response', async () => {
+     const mockResponse = {
+      ok: false,
+      statusText: 'Not Found',
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+    const result = await fetchExamples(repoPath);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('downloadExample', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should call downloadTemplate with correct arguments', async () => {
+    const name = 'example1';
+    const targetDir = '/target';
+    const repoBase = 'owner/repo/examples';
+
+    await downloadExample(name, targetDir, repoBase);
+
+    expect(downloadTemplate).toHaveBeenCalledWith('github:owner/repo/examples/example1', {
+      dir: targetDir,
+      force: true,
+    });
+  });
+
+  it('should handle repoBase ending with slash', async () => {
+    const name = 'example1';
+    const targetDir = '/target';
+    const repoBase = 'owner/repo/examples/';
+
+    await downloadExample(name, targetDir, repoBase);
+
+    expect(downloadTemplate).toHaveBeenCalledWith('github:owner/repo/examples/example1', {
+      dir: targetDir,
+      force: true,
+    });
+  });
+
+   it('should handle github: prefix', async () => {
+    const name = 'example1';
+    const targetDir = '/target';
+    const repoBase = 'github:owner/repo/examples';
+
+    await downloadExample(name, targetDir, repoBase);
+
+    expect(downloadTemplate).toHaveBeenCalledWith('github:owner/repo/examples/example1', {
+      dir: targetDir,
+      force: true,
+    });
+  });
+
+  it('should throw error if downloadTemplate fails', async () => {
+    (downloadTemplate as any).mockRejectedValue(new Error('Download failed'));
+
+    await expect(downloadExample('example1', '/target', 'owner/repo/examples'))
+      .rejects.toThrow('Failed to download example');
+  });
+});
+
+describe('transformProject', () => {
+  const targetDir = '/mock/target';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (fs.existsSync as any).mockReturnValue(true);
+    (fs.writeFileSync as any).mockImplementation(() => {});
+  });
+
+  it('should transform package.json dependencies', () => {
+    const pkgContent = JSON.stringify({
+      dependencies: {
+        '@helios-project/core': 'file:../../packages/core',
+        'react': '^18.0.0',
+      },
+    });
+    (fs.readFileSync as any).mockReturnValue(pkgContent);
+
+    transformProject(targetDir);
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      path.join(targetDir, 'package.json'),
+      expect.stringContaining('"@helios-project/core": "latest"')
+    );
+  });
+
+  it('should transform vite.config.ts', () => {
+    const viteContent = `
+import { defineConfig, searchForWorkspaceRoot } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  server: {
+    fs: {
+      allow: [searchForWorkspaceRoot(process.cwd())],
+    },
+  },
+  resolve: {
+    alias: {
+      '@helios-project/core': resolve(__dirname, '../../packages/core'),
+    },
+  },
+});
+    `;
+    (fs.readFileSync as any).mockImplementation((p: string) => {
+        if (p.endsWith('package.json')) return '{}';
+        if (p.endsWith('vite.config.ts')) return viteContent;
+        return '';
+    });
+
+    transformProject(targetDir);
+
+    // Verify searchForWorkspaceRoot is removed
+    const call = (fs.writeFileSync as any).mock.calls.find((call: any) => call[0].endsWith('vite.config.ts'));
+    const writtenContent = call[1];
+
+    expect(writtenContent).not.toContain('searchForWorkspaceRoot');
+    expect(writtenContent).not.toContain("'@helios-project/core':");
+  });
+});

--- a/packages/cli/src/utils/examples.ts
+++ b/packages/cli/src/utils/examples.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import degit from 'degit';
+import { downloadTemplate } from 'giget';
 import chalk from 'chalk';
 
 export async function fetchExamples(repoPath: string = 'BintzGavin/helios/examples'): Promise<string[]> {
@@ -41,15 +41,22 @@ export async function fetchExamples(repoPath: string = 'BintzGavin/helios/exampl
 export async function downloadExample(name: string, targetDir: string, repoBase: string = 'BintzGavin/helios/examples'): Promise<void> {
   // Ensure no double slashes if repoBase ends with /
   const base = repoBase.endsWith('/') ? repoBase.slice(0, -1) : repoBase;
-  const src = `${base}/${name}`;
 
-  const emitter = degit(src, {
-    cache: false,
-    force: true,
-    verbose: false,
-  });
+  // Construct giget source string
+  // giget expects input like "github:owner/repo/subdir" or "owner/repo/subdir" (defaults to github)
+  let source = `${base}/${name}`;
+  if (!source.includes(':')) {
+    source = `github:${source}`;
+  }
 
-  await emitter.clone(targetDir);
+  try {
+    await downloadTemplate(source, {
+      dir: targetDir,
+      force: true,
+    });
+  } catch (error) {
+    throw new Error(`Failed to download example '${name}' from '${source}': ${(error as Error).message}`);
+  }
 }
 
 export function transformProject(targetDir: string) {


### PR DESCRIPTION
Replaced the unmaintained `degit` library with `giget` for the `helios init --example` command. This ensures better reliability and support for various git providers. Added unit tests for the example fetching and downloading logic, including project transformation utilities. Updated documentation and version numbers accordingly.

---
*PR created automatically by Jules for task [12545421548278690821](https://jules.google.com/task/12545421548278690821) started by @BintzGavin*