### PR TITLE
✨ [RENDERER]: Optimize FFmpeg Image Pipe Format

### DIFF
--- a/.sys/plans/PERF-020-ffmpeg-image-pipe-format.md
+++ b/.sys/plans/PERF-020-ffmpeg-image-pipe-format.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-020
 slug: ffmpeg-image-pipe-format
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor"
 created: 2026-03-21
-completed: ""
-result: ""
+completed: "2026-03-21"
+result: "no-improvement"
 ---
 
 # PERF-020: Optimize FFmpeg Image Pipe Format

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -9,6 +9,7 @@ Last updated by: PERF-018
 
 ## What Doesn't Work (and Why)
 - [entries]
+- Explicitly specifying the video input codec (`-vcodec mjpeg` or `webp`) for FFmpeg `image2pipe` to bypass probing. The render time did not improve and remained identical within noise margins (36.605s vs 36.547s baseline). The CPU overhead in `image2pipe` probing is negligible compared to Playwright IPC and frame capture overhead in this microVM. (PERF-020)
 - Enabling `optimizeForSpeed: true` in CDP `Page.captureScreenshot` params. The render time and peak memory consumption remained identical within noise margins (35.455s vs 35.141s baseline). The underlying Chromium build might not effectively support or prioritize this flag in headless mode for this CPU-only microVM. (PERF-019)
 - Defaulting FFmpeg preset to `ultrafast`. The render time remained identical within noise margins (46.161s vs 46.307s baseline). In this CPU-bound microVM, DOM frame capture and IPC appear to be the dominant bottlenecks, making the encoding preset negligible. (PERF-014)
 - Conditionally using `jpeg_pipe` format with `mjpeg` codec for FFmpeg ingestion when intermediate image format is `jpeg`. The render time degraded (47.85s vs 46.706s). It appears that bypassing FFmpeg stream probing doesn't offset other ingestion/decoding overhead in this environment. (PERF-012)


### PR DESCRIPTION
💡 What: Executed experiment PERF-020 to test whether explicitly passing the video input codec to `image2pipe` to bypass stream probing improves DOM rendering performance.
🎯 Why: To document the result of explicitly providing the input codec format and determine if it affects rendering performance.
📊 Impact: The execution time did not improve. Render time remained identical within noise margins (36.605s vs 36.547s baseline). The modifications were reverted from the codebase.
🔬 Verification: Ran `npx tsx packages/renderer/tests/verify-codecs.ts` and successfully documented the result as "no-improvement" in `docs/status/RENDERER-EXPERIMENTS.md` and `.sys/plans/PERF-020-ffmpeg-image-pipe-format.md`.

---
*PR created automatically by Jules for task [1040775838871208003](https://jules.google.com/task/1040775838871208003) started by @BintzGavin*