### PR TITLE
✨ INFRASTRUCTURE: Fix Storage Adapter Bench

### DIFF
--- a/.sys/llmdocs/context-infrastructure.md
+++ b/.sys/llmdocs/context-infrastructure.md
@@ -61,8 +61,10 @@ packages/infrastructure/
 │       └── command.ts
 ├── tests/
 │   ├── benchmarks/
+│   │   ├── gcs-storage.bench.ts
 │   │   ├── job-manager.bench.ts
-│   │   └── local-storage.bench.ts
+│   │   ├── local-storage.bench.ts
+│   │   └── s3-storage.bench.ts
 ```
 
 ## Section C: Interfaces

--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,5 +1,8 @@
 # INFRASTRUCTURE PROGRESS
 
+## INFRASTRUCTURE v0.37.6
+- ✅ Completed: Fix Storage Adapter Bench - Fixed missing directory errors during vitest bench execution for S3StorageAdapter and GcsStorageAdapter by moving setup/teardown logic to standard beforeAll/afterAll hooks.
+
 ## INFRASTRUCTURE v0.37.5
 - ✅ Completed: GCS Storage Benchmark - Implemented performance benchmarks for GcsStorageAdapter.
 

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.37.5
+**Version**: 0.37.6
 
 ## Status Log
+- [v0.37.6] ✅ Completed: Fix Storage Adapter Bench - Fixed missing directory errors during vitest bench execution for S3StorageAdapter and GcsStorageAdapter by moving setup/teardown logic to standard beforeAll/afterAll hooks.
 - [v0.37.5] ✅ Completed: GCS Storage Benchmark - Implemented performance benchmarks for GcsStorageAdapter.
 - [v0.37.4] ✅ Completed: GCS Storage Benchmark Spec - Created spec for adding performance benchmarks to the GcsStorageAdapter.
 - [v0.37.3] ✅ Completed: S3 Storage Benchmark - Implemented performance benchmarks for S3StorageAdapter.

--- a/packages/infrastructure/tests/benchmarks/gcs-storage.bench.ts
+++ b/packages/infrastructure/tests/benchmarks/gcs-storage.bench.ts
@@ -1,4 +1,4 @@
-import { bench, describe } from 'vitest';
+import { bench, describe, beforeAll, afterAll } from 'vitest';
 import { GcsStorageAdapter } from '../../src/storage/gcs-storage.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -46,20 +46,18 @@ describe('GcsStorageAdapter IO Benchmark', () => {
       } catch {}
     };
 
-    const uploadAssetBundle = async () => {
-      try {
-        await adapter1MB.uploadAssetBundle(jobId1MB, localDir1MB);
-      } catch (e) {
-        // ignore if it doesn't exist during the final tear down iteration
-      }
-    };
+    beforeAll(async () => {
+      await setup1MB();
+    });
+
+    afterAll(async () => {
+      await teardown1MB();
+    });
 
     bench('GcsStorageAdapter.uploadAssetBundle - 1MB', async () => {
-      await uploadAssetBundle();
+      await adapter1MB.uploadAssetBundle(jobId1MB, localDir1MB);
     }, {
-      time: 500,
-      setup: setup1MB,
-      teardown: teardown1MB
+      time: 500
     });
   });
 
@@ -95,20 +93,18 @@ describe('GcsStorageAdapter IO Benchmark', () => {
       } catch {}
     };
 
-    const uploadAssetBundle = async () => {
-      try {
-        await adapter10MB.uploadAssetBundle(jobId10MB, localDir10MB);
-      } catch (e) {
-        // ignore if it doesn't exist during the final tear down iteration
-      }
-    };
+    beforeAll(async () => {
+      await setup10MB();
+    });
+
+    afterAll(async () => {
+      await teardown10MB();
+    });
 
     bench('GcsStorageAdapter.uploadAssetBundle - 10MB', async () => {
-      await uploadAssetBundle();
+      await adapter10MB.uploadAssetBundle(jobId10MB, localDir10MB);
     }, {
-      time: 500,
-      setup: setup10MB,
-      teardown: teardown10MB
+      time: 500
     });
   });
 

--- a/packages/infrastructure/tests/benchmarks/s3-storage.bench.ts
+++ b/packages/infrastructure/tests/benchmarks/s3-storage.bench.ts
@@ -1,4 +1,4 @@
-import { bench, describe } from 'vitest';
+import { bench, describe, beforeAll, afterAll } from 'vitest';
 import { S3StorageAdapter } from '../../src/storage/s3-storage.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -48,12 +48,18 @@ describe('S3StorageAdapter IO Benchmark', () => {
       } catch {}
     };
 
+    beforeAll(async () => {
+      await setup1MB();
+    });
+
+    afterAll(async () => {
+      await teardown1MB();
+    });
+
     bench('S3StorageAdapter.uploadAssetBundle - 1MB', async () => {
       await adapter1MB.uploadAssetBundle(jobId1MB, localDir1MB);
     }, {
-      time: 500,
-      setup: setup1MB,
-      teardown: teardown1MB
+      time: 500
     });
   });
 
@@ -91,12 +97,18 @@ describe('S3StorageAdapter IO Benchmark', () => {
       } catch {}
     };
 
+    beforeAll(async () => {
+      await setup10MB();
+    });
+
+    afterAll(async () => {
+      await teardown10MB();
+    });
+
     bench('S3StorageAdapter.uploadAssetBundle - 10MB', async () => {
       await adapter10MB.uploadAssetBundle(jobId10MB, localDir10MB);
     }, {
-      time: 500,
-      setup: setup10MB,
-      teardown: teardown10MB
+      time: 500
     });
   });
 


### PR DESCRIPTION
Moved benchmark setup and teardown logic for storage adapters into proper `beforeAll` and `afterAll` hooks to resolve directory missing errors and prevent vitest race conditions during benchmarking.

Fixes plan: `2026-03-05-INFRASTRUCTURE-Fix-Storage-Adapter-Bench.md`

---
*PR created automatically by Jules for task [4282552485413668176](https://jules.google.com/task/4282552485413668176) started by @BintzGavin*