### PR TITLE
✨ CLI: Scaffold Cloudflare Workers deployment

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -90,6 +90,7 @@ packages/cli/
 - `helios deploy setup`: Scaffold deployment configurations (Docker).
 - `helios deploy gcp`: Scaffold Google Cloud Run Job configuration.
 - `helios deploy aws`: Scaffold AWS Lambda deployment configuration.
+- `helios deploy cloudflare`: Scaffold Cloudflare Workers deployment configuration.
 
 ## D. Configuration
 

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.37.0
+
+- ✅ Deploy Cloudflare - Implemented `helios deploy cloudflare` to scaffold Cloudflare Workers deployment configuration.
+
 ## CLI v0.36.10
 
 - ✅ Merge Command Regression Tests - Implemented comprehensive unit tests for `helios merge`.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.36.10
+**Version**: 0.37.0
 
 ## Current State
 
@@ -41,6 +41,7 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 
 ## History
 
+[v0.37.0] ✅ Deploy Cloudflare - Implemented `helios deploy cloudflare` to scaffold Cloudflare Workers deployment configuration.
 [v0.36.10] ✅ Merge Command Regression Tests - Implemented comprehensive unit tests for `helios merge`.
 [v0.36.9] ✅ Cloud Worker Execution Azure Cloudflare - Added support for Cloudflare Workers and Azure Functions execution adapters to the job run command.
 [v0.36.8] ✅ Add Command Regression Tests - Implemented comprehensive unit tests for `helios add`.

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import { DOCKERFILE_TEMPLATE, DOCKER_COMPOSE_TEMPLATE } from '../templates/docker.js';
 import { CLOUD_RUN_JOB_TEMPLATE, README_GCP_TEMPLATE } from '../templates/gcp.js';
 import { AWS_DOCKERFILE_TEMPLATE, AWS_LAMBDA_HANDLER_TEMPLATE, AWS_SAM_TEMPLATE, README_AWS_TEMPLATE } from '../templates/aws.js';
