### PR TITLE
chore(player): sync package version to 0.76.8

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,7 @@
+## PLAYER v0.76.8
+- ✅ Completed: Sync Version - Updated package.json to match status file (0.76.8) and verified implementation with full test suite (326 tests passed).
+- ✅ Verified: Bridge Capture Resizing - Added specific unit tests for handleCaptureFrame in bridge.ts to verify resizing logic and error handling, complementing existing DirectController tests.
+
 ## PLAYER v0.76.7
 - ✅ Verified: Integrity Check - Ran full test suite (321 tests passed) and manually confirmed CaptureFrame resizing implementation in controllers.ts and bridge.ts matches the plan.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -60,6 +60,7 @@
 - **Export API**: Exposes public `export()` method for programmatic control over client-side exports, supporting Video (MP4/WebM) and Snapshot (PNG/JPEG) formats.
 - **Export Menu**: Implements a dedicated Export Menu in the player UI (replacing the direct export button action) to allow configuring format, resolution, filename, and captions before exporting or taking a snapshot.
 
+[v0.76.8] ✅ Completed: Sync Version - Updated package.json to match status file (0.76.8) and verified implementation with full test suite (326 tests passed).
 [v0.76.8] ✅ Verified: Bridge Capture Resizing - Added specific unit tests for handleCaptureFrame in bridge.ts to verify resizing logic and error handling, complementing existing DirectController tests.
 [v0.76.7] ✅ Verified: Integrity Check - Ran full test suite (321 tests passed) and manually confirmed CaptureFrame resizing implementation in controllers.ts and bridge.ts matches the plan.
 [v0.76.6] ✅ Verified: Fix CaptureFrame Resizing - Added comprehensive unit tests for OffscreenCanvas resizing logic in DirectController, verifying correct behavior when width/height options are provided.

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.76.7",
+  "version": "0.76.8",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",


### PR DESCRIPTION
This PR synchronizes the `@helios-project/player` package version with the internal documentation (docs/status/PLAYER.md) which was at v0.76.8 while package.json was at 0.76.7. This resolves a version drift likely caused by a previous incomplete release process.

Changes:
- Bumped `packages/player/package.json` to 0.76.8
- Added verification entry to `docs/status/PLAYER.md`
- Added verification entry to `docs/PROGRESS-PLAYER.md`

Verification:
- Ran `npm install` to restore dependencies.
- Built `packages/core` and `packages/player`.
- Ran `npm run test -w packages/player` (326 tests passed), including `bridge_capture.test.ts`.

---
*PR created automatically by Jules for task [74339420038662357](https://jules.google.com/task/74339420038662357) started by @BintzGavin*