### PR TITLE
✨ CLI: Implement Stateless Worker Architecture

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -115,3 +115,4 @@ interface HeliosConfig {
 - **Studio**: The `studio` command launches a Vite server with `studioApiPlugin`, allowing the Studio UI to trigger CLI actions (install/remove components) via the server.
 - **Renderer**: The `render` command orchestrates rendering using `@helios-project/renderer`. It supports custom browser executable paths via `PUPPETEER_EXECUTABLE_PATH` env var.
 - **Job**: The `job` command supports loading job specifications from local paths or remote HTTP/HTTPS URLs using the native `fetch` API.
+- **GCP Deployment**: The `deploy gcp` command scaffolds a Cloud Run Job that supports stateless execution via `HELIOS_JOB_SPEC` environment variable.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5,7 +5,7 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 ## Distributed Rendering
 *Helios must support distributed rendering suitable for cloud execution.*
 
-- [ ] Implement stateless worker architecture.
+- [x] Implement stateless worker architecture.
 - [x] Implement CLI job generation (`--emit-job`).
 - [x] Ensure deterministic frame seeking across all drivers.
 - [x] Support frame range rendering in CLI.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.33.0
+
+- ✅ Stateless Worker - Implemented support for stateless job execution via HELIOS_JOB_SPEC environment variable in GCP templates.
+
 ## CLI v0.32.0
 
 - ✅ Remote Job Spec - Implemented support for executing distributed render jobs from remote HTTP/HTTPS URLs in `helios job run`.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.32.0
+**Version**: 0.33.0
 
 ## Current State
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10176,7 +10176,7 @@
     },
     "packages/cli": {
       "name": "@helios-project/cli",
-      "version": "0.28.3",
+      "version": "0.32.0",
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/packages/cli/src/templates/gcp.ts
+++ b/packages/cli/src/templates/gcp.ts
@@ -12,7 +12,10 @@ spec:
           - image: gcr.io/PROJECT_ID/IMAGE_NAME:TAG # Replace with your image
             command: ["/bin/sh", "-c"]
             args:
-            - "npm exec -- helios job run job.json --chunk \${CLOUD_RUN_TASK_INDEX}"
+            - "npm exec -- helios job run \${HELIOS_JOB_SPEC} --chunk \${CLOUD_RUN_TASK_INDEX}"
+            env:
+            - name: HELIOS_JOB_SPEC
+              value: "job.json"
             resources:
               limits:
                 memory: "2Gi"
@@ -92,4 +95,19 @@ The output files will be stored in the container. To retrieve them, you should c
 2.  Configure the volume to use a GCS bucket.
 
 For more details, see [Cloud Run documentation on GCS integration](https://cloud.google.com/run/docs/configuring/services/cloud-storage-volume-mounts).
+
+### 7. (Optional) Stateless / Remote Job Execution
+
+To avoid rebuilding the Docker image for every new render job, you can use the stateless worker architecture.
+
+1.  **Upload your \`job.json\` to a remote URL** (e.g., Google Cloud Storage, S3, or any HTTP server).
+    Ensure the worker container has access to this URL.
+
+2.  **Execute the job with the \`HELIOS_JOB_SPEC\` environment variable**:
+
+    \`\`\`bash
+    gcloud run jobs execute helios-render-job --update-env-vars HELIOS_JOB_SPEC=https://storage.googleapis.com/my-bucket/job.json
+    \`\`\`
+
+    The worker will fetch the job specification from the URL and execute the assigned chunk.
 `;


### PR DESCRIPTION
💡 **What**: Updated GCP Cloud Run Job templates to use `HELIOS_JOB_SPEC` environment variable for job execution and documented the stateless worker architecture.
🎯 **Why**: To enable running distributed render jobs without rebuilding the container image for each job.
📊 **Impact**: Users can now deploy a single worker image and execute different jobs by overriding the `HELIOS_JOB_SPEC` env var (e.g., pointing to a remote JSON file).
🔬 **Verification**: Ran `packages/cli` tests (`npm test packages/cli/src/commands/__tests__/deploy.test.ts`) which passed. Verified generated template content manually.

---
*PR created automatically by Jules for task [8141941142909939017](https://jules.google.com/task/8141941142909939017) started by @BintzGavin*