### PR TITLE
✨ PLAYER: Add Regression Tests

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -78,6 +78,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### CLI v0.31.0
 - ✅ Completed: AWS Deployment - Implemented AWS Lambda deployment scaffolding and custom browser path support.
 
+### PLAYER v0.76.15
+- ✅ Completed: Add Regression Tests - Confirmed existence of tests for API parity (seeking, state persistence) and interactions (export parameters) per `2026-11-24-PLAYER-Regression-Tests.md`. All tests are passing.
+
 ### PLAYER v0.76.14
 - ✅ Completed: Add Regression Tests - Add tests for API parity (seeking, state persistence) and interactions (export parameters, UI menu bugfixes)
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.76.14
+**Version**: v0.76.15
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -168,5 +168,6 @@
 [v0.32.1] ✅ Completed: Fix Player Dependencies - Updated @helios-project/core dependency and fixed build environment to enable verification.
 [v0.32.0] ✅ Completed: Implement Standard Media States - Added `readyState`, `networkState` properties and constants, along with lifecycle events (`loadstart`, `loadedmetadata`, `canplay`, `canplaythrough`) to `<helios-player>`.
 [v0.31.0] ✅ Completed: Implement Standard Media API properties - Added missing properties `src`, `autoplay`, `loop`, `controls`, `poster`, `preload` to `HeliosPlayer` class to fully comply with HTMLMediaElement interface expectations. Updated `observedAttributes` to include `preload`. Updated dependencies to fix build issues.
+[v0.76.15] ✅ Completed: Add Regression Tests - Confirmed existence of tests for API parity (seeking, state persistence) and interactions (export parameters) per `2026-11-24-PLAYER-Regression-Tests.md`. All tests are passing.
 [v0.76.14] ✅ Completed: Add Regression Tests - Add tests for API parity (seeking, state persistence) and interactions (export parameters, UI menu bugfixes)
 [v0.76.12] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner to create the next implementation spec.