+import { WRANGLER_TOML_TEMPLATE, CLOUDFLARE_WORKER_TEMPLATE, README_CLOUDFLARE_TEMPLATE } from '../templates/cloudflare.js';
 
 export function registerDeployCommand(program: Command) {
   const deploy = program.command('deploy')
@@ -256,5 +257,99 @@ export function registerDeployCommand(program: Command) {
 
       console.log(chalk.blue('\nAWS Lambda setup complete!'));
       console.log('See README-AWS.md for deployment instructions.');
+    });
+
+  deploy
+    .command('cloudflare')
+    .description('Scaffold Cloudflare Workers deployment configuration')
+    .action(async () => {
+      const cwd = process.cwd();
+      const wranglerPath = path.join(cwd, 'wrangler.toml');
+      const workerPath = path.join(cwd, 'src', 'worker.ts');
+      const readmePath = path.join(cwd, 'README-CLOUDFLARE.md');
+
+      console.log(chalk.blue('Scaffolding Cloudflare Workers deployment files...'));
+
+      // wrangler.toml
+      let writeWrangler = true;
+      if (fs.existsSync(wranglerPath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'wrangler.toml already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeWrangler = response.value;
+      }
+
+      if (writeWrangler) {
+        fs.writeFileSync(wranglerPath, WRANGLER_TOML_TEMPLATE);
+        console.log(chalk.green('✔ Created wrangler.toml'));
+      } else {
+        console.log(chalk.gray('Skipped wrangler.toml'));
+      }
+
+      // src/worker.ts
+      let writeWorker = true;
+      if (fs.existsSync(workerPath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'src/worker.ts already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeWorker = response.value;
+      }
+
+      if (writeWorker) {
+        const srcDir = path.dirname(workerPath);
+        if (!fs.existsSync(srcDir)) {
+          fs.mkdirSync(srcDir, { recursive: true });
+        }
+        fs.writeFileSync(workerPath, CLOUDFLARE_WORKER_TEMPLATE);
+        console.log(chalk.green('✔ Created src/worker.ts'));
+      } else {
+        console.log(chalk.gray('Skipped src/worker.ts'));
+      }
+
+      // README-CLOUDFLARE.md
+      let writeReadme = true;
+      if (fs.existsSync(readmePath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'README-CLOUDFLARE.md already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeReadme = response.value;
+      }
+
+      if (writeReadme) {
+        fs.writeFileSync(readmePath, README_CLOUDFLARE_TEMPLATE);
+        console.log(chalk.green('✔ Created README-CLOUDFLARE.md'));
+      } else {
+        console.log(chalk.gray('Skipped README-CLOUDFLARE.md'));
+      }
+
+      console.log(chalk.blue('\nCloudflare Workers setup complete!'));
+      console.log('See README-CLOUDFLARE.md for deployment instructions.');
     });
 }

--- a/packages/cli/src/templates/cloudflare.ts
+++ b/packages/cli/src/templates/cloudflare.ts
@@ -1,0 +1,90 @@
+export const WRANGLER_TOML_TEMPLATE = `name = "helios-render-worker"
+main = "src/worker.ts"
+compatibility_date = "2024-03-04"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+# Optional: Add any environment variables here
+# HELIOS_API_KEY = "your-api-key"
+`;
+
+export const CLOUDFLARE_WORKER_TEMPLATE = `import { WorkerRuntime, CloudflareWorkersAdapter } from '@helios-project/infrastructure';
+
+export interface Env {
+  // Bindings like KV, D1, etc. can be added here
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    if (request.method !== 'POST') {
+      return new Response('Method Not Allowed', { status: 405 });
+    }
+
+    try {
+      const payload = await request.json() as any;
+      const { jobPath, chunkIndex } = payload;
+
+      if (!jobPath || chunkIndex === undefined) {
+         return new Response(JSON.stringify({ error: 'Missing jobPath or chunkIndex in payload' }), {
+           status: 400,
+           headers: { 'Content-Type': 'application/json' }
+         });
+      }
+
+      // Initialize the runtime and the adapter
+      const adapter = new CloudflareWorkersAdapter();
+      const runtime = new WorkerRuntime(adapter);
+
+      // Execute the job chunk
+      const result = await runtime.executeChunk(jobPath, chunkIndex);
+
+      return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    } catch (error: any) {
+      console.error('Worker execution failed:', error);
+      return new Response(JSON.stringify({ error: error.message || 'Internal Server Error' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+  },
+};
+`;
+
+export const README_CLOUDFLARE_TEMPLATE = `# Helios Cloudflare Worker Deployment
+
+This directory contains the configuration and script required to deploy a Helios rendering worker to Cloudflare Workers.
+
+## Prerequisites
+
+1.  **Cloudflare Account:** You need an active Cloudflare account.
+2.  **Wrangler CLI:** Ensure you have Wrangler installed globally or as a dev dependency.
+    \`\`\`bash
+    npm install -g wrangler
+    \`\`\`
+3.  **Authentication:** Authenticate Wrangler with your Cloudflare account.
+    \`\`\`bash
+    wrangler login
+    \`\`\`
+
+## Deployment
+
+1.  **Review Configuration:** Check the \`wrangler.toml\` file to customize the worker name or add environment variables.
+2.  **Deploy:** Run the following command to deploy the worker to Cloudflare's edge network.
+    \`\`\`bash
+    wrangler deploy
+    \`\`\`
+3.  **Note the URL:** After deployment, Wrangler will output the URL of your new worker (e.g., \`https://helios-render-worker.<your-subdomain>.workers.dev\`).
+
+## Executing Jobs
+
+Once deployed, you can use the Helios CLI to execute distributed rendering jobs against your Cloudflare Worker.
+
+\`\`\`bash
+helios job run <path-to-job.json> --adapter cloudflare --endpoint <your-worker-url>
+\`\`\`
+
+Replace \`<path-to-job.json>\` with your job specification and \`<your-worker-url>\` with the URL provided by Wrangler.
+`;


### PR DESCRIPTION
Implemented `helios deploy cloudflare` to scaffold Cloudflare Workers deployment configuration files. This addresses the missing deployment subcommand for the newly added `CloudflareWorkersAdapter`. The command generates `wrangler.toml`, `src/worker.ts`, and `README-CLOUDFLARE.md` directly in the project root, streamlining the deployment process for Cloudflare edge rendering. Tests and functionality were successfully verified.

---
*PR created automatically by Jules for task [14909824622670645570](https://jules.google.com/task/14909824622670645570) started by @BintzGavin*