### PR TITLE
chore: add commit/PR creation instructions to renderer prompts

### DIFF
--- a/docs/prompts/execution-renderer.md
+++ b/docs/prompts/execution-renderer.md
@@ -330,10 +330,29 @@ If the experiment queue from the plan is exhausted and you've tried everything o
 
 Once the experiment loop has begun, do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "should I try something else?". You are autonomous. The loop runs until your plan's experiments are exhausted, then self-generate more experiments within the plan's focus area.
 
-When you are about to stop (session ending, or all ideas exhausted):
+## Session Completion
+
+When all experiments are exhausted:
+
 1. Update your plan's frontmatter to `status: complete` with the appropriate `result`
 2. Add a Results Summary section to the bottom of your plan file
 3. Ensure all discarded experiments have been fully reverted — only kept improvements should remain in the code
+4. Commit and create a PR
+
+**Commit Convention:**
+- Title: `✨ RENDERER: [Summary of improvements]`
+- Description with:
+  * 💡 **What**: The experiments run and their outcomes
+  * 🎯 **Why**: The performance bottleneck targeted
+  * 📊 **Impact**: Before/after render times and percentage improvement
+  * 🔬 **Verification**: What was tested (4-gate verification, benchmark results)
+  * 📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-NNN-slug.md`)
+
+**PR Creation:**
+- Title: `✨ RENDERER: [Summary of improvements]`
+- Description: Same format as commit description
+- Include the TSV results summary in the PR body
+- Create the PR immediately after committing
 
 ## Final Check
 
@@ -345,3 +364,9 @@ Before each experiment:
 - ✅ No leftover changes from discarded experiments remain in any file
 - ✅ Results are logged in your plan-specific TSV
 - ✅ Your plan's frontmatter status is `claimed`
+
+Before session completion:
+- ✅ All discarded experiments are fully reverted
+- ✅ Plan frontmatter updated to `status: complete`
+- ✅ Results summary added to plan file
+- ✅ Commit created and PR opened

--- a/docs/prompts/planning-renderer.md
+++ b/docs/prompts/planning-renderer.md
@@ -267,9 +267,24 @@ The plan should be detailed enough that an Executor can implement it without add
 - Variations are listed if the core approach has multiple options
 - No code exists in `packages/renderer/` directories
 
-### 6. 🎁 PRESENT — Save and stop:
+### 6. 🎁 PRESENT — Save and share:
 
-Save the plan file. Your task is COMPLETE the moment the `.md` plan is saved.
+Save the plan file.
+
+**Commit Convention:**
+- Title: `📋 RENDERER: [Experiment Focus]`
+- Description with:
+  * 💡 **What**: The experiment being planned
+  * 🎯 **Why**: What bottleneck this targets and expected impact
+  * 🔬 **Approach**: The core strategy (in one sentence)
+  * 📎 **Plan**: Reference the plan file path (`/.sys/plans/PERF-NNN-slug.md`)
+
+**PR Creation:**
+- Title: `📋 RENDERER: [Experiment Focus]`
+- Description: Same format as commit description
+- Create the PR immediately after committing
+
+Your task is COMPLETE once the PR is created.
 
 ## Final Check
 
@@ -278,3 +293,4 @@ Before outputting:
 - Is the implementation spec detailed enough to follow step-by-step?
 - Did you write any code in `packages/renderer/`? If yes, DELETE IT.
 - Does the plan have valid YAML frontmatter with `status: unclaimed`?
+- Did you create a commit and PR?


### PR DESCRIPTION
Adds explicit PRESENT sections to both renderer prompts following the convention from other agent prompts.

**Planner:** `📋 RENDERER: [Experiment Focus]` with What/Why/Approach/Plan reference
**Executor:** `✨ RENDERER: [Summary of improvements]` with What/Why/Impact/Verification/Plan reference, plus TSV results in the PR body

Both agents now create a commit and PR as the final step of their session.