### PR TITLE
Async Seek in DirectController

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.76.10
+- ✅ Completed: Async Seek - Updated `DirectController.seek` to wait for two `requestAnimationFrame` cycles before resolving, ensuring visual frame rendering is complete.
+
 ## PLAYER v0.76.9
 - ✅ Completed: Update Context Documentation - Regenerated context-player.md to reflect the latest API and features.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.76.9
+**Version**: v0.76.10
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -60,6 +60,7 @@
 - **Export API**: Exposes public `export()` method for programmatic control over client-side exports, supporting Video (MP4/WebM) and Snapshot (PNG/JPEG) formats.
 - **Export Menu**: Implements a dedicated Export Menu in the player UI (replacing the direct export button action) to allow configuring format, resolution, filename, and captions before exporting or taking a snapshot.
 
+[v0.76.10] ✅ Completed: Async Seek - Updated `DirectController.seek` to wait for two `requestAnimationFrame` cycles before resolving, ensuring visual frame rendering is complete.
 [v0.76.9] ✅ Completed: Update Context Documentation - Regenerated context-player.md to reflect the latest API and features.
 [v0.76.8] ✅ Verified: Exporter Integration - Added integration test to `exporter.test.ts` confirming that `ClientSideExporter` correctly propagates `width` and `height` options to `captureFrame`, ensuring resolution-independent exports work as intended.
 [v0.76.8] ✅ Completed: Sync Version - Updated package.json to match status file (0.76.8) and verified implementation with full test suite (326 tests passed).

--- a/packages/player/src/controllers.test.ts
+++ b/packages/player/src/controllers.test.ts
@@ -108,15 +108,17 @@ describe('DirectController', () => {
         controller = new DirectController(helios, mockIframe);
     });
 
-    it('should delegate play/pause/seek to instance', () => {
+    it('should delegate play/pause/seek to instance', async () => {
         controller.play();
         expect(mockHeliosInstance.play).toHaveBeenCalled();
 
         controller.pause();
         expect(mockHeliosInstance.pause).toHaveBeenCalled();
 
-        controller.seek(10);
+        const rafSpy = vi.spyOn(mockIframe.contentWindow as any, 'requestAnimationFrame');
+        await controller.seek(10);
         expect(mockHeliosInstance.seek).toHaveBeenCalledWith(10);
+        expect(rafSpy).toHaveBeenCalledTimes(2);
     });
 
     it('should set playback rate and input props', () => {

--- a/packages/player/src/controllers.ts
+++ b/packages/player/src/controllers.ts
@@ -48,9 +48,16 @@ export class DirectController implements HeliosController {
   }
   play() { this.instance.play(); }
   pause() { this.instance.pause(); }
-  seek(frame: number) {
+  seek(frame: number): Promise<void> {
     this.instance.seek(frame);
-    return Promise.resolve();
+    return new Promise((resolve) => {
+      const win = this.iframe?.contentWindow || window;
+      win.requestAnimationFrame(() => {
+        win.requestAnimationFrame(() => {
+          resolve();
+        });
+      });
+    });
   }
   setAudioVolume(volume: number) { this.instance.setAudioVolume(volume); }
   setAudioMuted(muted: boolean) { this.instance.setAudioMuted(muted); }


### PR DESCRIPTION
Updated `DirectController.seek` to be asynchronous, waiting for two `requestAnimationFrame` cycles before resolving. This ensures that the visual frame rendering is complete before the seek operation is considered finished. Updated unit tests to verify this behavior.

---
*PR created automatically by Jules for task [1775718832611035858](https://jules.google.com/task/1775718832611035858) started by @BintzGavin*