### PR TITLE
✨ INFRASTRUCTURE: Report Blocked Status

### DIFF
--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -2,6 +2,7 @@
 **Version**: 0.38.1
 
 ## Status Log
+- [v0.38.1] 🚫 Blocked: No uncompleted implementation plans found for my domain in `/.sys/plans/`. I must stop working.
 - [v0.38.1] ✅ Completed: CloudRunAdapter Benchmark Spec - Created spec for adding performance benchmarks to the CloudRunAdapter.
 - [v0.38.0] ✅ Completed: JobExecutor Example - Created an example script demonstrating the standalone use of JobExecutor for custom orchestration logic.
 - [v0.37.15] ✅ Completed: AWS Lambda Adapter Benchmark Spec - Created spec for adding performance benchmarks to the AwsLambdaAdapter.


### PR DESCRIPTION
✨ INFRASTRUCTURE: Report Blocked Status

💡 **What**: Added a 'Blocked' note to `docs/status/INFRASTRUCTURE.md` because there are no *uncompleted* implementation plans in `/.sys/plans/` for the INFRASTRUCTURE domain.
🎯 **Why**: To abide by the protocol rule "no work without a plan". The Executor must log a block when no plans are available to execute.
📊 **Impact**: Safely pauses INFRASTRUCTURE execution without hallucinatory or unauthorized changes to out-of-bounds files until new plans are authored by the Planner.
🔬 **Verification**: Ran `npm run lint` and `npm test` within `packages/infrastructure` to confirm no regressions. Checked `.sys/plans/` and status files.

---
*PR created automatically by Jules for task [5242602820543039312](https://jules.google.com/task/5242602820543039312) started by @BintzGavin*