### PR TITLE
✨ CLI: Merge Command Regression Tests

### DIFF
--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.37.2
+
+- ✅ Merge Command Regression Tests Complete - Added missing regression test for `transcodeMerge` error handling in the `helios merge` command.
+
 ## CLI v0.37.1
 
 - ✅ List Command Regression Tests - Implemented comprehensive unit tests for `helios list`.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.37.1
+**Version**: 0.37.2
 
 ## Current State
 
@@ -41,6 +41,7 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 
 ## History
 
+[v0.37.2] ✅ Merge Command Regression Tests Complete - Added missing regression test for `transcodeMerge` error handling in the `helios merge` command.
 [v0.37.1] ✅ List Command Regression Tests - Implemented comprehensive unit tests for `helios list`.
 [v0.37.0] ✅ Deploy Cloudflare - Implemented `helios deploy cloudflare` to scaffold Cloudflare Workers deployment configuration.
 [v0.36.10] ✅ Merge Command Regression Tests - Implemented comprehensive unit tests for `helios merge`.

--- a/packages/cli/src/commands/__tests__/merge.test.ts
+++ b/packages/cli/src/commands/__tests__/merge.test.ts
@@ -79,4 +79,13 @@ describe('helios merge command', () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Merge failed: Mock renderer error'));
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  it('should handle errors thrown by transcodeMerge and exit with 1', async () => {
+    vi.mocked(transcodeMerge).mockRejectedValueOnce(new Error('Mock transcode error'));
+
+    await program.parseAsync(['node', 'test', 'merge', 'output.mp4', 'input1.mp4', '--video-codec', 'libx264']);
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Merge failed: Mock transcode error'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
 });


### PR DESCRIPTION
Added missing `transcodeMerge` error handling regression test to `helios merge` command and updated documentation to reflect v0.37.2 progress.

---
*PR created automatically by Jules for task [13498981959289388905](https://jules.google.com/task/13498981959289388905) started by @BintzGavin*