### PR TITLE
Implement RenderExecutor for worker chunk execution

### DIFF
--- a/packages/infrastructure/src/index.ts
+++ b/packages/infrastructure/src/index.ts
@@ -7,3 +7,4 @@ export function initInfrastructure() {
 export * from './types/index.js';
 export * from './adapters/index.js';
 export * from './stitcher/index.js';
+export * from './worker/index.js';

--- a/packages/infrastructure/src/worker/index.ts
+++ b/packages/infrastructure/src/worker/index.ts
@@ -1,2 +1,3 @@
+export * from './render-executor.js';
 export * from '../types/job.js';
 export * from '../types/adapter.js';

--- a/packages/infrastructure/src/worker/render-executor.ts
+++ b/packages/infrastructure/src/worker/render-executor.ts
@@ -1,0 +1,59 @@
+import { spawn } from 'node:child_process';
+import { JobSpec, WorkerResult } from '../types/index.js';
+import { parseCommand } from '../utils/command.js';
+
+export class RenderExecutor {
+  private workspaceDir: string;
+
+  constructor(workspaceDir: string) {
+    this.workspaceDir = workspaceDir;
+  }
+
+  async executeChunk(jobSpec: JobSpec, chunkId: number): Promise<WorkerResult> {
+    const chunk = jobSpec.chunks.find((c) => c.id === chunkId);
+    if (!chunk) {
+      throw new Error(`Chunk with ID ${chunkId} not found in job spec`);
+    }
+
+    const startTime = Date.now();
+    const { command, args } = parseCommand(chunk.command);
+
+    return new Promise((resolve, reject) => {
+      // Use spawn to execute the command
+      const child = spawn(command, args, {
+        cwd: this.workspaceDir,
+        env: { ...process.env }, // Inherit environment variables
+        shell: false, // Security: avoid shell injection
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      if (child.stdout) {
+        child.stdout.on('data', (data) => {
+          stdout += data.toString();
+        });
+      }
+
+      if (child.stderr) {
+        child.stderr.on('data', (data) => {
+          stderr += data.toString();
+        });
+      }
+
+      child.on('error', (err) => {
+        reject(err);
+      });
+
+      child.on('close', (code) => {
+        const durationMs = Date.now() - startTime;
+        resolve({
+          exitCode: code ?? -1,
+          stdout,
+          stderr,
+          durationMs,
+        });
+      });
+    });
+  }
+}

--- a/packages/infrastructure/tests/render-executor.test.ts
+++ b/packages/infrastructure/tests/render-executor.test.ts
@@ -1,0 +1,54 @@
+
+import { describe, it, expect } from 'vitest';
+import { RenderExecutor } from '../src/worker/render-executor.js';
+import { JobSpec } from '../src/types/job-spec.js';
+import { parseCommand } from '../src/utils/command.js';
+
+describe('RenderExecutor', () => {
+  const executor = new RenderExecutor('/tmp');
+
+  const jobSpec: JobSpec = {
+    metadata: {
+      totalFrames: 10,
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      duration: 1,
+    },
+    chunks: [
+      {
+        id: 1,
+        startFrame: 0,
+        frameCount: 5,
+        outputFile: 'out1.mp4',
+        // Simple command without quotes to avoid parsing issues in simple parser
+        command: 'echo chunk1'
+      },
+      {
+        id: 2,
+        startFrame: 5,
+        frameCount: 5,
+        outputFile: 'out2.mp4',
+        // Using a command that will definitely fail
+        command: 'node -e process.exit(1)'
+      }
+    ],
+    mergeCommand: 'echo merge'
+  };
+
+  it('should execute a successful command', async () => {
+    const result = await executor.executeChunk(jobSpec, 1);
+    expect(result.exitCode).toBe(0);
+    // echo output ends with newline
+    expect(result.stdout.trim()).toBe('chunk1');
+  });
+
+  it('should capture exit code from failing command', async () => {
+    const result = await executor.executeChunk(jobSpec, 2);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('should throw if chunk ID not found', async () => {
+    await expect(executor.executeChunk(jobSpec, 999)).rejects.toThrow(/Chunk with ID 999 not found/);
+  });
+});


### PR DESCRIPTION
Implements `RenderExecutor` in `packages/infrastructure` to enable stateless workers to execute render chunks defined in `JobSpec`. This component is responsible for parsing the command from the job chunk and executing it via `child_process.spawn`, capturing stdout/stderr and exit codes. It serves as the core execution logic within worker adapters (e.g., Lambda, Cloud Run).

---
*PR created automatically by Jules for task [12548189431678978160](https://jules.google.com/task/12548189431678978160) started by @BintzGavin*