### PR TITLE
✨ INFRASTRUCTURE: Verify CloudRunAdapter test coverage

### DIFF
--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -462,3 +462,6 @@
 
 ### INFRASTRUCTURE v0.53.31
 - ✅ Completed: CloudRun & Local Worker Adapter Coverage - Expanded test coverage for CloudRun and Local Worker adapters to 100%.
+
+### INFRASTRUCTURE v0.53.33
+- ✅ Completed: CloudRunAdapter Test Coverage - Verified existing 100% test coverage for `CloudRunAdapter`, including edge cases for cached client, missing stderr, and undefined response data, resolving obsolete implementation plan.

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.53.32
+**Version**: 0.53.33
 
 ## Status Log
+- [v0.53.33] ✅ Completed: CloudRunAdapter Test Coverage - Verified existing 100% test coverage for `CloudRunAdapter`, including edge cases for cached client, missing stderr, and undefined response data, resolving obsolete implementation plan.
 - [v0.53.32] ✅ Completed: CloudRunAdapter Test Coverage - Expanded test coverage for `CloudRunAdapter` to 100% by adding edge cases for cached client, missing stderr, and undefined response data.
 - [v0.53.31] ✅ Completed: Storage Adapter Test Coverage - Expanded test coverage for `S3StorageAdapter`, `GcsStorageAdapter`, and `LocalStorageAdapter` to 100% by adding tests for unhandled error throwing edges in cleanup and url parsing.
 - [v0.53.30] ✅ Completed: CloudRun and Local Adapter Coverage Expansion - Expanded test coverage for `CloudRunAdapter` and `LocalWorkerAdapter` to 100% by adding tests for missing `chunkId`, `timeoutId` cleanup on abort, and stderr accumulation.


### PR DESCRIPTION
This commit addresses the plan `2027-01-12-INFRASTRUCTURE-CloudRunAdapter-Coverage.md`.

During exploration, I discovered that the requested tests for `CloudRunAdapter` edge cases (cached client, missing stderr, and undefined response data) were already present in `packages/infrastructure/tests/cloudrun-adapter.test.ts` and that the file already had 100% coverage.

Instead of duplicating tests, I:
1. Updated `docs/status/INFRASTRUCTURE.md` to note that the existing 100% test coverage was verified, resolving the obsolete plan.
2. Bumped the INFRASTRUCTURE version to `0.53.33`.
3. Added the completion entry to `docs/PROGRESS-INFRASTRUCTURE.md`.
4. Verified that all infrastructure tests still pass successfully.

---
*PR created automatically by Jules for task [2913136405138472190](https://jules.google.com/task/2913136405138472190) started by @BintzGavin*