### PR TITLE
✨ STUDIO: Add WebCodecs Preference to Render Config

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -64,7 +64,8 @@ The Studio is launched via the `helios` CLI (from `@helios-project/cli`).
 - **Renderer**: Uses `RenderOrchestrator` for planning and executing renders.
 - **CLI**: The Studio backend exposes endpoints that the CLI can leverage (e.g., for `helios render` with HMR support, though currently CLI uses Renderer directly).
 
-## F. Recent Changes (v0.114.2)
+## F. Recent Changes (v0.115.0)
+- **Completed: WebCodecs Preference**: Added `webCodecsPreference` configuration to Studio Renders Panel.
 - **Completed: React Components Example**: Added documentation and verified `react-components-demo` example.
 - **Verified: Regression Test**: Validated Studio UI functionality via Playwright script (`scripts/verify-ui.ts`).
 - **Verified: Registry Filtering Support**: Confirmed that Studio supports cross-framework component discovery.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+## STUDIO v0.115.0
+- ✅ Completed: WebCodecs Preference - Added `webCodecsPreference` configuration to Studio Renders Panel, allowing users to select Hardware, Software, or Disabled modes for rendering.
+
 ## STUDIO v0.114.2
 - ✅ Completed: React Components Example - Added documentation and verified `react-components-demo` example.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -13,6 +13,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - **STUDIO**: Update `docs/PROGRESS-STUDIO.md`
 - **SKILLS**: Update `docs/PROGRESS-SKILLS.md`
 
+### STUDIO v0.115.0
+- ✅ Completed: WebCodecs Preference - Added `webCodecsPreference` configuration to Studio Renders Panel, allowing users to select Hardware, Software, or Disabled modes for rendering.
+
 ### CLI v0.32.0
 - ✅ Completed: Remote Job Spec - Implemented support for executing distributed render jobs from remote HTTP/HTTPS URLs in `helios job run`.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.114.2
+**Version**: 0.115.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -11,6 +11,7 @@
 > **Note**: Status versions in this file may precede package release versions (`package.json`). Always verify `package.json` for the currently installed version.
 
 ## Recent Updates
+- [v0.115.0] ✅ Completed: WebCodecs Preference - Added `webCodecsPreference` configuration to Studio Renders Panel, allowing users to select Hardware, Software, or Disabled modes for rendering.
 - [v0.114.2] ✅ Completed: React Components Example - Added documentation and verified `react-components-demo` example.
 - [v0.114.1] ✅ Verified: Regression Test - Validated Studio UI functionality via Playwright script (`scripts/verify-ui.ts`), confirming critical UI elements (Timeline, Renders Panel) load correctly.
 - [v0.114.0] ✅ Verified: Registry Filtering Support - Confirmed that Studio supports cross-framework component discovery (e.g., vanilla components in React projects) via updated CLI logic.

--- a/packages/studio/src/components/RendersPanel/RenderConfig.tsx
+++ b/packages/studio/src/components/RendersPanel/RenderConfig.tsx
@@ -7,6 +7,7 @@ export interface RenderConfigData {
   concurrency?: number;
   hwAccel?: string;
   scale?: number;
+  webCodecsPreference?: 'hardware' | 'software' | 'disabled';
 }
 
 interface RenderConfigProps {
@@ -154,6 +155,20 @@ export const RenderConfig: React.FC<RenderConfigProps> = ({ config, onChange }) 
           <option value="qsv">Intel QSV</option>
           <option value="videotoolbox">Apple VideoToolbox</option>
           <option value="none">None (CPU)</option>
+        </select>
+      </div>
+
+      <div style={{ marginBottom: '8px' }}>
+        <label htmlFor="render-webcodecs" style={labelStyle}>WebCodecs Preference</label>
+        <select
+          id="render-webcodecs"
+          value={config.webCodecsPreference || 'hardware'}
+          onChange={(e) => handleChange('webCodecsPreference', e.target.value)}
+          style={inputStyle}
+        >
+          <option value="hardware">Hardware (Default)</option>
+          <option value="software">Software Only</option>
+          <option value="disabled">Disabled</option>
         </select>
       </div>
 

--- a/packages/studio/src/context/StudioContext.tsx
+++ b/packages/studio/src/context/StudioContext.tsx
@@ -40,6 +40,7 @@ export interface RenderConfig {
   concurrency?: number;
   hwAccel?: string;
   scale?: number;
+  webCodecsPreference?: 'hardware' | 'software' | 'disabled';
 }
 
 export interface RenderJob {

--- a/packages/studio/src/server/render-manager.ts
+++ b/packages/studio/src/server/render-manager.ts
@@ -128,6 +128,7 @@ export interface StartRenderOptions {
   inputProps?: Record<string, any>;
   concurrency?: number;
   hwAccel?: string;
+  webCodecsPreference?: 'hardware' | 'software' | 'disabled';
 }
 
 function rendererOptionsToFlags(options: RendererOptions): string {
@@ -140,6 +141,7 @@ function rendererOptionsToFlags(options: RendererOptions): string {
   if (options.audioCodec) flags.push(`--audio-codec ${options.audioCodec}`);
   if (options.videoCodec) flags.push(`--video-codec ${options.videoCodec}`);
   if (options.browserConfig?.headless === false) flags.push('--no-headless');
+  if (options.webCodecsPreference) flags.push(`--webcodecs-preference ${options.webCodecsPreference}`);
   return flags.join(' ');
 }
 
@@ -182,7 +184,8 @@ export function getRenderJobSpec(options: StartRenderOptions): JobSpec {
     videoCodec: options.videoCodec,
     pixelFormat: options.pixelFormat,
     inputProps: options.inputProps,
-    concurrency: options.concurrency || 1
+    concurrency: options.concurrency || 1,
+    webCodecsPreference: options.webCodecsPreference
   };
 
   const plan = RenderOrchestrator.plan(compositionUrl, outputPath, renderOptions);
@@ -295,7 +298,8 @@ export async function startRender(options: StartRenderOptions, serverPort: numbe
         pixelFormat: options.pixelFormat,
         inputProps: options.inputProps,
         concurrency: options.concurrency,
-        hwAccel: options.hwAccel
+        hwAccel: options.hwAccel,
+        webCodecsPreference: options.webCodecsPreference
       };
 
       await RenderOrchestrator.render(fullUrl, outputPath, renderOptions, {


### PR DESCRIPTION
- Added `webCodecsPreference` to `RenderConfig` interface in `StudioContext.tsx`.
- Added UI dropdown in `RenderConfig.tsx` for WebCodecs preference selection.
- Updated `render-manager.ts` to pass the preference to `DistributedRenderOptions` and generate the CLI flag `--webcodecs-preference`.

---
*PR created automatically by Jules for task [10365387254043343974](https://jules.google.com/task/10365387254043343974) started by @BintzGavin*