### PR TITLE
✨ RENDERER: Optimize Chromium Launch Arguments

### DIFF
--- a/.jules/RENDERER.md
+++ b/.jules/RENDERER.md
@@ -13,3 +13,9 @@
 ## [1.79.1] - GSAP Fragility
 **Learning:** `SeekTimeDriver` relies on the `window.__helios_gsap_timeline__` global for synchronization, which is fragile if the user doesn't expose it correctly or uses multiple timelines.
 **Action:** Future task should consider more robust discovery mechanisms or an explicit registration API.
+## Performance Trajectory
+Current best: 51.645s (baseline was 53.107s, -2.75%)
+Last updated by: PERF-006
+
+## What Works
+- Removed GL flags and forced Chromium into native Skia CPU pathways via `--disable-gpu`, `--disable-software-rasterizer`, and `--disable-gpu-compositing`. Reduces translation overhead from SwiftShader (~2.75% faster). (PERF-006)

--- a/.sys/plans/PERF-006-optimize-chromium-args.md
+++ b/.sys/plans/PERF-006-optimize-chromium-args.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-006
 slug: optimize-chromium-args
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: "2024-03-24"
+result: "improved"
 ---
 
 # PERF-006: Optimize Chromium Launch Arguments for CPU-only MicroVM
@@ -76,3 +76,11 @@ Run a standard Canvas smoke test using `mode: 'canvas'`. Because `mode: 'canvas'
 
 ## Prior Art
 - Puppeteer / Playwright performance guides for Docker/CI environments (which are typically CPU-only) strongly recommend `--disable-gpu` and `--disable-dev-shm-usage` to avoid SwiftShader overhead for standard web scraping and PDF/Screenshot generation.
+
+## Results Summary
+- **Best render time**: 51.645s (vs baseline 53.107s)
+- **Improvement**: 2.75%
+- **Kept experiments**:
+  - Remove GL flags (`--use-gl=egl`, `--ignore-gpu-blocklist`, `--enable-gpu-rasterization`, `--enable-zero-copy`)
+  - Add disable flags (`--disable-gpu`, `--disable-software-rasterizer`, `--disable-gpu-compositing`)
+- **Discarded experiments**: none

--- a/packages/renderer/.sys/perf-results-PERF-006.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-006.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	53.107	150	2.82	37.6	keep	baseline
+2	51.645	150	2.90	37.5	keep	disable GPU flags for native Skia CPU pathways

--- a/packages/renderer/src/Renderer.ts
+++ b/packages/renderer/src/Renderer.ts
@@ -11,10 +11,9 @@ import { FFmpegInspector } from './utils/FFmpegInspector.js';
 import { RendererOptions, RenderJobOptions } from './types.js';
 
 const DEFAULT_BROWSER_ARGS = [
-  '--use-gl=egl',
-  '--ignore-gpu-blocklist',
-  '--enable-gpu-rasterization',
-  '--enable-zero-copy',
+  '--disable-gpu',
+  '--disable-software-rasterizer',
+  '--disable-gpu-compositing',
   '--disable-web-security',
   '--allow-file-access-from-files',
 ];


### PR DESCRIPTION
✨ RENDERER: Optimize Chromium Launch Arguments

💡 What: Removed GL flags and forced Chromium into native Skia CPU pathways via `--disable-gpu`, `--disable-software-rasterizer`, and `--disable-gpu-compositing`.
🎯 Why: To reduce translation overhead from SwiftShader in CPU-only microVM environments.
📊 Impact: Render time reduced from 53.107s to 51.645s (~2.75% improvement).
🔬 Verification: 4-gate verification and benchmark median of 3 runs (150 frames, 30fps).
📎 Plan: /.sys/plans/PERF-006-optimize-chromium-args.md

---
*PR created automatically by Jules for task [11809748916066583195](https://jules.google.com/task/11809748916066583195) started by @BintzGavin*