### PR TITLE
✨ CLI: Implement Google Cloud Run Job deployment scaffold

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -43,7 +43,8 @@ packages/cli/
 │   │   ├── manifest.ts     # Local registry manifest
 │   │   └── types.ts        # Registry types
 │   ├── templates/          # Project templates
-│   │   └── docker.ts       # Docker templates
+│   │   ├── docker.ts       # Docker templates
+│   │   └── gcp.ts          # GCP templates
 │   ├── types/              # Shared types
 │   └── utils/
 │       ├── config.test.ts  # Config tests
@@ -81,6 +82,7 @@ packages/cli/
 - `helios preview`: Preview the production build.
 - `helios skills install`: Install agent skills.
 - `helios deploy setup`: Scaffold deployment configurations (Docker).
+- `helios deploy gcp`: Scaffold Google Cloud Run Job configuration.
 
 ## D. Configuration
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -11,7 +11,8 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] Support frame range rendering in CLI.
 - [x] Implement output stitching without re-encoding (verify `concat` demuxer workflow).
 - [x] Implement RenderExecutor abstraction for pluggable execution.
-- [ ] Cloud execution adapter (AWS Lambda / Google Cloud Run).
+- [x] Cloud execution adapter (Google Cloud Run).
+- [ ] Cloud execution adapter (AWS Lambda).
 
 
 ## Component Registry

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.30.0
+
+- ✅ Deploy GCP Command - Implemented `helios deploy gcp` to scaffold Google Cloud Run Job configuration and documentation.
+
 ## CLI v0.29.0
 
 - ✅ Deploy Command - Implemented `helios deploy setup` to scaffold Docker files and updated `helios render` to support environment variables for browser args.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.29.0
+**Version**: 0.30.0
 
 ## Current State
 
@@ -27,7 +27,7 @@ The Helios CLI (`packages/cli`) provides the command-line interface for the Heli
 - `helios skills` - Manages AI agent skills installation
 - `helios preview` - Previews the production build locally
 - `helios diff` - Compares local component code with the registry version
-- `helios deploy` - Scaffolds deployment configurations (e.g., Docker)
+- `helios deploy` - Scaffolds deployment configurations (e.g., Docker, Google Cloud Run)
 
 ## V2 Roadmap
 
@@ -84,3 +84,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.28.2] ✅ Registry Filtering - Verified `RegistryClient` cross-framework component sharing logic and consolidated test files.
 [v0.28.3] ✅ Init Examples Fix - Replaced `degit` with `giget` in `helios init --example` to ensure reliable template downloading.
 [v0.29.0] ✅ Deploy Command - Implemented `helios deploy setup` to scaffold Docker files and updated `helios render` to support environment variables for browser args.
+[v0.30.0] ✅ Deploy GCP Command - Implemented `helios deploy gcp` to scaffold Google Cloud Run Job configuration and documentation.

--- a/packages/cli/src/commands/__tests__/deploy.test.ts
+++ b/packages/cli/src/commands/__tests__/deploy.test.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import prompts from 'prompts';
 import { DOCKERFILE_TEMPLATE, DOCKER_COMPOSE_TEMPLATE } from '../../templates/docker.js';
+import { CLOUD_RUN_JOB_TEMPLATE, README_GCP_TEMPLATE } from '../../templates/gcp.js';
 
 // Mock fs and prompts
 vi.mock('fs');
@@ -30,88 +31,160 @@ describe('deploy command', () => {
     exitSpy.mockRestore();
   });
 
