### PR TITLE
📋 RENDERER: Optimize Intermediate Format to JPEG

### DIFF
--- a/.sys/plans/PERF-011-optimize-intermediate-format-jpeg.md
+++ b/.sys/plans/PERF-011-optimize-intermediate-format-jpeg.md
@@ -1,0 +1,35 @@
+---
+id: PERF-011
+slug: optimize-intermediate-format-jpeg
+status: unclaimed
+claimed_by: ""
+created: 2026-10-18
+completed: ""
+result: ""
+---
+
+# PERF-011: Optimize Intermediate Format to JPEG
+
+## Context & Goal
+The Frame Capture Loop (phase 4) in `packages/renderer/src/strategies/DomStrategy.ts` currently defaults to using `'png'` as the intermediate format when calling `Page.captureScreenshot` via CDP. In a CPU-bound microVM without a GPU, encoding a frame to PNG inside Chromium often takes a significant amount of time due to the complexity of the PNG compression algorithm. JPEG encoding is significantly faster than PNG encoding inside Skia, and the resulting I/O between Chromium, Node, and FFmpeg is smaller, eliminating IPC overhead. The goal is to intelligently default to `jpeg` (quality 90) when no alpha channel is required by the requested `pixelFormat`, falling back to `png` only when transparency is explicitly needed.
+
+## File Inventory
+- `packages/renderer/src/strategies/DomStrategy.ts`
+
+## Implementation Spec
+
+### Step 1: Intelligently default to JPEG in DomStrategy
+**File**: `packages/renderer/src/strategies/DomStrategy.ts`
+**What to change**:
+In the `capture()` method, modify the logic that determines the `format` and `quality` variables.
+- First, determine if `hasAlpha` is true based on whether the `pixelFormat` includes alpha channels (`yuva`, `rgba`, `bgra`, `argb`, `abgr`), mirroring existing logic.
+- If `this.options.intermediateImageFormat` is provided, use it.
+- If it is not provided, check `hasAlpha`. If `hasAlpha` is false, default the format to `jpeg` and the quality to `this.options.intermediateImageQuality ?? 90`.
+- If `hasAlpha` is true, fallback to the default `png` format.
+
+**Why**: JPEG encoding is significantly faster than PNG encoding, and the payload sizes transferred over IPC are smaller.
+**Risk**: Slight loss of quality due to JPEG compression, but at quality 90, it's virtually indistinguishable for video encoding that is already lossy (e.g. libx264).
+
+## Test Plan
+1. Run a standard Canvas smoke test by executing `npx tsx tests/verify-codecs.ts` inside the `packages/renderer` directory.
+2. Ensure output video is identical in quality by comparing test outputs. Ensure no skipped frames.

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -82,23 +82,36 @@ export class DomStrategy implements RenderStrategy {
   }
 
   async capture(page: Page, frameTime: number): Promise<Buffer> {
-    const format = this.options.intermediateImageFormat || 'png';
-    const quality = this.options.intermediateImageQuality;
     const pixelFormat = this.options.pixelFormat || 'yuv420p';
+
+    // Check if the requested pixel format supports alpha
+    const hasAlpha = pixelFormat.includes('yuva') ||
+                     pixelFormat.includes('rgba') ||
+                     pixelFormat.includes('bgra') ||
+                     pixelFormat.includes('argb') ||
+                     pixelFormat.includes('abgr');
+
+    let format = this.options.intermediateImageFormat;
+    let quality = this.options.intermediateImageQuality;
+
+    if (!format) {
+      if (hasAlpha) {
+        format = 'png';
+      } else {
+        format = 'jpeg';
+        quality = quality ?? 90;
+      }
+    }
 
     const screenshotOptions: any = {
       type: format,
     };
 
     if (format === 'jpeg') {
-      screenshotOptions.quality = quality;
+      if (quality !== undefined) {
+        screenshotOptions.quality = quality;
+      }
     } else {
-      // Check if the requested pixel format supports alpha
-      const hasAlpha = pixelFormat.includes('yuva') ||
-                       pixelFormat.includes('rgba') ||
-                       pixelFormat.includes('bgra') ||
-                       pixelFormat.includes('argb') ||
-                       pixelFormat.includes('abgr');
       screenshotOptions.omitBackground = hasAlpha;
     }
 


### PR DESCRIPTION
💡 What: The plan outlines a targeted performance optimization for `DomStrategy.ts`. The frame capture loop will be modified to intelligently default the intermediate image format to `jpeg` when transparency is not required by the requested `pixelFormat` (e.g. `yuv420p`), bypassing the slow PNG encoding overhead within Chromium.

🎯 Why: In the CPU-bound Jules microVM environment, encoding raw frames to PNG in the browser process before piping them over IPC represents a major performance bottleneck. Defaulting to JPEG when alpha is unnecessary significantly speeds up the capture loop and reduces data transfer overhead.

📊 Impact: Expected reduction in per-frame capture time and overall wall-clock render time for DOM-to-Video processing.

🔬 Verification: The plan was validated locally by executing `npx tsx tests/verify-codecs.ts` inside `packages/renderer`. Code changes were verified to be non-destructive and respect explicitly provided format overrides.

---
*PR created automatically by Jules for task [7130467436618536436](https://jules.google.com/task/7130467436618536436) started by @BintzGavin*