### PR TITLE
✨ STUDIO: Update Quickstart Guide

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -66,6 +66,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### INFRASTRUCTURE v0.2.0
 - ✅ Completed: Stateless Worker Interface - Implemented WorkerAdapter and LocalWorkerAdapter.
 
+### STUDIO v0.118.4
+- ✅ Completed: Update Quickstart Guide - Updated the Quickstart guide to emphasize the `helios init` command as the primary way to get started.
+
 ### STUDIO v0.118.3
 - ✅ Completed: Regression Tests - Fixed `UnhandledPromiseRejection` in `useAudioWaveform.test.ts` by explicitly catching mocked decoder rejection.
 

--- a/docs/site/getting-started/quickstart.md
+++ b/docs/site/getting-started/quickstart.md
@@ -9,26 +9,26 @@ Helios Engine is a library for creating video-ready animations using web technol
 
 ## The Fastest Way to Start
 
-The quickest way to get started is by cloning one of our examples.
+The quickest way to get started is by using the Helios CLI to scaffold a new project.
 
-### Using an Example
+### Using the CLI
 
-1.  Clone the repository (if you haven't already):
+1.  Initialize a new project:
     ```bash
-    git clone https://github.com/helios-project/helios.git
-    cd helios
+    npx helios init <project-name>
     ```
 
-2.  Install dependencies:
+2.  Navigate to the directory and install dependencies:
     ```bash
+    cd <project-name>
     npm install
     ```
 
-3.  Run the React example:
+3.  Start the development server and open Helios Studio:
     ```bash
-    npm run dev:react-dom
+    npm run dev
     ```
-    Open your browser to the URL shown (usually `http://localhost:5173/composition.html`).
+    Open your browser to the URL shown to access Helios Studio.
 
 ## What's Next?
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.118.3
+**Version**: 0.118.4
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -11,6 +11,7 @@
 > **Note**: Status versions in this file may precede package release versions (`package.json`). Always verify `package.json` for the currently installed version.
 
 ## Recent Updates
+- [v0.118.4] ✅ Completed: Update Quickstart Guide - Updated the Quickstart guide to emphasize the `helios init` command as the primary way to get started.
 - [v0.118.3] ✅ Completed: Regression Tests - Fixed `UnhandledPromiseRejection` in `useAudioWaveform.test.ts` by explicitly catching mocked decoder rejection.
 - [v0.118.2] ⏳ Planned: Update Quickstart Guide - Generate spec to update the documentation with CLI init method.
 - [v0.118.1] ✅ Completed: Regression Tests - Implemented unit and regression tests for `TimelineAudioTrack` component and `useAudioWaveform` hook.


### PR DESCRIPTION
💡 **What**: Updated the Quickstart guide in docs/site/getting-started/quickstart.md to emphasize using the `helios init` CLI command instead of cloning the repository.
🎯 **Why**: To align with modern developer tool practices and the README recommendations, providing users with a faster, cleaner initial experience.
📊 **Impact**: New users will now use standard scaffolding (`npx helios init`) instead of downloading source files directly.
🔬 **Verification**: Verified markdown formatting and ran tests/linting across affected workspace packages to ensure no regressions.

---
*PR created automatically by Jules for task [2072024931443000490](https://jules.google.com/task/2072024931443000490) started by @BintzGavin*