### PR TITLE
✨ INFRASTRUCTURE: Kubernetes Adapter

### DIFF
--- a/.sys/llmdocs/context-infrastructure.md
+++ b/.sys/llmdocs/context-infrastructure.md
@@ -102,6 +102,7 @@ The `packages/infrastructure/src/types/index.ts` file acts as the public API def
 - `vercel-adapter.ts`: Facilitates scheduling execution on Vercel Serverless Functions using the native fetch API.
 - `fly-machines-adapter.ts`: Facilitates scheduling execution on Fly.io Machines using the native fetch API.
 - `docker-adapter.ts`: Facilitates scheduling execution on local Docker containers or Docker Swarm.
+- `kubernetes-adapter.ts`: Facilitates scheduling execution across a Kubernetes cluster via the Batch Job API.
 - `local-adapter.ts`: Facilitates scheduling execution on the local host (typically for debugging).
 
 ## Section E: Integration

--- a/.sys/llmdocs/context-system.md
+++ b/.sys/llmdocs/context-system.md
@@ -11,7 +11,7 @@
    - `helios.diagnose()` for environment checks.
 5. **Documentation and Examples**
    - Quickstart, Realistic Examples (React, Vue, Svelte).
-6. **Distributed Rendering Research** (Scaffolding Complete)
+6. **Distributed Rendering Architecture** (Execution Adapters Implemented)
 7. **Helios Studio**
    - Browser-based IDE for composition (UI, Playback Controls, Asset Discovery, MCP Server implemented).
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -44,7 +44,7 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 
 #### Tier 2 — High Impact, Medium Friction
 
-- [ ] **Cloud execution adapter (Kubernetes Job API).**
+- [x] **Cloud execution adapter (Kubernetes Job API).**
   - Enterprise standard. Any K8s cluster becomes a render farm.
   - **Adapter pattern**: Create K8s Job resource → watch for completion → read logs for output.
   - **Auth**: kubeconfig / in-cluster service account.

--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,5 +1,8 @@
 # INFRASTRUCTURE PROGRESS
 
+## INFRASTRUCTURE v0.51.0
+- ✅ Completed: Kubernetes Adapter - Implemented `KubernetesAdapter` for cloud execution using the Kubernetes Job API.
+
 ## INFRASTRUCTURE v0.50.0
 - ✅ Completed: Hetzner Cloud Adapter - Implemented `HetznerCloudAdapter` for distributed rendering on Hetzner Cloud VMs.
 

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.50.0
+**Version**: 0.51.0
 
 ## Status Log
+- [v0.51.0] ✅ Completed: Kubernetes Adapter - Implemented `KubernetesAdapter` for cloud execution using the Kubernetes Job API.
 - [v0.50.0] ✅ Completed: Hetzner Cloud Adapter - Implemented `HetznerCloudAdapter` for distributed rendering on Hetzner Cloud VMs.
 - [v0.49.0] ✅ Completed: Fly Machines Adapter - Implemented `FlyMachinesAdapter` for distributed rendering on Fly.io infrastructure.
 - [v0.48.1] ✅ Completed: Fix Sync Workspace Bench - Fixed execution issues in `syncWorkspaceDependencies` benchmark by moving setup out of `beforeAll`.

--- a/packages/infrastructure/examples/kubernetes-adapter-example.ts
+++ b/packages/infrastructure/examples/kubernetes-adapter-example.ts
@@ -1,0 +1,29 @@
+import { KubernetesAdapter } from '../src/adapters/kubernetes-adapter.js';
+import { WorkerJob } from '../src/types/job.js';
+
+async function run() {
+  console.log('Starting KubernetesAdapter example...');
+
+  const adapter = new KubernetesAdapter({
+    namespace: 'default',
+    image: 'ubuntu:latest',
+    pollIntervalMs: 5000,
+  });
+
+  const job: WorkerJob = {
+    command: 'echo',
+    args: ['Hello from Kubernetes!'],
+    onStdout: (data) => console.log(`[STDOUT] ${data}`),
+    onStderr: (data) => console.log(`[STDERR] ${data}`),
+  };
+
+  console.log('Executing job...');
+  try {
+    const result = await adapter.execute(job);
+    console.log('Execution completed:', result);
+  } catch (error) {
+    console.error('Execution failed:', error);
+  }
+}
+
+run();

--- a/packages/infrastructure/package.json
+++ b/packages/infrastructure/package.json
@@ -33,6 +33,7 @@
     "@aws-sdk/client-lambda": "^3.999.0",
     "@aws-sdk/client-s3": "^3.1000.0",
     "@google-cloud/storage": "^7.19.0",
+    "@kubernetes/client-node": "^0.20.0",
     "google-auth-library": "^10.6.1"
   }
 }

