### PR TITLE
🛑 INFRASTRUCTURE: Mark Domain as Blocked (No Plans)

### DIFF
--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -2,6 +2,7 @@
 **Version**: 0.52.0
 
 ## Status Log
+- [v0.52.0] 🚫 Blocked: No uncompleted implementation plans found for my domain in `/.sys/plans/`. I must stop working.
 - [v0.52.0] ✅ Completed: Azure Functions Adapter - Verified and Documented existing `AzureFunctionsAdapter` for Azure Functions to support distributed rendering.
 - [v0.51.1] ✅ Completed: Azure Functions Benchmark & Example - Added performance benchmark using `vitest bench` and a standalone example script for the Azure Functions adapter.
 - [v0.51.0] ✅ Completed: Kubernetes Adapter - Implemented `KubernetesAdapter` for cloud execution using the Kubernetes Job API.


### PR DESCRIPTION
I checked `/.sys/plans/` and `docs/status/INFRASTRUCTURE.md` for any uncompleted plans for my domain, but all plans (including `2026-12-20-INFRASTRUCTURE-Kubernetes-Adapter.md`) were already marked as `✅ Completed`. Because I am forbidden from creating my own plans, modifying other domains, or implementing features without a plan, I have updated my status file to indicate that I am currently **Blocked**. I ran all `packages/infrastructure` tests and linting to ensure my status update caused no regressions. I am now stopping work.

---
*PR created automatically by Jules for task [3812198979833983023](https://jules.google.com/task/3812198979833983023) started by @BintzGavin*