### PR TITLE
✨ RENDERER: Optimize FFmpeg Image Pipe Format

### DIFF
--- a/.sys/plans/PERF-012-optimize-intermediate-format-jpeg-pipe.md
+++ b/.sys/plans/PERF-012-optimize-intermediate-format-jpeg-pipe.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-012
 slug: optimize-intermediate-format-jpeg-pipe
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: 2026-10-18
+result: failed
 ---
 
 # PERF-012: Optimize FFmpeg Image Pipe Format
@@ -60,3 +60,9 @@ In `DomStrategy.ts`, locate the `getFFmpegArgs` method. Modify the `videoInputAr
 ## Test Plan
 1. Run a standard Canvas smoke test by executing `npx tsx tests/run-all.ts` inside the `packages/renderer` directory.
 2. Execute the DOM render benchmark and measure if wall-clock time improves compared to the PERF-011 baseline (46.706s).
+
+## Results Summary
+- **Best render time**: 46.706s (vs baseline 46.706s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [jpeg_pipe ingest via mjpeg codec]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -7,6 +7,7 @@ Last updated by: PERF-011
 
 ## What Doesn't Work (and Why)
 - [entries]
+- Conditionally using `jpeg_pipe` format with `mjpeg` codec for FFmpeg ingestion when intermediate image format is `jpeg`. The render time degraded (47.85s vs 46.706s). It appears that bypassing FFmpeg stream probing doesn't offset other ingestion/decoding overhead in this environment. (PERF-012)
 
 ## Open Questions
 - [entries]

--- a/packages/renderer/.sys/perf-results-PERF-012.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-012.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	46.706	150	3.21	36.3	keep	baseline (jpeg format)
+2	47.850	150	3.13	4.3	discard	jpeg_pipe ingest via mjpeg codec


### PR DESCRIPTION
✨ RENDERER: Optimize FFmpeg Image Pipe Format

💡 **What**: The experiment tested conditionally using `jpeg_pipe` format and `mjpeg` codec for FFmpeg ingestion when intermediate format is `jpeg`.
🎯 **Why**: To reduce CPU overhead during FFmpeg ingest by bypassing stream probing.
📊 **Impact**: The change slightly degraded performance from 46.706s to 47.85s. The experiment was discarded.
🔬 **Verification**: 
- 150-frame DOM benchmark run on `simple-animation`.
- Code changes were restored after the degradation was confirmed.
- `docs/status/RENDERER-EXPERIMENTS.md` updated to document the failure.
📎 **Plan**: `.sys/plans/PERF-012-optimize-intermediate-format-jpeg-pipe.md`

### Benchmark Results
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	46.706	150	3.21	36.3	keep	baseline (jpeg format)
2	47.850	150	3.13	4.3	discard	jpeg_pipe ingest via mjpeg codec
```

---
*PR created automatically by Jules for task [12007228463515733199](https://jules.google.com/task/12007228463515733199) started by @BintzGavin*