### PR TITLE
✨ PLAYER: Enforce Blocked Protocol

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -1,3 +1,9 @@
 ## [v0.76.10] - Strict Role Adherence
 **Learning:** I mistakenly implemented feature code (modifying `audio-utils.ts`) instead of strictly creating a spec file as required by the "Planner" role. This violates the protocol.
 **Action:** When assigned the "Planner" role, I must ONLY produce Markdown files in `/.sys/plans/` and NEVER modify source code in `packages/`.
+## v0.76.12 - Enforcing Blocked Protocol
+**Learning:** If there are no uncompleted implementation plans explicitly listed for my domain in `/.sys/plans/`, I must strictly adhere to the 'EXECUTOR'S PHILOSOPHY' and STOP. Attempting to artificially fulfill context file regeneration steps when there is no new code to write violates the boundary protocol and introduces unmaintainable clutter.
+**Action:** Before writing any code or updating documentation, always verify that a valid, uncompleted plan exists. If none exists, immediately update the status and backlog files to indicate a blocked state and ask for the next plan.
+## v0.76.12 - Context File Preservation
+**Learning:** Even if no new implementation code is written (e.g., when blocked), I must NEVER delete the `/.sys/llmdocs/context-player.md` file. Deleting it destroys the shared context that other agents rely on.
+**Action:** Always preserve the context file. Only modify it to reflect actual changes to the codebase.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -47,3 +47,6 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 
 - [ ] **Documentation**: Add Quickstart guide.
 - [x] ⛔ Renderer Verification Blocked: packages/studio dependency mismatch
+
+## PLAYER Agent Status
+- [ ] 🚫 Blocked: No new plan found in `/.sys/plans/` for `PLAYER`. Waiting for Planner to create the next implementation spec.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -167,3 +167,4 @@
 [v0.32.1] ✅ Completed: Fix Player Dependencies - Updated @helios-project/core dependency and fixed build environment to enable verification.
 [v0.32.0] ✅ Completed: Implement Standard Media States - Added `readyState`, `networkState` properties and constants, along with lifecycle events (`loadstart`, `loadedmetadata`, `canplay`, `canplaythrough`) to `<helios-player>`.
 [v0.31.0] ✅ Completed: Implement Standard Media API properties - Added missing properties `src`, `autoplay`, `loop`, `controls`, `poster`, `preload` to `HeliosPlayer` class to fully comply with HTMLMediaElement interface expectations. Updated `observedAttributes` to include `preload`. Updated dependencies to fix build issues.
+[v0.76.12] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner to create the next implementation spec.


### PR DESCRIPTION
Enforces the executor protocol by halting execution and updating the status as `Blocked` since there are no remaining plans for the `PLAYER` domain. Added critical learnings to `.jules/PLAYER.md` to ensure `/.sys/llmdocs/context-player.md` is never deleted or artificially regenerated when no code changes occur, preventing loss of shared architectural context.

---
*PR created automatically by Jules for task [12686995229541534147](https://jules.google.com/task/12686995229541534147) started by @BintzGavin*