### PR TITLE
✨ PLAYER: Add unit tests for CaptureFrame resizing

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -70,7 +70,14 @@ The `<helios-player>` observes the following attributes:
 - `sandbox`: Configures iframe sandbox flags (default: `allow-scripts allow-same-origin`).
 - `controlslist`: Allows hiding specific controls (`nodownload`, `nofullscreen`).
 - `disablepictureinpicture`: Boolean attribute to disable the PiP button.
+- `interactive`: Boolean attribute to enable interactive mode (prevents click-to-pause).
 - `input-props`: JSON string of properties to pass to the composition.
+
+### Media Session Attributes
+- `media-title`: Title of the media for OS integration.
+- `media-artist`: Artist of the media for OS integration.
+- `media-album`: Album of the media for OS integration.
+- `media-artwork`: URL of the artwork for OS integration.
 
 ### Export Attributes
 - `export-mode`: Controls export behavior (`auto`, `canvas`, `dom`).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### PLAYER v0.76.8
+- ✅ Verified: Bridge Capture Resizing - Added specific unit tests for handleCaptureFrame in bridge.ts to verify resizing logic and error handling, complementing existing DirectController tests.
+
 ### PLAYER v0.76.7
 - ✅ Verified: Integrity Check - Ran full test suite (321 tests passed) and manually confirmed CaptureFrame resizing implementation in controllers.ts and bridge.ts matches the plan.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.76.7
+**Version**: v0.76.8
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -60,6 +60,7 @@
 - **Export API**: Exposes public `export()` method for programmatic control over client-side exports, supporting Video (MP4/WebM) and Snapshot (PNG/JPEG) formats.
 - **Export Menu**: Implements a dedicated Export Menu in the player UI (replacing the direct export button action) to allow configuring format, resolution, filename, and captions before exporting or taking a snapshot.
 
+[v0.76.8] ✅ Verified: Bridge Capture Resizing - Added specific unit tests for handleCaptureFrame in bridge.ts to verify resizing logic and error handling, complementing existing DirectController tests.
 [v0.76.7] ✅ Verified: Integrity Check - Ran full test suite (321 tests passed) and manually confirmed CaptureFrame resizing implementation in controllers.ts and bridge.ts matches the plan.
 [v0.76.6] ✅ Verified: Fix CaptureFrame Resizing - Added comprehensive unit tests for OffscreenCanvas resizing logic in DirectController, verifying correct behavior when width/height options are provided.
 [v0.76.5] ✅ Completed: Fix CaptureFrame Resizing - Updated DirectController and BridgeController to correctly resize canvas captures when width/height options are provided.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10176,7 +10176,7 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.28.2",
+      "version": "0.28.3",
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -10219,7 +10219,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.76.6",
+      "version": "0.76.7",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^5.13.0",

