### PR TITLE
✨ CLI: Merge Command Regression Tests

### DIFF
--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.36.10
+
+- ✅ Merge Command Regression Tests - Implemented comprehensive unit tests for `helios merge`.
+
 ## CLI v0.36.9
 
 - ✅ Cloud Worker Execution Azure Cloudflare - Added support for Cloudflare Workers and Azure Functions execution adapters to the job run command.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.36.9
+**Version**: 0.36.10
 
 ## Current State
 
@@ -41,6 +41,7 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 
 ## History
 
+[v0.36.10] ✅ Merge Command Regression Tests - Implemented comprehensive unit tests for `helios merge`.
 [v0.36.9] ✅ Cloud Worker Execution Azure Cloudflare - Added support for Cloudflare Workers and Azure Functions execution adapters to the job run command.
 [v0.36.8] ✅ Add Command Regression Tests - Implemented comprehensive unit tests for `helios add`.
 [v0.36.7] ✅ Add Command Regression Tests - Implemented comprehensive unit tests for `helios add`.

--- a/packages/cli/src/commands/__tests__/merge.test.ts
+++ b/packages/cli/src/commands/__tests__/merge.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerMergeCommand } from '../merge.js';
+import { concatenateVideos } from '@helios-project/renderer';
+import { transcodeMerge } from '../../utils/ffmpeg.js';
+import path from 'path';
+
+vi.mock('@helios-project/renderer', () => ({
+  concatenateVideos: vi.fn(),
+}));
+
+vi.mock('../../utils/ffmpeg.js', () => ({
+  transcodeMerge: vi.fn(),
+}));
+
+describe('helios merge command', () => {
+  let program: Command;
+  let logSpy: any;
+  let errorSpy: any;
+  let exitSpy: any;
+
+  beforeEach(() => {
+    program = new Command();
+    registerMergeCommand(program);
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should parse arguments and call concatenateVideos when no transcoding flags are present', async () => {
+    await program.parseAsync(['node', 'test', 'merge', 'output.mp4', 'input1.mp4', 'input2.mp4']);
+
+    expect(concatenateVideos).toHaveBeenCalledWith(
+      [path.resolve(process.cwd(), 'input1.mp4'), path.resolve(process.cwd(), 'input2.mp4')],
+      path.resolve(process.cwd(), 'output.mp4')
+    );
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Merge complete'));
+    expect(transcodeMerge).not.toHaveBeenCalled();
+  });
+
+  it('should throw an error and exit with code 1 if no inputs are provided', async () => {
+    await program.parseAsync(['node', 'test', 'merge', 'output.mp4']);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('No input files provided'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(concatenateVideos).not.toHaveBeenCalled();
+  });
+
+  it('should call transcodeMerge when transcoding flags are provided', async () => {
+    await program.parseAsync([
+      'node', 'test', 'merge', 'output.mp4', 'input1.mp4', '--video-codec', 'libx264', '--quality', '23'
+    ]);
+
+    expect(transcodeMerge).toHaveBeenCalledWith(
+      [path.resolve(process.cwd(), 'input1.mp4')],
+      path.resolve(process.cwd(), 'output.mp4'),
+      {
+        videoCodec: 'libx264',
+        audioCodec: undefined,
+        quality: '23',
+        preset: undefined
+      }
+    );
+    expect(concatenateVideos).not.toHaveBeenCalled();
+  });
+
+  it('should handle errors thrown by concatenateVideos and exit with 1', async () => {
+    vi.mocked(concatenateVideos).mockRejectedValueOnce(new Error('Mock renderer error'));
+
+    await program.parseAsync(['node', 'test', 'merge', 'output.mp4', 'input1.mp4']);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Merge failed: Mock renderer error'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
✨ CLI: Merge Command Regression Tests

💡 What: Implemented comprehensive regression tests for the `helios merge` command in `packages/cli/src/commands/__tests__/merge.test.ts`.
🎯 Why: To close the vision gap of lack of test coverage for the merge command.
📊 Impact: Ensures stability of the merge command, guarding against regressions in input parsing and transcoding execution.
🔬 Verification: Run `npm run test` inside the `packages/cli` directory to verify tests pass.

---
*PR created automatically by Jules for task [10562295743699839029](https://jules.google.com/task/10562295743699839029) started by @BintzGavin*