### PR TITLE
Create Worker Runtime Plan

### DIFF
--- a/.sys/plans/2026-02-23-INFRASTRUCTURE-Worker-Runtime.md
+++ b/.sys/plans/2026-02-23-INFRASTRUCTURE-Worker-Runtime.md
@@ -1,0 +1,61 @@
+# INFRASTRUCTURE: Worker Runtime
+
+## 1. Context & Goal
+- **Objective**: Implement `WorkerRuntime` in `packages/infrastructure/src/worker/runtime.ts` to orchestrate job fetching and execution within stateless workers.
+- **Trigger**: Vision requirement for "Stateless Workers" and "Cloud Execution". `RenderExecutor` exists but needs a higher-level controller to fetch the Job Spec and invoke the execution logic.
+- **Impact**: This runtime logic will be used by AWS Lambda, Google Cloud Run, and other worker implementations to receive a job payload (URL + ChunkID), retrieve the definition, and execute the work.
+
+## 2. File Inventory
+- **Create**: `packages/infrastructure/src/worker/runtime.ts`
+- **Modify**: `packages/infrastructure/src/worker/index.ts` (export the new runtime)
+- **Read-Only**:
+  - `packages/infrastructure/src/worker/render-executor.ts`
+  - `packages/infrastructure/src/types/job-spec.ts`
+
+## 3. Implementation Spec
+- **Architecture**:
+  - `WorkerRuntime` class acts as the facade for the worker process.
+  - It supports fetching `JobSpec` from both HTTP(S) URLs and local file paths (for testing/hybrid use).
+  - It delegates the actual command execution to `RenderExecutor`.
+- **Pseudo-Code**:
+  ```typescript
+  export class WorkerRuntime {
+    constructor(private config: { workspaceDir: string }) {}
+
+    async run(jobPath: string, chunkId: number): Promise<WorkerResult> {
+      // 1. Determine if jobPath is URL or File
+      let jobSpec: JobSpec;
+      if (isUrl(jobPath)) {
+        // Fetch JSON
+        jobSpec = await fetchJson(jobPath);
+      } else {
+        // Read File
+        jobSpec = await readJson(jobPath);
+      }
+
+      // 2. Validate JobSpec (basic check)
+      if (!jobSpec.chunks) throw new Error("Invalid JobSpec");
+
+      // 3. Execute
+      const executor = new RenderExecutor(this.config.workspaceDir);
+      return executor.executeChunk(jobSpec, chunkId);
+    }
+  }
+  ```
+- **Public API Changes**: Export `WorkerRuntime` class.
+- **Dependencies**: `RenderExecutor`, `JobSpec`, `WorkerResult`.
+- **Cloud Considerations**: Uses global `fetch` (Node 18+) for network requests. Handles filesystem operations for local fallback.
+
+## 4. Test Plan
+- **Verification**: Create `packages/infrastructure/tests/worker/runtime.test.ts`.
+- **Success Criteria**:
+  - Mock `global.fetch` to return a sample `JobSpec`.
+  - Call `WorkerRuntime.run('http://example.com/job.json', 0)`.
+  - Verify `RenderExecutor` executes the correct chunk.
+  - Test local file path resolution.
+- **Edge Cases**:
+  - Network failure (fetch throws).
+  - Invalid JSON.
+  - Chunk ID not found (propagated from RenderExecutor).
+  - URL vs File path detection.
+- **Integration Verification**: `npm test` in `packages/infrastructure`.


### PR DESCRIPTION
Created `.sys/plans/2026-02-23-INFRASTRUCTURE-Worker-Runtime.md` which specifies the implementation details for the `WorkerRuntime` class. This class will serve as the entry point for stateless workers, managing job specification retrieval and delegation to the `RenderExecutor`.

---
*PR created automatically by Jules for task [15463222771899016161](https://jules.google.com/task/15463222771899016161) started by @BintzGavin*