### PR TITLE
📋 INFRASTRUCTURE: Fix Local Storage Bench Spec

### DIFF
--- a/.jules/INFRASTRUCTURE.md
+++ b/.jules/INFRASTRUCTURE.md
@@ -65,3 +65,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## 0.28.3 - Dynamic JobSpec Storage Gap
 **Learning:** Remote cloud workers fail to fetch dynamically updated `JobSpec` configurations because `JobManager` does not persist the updated spec (containing the new `assetsUrl`) to a shared `ArtifactStorage` URL before dispatching the execution. While local assets were being uploaded, the actual JSON `JobSpec` instruction file was not, leaving the cloud execution adapter stranded with a stale or unresolvable local path.
 **Action:** Plan to add `uploadJobSpec` to `ArtifactStorage` and integrate it into `JobManager.runJob` to ensure stateless workers receive accurate, dynamic job definitions.
+
+## 0.24.0 - Vitest Bench Options Side-Effects
+**Learning:** In Vitest benchmarks (`vitest bench`), using `setup` and `teardown` options within the `bench()` configuration executes multiple times in the hot loop. This causes race conditions, missing directories, or disk bloat when setting up heavy file systems or directories.
+**Action:** Place heavy setup operations in standard `beforeAll` and `afterAll` hooks outside the benchmark block instead to avoid side-effects and crashes.

--- a/.sys/plans/2026-03-06-INFRASTRUCTURE-Fix-Local-Storage-Bench.md
+++ b/.sys/plans/2026-03-06-INFRASTRUCTURE-Fix-Local-Storage-Bench.md
@@ -1,0 +1,40 @@
+#### 1. Context & Goal
+- **Objective**: Fix missing directory errors during vitest bench execution for `LocalStorageAdapter`.
+- **Trigger**: Benchmarks are failing on `LocalStorageAdapter` tests due to directory not existing errors. This is because vitest benchmark `setup` / `teardown` hooks defined in the bench options run multiple times differently from what we expect, causing race conditions in directory recreation or mysterious teardown logic taking place during the hot loop execution. We will modify the tests to use `beforeAll` and `afterAll` from `vitest` to do the setup once for the whole suite outside the hot loop and options, as requested by memory constraints, preventing these race conditions.
+- **Impact**: Enables benchmarking for `LocalStorageAdapter` to successfully run without crashes or missing directory errors.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**: `packages/infrastructure/tests/benchmarks/local-storage.bench.ts`
+- **Read-Only**: None
+
+#### 3. Implementation Spec
+- **Architecture**: In `packages/infrastructure/tests/benchmarks/local-storage.bench.ts`, group the tests into `describe('1MB Payload')` and `describe('10MB Payload')` (or similar grouping if needed, but definitely move the logic) and move the `setup` and `teardown` logic out of the `bench` options and into standard `beforeAll` and `afterAll` hooks provided by `vitest`. This ensures that the dummy files and directory are created strictly once before any benchmark iterations start, and are reliably torn down after all iterations are completely finished. The hot loop (the function within `bench()`) must not contain the file creation code.
+- **Pseudo-Code**:
+  ```typescript
+  import { bench, describe, beforeAll, afterAll } from 'vitest';
+
+  // ... inside describe block ...
+  describe('1MB Payload', () => {
+    beforeAll(async () => {
+      await setup1MB();
+    });
+
+    afterAll(async () => {
+      await teardown1MB();
+    });
+
+    bench('LocalStorageAdapter.uploadAssetBundle - 1MB', async () => {
+      await adapter1MB.uploadAssetBundle(jobId1MB, localDir1MB);
+    }, { time: 500 });
+  });
+  ```
+- **Public API Changes**: None
+- **Dependencies**: None
+- **Cloud Considerations**: None
+
+#### 4. Test Plan
+- **Verification**: `npm run bench -w packages/infrastructure -- tests/benchmarks/local-storage.bench.ts`
+- **Success Criteria**: The benchmarks successfully run and no missing directory errors are thrown. We see valid benchmark times without any test crashes.
+- **Edge Cases**: None.
+- **Integration Verification**: Verified through the isolated vitest benchmark command.

--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,5 +1,8 @@
 # INFRASTRUCTURE PROGRESS
 
+## INFRASTRUCTURE v0.37.7
+- ✅ Completed: Fix Local Storage Bench Spec - Created spec for fixing missing directory errors in the LocalStorageAdapter benchmark.
+
 ## INFRASTRUCTURE v0.37.6
 - ✅ Completed: Fix Storage Adapter Bench - Fixed missing directory errors during vitest bench execution for S3StorageAdapter and GcsStorageAdapter by moving setup/teardown logic to standard beforeAll/afterAll hooks.
 

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.37.6
+**Version**: 0.37.7
 
 ## Status Log
+- [v0.37.7] ✅ Completed: Fix Local Storage Bench Spec - Created spec for fixing missing directory errors in the LocalStorageAdapter benchmark.
 - [v0.37.6] ✅ Completed: Fix Storage Adapter Bench - Fixed missing directory errors during vitest bench execution for S3StorageAdapter and GcsStorageAdapter by moving setup/teardown logic to standard beforeAll/afterAll hooks.
 - [v0.37.5] ✅ Completed: GCS Storage Benchmark - Implemented performance benchmarks for GcsStorageAdapter.
 - [v0.37.4] ✅ Completed: GCS Storage Benchmark Spec - Created spec for adding performance benchmarks to the GcsStorageAdapter.


### PR DESCRIPTION
This PR generates a specification to fix the vitest missing directory errors occurring in `LocalStorageAdapter` benchmarks. I have recorded the learning in the journal and drafted an execution plan to instruct the executor to use vitest's standard `beforeAll`/`afterAll` hooks rather than the `bench()` configuration options.

---
*PR created automatically by Jules for task [6376624069000052476](https://jules.google.com/task/6376624069000052476) started by @BintzGavin*