### PR TITLE
📋 RENDERER: Optimize For Speed Flag

### DIFF
--- a/.sys/plans/PERF-019-optimizeForSpeed.md
+++ b/.sys/plans/PERF-019-optimizeForSpeed.md
@@ -1,0 +1,30 @@
+---
+id: PERF-019
+slug: optimizeForSpeed
+status: unclaimed
+claimed_by: ""
+created: 2026-10-18
+completed: ""
+result: ""
+---
+
+# PERF-019: Enable optimizeForSpeed flag in CDP Page.captureScreenshot
+
+## Context & Goal
+The DOM-to-Video path spends a significant amount of its time capturing frames. In `DomStrategy.ts`, we use `Page.captureScreenshot` through CDP, which has an experimental boolean flag `optimizeForSpeed`. Setting this to `true` optimizes image encoding for speed rather than resulting size. Given that these frames are immediately piped to FFmpeg and not persisted individually, size does not matter but speed is critical in our CPU-only Jules microVM environment. The goal is to optimize image encoding for speed.
+
+## File Inventory
+- `packages/renderer/src/strategies/DomStrategy.ts`
+
+## Implementation Spec
+
+### Step 1: Add optimizeForSpeed to CDP captureParams
+**File**: `packages/renderer/src/strategies/DomStrategy.ts`
+**What to change**:
+In the block where the `captureParams` object is built for `this.cdpSession.send('Page.captureScreenshot', captureParams)`, add `optimizeForSpeed: true`.
+**Why**: This instructs Chromium's internal encoder to prioritize speed over compression size when generating the base64 string.
+**Risk**: If the version of Chromium bundled with Playwright does not support the flag, it might error or silently ignore it. If there is an error, we may need to remove it or catch and fallback. If the image size gets substantially larger, IPC overhead might offset encoding gains.
+
+## Test Plan
+1. Run `npx tsx packages/renderer/tests/verify-codecs.ts` to ensure the codecs tests pass and no syntax errors are introduced.
+2. Execute the DOM rendering benchmark using a standard composition to verify output video frames are in chronological order, transparent backgrounds still work, and measure the wall-clock render time improvements.


### PR DESCRIPTION
💡 What: Created the execution plan PERF-019 for the `packages/renderer`.
🎯 Why: Utilizing `optimizeForSpeed` may decrease the frame encoding time within Chromium, which could improve rendering speeds since intermediate frames are immediately piped to FFmpeg and resulting size doesn't matter.
📊 Impact: Expected to reduce DOM capture bottleneck in the Jules microVM.
🔬 Verification: Ran the validation scripts locally to ensure no logic breaks, and verified that `optimizeForSpeed` is a valid experimental flag in the Chrome DevTools Protocol.
📎 Plan: `/.sys/plans/PERF-019-optimizeForSpeed.md`

---
*PR created automatically by Jules for task [5778822826970162870](https://jules.google.com/task/5778822826970162870) started by @BintzGavin*