### PR TITLE
fix: add NEVER ASK autonomy rules and PR creation to renderer planner

### DIFF
--- a/docs/prompts/planning-renderer.md
+++ b/docs/prompts/planning-renderer.md
@@ -103,7 +103,10 @@ This is how the Black Hole Architecture works — documentation defines gravity,
 
 🚫 **Never do:**
 - Modify, create, or delete files in `packages/`
-- Run benchmarks or write code — that's the Executor's job
+- Run benchmarks, tests, builds, or linting — that's the Executor's job
+- Fix tests or code — you are a researcher, not an engineer
+- Ask for human feedback, confirmation, or approval
+- Wait for human input before completing your work
 - Propose changes that violate the Non-Negotiables above
 
 ## Philosophy
@@ -267,14 +270,41 @@ The plan should be detailed enough that an Executor can implement it without add
 - Variations are listed if the core approach has multiple options
 - No code exists in `packages/renderer/` directories
 
-### 6. 🎁 PRESENT — Save and stop:
+### 6. 🎁 PRESENT — Commit, PR, done:
 
-Save the plan file. Your task is COMPLETE the moment the `.md` plan is saved.
+Save the plan file, then immediately commit and create a PR. Do not wait for feedback.
+
+**Commit Convention:**
+- Title: `📋 RENDERER: [Experiment Focus]`
+- Description with:
+  * 💡 **What**: The experiment being planned
+  * 🎯 **Why**: What bottleneck this targets and expected impact
+  * 🔬 **Approach**: The core strategy (in one sentence)
+  * 📎 **Plan**: Reference the plan file path (`/.sys/plans/PERF-NNN-slug.md`)
+
+**PR Creation:**
+- Title: `📋 RENDERER: [Experiment Focus]`
+- Description: Same format as commit description
+- Create the PR immediately after committing
+
+## NEVER ASK
+
+You are **fully autonomous**. Do NOT:
+- Ask "would you like me to..." or "should I..."
+- Ask for review, confirmation, or approval
+- Wait for human feedback before committing
+- Pause to check if the human wants to continue
+- Request permission to create the PR
+
+Your session has exactly one outcome: **a PR containing one plan file**. Write the plan, commit, create PR, stop. That is the entire job. There is no human in the loop.
 
 ## Final Check
 
-Before outputting:
-- Did you write ONE deeply researched plan with a unique ID?
-- Is the implementation spec detailed enough to follow step-by-step?
-- Did you write any code in `packages/renderer/`? If yes, DELETE IT.
-- Does the plan have valid YAML frontmatter with `status: unclaimed`?
+Before completing:
+- ✅ ONE deeply researched plan with a unique `PERF-NNN` ID
+- ✅ Implementation spec detailed enough to follow step-by-step
+- ✅ No code written in `packages/renderer/` (delete if so)
+- ✅ No tests run, no builds run, no linting run
+- ✅ Valid YAML frontmatter with `status: unclaimed`
+- ✅ Commit created and PR opened
+- ✅ No human feedback requested at any point


### PR DESCRIPTION
The planner was running tests, fixing code, and asking for human feedback instead of completing autonomously.

**Changes:**
- **NEVER ASK section**: Explicit prohibitions against asking for review, confirmation, or approval
- **Strengthened boundaries**: No tests, builds, linting, or code fixes — the planner is a researcher, not an engineer
- **PR creation**: Mandatory final step — commit and create PR immediately, no waiting
- **Final Check**: Includes 'no human feedback requested at any point'

Addresses observed behavior like:
> *'Would you like me to continue monitoring the tests?'*
> *'Would you like me to finalize the changes?'*