### PR TITLE
Add Timeline Drag & Drop to Studio Planner Prompt

### DIFF
--- a/docs/prompts/planning-studio.md
+++ b/docs/prompts/planning-studio.md
@@ -76,6 +76,7 @@ Compare README promises to `packages/studio/src`:
 - **Renders Panel** - Track rendering progress and manage render jobs
 - **Canvas Controls** - Zoom, resize, and toggle transparent backgrounds
 - **Hot Reloading** - Instant preview updates as you edit your composition code
+- **Timeline Drag & Drop** - Drag and drop media support (auto-detecting audio vs video) for the timeline, ensuring functionality within iframe environments.
 
 **CLI Command**: `npx helios studio` - Should run the studio dev server
 


### PR DESCRIPTION
Updated `docs/prompts/planning-studio.md` to include "Timeline Drag & Drop" as a planned feature in the "Vision Gaps to Hunt For" section. This ensures the `planner-studio` agent will identify this missing feature in upcoming cycles, specifically noting requirements for auto-detecting audio vs video and iframe support.

---
*PR created automatically by Jules for task [11190917999535221218](https://jules.google.com/task/11190917999535221218) started by @BintzGavin*