### PR TITLE
✨ RENDERER: Optimize SeekTimeDriver Promises

### DIFF
--- a/.sys/plans/PERF-024-optimize-seektime-promises.md
+++ b/.sys/plans/PERF-024-optimize-seektime-promises.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-024
 slug: optimize-seektime-promises
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2026-03-21
-completed: ""
-result: ""
+completed: "2026-03-21"
+result: "Keep: ~33.8s render time"
 ---
 
 # PERF-024: Optimize SeekTimeDriver Promises and Callbacks
@@ -53,3 +53,13 @@ Watch the output `.mp4` from `render-dom.ts` to ensure frames are properly timed
 ## Prior Art
 - PERF-021: Dropped capture idle wait (removed nested rAF loops).
 - PERF-023: Optimize SeekTimeDriver Evaluation Overhead.
+
+## Results Summary
+| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
+|---|---|---|---|---|---|---|
+| 1 | 34.071 | 150 | 4.40 | 0.0 | keep | baseline |
+| 2 | 34.011 | 150 | 4.41 | 0.0 | keep | baseline |
+| 3 | 34.348 | 150 | 4.37 | 0.0 | keep | baseline |
+| 4 | 33.839 | 150 | 4.43 | 0.0 | keep | remove requestAnimationFrame |
+| 5 | 33.787 | 150 | 4.44 | 0.0 | keep | remove requestAnimationFrame |
+| 6 | 33.820 | 150 | 4.44 | 0.0 | keep | remove requestAnimationFrame |

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,8 +1,9 @@
 ## Performance Trajectory
 Current best: 32.794s (baseline was 34.400s, -4.7%)
-Last updated by: PERF-022
+Last updated by: PERF-024
 
 ## What Works
+- [PERF-024] Optimized SeekTimeDriver by removing an unnecessary final `requestAnimationFrame` wait. Reduced render time to 33.787s (vs baseline 34.011s, -0.6%).
 - [PERF-023] Optimized array allocations in SeekTimeDriver by replacing .forEach closures with standard for loops. Render time improved (from ~43.838s to 32.815s, -25.1%).
 - [PERF-022] Cached expensive DOM traversal elements `findAllScopes` and `findAllMedia` upon first access in `SeekTimeDriver.ts`. Reduces redundant DOM traversal per frame via `document.createTreeWalker`. Reduced render time to 32.794s (vs baseline 34.400s, -4.7%).
 - [PERF-021] Optimized redundant `requestAnimationFrame` waits in SeekTimeDriver and DomStrategy, dropping capture idle wait. Reduced render time to 32.833s (vs baseline 35.281s, -6.9%).

--- a/packages/renderer/.sys/perf-results-PERF-024.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-024.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	34.071	150	4.40	0.0	keep	baseline
+2	34.011	150	4.41	0.0	keep	baseline
+3	34.348	150	4.37	0.0	keep	baseline
+4	33.839	150	4.43	0.0	keep	remove requestAnimationFrame
+5	33.787	150	4.44	0.0	keep	remove requestAnimationFrame
+6	33.820	150	4.44	0.0	keep	remove requestAnimationFrame

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -177,10 +177,6 @@ export class SeekTimeDriver implements TimeDriver {
               console.warn('[SeekTimeDriver] Error seeking Helios:', e);
             }
           }
-
-          await new Promise((resolve) => {
-            requestAnimationFrame(() => resolve());
-          });
         };
       })();
     `;


### PR DESCRIPTION
💡 What: Removed unnecessary `requestAnimationFrame` wait from `SeekTimeDriver`.
🎯 Why: To eliminate IPC and macrotask overhead per frame.
📊 Impact: Reduced median render time from ~34.071s to ~33.820s (~0.7% improvement).
🔬 Verification: Verified with `npm run build`, `npm test` targeting codecs, and manual verification of output video.
📎 Plan: `/.sys/plans/PERF-024-optimize-seektime-promises.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 34.071 | 150 | 4.40 | 0.0 | keep | baseline |
| 2 | 34.011 | 150 | 4.41 | 0.0 | keep | baseline |
| 3 | 34.348 | 150 | 4.37 | 0.0 | keep | baseline |
| 4 | 33.839 | 150 | 4.43 | 0.0 | keep | remove requestAnimationFrame |
| 5 | 33.787 | 150 | 4.44 | 0.0 | keep | remove requestAnimationFrame |
| 6 | 33.820 | 150 | 4.44 | 0.0 | keep | remove requestAnimationFrame |

---
*PR created automatically by Jules for task [2123591277898178097](https://jules.google.com/task/2123591277898178097) started by @BintzGavin*