### PR TITLE
✨ INFRASTRUCTURE: Document remaining Cloud Execution Adapters

### DIFF
--- a/docs/PROGRESS-INFRASTRUCTURE.md
+++ b/docs/PROGRESS-INFRASTRUCTURE.md
@@ -1,4 +1,7 @@
 # INFRASTRUCTURE PROGRESS
+### INFRASTRUCTURE v0.54.16
+- ✅ Completed: Cloud Execution Adapters Documentation - Documented DockerAdapter, DenoDeployAdapter, and HetznerCloudAdapter in README.md.
+
 
 ## INFRASTRUCTURE v0.54.15
 - ✅ Completed: CloudflareWorkersAdapter Test Coverage - Closed obsolete implementation plan as test coverage for `CloudflareWorkersAdapter` is already verified at 100%.

--- a/docs/status/INFRASTRUCTURE.md
+++ b/docs/status/INFRASTRUCTURE.md
@@ -1,5 +1,5 @@
 # INFRASTRUCTURE STATUS
-**Version**: 0.54.15
+**Version**: 0.54.16
 
 ## Status Log
 - [v0.28.0] 🚫 Blocked: No uncompleted implementation plans found for my domain in `/.sys/plans/`. I must stop working.
@@ -209,3 +209,4 @@
 - [v0.52.2] ✅ Completed: Kubernetes Adapter Refinement - Refined Kubernetes Adapter options.
 - [v0.53.31] ✅ Completed: CloudRun & Local Worker Adapter Coverage - Expanded test coverage for CloudRun and Local Worker adapters to 100%.
 - [v0.54.13] ✅ Completed: Vercel Azure Adapter Coverage - Improved test coverage to 100%
+- [v0.54.16] ✅ Completed: Cloud Execution Adapters Documentation - Documented DockerAdapter, DenoDeployAdapter, and HetznerCloudAdapter in README.md.

--- a/packages/infrastructure/README.md
+++ b/packages/infrastructure/README.md
@@ -96,11 +96,11 @@ Cloud adapters provide the critical abstraction layer that translates standardiz
 - **FlyMachinesAdapter**: Provisions and invokes containerized rendering tasks on Fly.io using the native `fetch` API via HTTP POST to the Machines API. It constructs machine definitions containing job and chunk coordinates injected as `HELIOS_JOB_PAYLOAD` environment variables, provisions machines with `auto_destroy` enabled, polls for execution completion by repeatedly fetching machine state, and manages machine lifecycle cleanup via explicit DELETE requests.
 - **LocalWorkerAdapter**: A testing-focused adapter that executes rendering chunks via local child processes, enabling rapid local development and determinism verification without requiring cloud deployments.
 - **KubernetesAdapter**: Allows execution of distributed rendering jobs across a Kubernetes cluster via the Batch V1 API using `@kubernetes/client-node`.
-- **DockerAdapter**: Executes rendering chunks via local child processes using `spawn('docker', ...)`.
+- **DockerAdapter**: Executes rendering chunks via local Docker child processes using `spawn('docker', ...)`. This provides an environment closer to cloud execution by running jobs within custom Docker images.
 - **ModalAdapter**: Provides an endpoint URL config for executing jobs, passing the job data via payload.
-- **DenoDeployAdapter**: Adapter for executing rendering chunks on Deno Deploy using endpoint URL and authorization tokens via native fetch POST requests.
+- **DenoDeployAdapter**: Adapter for executing rendering chunks on Deno Deploy using endpoint URL and authorization tokens via native fetch POST requests. It transmits the remote `jobDefUrl` and `chunkId` to be processed by Deno Edge workers.
 - **VercelAdapter**: Adapter for executing rendering chunks on Vercel Serverless Functions using endpoint URL, authorization token, and parsing job definition path and chunk IDs.
-- **HetznerCloudAdapter**: Adapter for executing rendering chunks using Hetzner Cloud API tokens, specifying server types, images, and managing remote server lifecycles.
+- **HetznerCloudAdapter**: Adapter for executing rendering chunks on Hetzner Cloud infrastructure. It provisions server instances programmatically using API tokens, runs the tasks, polls for status, and reliably cleans up the remote VM lifecycles afterward.
 
 ### Worker Runtime
 


### PR DESCRIPTION
Added documentation for `DockerAdapter`, `DenoDeployAdapter`, and `HetznerCloudAdapter` within the `Cloud Execution Adapters` section of `packages/infrastructure/README.md`. Also bumped the semantic version in `docs/status/INFRASTRUCTURE.md` to `0.54.16` and updated `docs/PROGRESS-INFRASTRUCTURE.md` accordingly. This resolves the documentation gap for newly added adapters while ensuring all tests passed.

---
*PR created automatically by Jules for task [17213983381166114645](https://jules.google.com/task/17213983381166114645) started by @BintzGavin*