### PR TITLE
✨ RENDERER: Pre-compile SeekTimeDriver Script

### DIFF
--- a/.sys/plans/PERF-018-optimize-seek-script-evaluate.md
+++ b/.sys/plans/PERF-018-optimize-seek-script-evaluate.md
@@ -1,0 +1,30 @@
+---
+id: PERF-018
+slug: optimize-seek-script-evaluate
+status: unclaimed
+claimed_by: ""
+created: 2026-10-18
+completed: ""
+result: ""
+---
+
+# PERF-018: Pre-compile SeekTimeDriver Script to Reduce IPC/V8 Overhead
+
+## Context & Goal
+The Frame Capture Loop in `packages/renderer/src/drivers/SeekTimeDriver.ts` is bottlenecked by the `setTime` method evaluating a script string via Playwright IPC on every single frame. This forces V8 to repeatedly parse and compile the same logic and pushes huge strings over WebSocket IPC. The goal is to optimize this by passing the arguments directly to the evaluate function instead of constructing a new string script for every frame. This eliminates repetitive string serialization and V8 compilation time per frame.
+
+## File Inventory
+- `packages/renderer/src/drivers/SeekTimeDriver.ts`
+
+## Implementation Spec
+
+### Step 1: Refactor SetTime to use evaluate arguments
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+Modify the `setTime` method to invoke the frame evaluate method by passing an anonymous arrow function and an arguments object containing the required parameters (the current time and the timeout limit). Inside the arrow function, invoke the pre-defined global function (e.g., `window.__helios_seek`) using the provided arguments.
+**Why**: Passing a small arrow function and an argument object is extremely lightweight. It serializes a tiny payload and re-uses the pre-compiled V8 function.
+**Risk**: Low. If the function is not yet available, the evaluation will throw, but the initialization script guarantees its presence.
+
+## Test Plan
+1. Run `cd packages/renderer && npx tsx tests/verify-codecs.ts` to ensure the codecs tests pass and no syntax errors are introduced.
+2. Execute the DOM rendering benchmark using a standard composition to verify output video frames are in chronological order, transparent backgrounds still work, and measure the wall-clock render time improvements.


### PR DESCRIPTION
💡 **What**:
Created the `PERF-018` experiment plan to optimize the `SeekTimeDriver` by pre-compiling its massive `setTime` script logic to reduce repetitive V8 parsing and IPC payload overhead on every frame.

🎯 **Why**:
The `setTime` frame evaluate loop currently serializes a multi-kilobyte script string for Playwright on each frame, creating a major CPU serialization bottleneck in the DOM render pipeline. Refactoring it to pass arguments to an anonymous global evaluation function will eliminate this string overhead.

📊 **Impact**:
Significantly reduces frame rendering latency in `dom` mode due to lower IPC latency and fewer redundant script parsings.

🔬 **Verification**:
Verified codecs verification tests and examined rendering logic and IPC logs to properly ground the plan in reality.

---
*PR created automatically by Jules for task [15298646442106969404](https://jules.google.com/task/15298646442106969404) started by @BintzGavin*