### PR TITLE
⛔ INFRASTRUCTURE: Blocked on sync dependency

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -50,3 +50,6 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 
 ## PLAYER Agent Status
 - [ ] 🚫 Blocked: No new plan found in `/.sys/plans/` for `PLAYER`. Waiting for Planner to create the next implementation spec.
+
+## INFRASTRUCTURE Agent Status
+- [ ] 🚫 Blocked: The only available plan (`2026-03-02-INFRASTRUCTURE-SyncDependency.md`) asks me to modify files outside of my domain (`packages/cli/package.json`), which strictly violates my boundaries.

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -2,6 +2,7 @@
 **Version**: 0.24.0
 
 ## Status Log
+- [v0.24.0] 🚫 Blocked: The only available plan (`2026-03-02-INFRASTRUCTURE-SyncDependency.md`) asks me to modify files outside of my domain (`packages/cli/package.json`), which strictly violates my boundaries.
 - [v0.24.0] ✅ Completed: Artifact Storage Cleanup - Integrated ArtifactStorage.deleteAssetBundle into JobManager to properly delete remote assets when a job is removed.
 - [v0.23.0] ✅ Completed: Orchestrator Asset Upload - Integrated ArtifactStorage into JobManager to automatically upload local job assets before distributed cloud executions begin.
 - [v0.22.0] ✅ Completed: Integrate Artifact Storage - Updated WorkerRuntime to support downloading remote job assets before rendering via ArtifactStorage interface and configured cloud entrypoints (AWS, Cloud Run) to accept storage adapters.


### PR DESCRIPTION
💡 **What**: Documented a blocked state in the INFRASTRUCTURE status and backlog files.
🎯 **Why**: The only available plan (`2026-03-02-INFRASTRUCTURE-SyncDependency.md`) instructs the INFRASTRUCTURE agent to modify `packages/cli/package.json`, which strictly violates the agent's domain boundary constraints ("Modify files outside your domain" and "Modify package.json... without instruction").
📊 **Impact**: Prevents cross-domain file modification violations while signaling to the Planner that a new, domain-appropriate plan is needed or that a different agent must execute the CLI dependency sync.
🔬 **Verification**: Ran `npm run test` and `npm run lint` in `packages/infrastructure` to verify no regressions were introduced while the agent is blocked.

---
*PR created automatically by Jules for task [16719367160124755727](https://jules.google.com/task/16719367160124755727) started by @BintzGavin*