### PR TITLE
Make quickstart prompt more prominent in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@ Paste this into an existing repo (preferably your marketing site):
 ```bash
 npx skills add BintzGavin/helios-skills
 ```
-Then tell your agent to "follow the skills instructions and generate one video of each guided type."
+
+Then tell your agent this prompt:
+
+> **follow the skills instructions and generate one video of each guided type.**
+
 This tends to get the best results using Opus 4.6. I've gotten mixed results with Gemini 3.1 so far.
 
 ---


### PR DESCRIPTION
This change updates the `README.md` to make the quickstart prompt more prominent, as requested. It uses a Markdown blockquote and bold text to clearly separate the prompt from the surrounding instructional text, making it easier for users to identify and copy-paste it into their AI agent.

---
*PR created automatically by Jules for task [17484868890495456360](https://jules.google.com/task/17484868890495456360) started by @BintzGavin*