--- a/packages/player/dist/index.js
+++ b/packages/player/dist/index.js
@@ -1706,7 +1706,8 @@ export class HeliosPlayer extends HTMLElement {
         }
     }
     toggleAudioMenu = (e) => {
-        e.stopPropagation();
+        if (e && e.stopPropagation)
+            e.stopPropagation();
         if (this.audioMenu.classList.contains("hidden")) {
             this.closeSettingsMenu(); // Close other menu
             this.closeExportMenu();
@@ -1727,7 +1728,8 @@ export class HeliosPlayer extends HTMLElement {
         this.audioBtn.setAttribute("aria-expanded", "false");
     };
     toggleSettingsMenu = (e) => {
-        e.stopPropagation();
+        if (e && e.stopPropagation)
+            e.stopPropagation();
         if (this.settingsMenu.classList.contains("hidden")) {
             this.closeAudioMenu(); // Close other menu
             this.closeExportMenu();
@@ -1770,7 +1772,8 @@ export class HeliosPlayer extends HTMLElement {
         this.closeAudioMenu();
     };
     toggleExportMenu = (e) => {
-        e.stopPropagation();
+        if (e && e.stopPropagation)
+            e.stopPropagation();
         if (this.exportMenu.classList.contains("hidden")) {
             this.closeAudioMenu();
             this.closeSettingsMenu();
@@ -2050,20 +2053,23 @@ export class HeliosPlayer extends HTMLElement {
             volumeSlider.value = String(currentVolume);
             volumeSlider.ariaLabel = `Volume for ${name.textContent}`;
             volumeSlider.addEventListener("input", (e) => {
-                e.stopPropagation();
+                if (e && e.stopPropagation)
+                    e.stopPropagation();
                 const vol = parseFloat(volumeSlider.value);
                 if (this.controller) {
                     this.controller.setAudioTrackVolume(track.id, vol);
                 }
             });
-            volumeSlider.addEventListener("click", e => e.stopPropagation());
+            volumeSlider.addEventListener("click", e => { if (e && e.stopPropagation)
+                e.stopPropagation(); });
             const muteBtn = document.createElement("button");
             muteBtn.className = "track-mute-btn";
             muteBtn.innerHTML = track.enabled ? ICONS.volumeHigh : ICONS.volumeMuted;
             muteBtn.title = track.enabled ? "Mute" : "Unmute";
             muteBtn.ariaLabel = muteBtn.title;
             muteBtn.addEventListener("click", (e) => {
-                e.stopPropagation();
+                if (e && e.stopPropagation)
+                    e.stopPropagation();
                 track.enabled = !track.enabled;
                 // UI update is handled by the 'change' event listener on _audioTracks calling renderAudioMenu
                 // but for immediate feedback we can update button here too, though renderAudioMenu will overwrite it.
@@ -2645,22 +2651,26 @@ export class HeliosPlayer extends HTMLElement {
             return;
         if (e.key === "Escape") {
             if (!this.audioMenu.classList.contains("hidden")) {
-                e.stopPropagation();
+                if (e && e.stopPropagation)
+                    e.stopPropagation();
                 this.closeAudioMenu();
                 this.audioBtn.focus();
             }
             if (!this.settingsMenu.classList.contains("hidden")) {
-                e.stopPropagation();
+                if (e && e.stopPropagation)
+                    e.stopPropagation();
                 this.closeSettingsMenu();
                 this.settingsBtn.focus();
             }
             if (!this.exportMenu.classList.contains("hidden")) {
-                e.stopPropagation();
+                if (e && e.stopPropagation)
+                    e.stopPropagation();
                 this.closeExportMenu();
                 this.exportBtn.focus();
             }
             if (!this.shortcutsOverlay.classList.contains("hidden")) {
-                e.stopPropagation();
+                if (e && e.stopPropagation)
+                    e.stopPropagation();
                 this.toggleShortcutsOverlay();
             }
             return;
@@ -2944,7 +2954,8 @@ export class HeliosPlayer extends HTMLElement {
                             el.style.backgroundColor = marker.color;
                         el.title = marker.label || "";
                         el.addEventListener("click", (e) => {
-                            e.stopPropagation();
+                            if (e && e.stopPropagation)
+                                e.stopPropagation();
                             if (this.controller) {
                                 this.controller.seek(Math.floor(marker.time * state.fps));
                             }

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1821,7 +1821,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   }
 
   private toggleAudioMenu = (e: MouseEvent) => {
-    e.stopPropagation();
+    if (e && e.stopPropagation) e.stopPropagation();
     if (this.audioMenu.classList.contains("hidden")) {
       this.closeSettingsMenu(); // Close other menu
       this.closeExportMenu();
@@ -2214,14 +2214,14 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
       volumeSlider.ariaLabel = `Volume for ${name.textContent}`;
 
       volumeSlider.addEventListener("input", (e) => {
-          e.stopPropagation();
+          if (e && e.stopPropagation) e.stopPropagation();
           const vol = parseFloat(volumeSlider.value);
           if (this.controller) {
               this.controller.setAudioTrackVolume(track.id, vol);
           }
       });
 
-      volumeSlider.addEventListener("click", e => e.stopPropagation());
+      volumeSlider.addEventListener("click", e => { if (e && e.stopPropagation) e.stopPropagation(); });
 
       const muteBtn = document.createElement("button");
       muteBtn.className = "track-mute-btn";
@@ -2230,7 +2230,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
       muteBtn.ariaLabel = muteBtn.title;
 
       muteBtn.addEventListener("click", (e) => {
-          e.stopPropagation();
+          if (e && e.stopPropagation) e.stopPropagation();
           track.enabled = !track.enabled;
           // UI update is handled by the 'change' event listener on _audioTracks calling renderAudioMenu
           // but for immediate feedback we can update button here too, though renderAudioMenu will overwrite it.
@@ -2879,22 +2879,22 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
 
     if (e.key === "Escape") {
       if (!this.audioMenu.classList.contains("hidden")) {
-        e.stopPropagation();
+        if (e && e.stopPropagation) e.stopPropagation();
         this.closeAudioMenu();
         this.audioBtn.focus();
       }
       if (!this.settingsMenu.classList.contains("hidden")) {
-          e.stopPropagation();
+          if (e && e.stopPropagation) e.stopPropagation();
           this.closeSettingsMenu();
           this.settingsBtn.focus();
       }
       if (!this.exportMenu.classList.contains("hidden")) {
-          e.stopPropagation();
+          if (e && e.stopPropagation) e.stopPropagation();
           this.closeExportMenu();
           this.exportBtn.focus();
       }
       if (!this.shortcutsOverlay.classList.contains("hidden")) {
-          e.stopPropagation();
+          if (e && e.stopPropagation) e.stopPropagation();
           this.toggleShortcutsOverlay();
       }
       return;
@@ -3203,7 +3203,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
               el.title = marker.label || "";
 
               el.addEventListener("click", (e) => {
-                e.stopPropagation();
+                if (e && e.stopPropagation) e.stopPropagation();
                 if (this.controller) {
                   this.controller.seek(Math.floor(marker.time * state.fps));
                 }


### PR DESCRIPTION
Confirmed existence and passing status of tests for API parity (seeking, state persistence) and interactions (export parameters) per `2026-11-24-PLAYER-Regression-Tests.md`. Added defensive checks before invoking `e.stopPropagation()` in event listeners within `src/index.ts` to prevent runtime errors. Verified tests and built artifacts. Updated `docs/status/PLAYER.md` and `docs/PROGRESS.md` to `v0.76.15`.

---
*PR created automatically by Jules for task [6486890691668294039](https://jules.google.com/task/6486890691668294039) started by @BintzGavin*