### PR TITLE
✨ PLAYER: Regression Tests for MediaProperties

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -1,6 +1,6 @@
 # Context: PLAYER
 
-**Version**: v0.76.14
+**Version**: v0.76.17
 
 ## Section A: Component Structure
 

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.76.17
+- ✅ Completed: Regression Tests for MediaProperties - Added comprehensive tests for cross-origin security checks and media property parity (videoWidth/Height).
+
 ## PLAYER v0.76.16
 - ✅ Completed: Audio Context Manager Tests - Added comprehensive unit test coverage for SharedAudioContextManager and SharedAudioSource logic to prevent regressions.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.76.16
+**Version**: v0.76.17
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -10,6 +10,7 @@
 - **Responsibility**: `<helios-player>` Web Component, UI controls, iframe bridge.
 
 ## Current State
+[v0.76.17] ✅ Completed: Regression Tests for MediaProperties - Added comprehensive tests for cross-origin security checks and media property parity (videoWidth/Height).
 [v0.76.16] ✅ Completed: Audio Context Manager Tests - Added comprehensive unit test coverage for SharedAudioContextManager and SharedAudioSource logic to prevent regressions.
 [v0.76.15] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner to create the next implementation spec.
 - `<helios-player>` uses a modular architecture with `HeliosController` (Direct/Bridge) and `ClientSideExporter`.

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -284,6 +284,26 @@ describe('HeliosPlayer API Parity', () => {
     expect(player.currentSrc).toBe('test.html');
   });
 
+  it('should support videoWidth and videoHeight properties', () => {
+    // Should fallback to attributes when controller has no state
+    player.setAttribute('width', '800');
+    player.setAttribute('height', '600');
+    expect(player.videoWidth).toBe(800);
+    expect(player.videoHeight).toBe(600);
+
+    // Mock controller state with dimensions
+    const mockController = {
+      getState: () => ({ width: 1920, height: 1080 }),
+      pause: vi.fn(),
+      dispose: vi.fn(),
+    };
+    (player as any).controller = mockController;
+
+    // Should prioritize controller state over attributes
+    expect(player.videoWidth).toBe(1920);
+    expect(player.videoHeight).toBe(1080);
+  });
+
   it('should support error property', () => {
     expect(player.error).toBeNull();
 

--- a/packages/player/src/bridge.test.ts
+++ b/packages/player/src/bridge.test.ts
@@ -116,4 +116,14 @@ describe('connectToParent', () => {
 
         expect(mockHelios.play).not.toHaveBeenCalled();
     });
+
+    it('should IGNORE messages from nested iframes', () => {
+        connectToParent(mockHelios);
+
+        // Send message from an untrusted source (e.g. nested iframe)
+        const nestedIframe = {};
+        triggerMessage({ type: 'HELIOS_PLAY' }, nestedIframe);
+
+        expect(mockHelios.play).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
💡 What: Added comprehensive regression tests to `<helios-player>` to verify cross-origin security checks (ignoring nested iframe messages) and media property getter fallbacks (`videoWidth`, `videoHeight`).
🎯 Why: The PLAYER domain reached gravitational equilibrium, requiring fallback to regression testing to ensure the existing postMessage bridge and properties remain robust and avoid unintended regressions during refactors.
📊 Impact: Solidifies the security posture of the postMessage bridge. Ensures reliable media dimension reporting regardless of controller instantiation state.
🔬 Verification: Tests pass successfully locally when running `npm run test -w packages/player`.

---
*PR created automatically by Jules for task [7809160357457272199](https://jules.google.com/task/7809160357457272199) started by @BintzGavin*