### PR TITLE
✨ CLI: Scaffold Fly.io Deployment Command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -91,6 +91,7 @@ packages/cli/
 - `helios deploy gcp`: Scaffold Google Cloud Run Job configuration.
 - `helios deploy aws`: Scaffold AWS Lambda deployment configuration.
 - `helios deploy cloudflare`: Scaffold Cloudflare Workers deployment configuration.
+- `helios deploy fly`: Scaffold Fly.io Machines deployment configuration.
 
 ## D. Configuration
 

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -2,6 +2,10 @@
 
 This file tracks progress for the CLI domain (`packages/cli`).
 
+## CLI v0.38.0
+
+- ✅ Completed: Scaffold Fly.io Deployment Command - Implemented helios deploy fly to scaffold fly.toml, Dockerfile, and README-FLY.md for Fly.io Machines.
+
 ## CLI v0.37.4
 
 - ✅ Completed: Add Command Regression Tests - Implemented comprehensive unit tests for helios add.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.37.4
+**Version**: 0.38.0
 
 ## Current State
 
@@ -106,3 +106,4 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 [v0.36.0] ✅ Cloud Worker Execution - Integrated AwsLambdaAdapter and CloudRunAdapter into helios job run.
 [v0.36.2] ✅ Init Command Tests Spec - Created specification plan for implementing regression tests for the `helios init` command to ensure scaffolding stability.
 [v0.36.1] ✅ Add Command Scaffold - Verified the existing `helios add` command fulfills the scaffolding requirements outlined in the plan.
+[v0.38.0] ✅ Completed: Scaffold Fly.io Deployment Command - Implemented helios deploy fly to scaffold fly.toml, Dockerfile, and README-FLY.md for Fly.io Machines.

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -7,6 +7,7 @@ import { DOCKERFILE_TEMPLATE, DOCKER_COMPOSE_TEMPLATE } from '../templates/docke
 import { CLOUD_RUN_JOB_TEMPLATE, README_GCP_TEMPLATE } from '../templates/gcp.js';
 import { AWS_DOCKERFILE_TEMPLATE, AWS_LAMBDA_HANDLER_TEMPLATE, AWS_SAM_TEMPLATE, README_AWS_TEMPLATE } from '../templates/aws.js';
 import { WRANGLER_TOML_TEMPLATE, CLOUDFLARE_WORKER_TEMPLATE, README_CLOUDFLARE_TEMPLATE } from '../templates/cloudflare.js';
