### PR TITLE
✨ INFRASTRUCTURE: Orchestrator Asset Upload

### DIFF
--- a/.sys/llmdocs/context-infrastructure.md
+++ b/.sys/llmdocs/context-infrastructure.md
@@ -4,7 +4,7 @@
 The `@helios-project/infrastructure` package orchestrates distributed rendering across various compute environments (e.g., local child processes, Google Cloud Run, AWS Lambda). It embraces a stateless worker design, where frames can be independently rendered via a consistent command interface.
 
 The orchestration lifecycle involves:
-1. `JobManager`: Manages active rendering jobs. Employs `JobRepository` for state persistence and delegates execution to `JobExecutor`. Supports pausing, resuming, and deleting jobs.
+1. `JobManager`: Manages active rendering jobs. Employs `JobRepository` for state persistence and delegates execution to `JobExecutor`. Supports pausing, resuming, and deleting jobs. Integrates `ArtifactStorage` to automatically upload local job assets before distributed cloud executions begin.
 2. `JobExecutor`: Takes a `JobSpec` and executes discrete rendering chunks via a `WorkerAdapter`. It gathers metrics, logs, limits concurrency, and provides `AbortSignal` implementation for graceful cancellation.
 3. `WorkerAdapter`: Adapters implementing `execute(job: WorkerJob): Promise<WorkerResult>`. Current implementations include Local (child process execution), AWS Lambda, and Cloud Run.
 4. `VideoStitcher`: A specialized entity (`FfmpegStitcher`) designed to securely concatenate rendered chunk artifacts seamlessly without re-encoding to assemble the final output video.

--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,5 +1,8 @@
 # INFRASTRUCTURE PROGRESS
 
+## INFRASTRUCTURE v0.23.0
+- ✅ Completed: Orchestrator Asset Upload - Integrated ArtifactStorage into JobManager to automatically upload local job assets before distributed cloud executions begin.
+
 ## INFRASTRUCTURE v0.22.0
 - ✅ Completed: Integrate Artifact Storage - Updated WorkerRuntime to support downloading remote job assets before rendering via ArtifactStorage interface and configured cloud entrypoints (AWS, Cloud Run) to accept storage adapters.
 

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.22.0
+**Version**: 0.23.0
 
 ## Status Log
+- [v0.23.0] ✅ Completed: Orchestrator Asset Upload - Integrated ArtifactStorage into JobManager to automatically upload local job assets before distributed cloud executions begin.
 - [v0.22.0] ✅ Completed: Integrate Artifact Storage - Updated WorkerRuntime to support downloading remote job assets before rendering via ArtifactStorage interface and configured cloud entrypoints (AWS, Cloud Run) to accept storage adapters.
 - [v0.21.0] ✅ Completed: Cloud Artifact Storage Implementation - Implemented ArtifactStorage interface and LocalStorageAdapter to manage job assets during distributed cloud executions.
 - [v0.20.0] ✅ Completed: Cloud Artifact Storage Spec - Created spec for artifact storage interface and LocalStorageAdapter to manage job assets during distributed cloud executions.


### PR DESCRIPTION
💡 What:
Integrated `ArtifactStorage` into `JobManager` to automatically upload local job assets before executing distributed rendering jobs.

🎯 Why:
Closes the gap in the distributed rendering pipeline by ensuring that remote workers running in the cloud receive the necessary asset files uploaded by the orchestrator before rendering begins.

📊 Impact:
Completes the full end-to-end distributed rendering flow, decoupling local asset storage from remote chunk execution.

🔬 Verification:
Run `npm test` inside `packages/infrastructure`. A dedicated test verifies `uploadAssetBundle` is correctly invoked on the provided `storage` adapter and the updated `assetsUrl` propagates to the JobSpec.

---
*PR created automatically by Jules for task [13313313729611086323](https://jules.google.com/task/13313313729611086323) started by @BintzGavin*