### PR TITLE
✨ CLI: Remove Command Regression Tests

### DIFF
--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.36.3
+
+- ✅ Remove Command Regression Tests - Implemented comprehensive unit tests for `helios remove`.
+
 ## CLI v0.36.2
 
 - ✅ Init Command Tests Spec - Created specification plan for implementing regression tests for the `helios init` command to ensure scaffolding stability.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.36.2
+**Version**: 0.36.3
 
 ## Current State
 
@@ -41,6 +41,7 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 
 ## History
 
+[v0.36.3] ✅ Remove Command Regression Tests - Implemented comprehensive unit tests for `helios remove`.
 [v0.1.0] ✅ Initial CLI with `helios studio` command
 [v0.1.1] ✅ Pass Project Root to Studio - Injected HELIOS_PROJECT_ROOT env var in studio command
 [v0.2.0] ✅ Scaffold Init Command - Implemented `helios init` to generate `helios.config.json`

--- a/packages/cli/src/commands/__tests__/remove.test.ts
+++ b/packages/cli/src/commands/__tests__/remove.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { registerRemoveCommand } from '../remove.js';
+import { Command } from 'commander';
+import fs from 'fs';
+import prompts from 'prompts';
+import * as configUtil from '../../utils/config.js';
+import * as uninstallUtil from '../../utils/uninstall.js';
+import { RegistryClient } from '../../registry/client.js';
+
+vi.mock('fs');
+vi.mock('prompts');
+vi.mock('../../utils/config.js');
+vi.mock('../../utils/uninstall.js');
+vi.mock('../../registry/client.js');
+
+describe('remove command', () => {
+  let program: Command;
+  let exitSpy: any;
+
+  beforeEach(() => {
+    program = new Command();
+    registerRemoveCommand(program);
+    vi.resetAllMocks();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+
+    vi.mocked(configUtil.loadConfig).mockReturnValue({
+      framework: 'react',
+      directories: { components: 'src/components' },
+      components: ['test-component'],
+      registry: 'http://localhost'
+    } as any);
+
+    vi.mocked(RegistryClient.prototype.findComponent).mockResolvedValue({
+      name: 'test-component',
+      files: [{ name: 'TestComponent.tsx' }]
+    } as any);
+
+    // Mock fs.existsSync to be false by default
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should bypass removal with --keep-files', async () => {
+    await program.parseAsync(['node', 'test', 'remove', 'test-component', '--keep-files']);
+    expect(uninstallUtil.uninstallComponent).toHaveBeenCalledWith(
+      expect.any(String),
+      'test-component',
+      expect.objectContaining({ removeFiles: false })
+    );
+  });
+
+  it('should proceed without prompts if component is not in config', async () => {
+    vi.mocked(configUtil.loadConfig).mockReturnValue({
+      components: []
+    } as any);
+    await program.parseAsync(['node', 'test', 'remove', 'not-in-config']);
+    expect(uninstallUtil.uninstallComponent).toHaveBeenCalledWith(
+      expect.any(String),
+      'not-in-config',
+      expect.objectContaining({ removeFiles: true })
+    );
+    expect(prompts).not.toHaveBeenCalled();
+  });
+
+  it('should proceed without prompts if files do not exist', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    await program.parseAsync(['node', 'test', 'remove', 'test-component']);
+    expect(uninstallUtil.uninstallComponent).toHaveBeenCalledWith(
+      expect.any(String),
+      'test-component',
+      expect.objectContaining({ removeFiles: true })
+    );
+    expect(prompts).not.toHaveBeenCalled();
+  });
+
+  it('should abort removal if user cancels prompt', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(prompts).mockResolvedValue({ value: false });
+    await program.parseAsync(['node', 'test', 'remove', 'test-component']);
+    expect(prompts).toHaveBeenCalled();
+    expect(uninstallUtil.uninstallComponent).not.toHaveBeenCalled();
+  });
+
+  it('should proceed with removal if user confirms prompt', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(prompts).mockResolvedValue({ value: true });
+    await program.parseAsync(['node', 'test', 'remove', 'test-component']);
+    expect(prompts).toHaveBeenCalled();
+    expect(uninstallUtil.uninstallComponent).toHaveBeenCalledWith(
+      expect.any(String),
+      'test-component',
+      expect.objectContaining({ removeFiles: true })
+    );
+  });
+
+  it('should skip confirmation with --yes flag', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    await program.parseAsync(['node', 'test', 'remove', 'test-component', '--yes']);
+    expect(prompts).not.toHaveBeenCalled();
+    expect(uninstallUtil.uninstallComponent).toHaveBeenCalledWith(
+      expect.any(String),
+      'test-component',
+      expect.objectContaining({ removeFiles: true })
+    );
+  });
+
+  it('should handle config load failure', async () => {
+    vi.mocked(configUtil.loadConfig).mockReturnValue(null as any);
+    await program.parseAsync(['node', 'test', 'remove', 'test-component']);
+    expect(uninstallUtil.uninstallComponent).toHaveBeenCalledWith(
+      expect.any(String),
+      'test-component',
+      expect.objectContaining({ removeFiles: true })
+    );
+  });
+});


### PR DESCRIPTION
✨ CLI: Remove Command Regression Tests

💡 What: Implemented comprehensive regression tests for the `helios remove` command using vitest. Added tests to verify interaction prompts, config fallbacks, file preservation, and flags.
🎯 Why: To fulfill the 'Regression tests' fallback action gap and guarantee stability for the `remove` command. Ensures that the complex removal logic correctly interacts with the registry client and file system without regression risks during future upgrades.
📊 Impact: Validates the command handles all major interaction flows (like `--keep-files`, `--yes`, and prompt cancellations) automatically. Protects against future feature changes inadvertently breaking deletion mechanics.
🔬 Verification: Tests pass locally using `npm run test -w packages/cli`. Verified all branches logic in `packages/cli/src/commands/remove.ts`.

Refs: .sys/plans/2026-11-25-CLI-Remove-Regression-Tests.md

---
*PR created automatically by Jules for task [13953484178760020392](https://jules.google.com/task/13953484178760020392) started by @BintzGavin*