-  it('should create files when they do not exist', async () => {
-    // Mock fs.existsSync to return false (files don't exist)
-    vi.mocked(fs.existsSync).mockReturnValue(false);
+  describe('setup subcommand', () => {
+    it('should create files when they do not exist', async () => {
+      // Mock fs.existsSync to return false (files don't exist)
+      vi.mocked(fs.existsSync).mockReturnValue(false);
 
-    // Mock fs.writeFileSync
-    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      // Mock fs.writeFileSync
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
 
-    // Run command
-    await program.parseAsync(['node', 'test', 'deploy', 'setup']);
+      // Run command
+      await program.parseAsync(['node', 'test', 'deploy', 'setup']);
 
-    // Check if files were created
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
-      expect.stringContaining('Dockerfile'),
-      DOCKERFILE_TEMPLATE
-    );
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
-      expect.stringContaining('docker-compose.yml'),
-      DOCKER_COMPOSE_TEMPLATE
-    );
+      // Check if files were created
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('Dockerfile'),
+        DOCKERFILE_TEMPLATE
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('docker-compose.yml'),
+        DOCKER_COMPOSE_TEMPLATE
+      );
+    });
+
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      // Mock fs.existsSync to return true
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      // Mock prompts to return true
+      vi.mocked(prompts).mockResolvedValue({ value: true });
+
+      // Mock fs.writeFileSync
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      // Run command
+      await program.parseAsync(['node', 'test', 'deploy', 'setup']);
+
+      // Check prompts
+      expect(prompts).toHaveBeenCalledTimes(2);
+
+      // Check if files were overwritten
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('Dockerfile'),
+        DOCKERFILE_TEMPLATE
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('docker-compose.yml'),
+        DOCKER_COMPOSE_TEMPLATE
+      );
+    });
+
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      // Mock fs.existsSync to return true
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      // Mock prompts to return false
+      vi.mocked(prompts).mockResolvedValue({ value: false });
+
+      // Mock fs.writeFileSync
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      // Run command
+      await program.parseAsync(['node', 'test', 'deploy', 'setup']);
+
+      // Check prompts
+      expect(prompts).toHaveBeenCalledTimes(2);
+
+      // Check if files were NOT overwritten
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should handle cancellation (undefined value)', async () => {
+       // Mock fs.existsSync to return true
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      // Mock prompts to return undefined value (cancelled)
+      vi.mocked(prompts).mockResolvedValue({});
+
+      // Run command
+      await program.parseAsync(['node', 'test', 'deploy', 'setup']);
+
+      // Check if process.exit was called
+      expect(exitSpy).toHaveBeenCalledWith(0);
+
+      // Ensure no files written
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
   });
 
-  it('should prompt if files exist and overwrite if confirmed', async () => {
-    // Mock fs.existsSync to return true
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+  describe('gcp subcommand', () => {
+    it('should create GCP files when they do not exist', async () => {
+      // Mock fs.existsSync to return false
+      vi.mocked(fs.existsSync).mockReturnValue(false);
 
-    // Mock prompts to return true
-    vi.mocked(prompts).mockResolvedValue({ value: true });
+      // Mock fs.writeFileSync
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
 
-    // Mock fs.writeFileSync
-    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      // Run command
+      await program.parseAsync(['node', 'test', 'deploy', 'gcp']);
 
-    // Run command
-    await program.parseAsync(['node', 'test', 'deploy', 'setup']);
+      // Check if files were created
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('cloud-run-job.yaml'),
+        CLOUD_RUN_JOB_TEMPLATE
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('README-GCP.md'),
+        README_GCP_TEMPLATE
+      );
+    });
 
-    // Check prompts
-    expect(prompts).toHaveBeenCalledTimes(2);
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      // Mock fs.existsSync to return true
+      vi.mocked(fs.existsSync).mockReturnValue(true);
 
-    // Check if files were overwritten
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
-      expect.stringContaining('Dockerfile'),
-      DOCKERFILE_TEMPLATE
-    );
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
-      expect.stringContaining('docker-compose.yml'),
-      DOCKER_COMPOSE_TEMPLATE
-    );
-  });
+      // Mock prompts to return true
+      vi.mocked(prompts).mockResolvedValue({ value: true });
 
