### PR TITLE
✨ PLAYER: Media Session Properties

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -10,3 +10,6 @@
 ## v0.76.13 - Regression Fallback
 **Learning:** The PLAYER domain has reached gravitational equilibrium with the documented vision. No missing features exist from the README.
 **Action:** When no feature deltas exist, always fall back to improving test coverage and documentation stability instead of creating unwarranted logic changes.
+## v0.77.0 - Documentation Synchronization
+**Learning:** During the implementation of the media session properties, I learned that strict adherence to the protocol requires not only modifying the source files (`src/index.ts`) but also updating the corresponding tracking and context files (`docs/status/PLAYER.md`, `docs/PROGRESS.md`, `.sys/llmdocs/context-player.md`) in the repository. Modifying compiled build artifacts (`dist/`) directly is incorrect and will cause issues.
+**Action:** Always ensure that modifications are made only to source files, and follow the protocol to update status and documentation files before finalizing a commit.

--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -113,3 +113,10 @@
 - `requestPictureInPicture(): Promise<PictureInPictureWindow>`
 - `startAudioMetering(): void`
 - `stopAudioMetering(): void`
+## Section E: Media Session Properties
+
+The following standard media session metadata attributes are available as properties on the `HeliosPlayer` class, mapping to the respective DOM attributes:
+- `mediaTitle`: Maps to `media-title` attribute
+- `mediaArtist`: Maps to `media-artist` attribute
+- `mediaAlbum`: Maps to `media-album` attribute
+- `mediaArtwork`: Maps to `media-artwork` attribute

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -87,6 +87,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### CLI v0.31.0
 - ✅ Completed: AWS Deployment - Implemented AWS Lambda deployment scaffolding and custom browser path support.
 
+### PLAYER v0.77.0
+- ✅ Completed: Media Session Properties - Exposed mediaTitle, mediaArtist, mediaAlbum, and mediaArtwork properties on HeliosPlayer to match HTMLMediaElement parity.
+
 ### PLAYER v0.76.15
 - ✅ Completed: Add Regression Tests - Confirmed existence of tests for API parity (seeking, state persistence) and interactions (export parameters) per `2026-11-24-PLAYER-Regression-Tests.md`. All tests are passing.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,5 @@
-**Version**: 0.76.24
+**Version**: 0.77.0
+[v0.77.0] ✅ Completed: Media Session Properties - Exposed mediaTitle, mediaArtist, mediaAlbum, and mediaArtwork properties on HeliosPlayer to match HTMLMediaElement parity.
 [v0.76.24] ✅ Completed: Bridge Coverage Expansion 2 - Added missing unit test coverage for bridge.ts message handling (e.g., HELIOS_SEEK, HELIOS_SET_PLAYBACK_RANGE).
 
 **Posture**: STABLE AND FEATURE COMPLETE

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1451,6 +1451,38 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     }
   }
 
+  public get mediaTitle(): string {
+    return this.getAttribute("media-title") || "";
+  }
+
+  public set mediaTitle(val: string) {
+    this.setAttribute("media-title", val);
+  }
+
+  public get mediaArtist(): string {
+    return this.getAttribute("media-artist") || "";
+  }
+
+  public set mediaArtist(val: string) {
+    this.setAttribute("media-artist", val);
+  }
+
+  public get mediaAlbum(): string {
+    return this.getAttribute("media-album") || "";
+  }
+
+  public set mediaAlbum(val: string) {
+    this.setAttribute("media-album", val);
+  }
+
+  public get mediaArtwork(): string {
+    return this.getAttribute("media-artwork") || "";
+  }
+
+  public set mediaArtwork(val: string) {
+    this.setAttribute("media-artwork", val);
+  }
+
   public async requestPictureInPicture(): Promise<PictureInPictureWindow> {
     if (!document.pictureInPictureEnabled) {
       throw new Error("Picture-in-Picture not supported");


### PR DESCRIPTION
💡 What: Added getters and setters for mediaTitle, mediaArtist, mediaAlbum, and mediaArtwork to HeliosPlayer.\n🎯 Why: The README lists these attributes, but they were not exposed as JavaScript properties on the class, causing a gap in the API surface.\n📊 Impact: Allows programmatic access and modification of the media session metadata, improving parity with the HTMLMediaElement interface.\n🔬 Verification: Confirmed via tests and manual verification that properties correspond to DOM attributes.

---
*PR created automatically by Jules for task [4042769777468849225](https://jules.google.com/task/4042769777468849225) started by @BintzGavin*