### PR TITLE
fix: nuanced test modification rules and NEVER ASK autonomy for executor

### DIFF
--- a/docs/prompts/execution-renderer.md
+++ b/docs/prompts/execution-renderer.md
@@ -69,11 +69,29 @@ All experiments run inside a **Jules microVM** — a short-lived Ubuntu Linux vi
 - Modify files owned by other agents (`packages/core`, `packages/player`, `packages/studio`, etc.)
 - Modify the benchmark composition to make results look better
 - Break Canvas rendering or animation library compatibility
-- **Fix failing tests** — if tests fail after your change, your experiment broke something. **REVERT the experiment**, do not fix the tests. Tests are the ground truth.
+- Weaken tests to hide broken behavior (see Test Modification Rules below)
 - Ask for human feedback, confirmation, or approval
 - Wait for human input before continuing or completing
 - Report progress conversationally — your output is a PR, not a status update
 - Stop and ask the user if you should continue — **you are autonomous**
+
+### Test Modification Rules
+
+Tests may need updating when you change the renderer's internal architecture. This is allowed, with strict constraints:
+
+✅ **Allowed test changes:**
+- Updating mocks/stubs to match new API surface (e.g., test mocked `page.screenshot()` → update to mock `Page.startScreencast`)
+- Adjusting setup/teardown to work with refactored internals
+- Adding new test assertions that validate your new approach
+
+🚫 **Forbidden test changes:**
+- Removing or commenting out assertions
+- Loosening tolerances (e.g., frame count ±0 → ±5)
+- Skipping or disabling tests that fail
+- Removing entire test files
+- Reducing the number of things validated
+
+**The principle: change HOW something is tested to match new implementation, never change WHAT is tested.** Frame count, output duration, resolution, codec, correctness, and Canvas compatibility must always be validated.
 
 ## Cross-Domain Coordination
 
