### PR TITLE
✨ INFRASTRUCTURE: Realtime Log Streaming

### DIFF
--- a/.sys/llmdocs/context-infrastructure.md
+++ b/.sys/llmdocs/context-infrastructure.md
@@ -73,6 +73,8 @@ export interface WorkerJob {
   timeout?: number;
   meta?: Record<string, any>;
   signal?: AbortSignal;
+  onStdout?: (data: string) => void;
+  onStderr?: (data: string) => void;
 }
 
 export interface WorkerResult {

--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,5 +1,8 @@
 # INFRASTRUCTURE PROGRESS
 
+## INFRASTRUCTURE v0.15.0
+- ✅ Completed: Realtime Log Streaming - Added onStdout and onStderr streaming to WorkerJob and JobExecutor to support live progress tracking for chunk execution.
+
 ## INFRASTRUCTURE v0.14.0
 - ✅ Completed: Cloud Adapter Deterministic Verification - Implemented E2E integration test validating deterministic seeking across stateless rendering chunks to ensure identical frame outputs across worker adapters.
 

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.14.0
+**Version**: 0.15.0
 
 ## Status Log
+- [v0.15.0] ✅ Completed: Realtime Log Streaming - Added onStdout and onStderr streaming to WorkerJob and JobExecutor to support live progress tracking for chunk execution.
 - [v0.14.0] ✅ Completed: Cloud Adapter Deterministic Verification - Implemented E2E integration test validating deterministic seeking across stateless rendering chunks to ensure identical frame outputs across worker adapters.
 - [v0.13.1] ✅ Completed: Enhance Worker Job Cancellation - Passed signal to mergeAdapter in JobExecutor
 - [v0.13.0] ✅ Completed: Enhance Worker Job Cancellation - Propagated `AbortSignal` from `JobExecutor` to `WorkerAdapter` implementations to enable true graceful cancellation of running chunks.

--- a/packages/infrastructure/src/adapters/local-adapter.ts
+++ b/packages/infrastructure/src/adapters/local-adapter.ts
@@ -7,7 +7,7 @@ import { WorkerAdapter, WorkerJob, WorkerResult } from '../types/index.js';
 export class LocalWorkerAdapter implements WorkerAdapter {
   async execute(job: WorkerJob): Promise<WorkerResult> {
     const startTime = Date.now();
-    const { command, args = [], env, cwd, timeout, signal } = job;
+    const { command, args = [], env, cwd, timeout, signal, onStdout, onStderr } = job;
 
     return new Promise((resolve, reject) => {
       if (signal?.aborted) {
@@ -28,13 +28,17 @@ export class LocalWorkerAdapter implements WorkerAdapter {
 
       if (child.stdout) {
         child.stdout.on('data', (data) => {
-          stdout += data.toString();
+          const str = data.toString();
+          stdout += str;
+          onStdout?.(str);
         });
       }
 
       if (child.stderr) {
         child.stderr.on('data', (data) => {
-          stderr += data.toString();
+          const str = data.toString();
+          stderr += str;
+          onStderr?.(str);
         });
       }
 

--- a/packages/infrastructure/src/orchestrator/job-executor.ts
+++ b/packages/infrastructure/src/orchestrator/job-executor.ts
@@ -46,6 +46,16 @@ export interface JobExecutionOptions {
   onChunkComplete?: (chunkId: number, result: WorkerResult) => void | Promise<void>;
 
   /**
+   * Callback invoked when a chunk emits stdout data.
+   */
+  onChunkStdout?: (chunkId: number, data: string) => void;
+
+  /**
+   * Callback invoked when a chunk emits stderr data.
+   */
+  onChunkStderr?: (chunkId: number, data: string) => void;
+
+  /**
    * Signal to abort the job execution.
    */
   signal?: AbortSignal;
@@ -139,7 +149,9 @@ export class JobExecutor {
                 chunkId: chunk.id,
                 ...chunk
               },
-              signal: options.signal
+              signal: options.signal,
+              onStdout: options.onChunkStdout ? (data) => options.onChunkStdout!(chunk.id, data) : undefined,
+              onStderr: options.onChunkStderr ? (data) => options.onChunkStderr!(chunk.id, data) : undefined
             });
 
             if (result.exitCode !== 0) {

--- a/packages/infrastructure/src/types/job.ts
+++ b/packages/infrastructure/src/types/job.ts
@@ -13,4 +13,8 @@ export interface WorkerJob {
   meta?: Record<string, any>;
   /** Optional AbortSignal to gracefully cancel the job execution */
   signal?: AbortSignal;
+  /** Optional callback for real-time stdout streaming */
+  onStdout?: (data: string) => void;
+  /** Optional callback for real-time stderr streaming */
+  onStderr?: (data: string) => void;
 }


### PR DESCRIPTION
✨ INFRASTRUCTURE: Realtime Log Streaming

💡 What: Added `onStdout` and `onStderr` optional callbacks to `WorkerJob` and extended `JobExecutionOptions` to accept `onChunkStdout` and `onChunkStderr` for real-time live log streaming.
🎯 Why: Distributed rendering via `JobExecutor` previously buffered all stdout and stderr output, leaving interfaces like the CLI blind to progress until a chunk finished. Real-time streaming bridges this gap, allowing user interfaces to stay responsive and monitor the progress of specific jobs dynamically.
📊 Impact: Unblocks the `job run` execution CLI from adopting the underlying `JobExecutor` abstraction since it requires streaming outputs to function identically to direct process spawns.
🔬 Verification: Ran `npm run lint` and `npm test` inside `packages/infrastructure`. All 90 tests passed, and type-checks successfully passed without issue.

References: .sys/plans/2026-11-10-INFRASTRUCTURE-Realtime-Log-Streaming.md

---
*PR created automatically by Jules for task [8452625369161027196](https://jules.google.com/task/8452625369161027196) started by @BintzGavin*