### PR TITLE
✨ CLI: Update Command Regression Tests

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -21,8 +21,11 @@ packages/cli/
 │   ├── commands/
 │   │   ├── __tests__/
 │   │   │   ├── deploy.test.ts # Deploy command tests
+│   │   │   ├── init.test.ts   # Init command tests
 │   │   │   ├── job.test.ts    # Job command tests
-│   │   │   └── render.test.ts # Render command tests
+│   │   │   ├── remove.test.ts # Remove command tests
+│   │   │   ├── render.test.ts # Render command tests
+│   │   │   └── update.test.ts # Update command tests
 │   │   ├── add.ts          # Adds components
 │   │   ├── build.ts        # Builds for production
 │   │   ├── components.ts   # Lists registry components

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,14 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.36.6
+
+- ✅ Update Command Regression Tests - Implemented comprehensive unit tests for `helios update`.
+
+## CLI v0.36.5
+
+- ✅ Update Command Tests Spec - Created specification plan for implementing regression tests for the `helios update` command.
+
 ## CLI v0.36.4
 
 - ✅ Init Command Regression Tests - Implemented comprehensive regression tests for `helios init`.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.36.5
+**Version**: 0.36.6
 
 ## Current State
 
@@ -41,6 +41,7 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 
 ## History
 
+[v0.36.6] ✅ Update Command Regression Tests - Implemented comprehensive unit tests for `helios update`.
 [v0.36.5] ✅ Update Command Tests Spec - Created specification plan for implementing regression tests for the `helios update` command.
 [v0.36.4] ✅ Init Command Regression Tests - Implemented comprehensive regression tests for `helios init`.
 [v0.36.3] ✅ Remove Command Regression Tests - Implemented comprehensive unit tests for `helios remove`.

--- a/packages/cli/src/commands/__tests__/update.test.ts
+++ b/packages/cli/src/commands/__tests__/update.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { registerUpdateCommand } from '../update.js';
+import { Command } from 'commander';
+import readline from 'readline';
+import * as configUtil from '../../utils/config.js';
+import * as installUtil from '../../utils/install.js';
+import { RegistryClient } from '../../registry/client.js';
+
+vi.mock('readline', () => {
+  return {
+    default: {
+      createInterface: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../utils/config.js');
+vi.mock('../../utils/install.js');
+vi.mock('../../registry/client.js');
+
+describe('update command', () => {
+  let program: Command;
+  let exitSpy: any;
+
+  beforeEach(() => {
+    program = new Command();
+    registerUpdateCommand(program);
+    vi.resetAllMocks();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+
+    vi.mocked(configUtil.loadConfig).mockReturnValue({
+      framework: 'react',
+      directories: { components: 'src/components', lib: 'src/lib' },
+      components: ['test-component'],
+    });
+
+    vi.mocked(installUtil.installComponent).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should exit if configuration file is missing', async () => {
+    vi.mocked(configUtil.loadConfig).mockReturnValue(null);
+
+    await program.parseAsync(['node', 'test', 'update', 'test-component']);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(installUtil.installComponent).not.toHaveBeenCalled();
+  });
+
+  it('should exit if component is not installed', async () => {
+    vi.mocked(configUtil.loadConfig).mockReturnValue({
+      framework: 'react',
+      directories: { components: 'src/components', lib: 'src/lib' },
+      components: ['other-component'],
+    });
+
+    await program.parseAsync(['node', 'test', 'update', 'test-component']);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(installUtil.installComponent).not.toHaveBeenCalled();
+  });
+
+  it('should update component if user answers yes', async () => {
+    const mockQuestion = vi.fn((query, cb) => cb('y'));
+    const mockClose = vi.fn();
+    vi.mocked(readline.createInterface).mockReturnValue({
+      question: mockQuestion,
+      close: mockClose,
+    } as any);
+
+    await program.parseAsync(['node', 'test', 'update', 'test-component']);
+
+    expect(mockQuestion).toHaveBeenCalled();
+    expect(mockClose).toHaveBeenCalled();
+    expect(installUtil.installComponent).toHaveBeenCalledWith(
+      expect.any(String),
+      'test-component',
+      {
+        install: true,
+        overwrite: true,
+        client: expect.any(Object),
+      }
+    );
+  });
+
+  it('should update component if user answers yes with variations', async () => {
+    const mockQuestion = vi.fn((query, cb) => cb('Yes'));
+    const mockClose = vi.fn();
+    vi.mocked(readline.createInterface).mockReturnValue({
+      question: mockQuestion,
+      close: mockClose,
+    } as any);
+
+    await program.parseAsync(['node', 'test', 'update', 'test-component']);
+
+    expect(mockQuestion).toHaveBeenCalled();
+    expect(installUtil.installComponent).toHaveBeenCalled();
+  });
+
+  it('should not update component if user answers no', async () => {
+    const mockQuestion = vi.fn((query, cb) => cb('n'));
+    const mockClose = vi.fn();
+    vi.mocked(readline.createInterface).mockReturnValue({
+      question: mockQuestion,
+      close: mockClose,
+    } as any);
+
+    await program.parseAsync(['node', 'test', 'update', 'test-component']);
+
+    expect(mockQuestion).toHaveBeenCalled();
+    expect(installUtil.installComponent).not.toHaveBeenCalled();
+  });
+
+  it('should skip prompt and update if --yes flag is provided', async () => {
+    await program.parseAsync(['node', 'test', 'update', 'test-component', '--yes']);
+
+    expect(readline.createInterface).not.toHaveBeenCalled();
+    expect(installUtil.installComponent).toHaveBeenCalledWith(
+      expect.any(String),
+      'test-component',
+      {
+        install: true,
+        overwrite: true,
+        client: expect.any(Object),
+      }
+    );
+  });
+
+  it('should skip install if --no-install flag is provided', async () => {
+    await program.parseAsync(['node', 'test', 'update', 'test-component', '--yes', '--no-install']);
+
+    expect(installUtil.installComponent).toHaveBeenCalledWith(
+      expect.any(String),
+      'test-component',
+      {
+        install: false,
+        overwrite: true,
+        client: expect.any(Object),
+      }
+    );
+  });
+});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -13,17 +13,20 @@ export function registerUpdateCommand(program: Command) {
     .option('--no-install', 'Skip dependency installation')
     .action(async (component, options) => {
       const config = loadConfig();
-      const client = new RegistryClient(config?.registry);
 
       if (!config) {
         console.error(chalk.red('Configuration file not found. Run "helios init" first.'));
         process.exit(1);
+        return;
       }
+
+      const client = new RegistryClient(config.registry);
 
       if (!config.components || !config.components.includes(component)) {
         console.error(chalk.red(`Component "${component}" is not installed.`));
         console.log(chalk.gray(`Run "helios add ${component}" to install it.`));
         process.exit(1);
+        return;
       }
 
       if (!options.yes) {


### PR DESCRIPTION
Implemented unit tests for the `helios update` command to verify various interactive prompts and update handling flows as defined by the specification in `2026-03-07-CLI-Update-Regression-Tests.md`. Also added an early `return` after `process.exit(1)` in `update.ts` to ensure the testing framework doesn't hang after exit intercepts. Updated CLI documentation, status, and progress logs.

---
*PR created automatically by Jules for task [14558823154298142017](https://jules.google.com/task/14558823154298142017) started by @BintzGavin*