### PR TITLE
✨ [RENDERER]: Discard FFmpeg ultrafast preset optimization

### DIFF
--- a/.sys/plans/PERF-014-ffmpeg-ultrafast.md
+++ b/.sys/plans/PERF-014-ffmpeg-ultrafast.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-014
 slug: ffmpeg-ultrafast
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: 2026-10-18
+result: no-improvement
 ---
 
 # PERF-014: Optimize FFmpeg with Ultrafast Preset
@@ -30,3 +30,9 @@ Modify this logic so that it defines a local variable representing the preset to
 
 ## Test Plan
 1. Execute `npx tsx tests/verify-dom-media-attributes.ts` inside the `packages/renderer` directory to ensure the FFmpegBuilder arguments are correctly formed.
+
+## Results Summary
+- **Best render time**: 46.307s (vs baseline 46.307s)
+- **Improvement**: 0%
+- **Kept experiments**:
+- **Discarded experiments**: [PERF-014: Defaulting FFmpeg preset to ultrafast]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -8,6 +8,7 @@ Last updated by: PERF-013
 
 ## What Doesn't Work (and Why)
 - [entries]
+- Defaulting FFmpeg preset to `ultrafast`. The render time remained identical within noise margins (46.161s vs 46.307s baseline). In this CPU-bound microVM, DOM frame capture and IPC appear to be the dominant bottlenecks, making the encoding preset negligible. (PERF-014)
 - Conditionally using `jpeg_pipe` format with `mjpeg` codec for FFmpeg ingestion when intermediate image format is `jpeg`. The render time degraded (47.85s vs 46.706s). It appears that bypassing FFmpeg stream probing doesn't offset other ingestion/decoding overhead in this environment. (PERF-012)
 
 ## Open Questions

--- a/packages/renderer/.sys/perf-results-PERF-014.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-014.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	46.307	150	3.24	36.1	keep	baseline
+2	46.161	150	3.25	36.2	discard	default to ultrafast preset


### PR DESCRIPTION
💡 What: Discarded defaulting FFmpeg preset to ultrafast
🎯 Why: Optimize encoding step
📊 Impact: 0% improvement (46.161s vs 46.307s baseline)
🔬 Verification: Benchmark results, output validation
📎 Plan: PERF-014

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	46.307	150	3.24	36.1	keep	baseline
2	46.161	150	3.25	36.2	discard	default to ultrafast preset
```

---
*PR created automatically by Jules for task [8180197945065620190](https://jules.google.com/task/8180197945065620190) started by @BintzGavin*