### PR TITLE
✨ PLAYER: Regression Tests for Media Session

### DIFF
--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.76.20
+- ✅ Completed: Regression Tests for Media Session - Added comprehensive edge case tests for HeliosMediaSession to prevent regressions.
+
 ## PLAYER v0.76.19
 - ✅ Completed: Regression Tests for MediaProperties - Added comprehensive tests for cross-origin security checks and media property parity (videoWidth/Height).
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: v0.76.19
+**Version**: v0.76.20
 
 **Posture**: STABLE AND FEATURE COMPLETE
 
@@ -10,6 +10,7 @@
 - **Responsibility**: `<helios-player>` Web Component, UI controls, iframe bridge.
 
 ## Current State
+[v0.76.20] ✅ Completed: Regression Tests for Media Session - Added comprehensive edge case tests for HeliosMediaSession to prevent regressions.
 [v0.76.18] ✅ Completed: Regression Tests for InputProps - Added comprehensive tests for `input-props` JSON parsing edge cases (explicit "null", empty strings).
 [v0.76.17] ✅ Completed: Regression Tests for MediaProperties - Added comprehensive tests for cross-origin security checks and media property parity (videoWidth/Height).
 [v0.76.16] ✅ Completed: Audio Context Manager Tests - Added comprehensive unit test coverage for SharedAudioContextManager and SharedAudioSource logic to prevent regressions.

--- a/packages/player/src/features/media-session.test.ts
+++ b/packages/player/src/features/media-session.test.ts
@@ -157,4 +157,55 @@ describe('HeliosMediaSession', () => {
     expect(mockSetActionHandler).toHaveBeenCalledWith('play', null);
     expect(mockMediaSession.playbackState).toBe('none');
   });
+
+  it('should handle undefined mediaSession', () => {
+    const oldMediaSession = navigator.mediaSession;
+    delete (navigator as any).mediaSession;
+    const session = new HeliosMediaSession(player, controller);
+    expect(session['unsubscribe']).toBeNull();
+    // Verify calling methods doesn't throw
+    expect(() => session.updateMetadata()).not.toThrow();
+    expect(() => session.setupHandlers()).not.toThrow();
+    expect(() => session.updateState({ isPlaying: true })).not.toThrow();
+    expect(() => session.destroy()).not.toThrow();
+    (navigator as any).mediaSession = oldMediaSession;
+  });
+
+  it('should handle seekbackward and seekforward clamping', () => {
+    new HeliosMediaSession(player, controller);
+    const seekBackwardHandler = mockSetActionHandler.mock.calls.find((c: any) => c[0] === 'seekbackward')[1];
+    const seekForwardHandler = mockSetActionHandler.mock.calls.find((c: any) => c[0] === 'seekforward')[1];
+
+    (controller.getState as any).mockReturnValue({ duration: 10, fps: 30, currentFrame: 150 }); // 5 seconds in
+    seekBackwardHandler({ seekOffset: 10 }); // Back 10s should clamp to 0
+    expect(controller.seek).toHaveBeenCalledWith(0);
+
+    (controller.getState as any).mockReturnValue({ duration: 10, fps: 30, currentFrame: 150 });
+    seekForwardHandler({ seekOffset: 10 }); // Forward 10s should clamp to duration
+    expect(controller.seek).toHaveBeenCalledWith(300); // 10s * 30fps
+  });
+
+  it('should ignore seekto without seekTime', () => {
+    new HeliosMediaSession(player, controller);
+    const seekHandler = mockSetActionHandler.mock.calls.find((c: any) => c[0] === 'seekto')[1];
+    controller.seek = vi.fn();
+    seekHandler({});
+    expect(controller.seek).not.toHaveBeenCalled();
+  });
+
+  it('should ignore updateState with invalid duration or fps', () => {
+    const session = new HeliosMediaSession(player, controller);
+    mockSetPositionState.mockClear();
+    session.updateState({ duration: 0, fps: 30, currentFrame: 0 });
+    expect(mockSetPositionState).not.toHaveBeenCalled();
+
+    session.updateState({ duration: 10, fps: 0, currentFrame: 0 });
+    expect(mockSetPositionState).not.toHaveBeenCalled();
+  });
+
+  it('should safely destroy when unsubscribe is null', () => {
+    const session = new HeliosMediaSession(player, controller);
+    session['unsubscribe'] = null; // simulate it never subscribed or already unsubscribed
+    expect(() => session.destroy()).not.toThrow();
+  });
 });


### PR DESCRIPTION
Implemented comprehensive regression tests for the `HeliosMediaSession` feature to ensure its logic and edge cases are robustly verified, fulfilling the objective outlined in `2026-12-20-PLAYER-Regression-Tests-MediaSession.md`.

- Added tests for behavior when `navigator.mediaSession` is undefined.
- Added tests for `seekbackward` and `seekforward` boundary clamping.
- Added tests for `seekto` missing `seekTime`.
- Added tests for `updateState` edge cases (invalid duration/fps).
- Added test for `destroy` when `unsubscribe` is null.
- Verified workspace stability with `npm run test` (361 passing tests).
- Incremented version to `v0.76.20` and updated status/progress logs.

---
*PR created automatically by Jules for task [10734664282707127206](https://jules.google.com/task/10734664282707127206) started by @BintzGavin*