### PR TITLE
✨ INFRASTRUCTURE: Blocked Status Log

### DIFF
--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,5 +1,8 @@
 # INFRASTRUCTURE PROGRESS
 
+## INFRASTRUCTURE v0.38.11
+- 🚫 Blocked: No uncompleted implementation plans found for my domain in `/.sys/plans/`. I must stop working.
+
 ## INFRASTRUCTURE v0.38.10
 - ✅ Completed: GCS Storage Benchmark - Implemented performance benchmarks for GcsStorageAdapter.
 

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.38.10
+**Version**: 0.38.11
 
 ## Status Log
+- [v0.38.11] 🚫 Blocked: No uncompleted implementation plans found for my domain in `/.sys/plans/`. I must stop working.
 - [v0.38.10] ✅ Completed: GCS Storage Benchmark - Implemented performance benchmarks for GcsStorageAdapter.
 - [v0.38.9] ✅ Completed: FileJobRepository Example - Created an example script demonstrating the standalone use of `FileJobRepository` with `JobManager` for persistent job state storage.
 - [v0.38.8] ✅ Completed: WorkerRuntime Benchmark - Implemented performance benchmarks for WorkerRuntime.


### PR DESCRIPTION
Added Blocked status log for INFRASTRUCTURE domain since no uncompleted plans exist in `/.sys/plans/`. Cleaned up workspace.

---
*PR created automatically by Jules for task [13526817426863457386](https://jules.google.com/task/13526817426863457386) started by @BintzGavin*