### PR TITLE
📋 INFRASTRUCTURE: Document Cloudflare Workers Adapter

### DIFF
--- a/.sys/plans/2027-01-13-INFRASTRUCTURE-Document-Cloudflare-Workers-Adapter.md
+++ b/.sys/plans/2027-01-13-INFRASTRUCTURE-Document-Cloudflare-Workers-Adapter.md
@@ -1,0 +1,27 @@
+#### 1. Context & Goal
+- **Objective**: Add documentation for the `CloudflareWorkersAdapter` to the `packages/infrastructure/README.md` file.
+- **Trigger**: The V2 Infrastructure vision states that "Documentation clarity" is an allowed fallback action when domains reach gravitational equilibrium. The Cloudflare Workers adapter is implemented and tested but not documented in the Cloud Execution Adapters section of the README.
+- **Impact**: Ensures that users know how to use the `CloudflareWorkersAdapter` for distributed cloud executions, completing the documentation gaps for implemented cloud providers.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**: `packages/infrastructure/README.md`
+  - Add `CloudflareWorkersAdapter` to the "Cloud Execution Adapters" section.
+- **Read-Only**: `packages/infrastructure/src/adapters/cloudflare-workers-adapter.ts`
+  - Reference the `CloudflareWorkersAdapterConfig` to correctly describe its capabilities (`serviceUrl`, `authToken`, `jobDefUrl`).
+
+#### 3. Implementation Spec
+- **Architecture**: No architectural changes. Just documentation.
+- **Pseudo-Code**:
+  - Open `packages/infrastructure/README.md`.
+  - Find the `### Cloud Execution Adapters` section.
+  - Add a new bullet point describing `CloudflareWorkersAdapter` and how it works (using `fetch` to make an HTTP POST to the configured `serviceUrl` with the `jobDefUrl` and `chunkId`, using `authToken` if provided).
+- **Public API Changes**: None
+- **Dependencies**: None
+- **Cloud Considerations**: The Cloudflare Workers adapter relies on making an HTTP POST to a configured `serviceUrl` with the `jobDefUrl` and `chunkIndex`, using `authToken` if provided in the Authorization header.
+
+#### 4. Test Plan
+- **Verification**: `npm run test` (to ensure README edits didn't break anything unexpectedly, though highly unlikely).
+- **Success Criteria**: The README includes `CloudflareWorkersAdapter` in the list of Cloud Execution Adapters alongside `AwsLambdaAdapter`, `CloudRunAdapter`, etc.
+- **Edge Cases**: N/A (Documentation change only)
+- **Integration Verification**: N/A (Documentation change only)


### PR DESCRIPTION
This commit creates the `.sys/plans/2027-01-13-INFRASTRUCTURE-Document-Cloudflare-Workers-Adapter.md` spec file to instruct the executor to document the `CloudflareWorkersAdapter` in `packages/infrastructure/README.md`. As a planner, this resolves the V2 documentation clarity fallback requirement for domains at gravitational equilibrium. No implementation code was modified.

---
*PR created automatically by Jules for task [14292620438935946348](https://jules.google.com/task/14292620438935946348) started by @BintzGavin*