### PR TITLE
✨ INFRASTRUCTURE: Enhance Worker Job Cancellation

### DIFF
--- a/.sys/llmdocs/context-infrastructure.md
+++ b/.sys/llmdocs/context-infrastructure.md
@@ -74,32 +74,28 @@ export interface WorkerJob {
 }
 
 export interface WorkerResult {
-  jobId: string;
-  chunkIndex: number;
-  status: 'completed' | 'failed';
-  outputUrl?: string;
-  error?: string;
-  totalDurationMs?: number;
-  stdout?: string;
-  stderr?: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
 }
 
 export interface WorkerAdapter {
-  executeChunk(job: WorkerJob): Promise<WorkerResult>;
+  execute(job: WorkerJob): Promise<WorkerResult>;
 }
 
 export interface JobExecutionOptions {
-  jobId: string;
-  spec: JobSpec;
   concurrency?: number;
+  jobDir?: string;
+  merge?: boolean;
   retries?: number;
   retryDelay?: number;
+  onProgress?: (completedChunks: number, totalChunks: number) => void;
+  onChunkComplete?: (chunkId: number, result: WorkerResult) => void | Promise<void>;
+  signal?: AbortSignal;
   mergeAdapter?: WorkerAdapter;
   stitcher?: VideoStitcher;
   outputFile?: string;
-  signal?: AbortSignal;
-  onProgress?: (completed: number, total: number) => void;
-  onChunkComplete?: (result: WorkerResult) => void;
 }
 ```
 

--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,5 +1,11 @@
 # INFRASTRUCTURE PROGRESS
 
+## INFRASTRUCTURE v0.13.1
+- ✅ Completed: Enhance Worker Job Cancellation - Passed signal to mergeAdapter in JobExecutor
+
+## INFRASTRUCTURE v0.13.0
+- ✅ Completed: Enhance Worker Job Cancellation - Propagated `AbortSignal` from `JobExecutor` to `WorkerAdapter` implementations to enable true graceful cancellation of running chunks.
+
 ## INFRASTRUCTURE v0.12.0
 - ✅ Completed: Robust Command Parsing and Housekeeping - Refactored parseCommand to use a state machine for handling quotes and escaped characters. Updated package version and added a lint script.
 - ✅ Completed: Observability Telemetry - Added test verifying `onChunkComplete` metrics and logs gathering during chunk execution in JobManager.

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.13.0
+**Version**: 0.13.1
 
 ## Status Log
+- [v0.13.1] ✅ Completed: Enhance Worker Job Cancellation - Passed signal to mergeAdapter in JobExecutor
 - [v0.13.0] ✅ Completed: Enhance Worker Job Cancellation - Propagated `AbortSignal` from `JobExecutor` to `WorkerAdapter` implementations to enable true graceful cancellation of running chunks.
 - [v0.12.0] ✅ Completed: Robust Command Parsing and Housekeeping - Refactored parseCommand to use a state machine for handling quotes and escaped characters. Updated package version and added a lint script.
 - [v0.12.0] ✅ Completed: Observability Telemetry - Added test verifying `onChunkComplete` metrics and logs gathering during chunk execution in JobManager.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12331,7 +12331,7 @@
     },
     "packages/infrastructure": {
       "name": "@helios-project/infrastructure",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "ELv2",
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.999.0",

--- a/packages/infrastructure/src/orchestrator/job-executor.ts
+++ b/packages/infrastructure/src/orchestrator/job-executor.ts
@@ -244,7 +244,8 @@ export class JobExecutor {
             command,
             args,
             cwd: jobDir,
-            env: process.env as Record<string, string>
+            env: process.env as Record<string, string>,
+            signal: options.signal
           });
 
           if (result.exitCode !== 0) {

--- a/packages/infrastructure/tests/job-executor.test.ts
+++ b/packages/infrastructure/tests/job-executor.test.ts
@@ -271,6 +271,27 @@ describe('JobExecutor', () => {
       warnSpy.mockRestore();
     });
 
+    it('should pass signal to mergeAdapter', async () => {
+      const controller = new AbortController();
+      const mockMergeAdapter: WorkerAdapter = {
+        execute: vi.fn().mockResolvedValue({
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+          durationMs: 100
+        })
+      };
+
+      await jobExecutor.execute(jobSpec, {
+        mergeAdapter: mockMergeAdapter,
+        signal: controller.signal
+      });
+
+      expect(mockMergeAdapter.execute).toHaveBeenCalledWith(expect.objectContaining({
+        signal: controller.signal
+      }));
+    });
+
     it('should fall back to mergeCommand if stitcher is provided without outputFile and mergeAdapter is used', async () => {
       const mockStitcher: VideoStitcher = {
         stitch: vi.fn().mockResolvedValue(undefined)


### PR DESCRIPTION
💡 What: Added `signal: options.signal` to `mergeAdapter.execute` payload in `JobExecutor`.
🎯 Why: To ensure that the merge step is correctly aborted when a job cancellation is requested.
📊 Impact: Fixes orphaned merge processes continuing to run after a job is cancelled.
🔬 Verification: Added test `should pass signal to mergeAdapter` in `job-executor.test.ts`. `npm test` and `npm run lint` pass.

---
*PR created automatically by Jules for task [10422304747995245926](https://jules.google.com/task/10422304747995245926) started by @BintzGavin*