### PR TITLE
✨ INFRASTRUCTURE: Mark agent as Blocked (No Uncompleted Plans)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -52,5 +52,6 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [ ] 🚫 Blocked: No new plan found in `/.sys/plans/` for `PLAYER`. Waiting for Planner to create the next implementation spec.
 
 ## INFRASTRUCTURE Agent Status
+- [ ] 🚫 Blocked: No new plan found in `/.sys/plans/` for `INFRASTRUCTURE`. Waiting for Planner to create the next implementation spec.
 - [ ] 🚫 Blocked: The only available plans (`2026-03-02-INFRASTRUCTURE-SyncDependency.md` and `2026-03-02-INFRASTRUCTURE-Workspace-Dependency-Synchronizer.md`) require modifying files outside of my domain (`packages/cli/package.json` and the root workspace package definitions), which strictly violates my boundaries. I must stop working.
 - [ ] 🚫 Blocked: The available plan (`2026-11-13-CLI-Cloud-Worker-Execution.md`) asks me to modify files outside of my domain (`packages/cli/src/commands/job.ts`), which strictly violates my boundaries. I cannot implement CLI execution commands.

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -2,6 +2,7 @@
 **Version**: 0.28.0
 
 ## Status Log
+- [v0.28.0] 🚫 Blocked: No uncompleted implementation plans found for my domain in `/.sys/plans/`. I must stop working.
 - [v0.28.0] ✅ Completed: GCS Storage Adapter - Implemented an `GcsStorageAdapter` to handle artifact uploads and downloads using Google Cloud Storage.
 - [v0.27.0] ✅ Completed: S3 Storage Adapter - Implemented an `S3StorageAdapter` to handle artifact uploads and downloads using AWS S3.
 - [v0.26.0] ✅ Completed: Cloud Deployment Tooling - Verified implementation of generic cloud deployment entrypoint generators (createAwsHandler and createCloudRunServer) within packages/infrastructure/src/worker/.


### PR DESCRIPTION
💡 **What**: 
Appended a "Blocked" state note to `docs/status/INFRASTRUCTURE.md` and `docs/BACKLOG.md` indicating that no actionable implementation plans were found for the INFRASTRUCTURE domain.

🎯 **Why**: 
The agent protocol strictly requires the EXECUTOR to stop working and document a blocked state when there are no valid `/.sys/plans/` spec files available for its assigned domain, preventing arbitrary or unauthorized code modifications.

📊 **Impact**: 
Signals to the planner agent or system orchestrator that the INFRASTRUCTURE executor is idle and requires a new implementation plan before it can resume work.

🔬 **Verification**: 
- Checked `docs/status/INFRASTRUCTURE.md` to ensure the blocked status was correctly appended.
- Checked `docs/BACKLOG.md` to ensure the blocked status was mirrored under the correct domain section.
- Ran `npm test` and `npm run lint` in `packages/infrastructure` to ensure the environment remains clean and stable.

---
*PR created automatically by Jules for task [1383011321691978715](https://jules.google.com/task/1383011321691978715) started by @BintzGavin*