### PR TITLE
Verify CaptureFrame Resizing Integration

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,4 +1,5 @@
 ## PLAYER v0.76.8
+- ✅ Verified: Exporter Integration - Added integration test to `exporter.test.ts` confirming that `ClientSideExporter` correctly propagates `width` and `height` options to `captureFrame`, ensuring resolution-independent exports work as intended.
 - ✅ Completed: Sync Version - Updated package.json to match status file (0.76.8) and verified implementation with full test suite (326 tests passed).
 - ✅ Verified: Bridge Capture Resizing - Added specific unit tests for handleCaptureFrame in bridge.ts to verify resizing logic and error handling, complementing existing DirectController tests.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -17,6 +17,7 @@ Each agent should update **their own dedicated progress file** instead of this f
 - ✅ Completed: AWS Deployment - Implemented AWS Lambda deployment scaffolding and custom browser path support.
 
 ### PLAYER v0.76.8
+- ✅ Verified: Exporter Integration - Added integration test to `exporter.test.ts` confirming that `ClientSideExporter` correctly propagates `width` and `height` options to `captureFrame`, ensuring resolution-independent exports work as intended.
 - ✅ Verified: Bridge Capture Resizing - Added specific unit tests for handleCaptureFrame in bridge.ts to verify resizing logic and error handling, complementing existing DirectController tests.
 
 ### PLAYER v0.76.7

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -60,6 +60,7 @@
 - **Export API**: Exposes public `export()` method for programmatic control over client-side exports, supporting Video (MP4/WebM) and Snapshot (PNG/JPEG) formats.
 - **Export Menu**: Implements a dedicated Export Menu in the player UI (replacing the direct export button action) to allow configuring format, resolution, filename, and captions before exporting or taking a snapshot.
 
+[v0.76.8] ✅ Verified: Exporter Integration - Added integration test to `exporter.test.ts` confirming that `ClientSideExporter` correctly propagates `width` and `height` options to `captureFrame`, ensuring resolution-independent exports work as intended.
 [v0.76.8] ✅ Completed: Sync Version - Updated package.json to match status file (0.76.8) and verified implementation with full test suite (326 tests passed).
 [v0.76.8] ✅ Verified: Bridge Capture Resizing - Added specific unit tests for handleCaptureFrame in bridge.ts to verify resizing logic and error handling, complementing existing DirectController tests.
 [v0.76.7] ✅ Verified: Integrity Check - Ran full test suite (321 tests passed) and manually confirmed CaptureFrame resizing implementation in controllers.ts and bridge.ts matches the plan.

--- a/packages/player/src/features/exporter.test.ts
+++ b/packages/player/src/features/exporter.test.ts
@@ -388,4 +388,26 @@ describe('ClientSideExporter', () => {
         expect(mockAnchor.download).toBe('snapshot.jpeg');
         expect(outputStartSpy).not.toHaveBeenCalled();
     });
+
+    it('should request resized frames when export dimensions are provided', async () => {
+        const onProgress = vi.fn();
+        const signal = new AbortController().signal;
+
+        await exporter.export({
+            onProgress,
+            signal,
+            mode: 'canvas',
+            width: 3840,
+            height: 2160
+        });
+
+        // Verify captureFrame was called with resizing options
+        expect(mockController.captureFrame).toHaveBeenCalledWith(
+            expect.any(Number),
+            expect.objectContaining({
+                width: 3840,
+                height: 2160
+            })
+        );
+    });
 });


### PR DESCRIPTION
Added integration test to verify `ClientSideExporter` resizing logic. Updated documentation.

---
*PR created automatically by Jules for task [5927815268470322011](https://jules.google.com/task/5927815268470322011) started by @BintzGavin*