### PR TITLE
✨ CLI: List Command Regression Tests

### DIFF
--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.37.1
+
+- ✅ List Command Regression Tests - Implemented comprehensive unit tests for `helios list`.
+
 ## CLI v0.37.0
 
 - ✅ Deploy Cloudflare - Implemented `helios deploy cloudflare` to scaffold Cloudflare Workers deployment configuration.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.37.0
+**Version**: 0.37.1
 
 ## Current State
 
@@ -41,6 +41,7 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 
 ## History
 
+[v0.37.1] ✅ List Command Regression Tests - Implemented comprehensive unit tests for `helios list`.
 [v0.37.0] ✅ Deploy Cloudflare - Implemented `helios deploy cloudflare` to scaffold Cloudflare Workers deployment configuration.
 [v0.36.10] ✅ Merge Command Regression Tests - Implemented comprehensive unit tests for `helios merge`.
 [v0.36.9] ✅ Cloud Worker Execution Azure Cloudflare - Added support for Cloudflare Workers and Azure Functions execution adapters to the job run command.

--- a/packages/cli/src/commands/__tests__/list.test.ts
+++ b/packages/cli/src/commands/__tests__/list.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerListCommand } from '../list.js';
+import { loadConfig } from '../../utils/config.js';
+
+vi.mock('../../utils/config.js', () => ({
+  loadConfig: vi.fn(),
+}));
+
+describe('registerListCommand', () => {
+  let program: Command;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    registerListCommand(program);
+
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: number) => {
+      throw new Error(`process.exit called with code ${code}`);
+    });
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should exit with code 1 when no config is found', async () => {
+    vi.mocked(loadConfig).mockReturnValue(null);
+
+    const outputArgs = ['node', 'test', 'list'];
+    await expect(program.parseAsync(outputArgs)).rejects.toThrow('process.exit called with code 1');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('No helios.config.json found'));
+  });
+
+  it('should log warning when components list is empty or undefined', async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      version: '1',
+      directories: { components: 'components', lib: 'lib' },
+      components: [],
+    });
+
+    const outputArgs = ['node', 'test', 'list'];
+    await program.parseAsync(outputArgs);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('No components installed yet.'));
+  });
+
+  it('should log installed components when they exist', async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      version: '1',
+      directories: { components: 'components', lib: 'lib' },
+      components: ['button', 'card'],
+    });
+
+    const outputArgs = ['node', 'test', 'list'];
+    await program.parseAsync(outputArgs);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Installed components:'));
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('button'));
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('card'));
+  });
+
+  it('should handle runtime errors gracefully', async () => {
+    vi.mocked(loadConfig).mockImplementation(() => {
+      throw new Error('Runtime error reading config');
+    });
+
+    const outputArgs = ['node', 'test', 'list'];
+    await expect(program.parseAsync(outputArgs)).rejects.toThrow('process.exit called with code 1');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Runtime error reading config'));
+  });
+});

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -13,6 +13,7 @@ export function registerListCommand(program: Command) {
         if (!config) {
           console.error(chalk.red('No helios.config.json found. Run "helios init" to start a project.'));
           process.exit(1);
+          return;
         }
 
         if (!config.components || config.components.length === 0) {
@@ -27,6 +28,7 @@ export function registerListCommand(program: Command) {
       } catch (error: any) {
         console.error(chalk.red(error.message));
         process.exit(1);
+        return;
       }
     });
 }


### PR DESCRIPTION
✨ CLI: List Command Regression Tests

💡 What: Implemented comprehensive Vitest unit tests for the `helios list` command in `packages/cli/src/commands/__tests__/list.test.ts`. Added safe early returns after `process.exit(1)` in `list.ts`.
🎯 Why: The CLI domain reached feature equilibrium. The fallback action is to increase test coverage. The `list` command lacked regression tests, risking instability in the component tracking workflow.
📊 Impact: Ensures `helios list` correctly parses configuration, handles errors, and displays installed components reliably without regressions.
🔬 Verification: Ran `npm run test` in `packages/cli` confirming all tests pass.

---
*PR created automatically by Jules for task [6942664680707763421](https://jules.google.com/task/6942664680707763421) started by @BintzGavin*