### PR TITLE
✨ CLI: Remote Job Spec Support

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -21,6 +21,7 @@ packages/cli/
 │   ├── commands/
 │   │   ├── __tests__/
 │   │   │   ├── deploy.test.ts # Deploy command tests
+│   │   │   ├── job.test.ts    # Job command tests
 │   │   │   └── render.test.ts # Render command tests
 │   │   ├── add.ts          # Adds components
 │   │   ├── build.ts        # Builds for production
@@ -77,7 +78,7 @@ packages/cli/
 - `helios diff <component>`: Compare local component with registry version.
 - `helios render <input>`: Render a composition.
   - Options: `--output`, `--width`, `--height`, `--fps`, `--duration`, `--quality`, `--mode`, `--emit-job`
-- `helios job run <spec>`: Run a distributed render job.
+- `helios job run <spec>`: Run a distributed render job from a local file or remote URL.
   - Options: `--concurrency`, `--chunks`
 - `helios merge <output> <inputs...>`: Merge video files.
 - `helios build`: Build the project for production.
@@ -113,3 +114,4 @@ interface HeliosConfig {
   - **Cross-Framework Support**: Allows installing `vanilla` components in framework-specific projects.
 - **Studio**: The `studio` command launches a Vite server with `studioApiPlugin`, allowing the Studio UI to trigger CLI actions (install/remove components) via the server.
 - **Renderer**: The `render` command orchestrates rendering using `@helios-project/renderer`. It supports custom browser executable paths via `PUPPETEER_EXECUTABLE_PATH` env var.
+- **Job**: The `job` command supports loading job specifications from local paths or remote HTTP/HTTPS URLs using the native `fetch` API.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.32.0
+
+- ✅ Remote Job Spec - Implemented support for executing distributed render jobs from remote HTTP/HTTPS URLs in `helios job run`.
+
 ## CLI v0.31.0
 
 - ✅ AWS Deployment - Implemented `helios deploy aws` to scaffold AWS Lambda deployment and updated `helios render` to support custom browser executable.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### CLI v0.32.0
+- ✅ Completed: Remote Job Spec - Implemented support for executing distributed render jobs from remote HTTP/HTTPS URLs in `helios job run`.
+
 ### CLI v0.31.0
 - ✅ Completed: AWS Deployment - Implemented AWS Lambda deployment scaffolding and custom browser path support.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.31.0
+**Version**: 0.32.0
 
 ## Current State
 
@@ -86,3 +86,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.29.0] ✅ Deploy Command - Implemented `helios deploy setup` to scaffold Docker files and updated `helios render` to support environment variables for browser args.
 [v0.30.0] ✅ Deploy GCP Command - Implemented `helios deploy gcp` to scaffold Google Cloud Run Job configuration and documentation.
 [v0.31.0] ✅ AWS Deployment - Implemented `helios deploy aws` to scaffold Lambda deployment and updated `helios render` to support custom browser executable.
+[v0.32.0] ✅ Remote Job Spec - Implemented support for executing distributed render jobs from remote HTTP/HTTPS URLs in `helios job run`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/cli",
-  "version": "0.28.3",
+  "version": "0.32.0",
   "description": "CLI for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/cli/src/commands/__tests__/job.test.ts
+++ b/packages/cli/src/commands/__tests__/job.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { loadJobSpec } from '../job';
+import path from 'path';
+import fs from 'fs';
+
+// Mock fs module
+vi.mock('fs', () => {
+  return {
+    default: {
+      existsSync: vi.fn(),
+      readFileSync: vi.fn(),
+    },
+    // Also mock named exports just in case, though job.ts uses default
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  };
+});
+
+// Mock fetch global
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+describe('loadJobSpec', () => {
+  const mockCwd = '/test/cwd';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Spy on process.cwd
+    vi.spyOn(process, 'cwd').mockReturnValue(mockCwd);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Remote URLs', () => {
+    it('should fetch and parse JSON from a valid URL', async () => {
+      const mockJobSpec = { chunks: [] };
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => mockJobSpec,
+      });
+
+      const url = 'http://example.com/job.json';
+      const result = await loadJobSpec(url);
+
+      expect(fetchMock).toHaveBeenCalledWith(url);
+      expect(result.jobSpec).toEqual(mockJobSpec);
+      expect(result.jobDir).toBe(mockCwd);
+    });
+
+    it('should throw an error if fetch fails', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      const url = 'http://example.com/job.json';
+      await expect(loadJobSpec(url)).rejects.toThrow('Failed to fetch job: Not Found (404)');
+    });
+  });
+
+  describe('Local Files', () => {
+    it('should read and parse JSON from a valid local file', async () => {
+      const mockJobSpec = { chunks: [] };
+      const filename = 'job.json';
+      const absolutePath = path.resolve(mockCwd, filename);
+
+      // Setup fs mocks
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(mockJobSpec));
+
+      const result = await loadJobSpec(filename);
+
+      expect(fs.existsSync).toHaveBeenCalledWith(absolutePath);
+      expect(fs.readFileSync).toHaveBeenCalledWith(absolutePath, 'utf-8');
+      expect(result.jobSpec).toEqual(mockJobSpec);
+      expect(result.jobDir).toBe(path.dirname(absolutePath));
+    });
+
+    it('should throw an error if local file does not exist', async () => {
+      const filename = 'job.json';
+      const absolutePath = path.resolve(mockCwd, filename);
+
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      await expect(loadJobSpec(filename)).rejects.toThrow(`Job file not found: ${absolutePath}`);
+    });
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,7 +20,7 @@ const program = new Command();
 program
   .name('helios')
   .description('Helios CLI')
-  .version('0.27.0');
+  .version('0.32.0');
 
 registerStudioCommand(program);
 registerInitCommand(program);


### PR DESCRIPTION
💡 **What**: Implemented support for HTTP/HTTPS URLs in `helios job run <file>`.
🎯 **Why**: To enable stateless worker architecture where jobs are fetched dynamically, avoiding the need for per-job container rebuilds.
📊 **Impact**: Allows Helios workers to be deployed as generic execution units that can pull work from any URL.
🔬 **Verification**: Added `packages/cli/src/commands/__tests__/job.test.ts` covering remote URL fetching (mocked) and local file loading. Verified with `npm test`.

---
*PR created automatically by Jules for task [5249686543443658035](https://jules.google.com/task/5249686543443658035) started by @BintzGavin*