### PR TITLE
✨ INFRASTRUCTURE: LocalAdapter Coverage

### DIFF
--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,5 +1,8 @@
 # INFRASTRUCTURE PROGRESS
 
+## INFRASTRUCTURE v0.53.34
+- ✅ Completed: LocalAdapter Coverage - Expanded test coverage for `LocalWorkerAdapter` by adding edge case for missing child.stderr, achieving 100% test coverage.
+
 ## INFRASTRUCTURE v0.53.32
 - ✅ Completed: CloudRunAdapter Test Coverage - Expanded test coverage for `CloudRunAdapter` to 100% by adding edge cases for cached client, missing stderr, and undefined response data.
 

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,7 +1,8 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.53.33
+**Version**: 0.53.34
 
 ## Status Log
+- [v0.53.34] ✅ Completed: LocalAdapter Coverage - Expanded test coverage for `LocalWorkerAdapter` by adding edge case for missing child.stderr, achieving 100% test coverage.
 - [v0.53.33] ✅ Completed: CloudRunAdapter Test Coverage - Verified existing 100% test coverage for `CloudRunAdapter`, including edge cases for cached client, missing stderr, and undefined response data, resolving obsolete implementation plan.
 - [v0.53.32] ✅ Completed: CloudRunAdapter Test Coverage - Expanded test coverage for `CloudRunAdapter` to 100% by adding edge cases for cached client, missing stderr, and undefined response data.
 - [v0.53.31] ✅ Completed: Storage Adapter Test Coverage - Expanded test coverage for `S3StorageAdapter`, `GcsStorageAdapter`, and `LocalStorageAdapter` to 100% by adding tests for unhandled error throwing edges in cleanup and url parsing.

--- a/packages/infrastructure/tests/adapters/local-adapter.test.ts
+++ b/packages/infrastructure/tests/adapters/local-adapter.test.ts
@@ -1,6 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import { LocalWorkerAdapter } from '../../src/adapters/index.js';
 import { WorkerJob } from '../../src/types/index.js';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(actual.spawn),
+  };
+});
 
 describe('LocalWorkerAdapter', () => {
   const adapter = new LocalWorkerAdapter();
@@ -174,5 +184,30 @@ describe('LocalWorkerAdapter', () => {
     controller.abort();
 
     await expect(promise).rejects.toThrow('Job was aborted');
+  });
+
+  it('should gracefully handle missing child.stderr stream', async () => {
+    const mockChild = new EventEmitter() as any;
+    mockChild.kill = () => {};
+    mockChild.stdout = new EventEmitter();
+    mockChild.stderr = undefined; // Specifically test undefined stderr
+
+    vi.mocked(spawn).mockImplementationOnce(() => {
+      setTimeout(() => mockChild.emit('close', 0), 10);
+      return mockChild;
+    });
+
+    const job: WorkerJob = {
+      command: 'mock-command',
+      args: [],
+    };
+
+    const result = await adapter.execute(job);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+
+    // Cleanup is automatic with mockImplementationOnce,
+    // but just to be sure we can clear mocks
+    vi.clearAllMocks();
   });
 });


### PR DESCRIPTION
Implementation of the LocalAdapter test coverage gap, testing the exact case where `child.stderr` is undefined. Bumps infrastructure version to 0.53.34 and updates appropriate logs. All package tests run successfully and linter passes.

---
*PR created automatically by Jules for task [1834284156545375557](https://jules.google.com/task/1834284156545375557) started by @BintzGavin*