--- a/packages/player/src/bridge_capture.test.ts
+++ b/packages/player/src/bridge_capture.test.ts
@@ -1,0 +1,280 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { connectToParent } from './bridge';
+
+// Mock AudioFader
+vi.mock('./features/audio-fader', () => ({
+    AudioFader: class {
+        connect = vi.fn();
+        enable = vi.fn();
+        disable = vi.fn();
+        dispose = vi.fn();
+    }
+}));
+
+// Mock Helios
+vi.mock('@helios-project/core', () => {
+    return {
+        Helios: vi.fn()
+    };
+});
+
+// Mock dom-capture
+vi.mock('./features/dom-capture', () => ({
+    captureDomToBitmap: vi.fn()
+}));
+
+// Mock audio-utils
+vi.mock('./features/audio-utils', () => ({
+    getAudioAssets: vi.fn()
+}));
+
+describe('connectToParent - handleCaptureFrame', () => {
+    let mockHelios: any;
+    let messageHandlers: ((ev: MessageEvent) => void)[] = [];
+    let parentPostMessage: any;
+    let mockCanvas: HTMLCanvasElement;
+    let mockContext: any;
+    let mockOffscreenCanvas: any;
+    let originalOffscreenCanvas: any;
+    let originalCreateImageBitmap: any;
+
+    beforeEach(() => {
+        messageHandlers = [];
+        mockHelios = {
+            play: vi.fn(),
+            pause: vi.fn(),
+            seek: vi.fn(),
+            setPlaybackRate: vi.fn(),
+            setPlaybackRange: vi.fn(),
+            clearPlaybackRange: vi.fn(),
+            setAudioVolume: vi.fn(),
+            setAudioMuted: vi.fn(),
+            setLoop: vi.fn(),
+            setInputProps: vi.fn(),
+            setCaptions: vi.fn(),
+            setDuration: vi.fn(),
+            setFps: vi.fn(),
+            setSize: vi.fn(),
+            setMarkers: vi.fn(),
+            getState: vi.fn().mockReturnValue({ activeCaptions: [] }),
+            subscribe: vi.fn(),
+            schema: {}
+        };
+
+        // Mock window.addEventListener
+        vi.spyOn(window, 'addEventListener').mockImplementation((event, handler) => {
+            if (event === 'message') {
+                messageHandlers.push(handler as any);
+            }
+        });
+
+        // Mock window.parent
+        parentPostMessage = vi.fn();
+        Object.defineProperty(window, 'parent', {
+            value: {
+                postMessage: parentPostMessage
+            },
+            writable: true
+        });
+
+        // Mock document.querySelector
+        mockCanvas = document.createElement('canvas');
+        mockCanvas.width = 1920;
+        mockCanvas.height = 1080;
+        vi.spyOn(document, 'querySelector').mockReturnValue(mockCanvas);
+
+        // Mock requestAnimationFrame
+        vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+            cb(0);
+            return 1;
+        });
+
+        // Mock OffscreenCanvas
+        originalOffscreenCanvas = global.OffscreenCanvas;
+        mockOffscreenCanvas = {
+            getContext: vi.fn().mockReturnValue({
+                drawImage: vi.fn()
+            })
+        };
+        vi.stubGlobal('OffscreenCanvas', vi.fn(function(width, height) {
+            return mockOffscreenCanvas;
+        }));
+
+        // Mock createImageBitmap
+        originalCreateImageBitmap = global.createImageBitmap;
+        vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue({} as ImageBitmap));
+
+        // Connect the bridge
+        connectToParent(mockHelios);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (originalOffscreenCanvas) {
+            vi.stubGlobal('OffscreenCanvas', originalOffscreenCanvas);
+        } else {
+            vi.stubGlobal('OffscreenCanvas', undefined);
+        }
+        if (originalCreateImageBitmap) {
+            vi.stubGlobal('createImageBitmap', originalCreateImageBitmap);
+        } else {
+            vi.stubGlobal('createImageBitmap', undefined);
+        }
+    });
+
+    const triggerMessage = (data: any, source: any = window.parent) => {
+        const event = new MessageEvent('message', { data, source });
+        messageHandlers.forEach(h => h(event));
+    };
+
+    it('should capture frame without resizing (using original canvas)', async () => {
+        triggerMessage({
+            type: 'HELIOS_CAPTURE_FRAME',
+            frame: 10,
+            mode: 'canvas',
+            selector: 'canvas'
+        });
+
+        // Wait for async operations
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(mockHelios.seek).toHaveBeenCalledWith(10);
+        // Should use canvas directly
+        expect(createImageBitmap).toHaveBeenCalledWith(mockCanvas);
+        expect(parentPostMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'HELIOS_FRAME_DATA',
+                frame: 10,
+                success: true
+            }),
+            '*',
+            expect.any(Array)
+        );
+    });
+
+    it('should capture frame with resizing (using OffscreenCanvas)', async () => {
+        const targetWidth = 1280;
+        const targetHeight = 720;
+
+        triggerMessage({
+            type: 'HELIOS_CAPTURE_FRAME',
+            frame: 10,
+            mode: 'canvas',
+            selector: 'canvas',
+            width: targetWidth,
+            height: targetHeight
+        });
+
+        // Wait for async operations
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(mockHelios.seek).toHaveBeenCalledWith(10);
+        expect(OffscreenCanvas).toHaveBeenCalledWith(targetWidth, targetHeight);
+        expect(mockOffscreenCanvas.getContext).toHaveBeenCalledWith('2d');
+        expect(mockOffscreenCanvas.getContext('2d').drawImage).toHaveBeenCalledWith(mockCanvas, 0, 0, targetWidth, targetHeight);
+
+        // Should use offscreen canvas as source
+        expect(createImageBitmap).toHaveBeenCalledWith(mockOffscreenCanvas);
+
+        expect(parentPostMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'HELIOS_FRAME_DATA',
+                frame: 10,
+                success: true
+            }),
+            '*',
+            expect.any(Array)
+        );
+    });
+
+    it('should capture frame with resizing (fallback when OffscreenCanvas missing)', async () => {
+        // Remove OffscreenCanvas
+        vi.stubGlobal('OffscreenCanvas', undefined);
+
+        const targetWidth = 1280;
+        const targetHeight = 720;
+
+        // Mock createElement for fallback canvas
+        const tempCanvas = document.createElement('canvas');
+        const tempContext = { drawImage: vi.fn() };
+        vi.spyOn(tempCanvas, 'getContext').mockReturnValue(tempContext as any);
+        vi.spyOn(document, 'createElement').mockReturnValue(tempCanvas as any);
+
+        triggerMessage({
+            type: 'HELIOS_CAPTURE_FRAME',
+            frame: 10,
+            mode: 'canvas',
+            selector: 'canvas',
+            width: targetWidth,
+            height: targetHeight
+        });
+
+        // Wait for async operations
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(mockHelios.seek).toHaveBeenCalledWith(10);
+        expect(document.createElement).toHaveBeenCalledWith('canvas');
+        expect(tempCanvas.width).toBe(targetWidth);
+        expect(tempCanvas.height).toBe(targetHeight);
+        expect(tempContext.drawImage).toHaveBeenCalledWith(mockCanvas, 0, 0, targetWidth, targetHeight);
+
+        // Should use temp canvas as source
+        expect(createImageBitmap).toHaveBeenCalledWith(tempCanvas);
+
+        expect(parentPostMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'HELIOS_FRAME_DATA',
+                frame: 10,
+                success: true
+            }),
+            '*',
+            expect.any(Array)
+        );
+    });
+
+    it('should handle canvas not found error', async () => {
+        vi.spyOn(document, 'querySelector').mockReturnValue(null);
+
+        triggerMessage({
+            type: 'HELIOS_CAPTURE_FRAME',
+            frame: 10,
+            mode: 'canvas',
+            selector: 'canvas'
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(parentPostMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'HELIOS_FRAME_DATA',
+                frame: 10,
+                success: false,
+                error: 'Canvas not found'
+            }),
+            '*'
+        );
+    });
+
+    it('should handle createImageBitmap error', async () => {
+        vi.mocked(createImageBitmap).mockRejectedValue(new Error('Bitmap Error'));
+
+        triggerMessage({
+            type: 'HELIOS_CAPTURE_FRAME',
+            frame: 10,
+            mode: 'canvas'
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(parentPostMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'HELIOS_FRAME_DATA',
+                frame: 10,
+                success: false,
+                error: 'Bitmap Error'
+            }),
+            '*'
+        );
+    });
+});


### PR DESCRIPTION
💡 What: Added a new unit test file `packages/player/src/bridge_capture.test.ts` to verify the `handleCaptureFrame` logic in `bridge.ts`.
🎯 Why: To ensure that the implementation of client-side export resizing (via `captureFrame`) works correctly in bridge mode, preventing regression and confirming that requested width/height parameters are respected.
📊 Impact: Increases test coverage for the player package and guarantees robust export behavior when scaling is applied.
🔬 Verification: Ran `npm test -w packages/player` and confirmed all 326 tests passed, including the 5 new tests.

---
*PR created automatically by Jules for task [9526344081116252035](https://jules.google.com/task/9526344081116252035) started by @BintzGavin*