-  it('should prompt if files exist and NOT overwrite if declined', async () => {
-    // Mock fs.existsSync to return true
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+      // Mock fs.writeFileSync
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
 
-    // Mock prompts to return false
-    vi.mocked(prompts).mockResolvedValue({ value: false });
+      // Run command
+      await program.parseAsync(['node', 'test', 'deploy', 'gcp']);
 
-    // Mock fs.writeFileSync
-    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+      // Check prompts
+      expect(prompts).toHaveBeenCalledTimes(2);
 
-    // Run command
-    await program.parseAsync(['node', 'test', 'deploy', 'setup']);
+      // Check if files were overwritten
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('cloud-run-job.yaml'),
+        CLOUD_RUN_JOB_TEMPLATE
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('README-GCP.md'),
+        README_GCP_TEMPLATE
+      );
+    });
 
-    // Check prompts
-    expect(prompts).toHaveBeenCalledTimes(2);
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      // Mock fs.existsSync to return true
+      vi.mocked(fs.existsSync).mockReturnValue(true);
 
-    // Check if files were NOT overwritten
-    expect(fs.writeFileSync).not.toHaveBeenCalled();
-  });
+      // Mock prompts to return false
+      vi.mocked(prompts).mockResolvedValue({ value: false });
 
-  it('should handle cancellation (undefined value)', async () => {
-     // Mock fs.existsSync to return true
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+      // Mock fs.writeFileSync
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
 
-    // Mock prompts to return undefined value (cancelled)
-    vi.mocked(prompts).mockResolvedValue({});
+      // Run command
+      await program.parseAsync(['node', 'test', 'deploy', 'gcp']);
 
-    // Run command
-    await program.parseAsync(['node', 'test', 'deploy', 'setup']);
+      // Check prompts
+      expect(prompts).toHaveBeenCalledTimes(2);
 
-    // Check if process.exit was called
-    expect(exitSpy).toHaveBeenCalledWith(0);
-
-    // Ensure no files written
-    expect(fs.writeFileSync).not.toHaveBeenCalled();
+      // Check if files were NOT overwritten
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import prompts from 'prompts';
 import chalk from 'chalk';
 import { DOCKERFILE_TEMPLATE, DOCKER_COMPOSE_TEMPLATE } from '../templates/docker.js';
+import { CLOUD_RUN_JOB_TEMPLATE, README_GCP_TEMPLATE } from '../templates/gcp.js';
 
 export function registerDeployCommand(program: Command) {
   const deploy = program.command('deploy')
@@ -74,5 +75,69 @@ export function registerDeployCommand(program: Command) {
       console.log(chalk.blue('\nSetup complete!'));
       console.log('To run your project in Docker:');
       console.log(chalk.cyan('  docker-compose up --build'));
+    });
+
+  deploy
+    .command('gcp')
+    .description('Scaffold Google Cloud Run Job configuration')
+    .action(async () => {
+      const cwd = process.cwd();
+      const jobConfigPath = path.join(cwd, 'cloud-run-job.yaml');
+      const readmePath = path.join(cwd, 'README-GCP.md');
+
+      console.log(chalk.blue('Scaffolding Google Cloud Run Job files...'));
+
+      // cloud-run-job.yaml
+      let writeJobConfig = true;
+      if (fs.existsSync(jobConfigPath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'cloud-run-job.yaml already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeJobConfig = response.value;
+      }
+
+      if (writeJobConfig) {
+        fs.writeFileSync(jobConfigPath, CLOUD_RUN_JOB_TEMPLATE);
+        console.log(chalk.green('✔ Created cloud-run-job.yaml'));
+      } else {
+        console.log(chalk.gray('Skipped cloud-run-job.yaml'));
+      }
+
+      // README-GCP.md
+      let writeReadme = true;
+      if (fs.existsSync(readmePath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'README-GCP.md already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeReadme = response.value;
+      }
+
+      if (writeReadme) {
+        fs.writeFileSync(readmePath, README_GCP_TEMPLATE);
+        console.log(chalk.green('✔ Created README-GCP.md'));
+      } else {
+        console.log(chalk.gray('Skipped README-GCP.md'));
+      }
+
+      console.log(chalk.blue('\nGCP setup complete!'));
+      console.log('See README-GCP.md for deployment instructions.');
     });
 }

--- a/packages/cli/src/templates/gcp.ts
+++ b/packages/cli/src/templates/gcp.ts
@@ -1,0 +1,95 @@
+export const CLOUD_RUN_JOB_TEMPLATE = `apiVersion: run.googleapis.com/v1
+kind: Job
+metadata:
+  name: helios-render-job
+spec:
+  template:
+    spec:
+      taskCount: 10 # Adjust this based on your job's requirements
+      template:
+        spec:
+          containers:
+          - image: gcr.io/PROJECT_ID/IMAGE_NAME:TAG # Replace with your image
+            command: ["/bin/sh", "-c"]
+            args:
+            - "npm exec -- helios job run job.json --chunk \${CLOUD_RUN_TASK_INDEX}"
+            resources:
+              limits:
+                memory: "2Gi"
+                cpu: "1000m"
+          timeoutSeconds: 3600 # Adjust timeout as needed
+          maxRetries: 3
+`;
+
+export const README_GCP_TEMPLATE = `# Deploying Helios to Google Cloud Run Jobs
+
+This guide explains how to run distributed rendering jobs on Google Cloud Run.
+
+## Prerequisites
+
+1.  **Google Cloud Project**: You need a Google Cloud Project with Cloud Run API enabled.
+2.  **gcloud CLI**: Install and configure the \`gcloud\` CLI.
+3.  **Docker**: Install Docker to build your image.
+
+## Steps
+
+### 1. Generate Job File
+
+First, generate the rendering job specification locally. This defines how the rendering is split into chunks.
+
+\`\`\`bash
+npm run render -- --emit-job job.json --video-codec libx264
+\`\`\`
+
+This will create a \`job.json\` file in your project root.
+
+### 2. Build and Push Docker Image
+
+Build your Docker image and push it to Google Container Registry (GCR) or Artifact Registry.
+
+\`\`\`bash
+export PROJECT_ID=your-project-id
+export IMAGE_NAME=helios-render
+export TAG=latest
+
+# Build the image
+docker build -t gcr.io/$PROJECT_ID/$IMAGE_NAME:$TAG .
+
+# Push the image
+docker push gcr.io/$PROJECT_ID/$IMAGE_NAME:$TAG
+\`\`\`
+
+### 3. Update Configuration
+
+Open \`cloud-run-job.yaml\` and update the following fields:
+
+-   \`image\`: Set to \`gcr.io/your-project-id/helios-render:latest\` (or your image URL).
+-   \`taskCount\`: Set to the number of chunks you want to process in parallel (ensure this matches or exceeds the chunks in \`job.json\`).
+
+### 4. Deploy the Job
+
+Deploy the job definition to Cloud Run.
+
+\`\`\`bash
+gcloud run jobs replace cloud-run-job.yaml
+\`\`\`
+
+### 5. Execute the Job
+
+Run the job.
+
+\`\`\`bash
+gcloud run jobs execute helios-render-job
+\`\`\`
+
+### 6. Retrieve Output
+
+The output files will be stored in the container. To retrieve them, you should configure your job to write to a Google Cloud Storage bucket.
+
+**Modify \`cloud-run-job.yaml\` to mount a GCS bucket:**
+
+1.  Add the volume mount to the container spec.
+2.  Configure the volume to use a GCS bucket.
+
+For more details, see [Cloud Run documentation on GCS integration](https://cloud.google.com/run/docs/configuring/services/cloud-storage-volume-mounts).
+`;


### PR DESCRIPTION
💡 What: Implemented 'helios deploy gcp' command to scaffold 'cloud-run-job.yaml' and 'README-GCP.md'.
🎯 Why: To enable users to deploy distributed rendering jobs to Google Cloud Run, closing the gap in 'Distributed Rendering' backlog.
📊 Impact: Users can now easily setup and deploy rendering jobs to GCP.
🔬 Verification: Ran 'npm test packages/cli' (specifically 'src/commands/__tests__/deploy.test.ts') which passed. Verified file creation and prompts.

---
*PR created automatically by Jules for task [2995720494322555006](https://jules.google.com/task/2995720494322555006) started by @BintzGavin*