### PR TITLE
✨ PLAYER: Video Volume Export

### DIFF
--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.76.10
+**Version**: v0.76.11
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -60,6 +60,7 @@
 - **Export API**: Exposes public `export()` method for programmatic control over client-side exports, supporting Video (MP4/WebM) and Snapshot (PNG/JPEG) formats.
 - **Export Menu**: Implements a dedicated Export Menu in the player UI (replacing the direct export button action) to allow configuring format, resolution, filename, and captions before exporting or taking a snapshot.
 
+[v0.76.11] ✅ Completed: Video Volume Export - Ensured WYSIWYG video volume in client-side exports by prioritizing runtime `volume` and `muted` properties over HTML attributes.
 [v0.76.10] ✅ Completed: Async Seek - Updated `DirectController.seek` to wait for two `requestAnimationFrame` cycles before resolving, ensuring visual frame rendering is complete.
 [v0.76.9] ✅ Completed: Update Context Documentation - Regenerated context-player.md to reflect the latest API and features.
 [v0.76.8] ✅ Verified: Exporter Integration - Added integration test to `exporter.test.ts` confirming that `ClientSideExporter` correctly propagates `width` and `height` options to `captureFrame`, ensuring resolution-independent exports work as intended.

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.76.8",
+  "version": "0.76.11",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/player/src/features/audio-utils.ts
+++ b/packages/player/src/features/audio-utils.ts
@@ -54,7 +54,9 @@ export async function getAudioAssets(
         volume = state.volume;
         muted = state.muted;
     } else {
-        volume = volumeAttr !== null ? parseFloat(volumeAttr) : tag.volume;
+        // Prioritize runtime property for WYSIWYG accuracy.
+        // The 'volume' attribute is non-standard on HTMLMediaElement and may be ignored by the browser.
+        volume = tag.volume;
         muted = tag.muted;
     }
 

--- a/packages/player/src/features/video-volume.test.ts
+++ b/packages/player/src/features/video-volume.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getAudioAssets } from './audio-utils';
+
+// Mock fetch
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+describe('getAudioAssets - Video Volume', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        fetchMock.mockResolvedValue({
+            arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+            headers: { get: () => 'audio/mpeg' }
+        });
+    });
+
+    it('prioritizes runtime volume property over volume attribute', async () => {
+        const doc = document.implementation.createHTMLDocument();
+        const video = doc.createElement('video');
+        video.src = 'http://example.com/video.mp4';
+
+        // Scenario: Attribute is set to '1' (default), but runtime volume is changed to '0.5'
+        video.setAttribute('volume', '1');
+        video.volume = 0.5;
+
+        doc.body.appendChild(video);
+
+        const assets = await getAudioAssets(doc);
+
+        expect(assets).toHaveLength(1);
+        expect(assets[0].volume).toBe(0.5);
+    });
+
+    it('prioritizes runtime muted property', async () => {
+        const doc = document.implementation.createHTMLDocument();
+        const video = doc.createElement('video');
+        video.src = 'http://example.com/video.mp4';
+
+        // Scenario: Attribute 'muted' is present (initially muted), but runtime unmuted
+        video.setAttribute('muted', '');
+        video.muted = false;
+
+        doc.body.appendChild(video);
+
+        const assets = await getAudioAssets(doc);
+
+        expect(assets).toHaveLength(1);
+        expect(assets[0].muted).toBe(false);
+    });
+});


### PR DESCRIPTION
This change updates the `getAudioAssets` utility in `@helios-project/player` to prioritize the runtime `volume` and `muted` properties of `<video>` and `<audio>` elements over their HTML attributes. This ensures that the audio levels in client-side exports accurately reflect the current state of the player (WYSIWYG), fixing potential discrepancies where attributes might not match the audible volume. A new test suite `video-volume.test.ts` has been added to verify this behavior.

---
*PR created automatically by Jules for task [12230578527191266846](https://jules.google.com/task/12230578527191266846) started by @BintzGavin*