### PR TITLE
✨ INFRASTRUCTURE: Blocked Status Log Update

### DIFF
--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -2,6 +2,7 @@
 **Version**: 0.40.21
 
 ## Status Log
+- [v0.40.21] 🚫 Blocked: No uncompleted implementation plans found for my domain in `/.sys/plans/`. I must stop working.
 - [v0.40.21] ✅ Completed: CloudRunServer Resiliency Tests Spec - Created spec for expanding CloudRunServer resiliency and regression tests.
 - [v0.40.21] ✅ Completed: FfmpegStitcher Resiliency Tests - Implemented comprehensive resiliency and regression tests for FfmpegStitcher error handling.
 - [v0.40.20] 🚫 Blocked: No uncompleted implementation plans found for my domain in `/.sys/plans/`. I must stop working.


### PR DESCRIPTION
Added a blocked status to the INFRASTRUCTURE status log.
There were no uncompleted implementation plans found in `/.sys/plans/` for the INFRASTRUCTURE domain.
Signals to the system that the agent requires a new plan to be generated before it can resume working.

---
*PR created automatically by Jules for task [9707837578924651467](https://jules.google.com/task/9707837578924651467) started by @BintzGavin*