+import { FLY_TOML_TEMPLATE, FLY_DOCKERFILE_TEMPLATE, README_FLY_TEMPLATE } from '../templates/fly.js';
 
 export function registerDeployCommand(program: Command) {
   const deploy = program.command('deploy')
@@ -351,5 +352,95 @@ export function registerDeployCommand(program: Command) {
 
       console.log(chalk.blue('\nCloudflare Workers setup complete!'));
       console.log('See README-CLOUDFLARE.md for deployment instructions.');
+    });
+
+  deploy
+    .command('fly')
+    .description('Scaffold Fly.io Machines deployment configuration')
+    .action(async () => {
+      const cwd = process.cwd();
+      const flyTomlPath = path.join(cwd, 'fly.toml');
+      const dockerfilePath = path.join(cwd, 'Dockerfile');
+      const readmePath = path.join(cwd, 'README-FLY.md');
+
+      console.log(chalk.blue('Scaffolding Fly.io deployment files...'));
+
+      // fly.toml
+      let writeFlyToml = true;
+      if (fs.existsSync(flyTomlPath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'fly.toml already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeFlyToml = response.value;
+      }
+
+      if (writeFlyToml) {
+        fs.writeFileSync(flyTomlPath, FLY_TOML_TEMPLATE);
+        console.log(chalk.green('✔ Created fly.toml'));
+      } else {
+        console.log(chalk.gray('Skipped fly.toml'));
+      }
+
+      // Dockerfile
+      let writeDockerfile = true;
+      if (fs.existsSync(dockerfilePath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'Dockerfile already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeDockerfile = response.value;
+      }
+
+      if (writeDockerfile) {
+        fs.writeFileSync(dockerfilePath, FLY_DOCKERFILE_TEMPLATE);
+        console.log(chalk.green('✔ Created Dockerfile'));
+      } else {
+        console.log(chalk.gray('Skipped Dockerfile'));
+      }
+
+      // README-FLY.md
+      let writeReadme = true;
+      if (fs.existsSync(readmePath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'README-FLY.md already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeReadme = response.value;
+      }
+
+      if (writeReadme) {
+        fs.writeFileSync(readmePath, README_FLY_TEMPLATE);
+        console.log(chalk.green('✔ Created README-FLY.md'));
+      } else {
+        console.log(chalk.gray('Skipped README-FLY.md'));
+      }
+
+      console.log(chalk.blue('\nFly.io setup complete!'));
+      console.log('See README-FLY.md for deployment instructions.');
     });
 }

--- a/packages/cli/src/templates/fly.ts
+++ b/packages/cli/src/templates/fly.ts
@@ -1,0 +1,84 @@
+export const FLY_TOML_TEMPLATE = `app = "helios-render-worker"
+primary_region = "ord"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  # Add any necessary environment variables here
+
+[experimental]
+  auto_rollback = true
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 8080
+  processes = ["app"]
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [services.concurrency]
+    type = "connections"
+    hard_limit = 25
+    soft_limit = 20
+`;
+
+export const FLY_DOCKERFILE_TEMPLATE = `FROM mcr.microsoft.com/playwright:v1.49.1-jammy
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+# Optional: Build step if you are compiling TypeScript
+# RUN npm run build
+
+# Expose port (if your worker listens for HTTP requests, otherwise not strictly required for purely event-driven workers)
+EXPOSE 8080
+
+# Start the worker
+CMD ["npm", "start"]
+`;
+
+export const README_FLY_TEMPLATE = `# Helios Fly.io Deployment
+
+This directory contains the configuration required to deploy a Helios rendering worker to Fly.io Machines.
+
+## Prerequisites
+
+1.  **Fly Account:** You need an active Fly.io account.
+2.  **flyctl CLI:** Ensure you have the Fly CLI installed (\`flyctl\` or \`fly\`).
+3.  **Authentication:** Authenticate with your Fly account.
+    \`\`\`bash
+    fly auth login
+    \`\`\`
+
+## Deployment
+
+1.  **Review Configuration:** Check the \`fly.toml\` file to customize the app name, region, and compute resources. You may want to configure a Machine with a GPU for heavy rendering.
+2.  **Launch App:** Since the \`fly.toml\` is already created, you can deploy directly. If the app doesn't exist yet, you may need to run \`fly launch\` and tell it to use the existing config.
+    \`\`\`bash
+    fly deploy
+    \`\`\`
+3.  **Note the App Name:** You will need the app name (e.g., \`helios-render-worker\`) to execute jobs.
+
+## Executing Jobs
+
+Once deployed, you can use the Helios CLI to execute distributed rendering jobs against your Fly.io Machines. You will need a Fly API token.
+
+\`\`\`bash
+export FLY_API_TOKEN="your_personal_access_token"
+helios job run <path-to-job.json> --adapter fly --app-name helios-render-worker
+\`\`\`
+
+Replace \`<path-to-job.json>\` with your job specification and \`helios-render-worker\` with the actual app name defined in \`fly.toml\`.
+`;


### PR DESCRIPTION
Implemented the `helios deploy fly` command to scaffold the Fly.io deployment templates, fulfilling the final gap in the CLI for the `FlyMachinesAdapter`.

Files changed:
- Created `packages/cli/src/templates/fly.ts` with template definitions
- Updated `packages/cli/src/commands/deploy.ts` with the new command and interactive file creation flows
- Updated `.sys/llmdocs/context-cli.md` documentation
- Updated `docs/status/CLI.md` and `docs/PROGRESS-CLI.md` tracker files

---
*PR created automatically by Jules for task [9409442325123307476](https://jules.google.com/task/9409442325123307476) started by @BintzGavin*