### PR TITLE
INFRASTRUCTURE: Realtime Log Streaming Spec

### DIFF
--- a/.jules/INFRASTRUCTURE.md
+++ b/.jules/INFRASTRUCTURE.md
@@ -21,3 +21,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.11.0] - Robust Command Parsing & Housekeeping Gap
 **Learning:** The `parseCommand` utility in `packages/infrastructure/src/utils/command.ts` currently splits strings purely by whitespace. This will break when `JobSpec` commands contain quoted arguments with spaces (e.g., `-metadata title="My Render"` or paths with spaces). Additionally, `package.json` is missing a `lint` script, which breaks CI/CD consistency, and its version (`0.1.0`) is out of sync with actual release status.
 **Action:** Plan to implement a robust command parser (handling quotes) and perform package housekeeping (sync version, add lint script) to ensure distributed render commands execute correctly on workers.
+
+## [0.14.0] - CLI Adoption Blocker for JobExecutor
+**Learning:** The `packages/cli` is blocked from adopting the infrastructure `JobExecutor` because `WorkerAdapter` implementations (like `LocalWorkerAdapter`) currently buffer output and return it only upon completion. The CLI requires real-time streaming of `stdout` and `stderr` to display progress during local chunk rendering.
+**Action:** Plan to implement real-time log streaming via `onStdout` and `onStderr` callbacks in the `WorkerJob` interface, and propagate them via `JobExecutionOptions` to unblock CLI adoption.

--- a/.sys/plans/2026-11-10-INFRASTRUCTURE-Realtime-Log-Streaming.md
+++ b/.sys/plans/2026-11-10-INFRASTRUCTURE-Realtime-Log-Streaming.md
@@ -1,0 +1,35 @@
+#### 1. Context & Goal
+- **Objective**: Implement real-time log streaming for `WorkerAdapter` implementations and orchestrators to enable CLI and interactive interfaces to monitor chunk execution progress.
+- **Trigger**: The V2 vision requires robust tooling around distributed rendering, but the current `JobExecutor` architecture strictly buffers outputs. The `packages/cli` command `job run` requires real-time streaming to standard output to maintain a responsive user experience.
+- **Impact**: Unblocks the eventual migration of `packages/cli`'s job handling logic to `packages/infrastructure`'s `JobExecutor` by adding the necessary `onStdout` and `onStderr` streaming capabilities natively to the worker abstraction.
+
+#### 2. File Inventory
+- **Create**:
+  - (None, modifying existing files)
+- **Modify**:
+  - `packages/infrastructure/src/types/job.ts`: Add `onStdout` and `onStderr` callbacks to the `WorkerJob` interface.
+  - `packages/infrastructure/src/orchestrator/job-executor.ts`: Add `onChunkStdout` and `onChunkStderr` callbacks to `JobExecutionOptions` and propagate them down to the adapter execution call.
+  - `packages/infrastructure/src/adapters/local-adapter.ts`: Update `LocalWorkerAdapter` to invoke `job.onStdout` and `job.onStderr` when child process data events fire, while continuing to buffer for the final result.
+- **Read-Only**:
+  - `packages/cli/src/commands/job.ts`: Context on CLI requirements for output.
+
+#### 3. Implementation Spec
+- **Architecture**: Extend the `WorkerJob` abstraction to include real-time log event handlers (`onStdout`, `onStderr`). Implement support in the primary local runtime adapter (`LocalWorkerAdapter`) since cloud adapters (Lambda/CloudRun) operate on a request-response model and don't natively stream without websockets or streaming APIs (they will safely ignore or no-op these callbacks). The `JobExecutor` will map global chunk stream events (`onChunkStdout`, `onChunkStderr`) to specific adapter invocations.
+- **Pseudo-Code**:
+  - `WorkerJob`: Add `onStdout?: (data: string) => void` and `onStderr?: (data: string) => void`
+  - `JobExecutionOptions`: Add `onChunkStdout?: (chunkId: number, data: string) => void` and `onChunkStderr?: (chunkId: number, data: string) => void`
+  - `JobExecutor`: When calling `this.adapter.execute`, pass `onStdout: (data) => options.onChunkStdout?.(chunk.id, data)` and equivalent for stderr.
+  - `LocalWorkerAdapter`: Inside the `child.stdout.on('data')` handler, call `job.onStdout(data.toString())` in addition to appending to the buffered `stdout` string.
+- **Public API Changes**:
+  - Interface `WorkerJob` gains optional `onStdout` and `onStderr` callback methods.
+  - Interface `JobExecutionOptions` gains optional `onChunkStdout` and `onChunkStderr` callback methods.
+- **Dependencies**: None.
+- **Cloud Considerations**: HTTP-based cloud adapters (AWS Lambda without Response Streaming, Cloud Run standard responses) cannot easily stream output. These adapters will continue to return buffered output at the end of execution. The `onStdout`/`onStderr` capability is strictly an *optional* enhancement for adapters that support it (primarily `LocalWorkerAdapter`), making it safe to introduce without breaking cloud deployments.
+
+#### 4. Test Plan
+- **Verification**: Run `npm test` inside `packages/infrastructure`.
+- **Success Criteria**:
+  - Existing tests for LocalWorkerAdapter and JobExecutor pass.
+  - (The actual implementation will include new tests for these callbacks in the respective test files)
+- **Edge Cases**: Ensure buffered output in `WorkerResult` remains intact even when callbacks are provided.
+- **Integration Verification**: Verify no existing execution logic breaks by running the full test suite.


### PR DESCRIPTION
Added a detailed execution plan (`2026-11-10-INFRASTRUCTURE-Realtime-Log-Streaming.md`) to implement real-time log streaming for `WorkerAdapter` implementations to enable the CLI to stream chunks locally. Also updated the journal with critical learnings.

---
*PR created automatically by Jules for task [18271904303255428982](https://jules.google.com/task/18271904303255428982) started by @BintzGavin*