### PR TITLE
✨ INFRASTRUCTURE: Cloudflare Workers Adapter Test Coverage

### DIFF
--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,5 +1,8 @@
 # INFRASTRUCTURE PROGRESS
 
+## INFRASTRUCTURE v0.53.8
+- ✅ Completed: Cloudflare Workers Adapter Test Coverage - Added test coverage to `cloudflare-workers-adapter.ts` lines 66 and 72 to reach 100% statement and branch coverage.
+
 ## INFRASTRUCTURE v0.53.7
 - ✅ Completed: Kubernetes Adapter Test Coverage Refinements - Achieved 100% test coverage for KubernetesAdapter edge cases.
 

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.53.7
+**Version**: 0.53.8
 
 ## Status Log
+- [v0.53.8] ✅ Completed: Cloudflare Workers Adapter Test Coverage - Added test coverage to `cloudflare-workers-adapter.ts` lines 66 and 72 to reach 100% statement and branch coverage.
 - [v0.53.7] ✅ Completed: Kubernetes Adapter Test Coverage Refinements - Achieved 100% test coverage for KubernetesAdapter edge cases.
 - [v0.53.6] ✅ Completed: Kubernetes Adapter Test Coverage - Improved test coverage for KubernetesAdapter.
 - [v0.53.5] ✅ Completed: HetznerCloudAdapter-Coverage - Improved test coverage to handle edge cases like polling timeouts, aborts, and cleanup errors.

--- a/packages/infrastructure/tests/adapters/cloudflare-workers-adapter.test.ts
+++ b/packages/infrastructure/tests/adapters/cloudflare-workers-adapter.test.ts
@@ -72,4 +72,36 @@ describe('CloudflareWorkersAdapter', () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('Job was cancelled');
   });
+
+  it('should use data.output as stdout fallback', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response(JSON.stringify({ exitCode: 0, output: 'Fallback output', stderr: '' }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const adapter = new CloudflareWorkersAdapter({ serviceUrl, jobDefUrl });
+    const result = await adapter.execute({ command: 'render', meta: { chunkId: 0 } });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('Fallback output');
+  });
+
+  it('should force exitCode 1 when response is not ok and exitCode is 0', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response(JSON.stringify({ exitCode: 0, stderr: 'HTTP Error 500' }), { status: 500, headers: { 'Content-Type': 'application/json' } }));
+    const adapter = new CloudflareWorkersAdapter({ serviceUrl, jobDefUrl });
+    const result = await adapter.execute({ command: 'render', meta: { chunkId: 0 } });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('HTTP Error 500');
+  });
+
+  it('should use default exit code if not provided (0 for ok response)', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response(JSON.stringify({ stdout: 'success' }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    const adapter = new CloudflareWorkersAdapter({ serviceUrl, jobDefUrl });
+    const result = await adapter.execute({ command: 'render', meta: { chunkId: 0 } });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('success');
+  });
+
+  it('should use default exit code if not provided (1 for non-ok response)', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(new Response(JSON.stringify({ stdout: 'error' }), { status: 500, statusText: 'Internal Server Error', headers: { 'Content-Type': 'application/json' } }));
+    const adapter = new CloudflareWorkersAdapter({ serviceUrl, jobDefUrl });
+    const result = await adapter.execute({ command: 'render', meta: { chunkId: 0 } });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('HTTP Error 500: Internal Server Error');
+  });
 });


### PR DESCRIPTION
Added missing test coverage for `data.output` fallback and default exit codes in the Cloudflare Workers adapter to reach 100% branch and statement coverage.

---
*PR created automatically by Jules for task [7318775595786539078](https://jules.google.com/task/7318775595786539078) started by @BintzGavin*