### PR TITLE
📋 CLI: Refactor job command to use JobExecutor

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -113,3 +113,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.33.0] - Job Spec Asset Gap
 **Learning:** While `helios job run` supported remote specs, the generated specs (`--emit-job`) still used local paths, breaking the "Stateless Worker" vision. Generic workers cannot resolve local paths.
 **Action:** When designing distributed systems, ensure that ALL inputs (specs AND assets) are resolvable via network URLs. Local paths are only valid for local execution or mounted volumes.
+
+## [0.35.0] - Pluggable Execution Disconnect
+**Learning:** `packages/infrastructure` implemented stateless worker adapters (AWS, GCP, Local) and a `JobExecutor`, but `packages/cli`'s `helios job run` was still using a hardcoded local `spawn` loop. The CLI must be actively integrated with new platform capabilities to realize the "Primary interface for ... workflows" vision.
+**Action:** Always check if core/infrastructure abstractions exist before maintaining custom implementations in the CLI. The CLI should act as the orchestrator/interface for lower-level domain logic.


### PR DESCRIPTION
Drafted spec file `.sys/plans/2026-11-02-CLI-Refactor-JobExecutor.md` outlining the refactoring of `helios job run` to use `@helios-project/infrastructure`'s `JobExecutor` and pluggable adapters, replacing hardcoded `spawn` loop logic. Updated `.jules/CLI.md` journal with learning about utilizing infrastructure abstractions.

---
*PR created automatically by Jules for task [4200748016626131304](https://jules.google.com/task/4200748016626131304) started by @BintzGavin*