### PR TITLE
✨ INFRASTRUCTURE: CloudRunServer Benchmark

### DIFF
--- a/.sys/llmdocs/context-infrastructure.md
+++ b/.sys/llmdocs/context-infrastructure.md
@@ -32,6 +32,7 @@ packages/infrastructure/tests
 ├── benchmarks
 │   ├── aws-adapter.bench.ts
 │   ├── cloudrun-adapter.bench.ts
+│   ├── cloudrun-server.bench.ts
 │   ├── ffmpeg-stitcher.bench.ts
 │   ├── file-job-repository.bench.ts
 │   ├── gcs-storage.bench.ts

--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,5 +1,8 @@
 # INFRASTRUCTURE PROGRESS
 
+## INFRASTRUCTURE v0.40.27
+- ✅ Completed: CloudRunServer Benchmark - Implemented performance benchmarks for the CloudRunServer using vitest bench.
+
 ## INFRASTRUCTURE v0.40.26
 - ✅ Completed: LocalWorkerAdapter Benchmark - Implemented performance benchmarks for the LocalWorkerAdapter using vitest bench.
 

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.40.26
+**Version**: 0.40.27
 
 ## Status Log
+- [v0.40.27] ✅ Completed: CloudRunServer Benchmark - Implemented performance benchmarks for the CloudRunServer using vitest bench.
 - [v0.40.26] ✅ Completed: LocalWorkerAdapter Benchmark - Implemented performance benchmarks for the LocalWorkerAdapter using vitest bench.
 [v0.40.25] ✅ Completed: AwsHandler Resiliency Tests - Added tests to verify handler behavior under malformed payloads and runtime errors
 - [v0.40.24] ✅ Completed: CloudRunServer Resiliency Tests - Implemented comprehensive resiliency and regression tests for createCloudRunServer error handling.

--- a/packages/infrastructure/tests/benchmarks/cloudrun-server.bench.ts
+++ b/packages/infrastructure/tests/benchmarks/cloudrun-server.bench.ts
@@ -1,0 +1,70 @@
+import { describe, bench, beforeAll, afterAll, vi } from 'vitest';
+import { createCloudRunServer } from '../../src/worker/cloudrun-server.js';
+import { WorkerRuntime } from '../../src/worker/runtime.js';
+import http from 'node:http';
+
+vi.mock('../../src/worker/runtime.js');
+
+describe('CloudRunServer Benchmark', () => {
+  let server: ReturnType<typeof createCloudRunServer>;
+  let httpServer: http.Server;
+  let dynamicPort: number;
+
+  beforeAll(async () => {
+    vi.mocked(WorkerRuntime.prototype.run).mockResolvedValue({
+      exitCode: 0,
+      stdout: 'Mock output',
+      stderr: ''
+    });
+
+    server = createCloudRunServer({ port: 0 }); // Use ephemeral port
+
+    await new Promise<void>((resolve) => {
+      httpServer = server.server.listen(0, () => {
+        const address = httpServer.address();
+        if (address && typeof address !== 'string') {
+          dynamicPort = address.port;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    // Force close connections to prevent keep-alive timeout hanging
+    httpServer.closeAllConnections?.();
+
+    await new Promise<void>((resolve, reject) => {
+      httpServer.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  });
+
+  bench('handle request', async () => {
+    const payload = JSON.stringify({ jobPath: '/tmp/test.json', chunkIndex: 0 });
+
+    const req = http.request({
+      hostname: 'localhost',
+      port: dynamicPort,
+      path: '/',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload)
+      }
+    });
+
+    req.write(payload);
+    req.end();
+
+    await new Promise<void>((resolve, reject) => {
+      req.on('response', (res) => {
+        res.on('data', () => {});
+        res.on('end', resolve);
+      });
+      req.on('error', reject);
+    });
+  });
+});


### PR DESCRIPTION
💡 **What**: Implemented a performance benchmark for `CloudRunServer` entrypoint using `vitest bench`. It uses a mock `WorkerRuntime` to isolate and measure HTTP request parsing and routing overhead.
🎯 **Why**: Understanding the overhead introduced by the `createCloudRunServer` wrapper is essential for tuning large-scale job distributions in the V2 distributed rendering vision.
📊 **Impact**: Establishes performance baselines for the HTTP handler inside GCP Cloud Run instances, guaranteeing request routing doesn't introduce performance bottlenecks compared to actual frame rendering logic.
🔬 **Verification**: Run `npm run bench -w packages/infrastructure -- tests/benchmarks/cloudrun-server.bench.ts --run`. The test passes reliably without `EADDRINUSE` due to correctly awaited dynamic port generation. No test regressions observed when running `npm run test -w packages/infrastructure`.

---
*PR created automatically by Jules for task [4082159975574104216](https://jules.google.com/task/4082159975574104216) started by @BintzGavin*