### PR TITLE
📋 CLI: Init Command Regression Tests Spec

### DIFF
--- a/.sys/plans/2026-03-04-CLI-Init-Regression-Tests.md
+++ b/.sys/plans/2026-03-04-CLI-Init-Regression-Tests.md
@@ -1,0 +1,37 @@
+#### 1. Context & Goal
+- **Objective**: Implement comprehensive regression tests for the `helios init` command.
+- **Trigger**: The CLI domain is currently aligned with V2 features, triggering the "Regression tests" fallback action as defined in AGENTS.md. The `init` command handles complex logic (scaffolding, examples, interactive prompts) but lacks unit tests in `packages/cli/src/commands/__tests__/`.
+- **Impact**: Ensures the stability of the project scaffolding experience and prevents future regressions when adding new frameworks, examples, or options.
+
+#### 2. File Inventory
+- **Create**:
+  - `packages/cli/src/commands/__tests__/init.test.ts` (Unit test suite for the init command)
+- **Modify**: None
+- **Read-Only**:
+  - `packages/cli/src/commands/init.ts` (To understand the logic being tested)
+  - `packages/cli/src/utils/examples.ts` (To mock example fetching and downloading)
+
+#### 3. Implementation Spec
+- **Architecture**:
+  - Use `vitest` to define the test suite for `registerInitCommand`.
+  - Use `vi.mock()` to mock external dependencies: `fs` (to avoid writing to actual disk), `prompts` (to simulate user input), and the utility functions in `../utils/examples.js`.
+  - Instantiate a new Commander program in each test, register the init command, and call `program.parseAsync()`.
+- **Pseudo-Code**:
+  - Mock `fs.existsSync`, `fs.mkdirSync`, `fs.promises.writeFile`, `fs.promises.mkdir`.
+  - Mock `prompts` to return specific answers for different test scenarios.
+  - Write test cases:
+    - Default scaffolding: Scaffolds a React project when `--yes` is provided.
+    - Directory check: Exits or prompts when the target directory is not empty.
+    - Framework scaffolding: Respects the `--framework` flag to scaffold Vue, Svelte, Solid, or Vanilla projects.
+    - Example usage: Calls `downloadExample` and `transformProject` when `--example` flag is provided.
+    - Interactive flow: correctly captures inputs for framework, component dir, and lib dir when prompts are triggered.
+- **Public API Changes**: None
+- **Dependencies**: None
+
+#### 4. Test Plan
+- **Verification**: Run the test suite using `npm run test -w packages/cli`.
+- **Success Criteria**: All tests in `packages/cli/src/commands/__tests__/init.test.ts` pass, successfully validating the internal logic of the init command across multiple scaffolding scenarios without writing files to the disk.
+- **Edge Cases**:
+  - Target directory is not empty and user declines to continue.
+  - The `fetchExamples` call returns an empty list, falling back to templates.
+  - Existing `helios.config.json` prevents overwriting unless `--yes` or an empty directory condition is met.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.36.2
+
+- ✅ Init Command Tests Spec - Created specification plan for implementing regression tests for the `helios init` command to ensure scaffolding stability.
+
 ## CLI v0.36.1
 
 - ✅ Add Command Scaffold - Verified the existing `helios add` command fulfills the scaffolding requirements outlined in the plan.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.36.1
+**Version**: 0.36.2
 
 ## Current State
 
@@ -91,4 +91,5 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.34.1] ✅ Remote Job Assets - Implemented `--base-url` alias and fixed remote asset resolution in distributed jobs.
 [v0.35.0] ✅ JobExecutor Integration - Refactored `helios job run` to use `@helios-project/infrastructure`'s `JobExecutor` and `LocalWorkerAdapter`.
 [v0.36.0] ✅ Cloud Worker Execution - Integrated AwsLambdaAdapter and CloudRunAdapter into helios job run.
+[v0.36.2] ✅ Init Command Tests Spec - Created specification plan for implementing regression tests for the `helios init` command to ensure scaffolding stability.
 [v0.36.1] ✅ Add Command Scaffold - Verified the existing `helios add` command fulfills the scaffolding requirements outlined in the plan.


### PR DESCRIPTION
This commit introduces a new architectural spec file in `/.sys/plans/` that defines the implementation details for adding missing unit tests to the `helios init` command. This closes a gap by focusing on the "Regression tests" fallback action since the CLI is currently stable and feature-complete for V2. The plan describes mocking `fs` and `prompts` to test interactive and filesystem operations without writing to disk. The CLI status and progress logs are also updated correctly.

---
*PR created automatically by Jules for task [1100281037941456651](https://jules.google.com/task/1100281037941456651) started by @BintzGavin*