### PR TITLE
✨ PLAYER: Regression Tests for InputProps

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.76.18
+- ✅ Completed: Regression Tests for InputProps - Added comprehensive tests for `input-props` JSON parsing edge cases (explicit "null", empty strings).
+
 ## PLAYER v0.76.17
 - ✅ Completed: Regression Tests for MediaProperties - Added comprehensive tests for cross-origin security checks and media property parity (videoWidth/Height).
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.76.17
+**Version**: v0.76.18
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -10,6 +10,7 @@
 - **Responsibility**: `<helios-player>` Web Component, UI controls, iframe bridge.
 
 ## Current State
+[v0.76.18] ✅ Completed: Regression Tests for InputProps - Added comprehensive tests for `input-props` JSON parsing edge cases (explicit "null", empty strings).
 [v0.76.17] ✅ Completed: Regression Tests for MediaProperties - Added comprehensive tests for cross-origin security checks and media property parity (videoWidth/Height).
 [v0.76.16] ✅ Completed: Audio Context Manager Tests - Added comprehensive unit test coverage for SharedAudioContextManager and SharedAudioSource logic to prevent regressions.
 [v0.76.15] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner to create the next implementation spec.

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.76.13",
+  "version": "0.76.18",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -1158,6 +1158,7 @@ describe('HeliosPlayer', () => {
 
         expect(mockController.setInputProps).toHaveBeenCalledWith(props);
         expect(player.inputProps).toEqual(props);
+        expect((player as any).pendingProps).toEqual(props);
     });
 
     it('should set input props via property', () => {
@@ -1201,6 +1202,7 @@ describe('HeliosPlayer', () => {
 
         // The property should be null
         expect(player.inputProps).toBeNull();
+        expect((player as any).pendingProps).toBeNull();
 
         warnSpy.mockRestore();
     });
@@ -1212,11 +1214,13 @@ describe('HeliosPlayer', () => {
         player.setAttribute('input-props', '{"valid": true}');
         expect(player.inputProps).toEqual({ valid: true });
 
-        // Setting to empty string should throw a warning in the JSON.parse try/catch
+        // Setting to empty string should clear the props without throwing a warning
         player.setAttribute('input-props', '');
 
-        // The catch block in attributeChangedCallback should catch the JSON error
-        expect(warnSpy).toHaveBeenCalled();
+        // Should not call warn since empty string is now handled gracefully
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(player.inputProps).toBeNull();
+        expect((player as any).pendingProps).toBeNull();
 
         warnSpy.mockRestore();
     });

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1727,7 +1727,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
 
     if (name === "input-props") {
       try {
-        const props = JSON.parse(newVal);
+        const props = (!newVal || newVal.trim() === "") ? null : JSON.parse(newVal);
         this.pendingProps = props;
         if (this.controller) {
           this.controller.setInputProps(props);


### PR DESCRIPTION
✨ PLAYER: Regression Tests for InputProps

💡 What: Added comprehensive tests for `input-props` JSON parsing edge cases (explicit "null", empty strings) in `index.test.ts`. Also refactored `index.ts` to cleanly handle empty string assignments without throwing console warnings.
🎯 Why: Enhance overall robustness of the `input-props` attribute handling and prevent future regressions.
📊 Impact: Validates the resilience of `HeliosPlayer` when dealing with edge case input properties and removes noisy console warnings on valid clearing actions.
🔬 Verification: Run `cd packages/player && npm install --no-save --workspaces=false && npm run test`. All tests pass successfully.

---
*PR created automatically by Jules for task [13057639296677673887](https://jules.google.com/task/13057639296677673887) started by @BintzGavin*