### PR TITLE
CLI: Plan Framework Override for Add Command

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -52,7 +52,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 
 ## [0.12.0] - Registry Lifecycle Gap
 **Learning:** While `helios add` and `helios list` existed, the CLI lacked a `helios remove` command, leading to potential state drift between `helios.config.json` and the file system. Users had to manually edit config files to unregister components.
-**Action:** When implementing CRUD workflows (like Registry management), always ensure the full lifecycle (Create, Read, Update, Delete) is supported to prevent orphaned state.
+**Action:** When implementing CRUD workflows (like Registry management), always implement the full lifecycle (Create, Read, Update, Delete) to prevent orphaned state.
 
 ## [0.15.0] - Distributed Orchestration Decoupling
 **Learning:** The "Distributed Rendering" vision requires a separation of "Planning" (job splitting) and "Execution" (rendering). The `RenderOrchestrator` in `packages/renderer` tightly couples them (calculating chunks and immediately spawning workers). This blocks external/cloud orchestration.
@@ -93,3 +93,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.28.0] - Status Drift
 **Learning:** `docs/status/CLI.md` claimed v0.28.0 features ("Enhance Components Command") were implemented, but the code was missing and `package.json` was v0.27.0.
 **Action:** When status files claim features, verify the code (`src/` and `package.json`) before assuming they exist. Status files are not truth; code is truth.
+
+## [0.28.3] - Role Constraints
+**Learning:** The Planner role is strictly limited to creating Markdown specifications in `/.sys/plans/` and must never modify source code. Attempting to implement the plan directly violates the role's constraints and leads to task failure.
+**Action:** Always verify the "IDENTITY" and "Boundaries" sections of the prompt before starting work. If assigned as a Planner, produce only the plan file.

--- a/.sys/plans/2026-02-20-CLI-add-framework-override.md
+++ b/.sys/plans/2026-02-20-CLI-add-framework-override.md
@@ -1,0 +1,46 @@
+#### 1. Context & Goal
+- **Objective**: Add a `-f, --framework <name>` flag to the `helios add` command to allow installing components from frameworks other than the project's default.
+- **Trigger**: The current implementation strictly enforces the project's configured framework, preventing users from installing utility components (e.g., 'vanilla') or experimenting with cross-framework components.
+- **Impact**: Enables greater flexibility in component usage, allowing users to mix and match or manually override framework detection when needed, aligning with the "Shadcn-style" registry vision where users own the code.
+
+#### 2. File Inventory
+- **Create**: None.
+- **Modify**:
+    - `packages/cli/src/commands/add.ts`: Add CLI option and pass to install function.
+    - `packages/cli/src/utils/install.ts`: Update `installComponent` to accept and prioritize the framework override.
+    - `packages/cli/src/utils/__tests__/install.test.ts`: Add test cases for framework override.
+- **Read-Only**: `packages/cli/src/registry/client.ts` (reference).
+
+#### 3. Implementation Spec
+- **Architecture**:
+    - Update `add` command definition in Commander to accept `-f, --framework <name>`.
+    - Pass this value to `installComponent` options.
+    - In `installComponent`, prioritize `options.framework` over `config.framework` when resolving the component tree.
+- **Pseudo-Code**:
+    - **`packages/cli/src/commands/add.ts`**:
+      ```typescript
+      program.command('add <component>')
+        .option('-f, --framework <name>', 'Override project framework')
+        .action(async (name, options) => {
+           // ...
+           await installComponent(..., { ..., framework: options.framework });
+        });
+      ```
+    - **`packages/cli/src/utils/install.ts`**:
+      ```typescript
+      export async function installComponent(..., options: { ..., framework?: string }) {
+         // ...
+         const framework = options.framework || config.framework;
+         const componentsToInstall = await resolveComponentTree(client, componentName, framework);
+         // ...
+      }
+      ```
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**:
+    - Run `npm test -w packages/cli` to verify existing and new tests pass.
+    - Create a new test case in `install.test.ts` that mocks `loadConfig` with `framework: 'react'` but calls `installComponent` with `framework: 'svelte'`, verifying that `RegistryClient.findComponent` is called with `'svelte'`.
+- **Success Criteria**:
+    - `helios add <component> --framework <name>` correctly requests the specified framework version from the registry.
+    - Existing behavior (defaulting to config) is preserved when flag is omitted.


### PR DESCRIPTION
Identified a gap in the CLI where `helios add` strictly enforces the project's configured framework. Created a detailed specification to add a `--framework` override flag, enhancing flexibility and aligning with the V2 vision of a Shadcn-style registry.

Also updated the CLI journal with a critical learning regarding the Planner agent's constraints.

---
*PR created automatically by Jules for task [4916673854585544634](https://jules.google.com/task/4916673854585544634) started by @BintzGavin*