### PR TITLE
✨ CLI: Add Command Regression Tests

### DIFF
--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.36.7
+
+- ✅ Add Command Regression Tests - Implemented comprehensive unit tests for `helios add`.
+
 ## CLI v0.36.6
 
 - ✅ Update Command Regression Tests - Implemented comprehensive unit tests for `helios update`.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.36.6
+**Version**: 0.36.7
 
 ## Current State
 
@@ -41,6 +41,7 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 
 ## History
 
+[v0.36.7] ✅ Add Command Regression Tests - Implemented comprehensive unit tests for `helios add`.
 [v0.36.6] ✅ Update Command Regression Tests - Implemented comprehensive unit tests for `helios update`.
 [v0.36.5] ✅ Update Command Tests Spec - Created specification plan for implementing regression tests for the `helios update` command.
 [v0.36.4] ✅ Init Command Regression Tests - Implemented comprehensive regression tests for `helios init`.

--- a/packages/cli/src/commands/__tests__/add.test.ts
+++ b/packages/cli/src/commands/__tests__/add.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerAddCommand } from '../add.js';
+import { getConfigOrThrow } from '../../utils/config.js';
+import { RegistryClient } from '../../registry/client.js';
+import { installComponent } from '../../utils/install.js';
+
+vi.mock('../../utils/config.js');
+vi.mock('../../registry/client.js');
+vi.mock('../../utils/install.js');
+
+describe('add command', () => {
+  let program: Command;
+  const originalExit = process.exit;
+  const originalError = console.error;
+
+  beforeEach(() => {
+    program = new Command();
+    registerAddCommand(program);
+    vi.clearAllMocks();
+
+    // Mock exit to prevent process from actually exiting
+    (process.exit as unknown as ReturnType<typeof vi.fn>) = vi.fn();
+    console.error = vi.fn();
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    console.error = originalError;
+  });
+
+  it('installs a component with default options', async () => {
+    vi.mocked(getConfigOrThrow).mockReturnValue({
+      version: '1.0.0',
+      directories: { components: 'src/components', lib: 'src/lib' },
+      components: [],
+    });
+
+    await program.parseAsync(['node', 'test', 'add', 'button']);
+
+    expect(getConfigOrThrow).toHaveBeenCalledWith(process.cwd());
+    expect(RegistryClient).toHaveBeenCalled();
+    expect(installComponent).toHaveBeenCalledWith(
+      process.cwd(),
+      'button',
+      expect.objectContaining({ install: true })
+    );
+  });
+
+  it('respects --no-install flag', async () => {
+    vi.mocked(getConfigOrThrow).mockReturnValue({
+      version: '1.0.0',
+      directories: { components: 'src/components', lib: 'src/lib' },
+      components: [],
+    });
+
+    await program.parseAsync(['node', 'test', 'add', 'button', '--no-install']);
+
+    expect(installComponent).toHaveBeenCalledWith(
+      process.cwd(),
+      'button',
+      expect.objectContaining({ install: false })
+    );
+  });
+
+  it('handles errors cleanly and exits with code 1', async () => {
+    const errorMsg = 'Config error';
+    vi.mocked(getConfigOrThrow).mockImplementation(() => {
+      throw new Error(errorMsg);
+    });
+
+    await program.parseAsync(['node', 'test', 'add', 'button']);
+
+    expect(console.error).toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -17,6 +17,7 @@ export function registerAddCommand(program: Command) {
       } catch (e: any) {
         console.error(chalk.red(e.message));
         process.exit(1);
+        return;
       }
     });
 }


### PR DESCRIPTION
Implemented comprehensive regression tests for the `helios add` command using `vitest`. Tests cover normal installation, the `--no-install` flag behavior, and error handling. Additionally, added an early return to `packages/cli/src/commands/add.ts` to prevent the vitest framework from hanging after a mocked `process.exit`.

The CLI domain has reached gravitational equilibrium. Executing the fallback action of implementing regression tests ensures the stability of the core component addition workflow and prevents future regressions.

Improved test coverage for the `packages/cli` package, specifically validating the `add` command's interaction with the registry and file system dependencies.

Tests execute successfully via `npm run test -w packages/cli -- src/commands/__tests__/add.test.ts` and verify expected behavior without introducing new side effects.

---
*PR created automatically by Jules for task [16957628316081338377](https://jules.google.com/task/16957628316081338377) started by @BintzGavin*