--- a/packages/infrastructure/src/adapters/index.ts
+++ b/packages/infrastructure/src/adapters/index.ts
@@ -8,3 +8,4 @@ export * from './deno-deploy-adapter.js';
 export * from './vercel-adapter.js';
 export * from './fly-machines-adapter.js';
 export * from './hetzner-cloud-adapter.js';
+export * from './kubernetes-adapter.js';

--- a/packages/infrastructure/src/adapters/kubernetes-adapter.ts
+++ b/packages/infrastructure/src/adapters/kubernetes-adapter.ts
@@ -1,0 +1,160 @@
+import * as k8s from '@kubernetes/client-node';
+import { WorkerAdapter, WorkerResult } from '../types/adapter.js';
+import { WorkerJob } from '../types/job.js';
+
+export interface KubernetesAdapterOptions {
+  kubeconfigPath?: string;
+  namespace?: string;
+  image: string;
+  jobNamePrefix?: string;
+  serviceAccountName?: string;
+  pollIntervalMs?: number;
+}
+
+export class KubernetesAdapter implements WorkerAdapter {
+  private kc: k8s.KubeConfig;
+  private batchV1Api: k8s.BatchV1Api;
+  private coreV1Api: k8s.CoreV1Api;
+
+  constructor(private options: KubernetesAdapterOptions) {
+    this.kc = new k8s.KubeConfig();
+    if (options.kubeconfigPath) {
+      this.kc.loadFromFile(options.kubeconfigPath);
+    } else {
+      this.kc.loadFromDefault();
+    }
+    this.batchV1Api = this.kc.makeApiClient(k8s.BatchV1Api);
+    this.coreV1Api = this.kc.makeApiClient(k8s.CoreV1Api);
+  }
+
+  async execute(job: WorkerJob): Promise<WorkerResult> {
+    const startTime = Date.now();
+    const namespace = this.options.namespace || 'default';
+    const prefix = this.options.jobNamePrefix || 'helios-worker';
+    const chunkId = job.meta?.chunkId || 'default';
+    const randomSuffix = Math.random().toString(36).substring(2, 7);
+    const jobName = `${prefix}-${chunkId}-${randomSuffix}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+
+    const env: k8s.V1EnvVar[] = [];
+    if (job.env) {
+      for (const [key, value] of Object.entries(job.env)) {
+        env.push({ name: key, value });
+      }
+    }
+
+    const k8sJob: k8s.V1Job = {
+      metadata: { name: jobName, namespace },
+      spec: {
+        backoffLimit: 0,
+        template: {
+          metadata: { labels: { jobName } },
+          spec: {
+            containers: [
+              {
+                name: 'worker',
+                image: this.options.image,
+                command: [job.command],
+                args: job.args || [],
+                env: env.length > 0 ? env : undefined,
+                workingDir: job.cwd,
+              },
+            ],
+            restartPolicy: 'Never',
+            serviceAccountName: this.options.serviceAccountName,
+          },
+        },
+      },
+    };
+
+    let exitCode = 1;
+    let stdout = '';
+    let stderr = '';
+
+    try {
+      await this.batchV1Api.createNamespacedJob(namespace, k8sJob);
+
+      let aborted = false;
+
+      const onAbort = () => {
+        aborted = true;
+      };
+      job.signal?.addEventListener('abort', onAbort);
+
+      try {
+        while (!aborted) {
+          const response = await this.batchV1Api.readNamespacedJob(jobName, namespace);
+          const jobResult = response.body ?? response; // Handle both mocked body shape and direct return
+
+          if (jobResult.status?.succeeded && jobResult.status.succeeded > 0) {
+            exitCode = 0;
+            break;
+          }
+          if (jobResult.status?.failed && jobResult.status.failed > 0) {
+            exitCode = 1;
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, this.options.pollIntervalMs || 2000));
+        }
+
+        if (aborted) {
+          exitCode = 1;
+          throw new Error('Job aborted');
+        }
+
+        const pods = await this.coreV1Api.listNamespacedPod(
+          namespace,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          `jobName=${jobName}`
+        );
+
+        const podsBody = pods.body ?? pods;
+        if (podsBody.items && podsBody.items.length > 0) {
+          const podName = podsBody.items[0].metadata?.name;
+          if (podName) {
+            const logResponse = await this.coreV1Api.readNamespacedPodLog(
+              podName,
+              namespace
+            );
+            const logs = logResponse.body ?? logResponse;
+            stdout = (logs as unknown as string) || '';
+            if (job.onStdout && stdout) {
+              job.onStdout(stdout);
+            }
+          }
+        }
+
+      } catch (error: any) {
+        if (aborted) {
+          stderr = 'Job aborted';
+        } else {
+          stderr = `Job monitoring failed: ${error.message || String(error)}`;
+          if (job.onStderr && stderr) {
+            job.onStderr(stderr);
+          }
+        }
+      } finally {
+        job.signal?.removeEventListener('abort', onAbort);
+      }
+
+    } catch (error: any) {
+      exitCode = 1;
+      stderr = `Failed to create Job: ${error.message || String(error)}`;
+    } finally {
+      try {
+        await this.batchV1Api.deleteNamespacedJob(jobName, namespace, undefined, undefined, undefined, undefined, 'Background');
+      } catch (error) {
+        // Ignore deletion errors
+      }
+    }
+
+    return {
+      exitCode,
+      stdout,
+      stderr,
+      durationMs: Date.now() - startTime,
+    };
+  }
+}

--- a/packages/infrastructure/tests/adapters/kubernetes-adapter.test.ts
+++ b/packages/infrastructure/tests/adapters/kubernetes-adapter.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { KubernetesAdapter } from '../../src/adapters/kubernetes-adapter.js';
+import { WorkerJob } from '../../src/types/job.js';
+
+vi.mock('@kubernetes/client-node', () => {
+  class KubeConfig {
+    loadFromDefault = vi.fn();
+    loadFromFile = vi.fn();
+    makeApiClient = vi.fn((apiType) => {
+      if (apiType.name === 'BatchV1Api') {
+        return {
+          createNamespacedJob: vi.fn().mockResolvedValue({}),
+          readNamespacedJob: vi.fn().mockResolvedValue({ body: { status: { succeeded: 1 } } }),
+          deleteNamespacedJob: vi.fn().mockResolvedValue({}),
+        };
+      } else if (apiType.name === 'CoreV1Api') {
+        return {
+          listNamespacedPod: vi.fn().mockResolvedValue({
+            body: { items: [{ metadata: { name: 'test-pod' } }] },
+          }),
+          readNamespacedPodLog: vi.fn().mockResolvedValue({ body: 'test log output' }),
+        };
+      }
+    });
+  }
+  return {
+    KubeConfig,
+    BatchV1Api: class BatchV1Api { static name = 'BatchV1Api'; },
+    CoreV1Api: class CoreV1Api { static name = 'CoreV1Api'; },
+  };
+});
+
+describe('KubernetesAdapter', () => {
+  let adapter: KubernetesAdapter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = new KubernetesAdapter({
+      image: 'test-image',
+      pollIntervalMs: 10,
+    });
+  });
+
+  it('should execute a job successfully', async () => {
+    const job: WorkerJob = {
+      command: 'echo',
+      args: ['hello'],
+      meta: { chunkId: '1' },
+    };
+
+    const result = await adapter.execute(job);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('test log output');
+    expect(result.stderr).toBe('');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should handle job abortion via AbortSignal', async () => {
+    // Delay the completion so we can intercept and abort it
+    vi.mocked(adapter['batchV1Api'].readNamespacedJob).mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+      return { body: { status: { succeeded: 0 } } } as any;
+    });
+
+    const controller = new AbortController();
+    const job: WorkerJob = {
+      command: 'echo',
+      args: ['hello'],
+      signal: controller.signal,
+    };
+
+    const executePromise = adapter.execute(job);
+    // Add small delay so loop can start
+    await new Promise(resolve => setTimeout(resolve, 10));
+    controller.abort();
+
+    const result = await executePromise;
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Job aborted');
+  });
+});

--- a/packages/infrastructure/tests/benchmarks/kubernetes-adapter.bench.ts
+++ b/packages/infrastructure/tests/benchmarks/kubernetes-adapter.bench.ts
@@ -1,0 +1,16 @@
+import { bench, describe } from 'vitest';
+import { KubernetesAdapter } from '../../src/adapters/kubernetes-adapter.js';
+
+describe('KubernetesAdapter Benchmark', () => {
+  const adapter = new KubernetesAdapter({
+    image: 'alpine',
+    pollIntervalMs: 1,
+  });
+
+  bench('execute job successfully', async () => {
+    await adapter.execute({
+      command: 'echo',
+      args: ['test'],
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces the `KubernetesAdapter` within `packages/infrastructure`, addressing the final Tier 2 cloud execution backend gap. It leverages the `@kubernetes/client-node` SDK to dynamically create, monitor, and clean up Kubernetes `Job` resources for executing Helios render chunks. All tracking documentation (`docs/BACKLOG.md`, `docs/status/INFRASTRUCTURE.md`, `docs/PROGRESS-INFRASTRUCTURE.md`, and `.sys/llmdocs/*`) has been accurately updated to reflect the new feature state.

---
*PR created automatically by Jules for task [18440171844591227008](https://jules.google.com/task/18440171844591227008) started by @BintzGavin*