### PR TITLE
feat(infrastructure): implement FfmpegStitcher for video concatenation

### DIFF
--- a/packages/infrastructure/src/index.ts
+++ b/packages/infrastructure/src/index.ts
@@ -6,3 +6,4 @@ export function initInfrastructure() {
 
 export * from './types/index.js';
 export * from './adapters/index.js';
+export * from './stitcher/index.js';

--- a/packages/infrastructure/src/stitcher/ffmpeg-stitcher.ts
+++ b/packages/infrastructure/src/stitcher/ffmpeg-stitcher.ts
@@ -1,0 +1,60 @@
+import { writeFile, unlink } from 'node:fs/promises';
+import { resolve, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { WorkerAdapter } from '../types/adapter.js';
+import { LocalWorkerAdapter } from '../adapters/local-adapter.js';
+
+export interface VideoStitcher {
+  stitch(inputs: string[], output: string): Promise<void>;
+}
+
+export class FfmpegStitcher implements VideoStitcher {
+  private adapter: WorkerAdapter;
+
+  constructor(adapter?: WorkerAdapter) {
+    this.adapter = adapter || new LocalWorkerAdapter();
+  }
+
+  async stitch(inputs: string[], output: string): Promise<void> {
+    if (inputs.length === 0) {
+      throw new Error('No input files provided for stitching');
+    }
+
+    // Create a temporary file for the concat list
+    // Use absolute paths to ensure ffmpeg finds them
+    const listContent = inputs.map(f => `file '${resolve(f)}'`).join('\n');
+    const listFileName = `concat-${randomUUID()}.txt`;
+    const listPath = join(tmpdir(), listFileName);
+
+    try {
+      await writeFile(listPath, listContent, 'utf-8');
+
+      // Run ffmpeg
+      // ffmpeg -f concat -safe 0 -i listPath -c copy output -y
+      const result = await this.adapter.execute({
+        command: 'ffmpeg',
+        args: [
+          '-f', 'concat',
+          '-safe', '0',
+          '-i', listPath,
+          '-c', 'copy',
+          output,
+          '-y' // Overwrite output
+        ]
+      });
+
+      if (result.exitCode !== 0) {
+        throw new Error(`FFmpeg stitching failed with exit code ${result.exitCode}: ${result.stderr}`);
+      }
+
+    } finally {
+      // Cleanup
+      try {
+        await unlink(listPath);
+      } catch (e) {
+        // Ignore cleanup errors
+      }
+    }
+  }
+}

--- a/packages/infrastructure/src/stitcher/index.ts
+++ b/packages/infrastructure/src/stitcher/index.ts
@@ -1,0 +1,1 @@
+export * from './ffmpeg-stitcher.js';

--- a/packages/infrastructure/tests/stitcher.test.ts
+++ b/packages/infrastructure/tests/stitcher.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { FfmpegStitcher } from '../src/stitcher/ffmpeg-stitcher.js';
+import { WorkerAdapter, WorkerJob, WorkerResult } from '../src/types/index.js';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+// Mock fs/promises
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+  return {
+    ...actual,
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    unlink: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe('FfmpegStitcher', () => {
+  let mockAdapter: WorkerAdapter;
+  let stitcher: FfmpegStitcher;
+
+  beforeEach(() => {
+    mockAdapter = {
+      execute: vi.fn().mockResolvedValue({
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        durationMs: 100,
+      } as WorkerResult),
+    };
+    stitcher = new FfmpegStitcher(mockAdapter);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should throw error if no inputs are provided', async () => {
+    await expect(stitcher.stitch([], 'output.mp4')).rejects.toThrow(
+      'No input files provided for stitching'
+    );
+  });
+
+  it('should generate concat list and run ffmpeg', async () => {
+    const inputs = ['/path/to/1.mp4', '/path/to/2.mp4'];
+    const output = 'output.mp4';
+
+    await stitcher.stitch(inputs, output);
+
+    // Verify file writing
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    const [filePath, content] = (fs.writeFile as any).mock.calls[0];
+
+    expect(filePath).toContain('concat-');
+    expect(content).toContain("file '/path/to/1.mp4'");
+    expect(content).toContain("file '/path/to/2.mp4'");
+
+    // Verify execution
+    expect(mockAdapter.execute).toHaveBeenCalledTimes(1);
+    const job = (mockAdapter.execute as any).mock.calls[0][0] as WorkerJob;
+
+    expect(job.command).toBe('ffmpeg');
+    expect(job.args).toContain('-f');
+    expect(job.args).toContain('concat');
+    expect(job.args).toContain(output);
+    expect(job.args).toContain(filePath); // Should pass the generated file path
+
+    // Verify cleanup
+    expect(fs.unlink).toHaveBeenCalledTimes(1);
+    expect(fs.unlink).toHaveBeenCalledWith(filePath);
+  });
+
+  it('should handle ffmpeg errors', async () => {
+    mockAdapter.execute = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'ffmpeg error',
+      durationMs: 100,
+    } as WorkerResult);
+
+    const inputs = ['/path/to/1.mp4'];
+    await expect(stitcher.stitch(inputs, 'output.mp4')).rejects.toThrow(
+      'FFmpeg stitching failed with exit code 1: ffmpeg error'
+    );
+
+    // Should still cleanup
+    expect(fs.unlink).toHaveBeenCalledTimes(1);
+  });
+
+  it('should cleanup temp file even if write fails', async () => {
+    (fs.writeFile as any).mockRejectedValueOnce(new Error('Write failed'));
+
+    const inputs = ['/path/to/1.mp4'];
+    await expect(stitcher.stitch(inputs, 'output.mp4')).rejects.toThrow('Write failed');
+
+    // Should attempt cleanup (though it might fail if file wasn't created, logic handles it)
+    expect(fs.unlink).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Implements `FfmpegStitcher` using the concat demuxer strategy to stitch video segments without re-encoding. This is a critical component for the distributed rendering architecture, allowing parallelized worker outputs to be efficiently assembled.

### Key Features
- **Zero-Copy Stitching:** Uses `ffmpeg -c copy` with the concat demuxer for fast assembly.
- **Worker Abstraction:** Executes FFmpeg commands via the `WorkerAdapter` interface, keeping the implementation environment-agnostic.
- **Robustness:** Handles temporary file generation and cleanup (using `try/finally` and UUIDs).
- **Testing:** Includes comprehensive unit tests mocking the file system and worker execution.

### Verification
- Ran `npm test -w packages/infrastructure` (passed).
- Verified correct FFmpeg command construction and file handling via mocks.


---
*PR created automatically by Jules for task [12289347495547775792](https://jules.google.com/task/12289347495547775792) started by @BintzGavin*