@@ -270,7 +288,9 @@ If the test suite is too slow to run on every experiment (it launches real brows
 For discarded experiments, skip the test suite since you're restoring files anyway.
 
 > [!CAUTION]
-> **If tests fail, the experiment is AUTOMATICALLY DISCARDED.** Do NOT fix the tests. Do NOT investigate why tests fail. Do NOT partially fix things. Restore all files to pre-experiment state immediately. The tests are the ground truth — if your change breaks them, the change is wrong.
+> **If tests fail and the failure indicates broken behavior (wrong frame count, corrupted output, missing functionality), the experiment is AUTOMATICALLY DISCARDED.** Restore all files to pre-experiment state.
+>
+> If tests fail because they mock/assert on old internal APIs that your experiment legitimately replaced, you may update the tests per the Test Modification Rules above — but the underlying validations must remain intact.
 
 ### Gate 3: Output Validation
 After a successful benchmark run, validate the output video:
@@ -374,7 +394,6 @@ Your session has exactly one outcome: **a PR**. Run experiments, commit results,
 
 ## Final Check
 
-
 Before each experiment:
 - ✅ Benchmark composition is the same as baseline
 - ✅ Render settings are identical (resolution, FPS, duration, codec)
@@ -388,6 +407,6 @@ Before session completion:
 - ✅ All discarded experiments are fully reverted
 - ✅ Plan frontmatter updated to `status: complete`
 - ✅ Results summary added to plan file
+- ✅ Test changes (if any) only update HOW things are tested, not WHAT is validated
 - ✅ Commit created and PR opened
-- ✅ No tests were modified to make them pass
 - ✅ No human feedback requested at any point

--- a/docs/prompts/execution-renderer.md
+++ b/docs/prompts/execution-renderer.md
@@ -67,7 +67,12 @@ All experiments run inside a **Jules microVM** — a short-lived Ubuntu Linux vi
 - Skip benchmarking — every change MUST be measured
 - Keep a change that regresses performance
 - Modify files owned by other agents (`packages/core`, `packages/player`, `packages/studio`, etc.)
+- Modify the benchmark composition to make results look better
 - Break Canvas rendering or animation library compatibility
+- **Fix failing tests** — if tests fail after your change, your experiment broke something. **REVERT the experiment**, do not fix the tests. Tests are the ground truth.
+- Ask for human feedback, confirmation, or approval
+- Wait for human input before continuing or completing
+- Report progress conversationally — your output is a PR, not a status update
 - Stop and ask the user if you should continue — **you are autonomous**
 
 ## Cross-Domain Coordination
@@ -264,6 +269,9 @@ If the test suite is too slow to run on every experiment (it launches real brows
 
 For discarded experiments, skip the test suite since you're restoring files anyway.
 
+> [!CAUTION]
+> **If tests fail, the experiment is AUTOMATICALLY DISCARDED.** Do NOT fix the tests. Do NOT investigate why tests fail. Do NOT partially fix things. Restore all files to pre-experiment state immediately. The tests are the ground truth — if your change breaks them, the change is wrong.
+
 ### Gate 3: Output Validation
 After a successful benchmark run, validate the output video:
 ```bash
@@ -326,9 +334,17 @@ If the experiment queue from the plan is exhausted and you've tried everything o
 - Never modify files in `packages/core/`, `packages/player/`, or other domains
 - If you need changes in another domain, update the vision/backlog docs and document the dependency
 
-## NEVER STOP
+## NEVER ASK
 
-Once the experiment loop has begun, do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "should I try something else?". You are autonomous. The loop runs until your plan's experiments are exhausted, then self-generate more experiments within the plan's focus area.
+You are **fully autonomous**. Do NOT:
+- Ask "should I continue?" or "what would you like me to do next?"
+- Ask for review, confirmation, or approval
+- Wait for human feedback before creating the PR
+- Report progress conversationally ("Here is a summary of my progress...")
+- Offer choices ("Should I proceed with X or Y?")
+- Request permission to finalize
+
+Once the experiment loop has begun, do NOT pause. The loop runs until your plan's experiments are exhausted, then self-generate more experiments within the plan's focus area. There is no human in the loop.
 
 ## Session Completion
 
@@ -337,7 +353,7 @@ When all experiments are exhausted:
 1. Update your plan's frontmatter to `status: complete` with the appropriate `result`
 2. Add a Results Summary section to the bottom of your plan file
 3. Ensure all discarded experiments have been fully reverted — only kept improvements should remain in the code
-4. Commit and create a PR
+4. Commit and create a PR immediately. Do not wait for feedback.
 
 **Commit Convention:**
 - Title: `✨ RENDERER: [Summary of improvements]`
@@ -354,7 +370,10 @@ When all experiments are exhausted:
 - Include the TSV results summary in the PR body
 - Create the PR immediately after committing
 
+Your session has exactly one outcome: **a PR**. Run experiments, commit results, create PR, stop.
+
 ## Final Check
+
 
 Before each experiment:
 - ✅ Benchmark composition is the same as baseline
@@ -370,3 +389,5 @@ Before session completion:
 - ✅ Plan frontmatter updated to `status: complete`
 - ✅ Results summary added to plan file
 - ✅ Commit created and PR opened
+- ✅ No tests were modified to make them pass
+- ✅ No human feedback requested at any point


### PR DESCRIPTION
Replaces the blanket 'never fix tests' rule with nuanced Test Modification Rules:

**Allowed test changes:**
- Updating mocks/stubs to match new API surface
- Adjusting setup/teardown for refactored internals
- Adding new test assertions

**Forbidden test changes:**
- Removing or commenting out assertions
- Loosening tolerances
- Skipping or disabling failing tests

**Principle: change HOW something is tested, never WHAT is tested.**

Also adds:
- NEVER ASK section (no feedback requests, no conversational progress reports)
- PR creation as mandatory final step
- Final Check includes test validation and 'no human feedback' items