### PR TITLE
docs: add recommended skills quickstart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ https://github.com/user-attachments/assets/89ee2a20-77c5-4440-ad68-9f9180d969bd
 
 ---
 
+## ⚡️ Recommended Quickstart: Helios Skills
+
+**The fastest way to get started.** With one prompt into OpenCode, Cursor, Antigravity, or Claude, you can generate 6 professional video types:
+
+**1 prompt →**
+• Launch announcement
+• Promo
+• Explainer
+• Product demo
+• Testimonial
+• Social cut
+
+Paste this into an existing repo (preferably your marketing site):
+
+```bash
+npx skills add BintzGavin/helios-skills
+```
+
+Then follow the skills instructions and generate one video of each guided type.
+
+---
+
 ## Quick Start
 
 ### Installation


### PR DESCRIPTION
Added a new section "Recommended Quickstart: Helios Skills" to `README.md` immediately before the existing "Quick Start" section.
This section promotes using `npx skills add BintzGavin/helios-skills` and AI agents (OpenCode, Cursor, etc.) to generate 6 types of videos with a single prompt.
This addresses the user request to highlight "skills" as the faster way to quickstart.

---
*PR created automatically by Jules for task [10079561253544757878](https://jules.google.com/task/10079561253544757878) started by @BintzGavin*