### PR TITLE
✨ STUDIO: Enhance MCP Server

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -4,6 +4,7 @@
 Studio is a framework-agnostic browser-based development environment for video composition.
 It consists of a CLI, a dev server built on top of Vite, and a browser-based UI.
 The architecture uses a unified state model via `HeliosState` and interacts with a local API backend for file system operations.
+It also includes an MCP (Model Context Protocol) server to expose tools to AI agents.
 
 ## Section B: File Tree
 ```
@@ -40,3 +41,4 @@ The `npx helios studio` command launches the dev server, which uses `vite-plugin
 - Integrates with `@helios-project/player` for rendering the preview frame.
 - Integrates with `@helios-project/renderer` for launching backend render processes.
 - Integrates with `@helios-project/cli` for injecting the registry manifest into the Studio API backend.
+- Exposes MCP tools (`create_composition`, `render_composition`, etc.) enabling intelligent AI agents to interact with the workspace programmatically.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+### STUDIO v0.118.0
+- ✅ Completed: Enhance MCP Server - Added support for inputProps, videoBitrate, and videoCodec to MCP server tools.
+
 ## STUDIO v0.117.0
 - ✅ Completed: Components Panel - Implemented a visual Components Panel in Helios Studio to browse and install components from the registry.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.117.0
+**Version**: 0.118.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -11,6 +11,7 @@
 > **Note**: Status versions in this file may precede package release versions (`package.json`). Always verify `package.json` for the currently installed version.
 
 ## Recent Updates
+- [v0.118.0] ✅ Completed: Enhance MCP Server - Added support for inputProps, videoBitrate, and videoCodec to MCP server tools.
 - [v0.117.0] ✅ Completed: Components Panel - Implemented a visual Components Panel in Helios Studio to browse and install components from the registry.
 - [v0.116.2] ✅ Completed: Schema Validation - Implemented visual validation feedback in the Studio Props Editor to enforce schema constraints (pattern, min/max) and guide users using a unified `validateValue` helper.
 - [v0.116.1] ✅ Verified: Regression Test - Confirmed Asset Move backend API and Studio UI stability via verification scripts (`verify-asset-move.ts`, `verify-ui.ts`).

--- a/packages/studio/src/server/mcp.test.ts
+++ b/packages/studio/src/server/mcp.test.ts
@@ -96,7 +96,7 @@ describe('createMcpServer', () => {
     expect(JSON.parse(result.content[0].text)).toEqual({ id: 'test', name: 'Test' });
   });
 
-  it('should handle render_composition tool with inputProps', async () => {
+  it('should handle render_composition tool with inputProps, videoBitrate, and videoCodec', async () => {
     const server = createMcpServer(getPort) as any;
     (findCompositions as any).mockResolvedValue([{ id: 'comp-1', url: '/@fs/path/to/comp' }]);
     (startRender as any).mockResolvedValue('job-123');
@@ -104,13 +104,17 @@ describe('createMcpServer', () => {
     const handler = server.tools['render_composition'].handler;
     const result = await handler({
       compositionId: 'comp-1',
-      inputProps: { text: 'Hello' }
+      inputProps: { text: 'Hello' },
+      videoBitrate: '5M',
+      videoCodec: 'libx264'
     });
 
     expect(startRender).toHaveBeenCalledWith(
       expect.objectContaining({
         compositionUrl: '/@fs/path/to/comp',
-        inputProps: { text: 'Hello' }
+        inputProps: { text: 'Hello' },
+        videoBitrate: '5M',
+        videoCodec: 'libx264'
       }),
       1234
     );

--- a/packages/studio/src/server/mcp.ts
+++ b/packages/studio/src/server/mcp.ts
@@ -122,7 +122,9 @@ export function createMcpServer(getPort: () => number, options: StudioPluginOpti
       height: z.number().optional(),
       fps: z.number().optional(),
       duration: z.number().optional(),
-      inputProps: z.record(z.string(), z.any()).optional()
+      inputProps: z.record(z.string(), z.any()).optional(),
+      videoBitrate: z.string().optional(),
+      videoCodec: z.string().optional()
     },
     async (args) => {
        try {
@@ -143,7 +145,9 @@ export function createMcpServer(getPort: () => number, options: StudioPluginOpti
                height: args.height,
                fps: args.fps,
                duration: args.duration,
-               inputProps: args.inputProps
+               inputProps: args.inputProps,
+               videoBitrate: args.videoBitrate,
+               videoCodec: args.videoCodec
            }, port);
 
            return {


### PR DESCRIPTION
Added `videoBitrate` and `videoCodec` to the `render_composition` tool in the Studio MCP Server to allow agents to configure video bitrate and codecs when starting render jobs. Added unit tests for the missing parameters. Updated the Studio documentation and logs to reflect these changes.

---
*PR created automatically by Jules for task [4651084114556471009](https://jules.google.com/task/4651084114556471009) started by @BintzGavin*