### PR TITLE
Implement captureStream() API on HeliosPlayer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10219,7 +10219,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.76.7",
+      "version": "0.76.8",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^5.13.0",


### PR DESCRIPTION
Implemented `captureStream()` on `HeliosPlayer`. This allows users to capture the live output of the player as a `MediaStream`, enabling integration with WebRTC, recording, or other real-time processing.

Key changes:
- Added `public async captureStream(): Promise<MediaStream>` to `HeliosPlayer`.
- Implemented logic to combine video from canvas and audio from the Helios engine's `AudioContext`.
- Enforced same-origin policy by requiring `DirectController`.
- Added unit tests covering successful capture, error handling for Bridge mode, and audio track connection.

---
*PR created automatically by Jules for task [12245617056716443115](https://jules.google.com/task/12245617056716443115) started by @BintzGavin*