### PR TITLE
✨ RENDERER: Discard Parallel Screencast Capture

### DIFF
--- a/.sys/plans/PERF-026-parallel-screencast.md
+++ b/.sys/plans/PERF-026-parallel-screencast.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-026
 slug: parallel-screencast
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: 2026-03-22
+result: discarded
 ---
 
 # PERF-026: Parallel Screencast Capture
@@ -59,3 +59,10 @@ Run `npx tsx packages/renderer/scripts/render.ts`. Expect to see FFmpeg error ou
 
 ## Correctness Check
 Verify `dom-animation.mp4` renders correctly with synchronized animations.
+
+## Results Summary
+- **Best render time**: 32.777s (vs baseline 32.718s)
+- **Improvement**: ~0% (Within noise margins)
+- **Kept experiments**: None
+- **Discarded experiments**:
+  - Replaced sequential `Page.captureScreenshot` with continuous `Page.startScreencast`. This architectural change fundamentally breaks the frame-by-frame synchronization required for rendering video because Chrome's `Page.startScreencast` is damage-driven (only emits frames on visual changes). This results in indefinite hangs during static scenes or when target selectors are missing. It is fundamentally incompatible with the renderer's strict sequential capture loop.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -14,6 +14,7 @@ Last updated by: PERF-025
 
 ## What Doesn't Work (and Why)
 - [entries]
+- [PERF-026] Replaced sequential `Page.captureScreenshot` with push-based `Page.startScreencast` in `DomStrategy`. This architectural change fundamentally breaks the frame-by-frame synchronization required for rendering video because Chrome's `Page.startScreencast` is damage-driven (only emits frames on visual changes). This results in indefinite hangs during static scenes or when target selectors are missing. It is fundamentally incompatible with the renderer's strict sequential capture loop.
 - Explicitly specifying the video input codec (`-vcodec mjpeg` or `webp`) for FFmpeg `image2pipe` to bypass probing. The render time did not improve and remained identical within noise margins (36.605s vs 36.547s baseline). The CPU overhead in `image2pipe` probing is negligible compared to Playwright IPC and frame capture overhead in this microVM. (PERF-020)
 - Enabling `optimizeForSpeed: true` in CDP `Page.captureScreenshot` params. The render time and peak memory consumption remained identical within noise margins (35.455s vs 35.141s baseline). The underlying Chromium build might not effectively support or prioritize this flag in headless mode for this CPU-only microVM. (PERF-019)
 - Defaulting FFmpeg preset to `ultrafast`. The render time remained identical within noise margins (46.161s vs 46.307s baseline). In this CPU-bound microVM, DOM frame capture and IPC appear to be the dominant bottlenecks, making the encoding preset negligible. (PERF-014)

--- a/packages/renderer/.sys/perf-results-PERF-026.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-026.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.777	150	4.58	36.9	discard	parallel screencast page.startScreencast


### PR DESCRIPTION
💡 What:
Evaluated an experiment replacing sequential `Page.captureScreenshot` with push-based `Page.startScreencast` in `DomStrategy`.

🎯 Why:
To investigate reducing the Playwright IPC request/response overhead involved in taking screenshots by capturing frames via a continuous stream.

📊 Impact:
The render time remained practically unchanged (~32.77s vs baseline 32.71s) within margin of error. However, `Page.startScreencast` is fundamentally incompatible with the renderer's strict frame-by-frame synchronization since it is damage-driven (only emits frames on visual changes). This results in indefinite hangs during static scenes and when dealing with missing target selectors. The experiment is therefore discarded.

🔬 Verification:
- Code modifications reverted to preserve frame synchronization logic.
- Benchmarks executed showing no significant speedup.
- Updated documentation in `.sys/plans/PERF-026-parallel-screencast.md` and `docs/status/RENDERER-EXPERIMENTS.md` with the outcome.
- Ran `npx tsx packages/renderer/tests/verify-codecs.ts` to ensure clean state.
- Recorded results in `.sys/perf-results-PERF-026.tsv`:

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.777	150	4.58	36.9	discard	parallel screencast page.startScreencast
```

📎 Plan: `/.sys/plans/PERF-026-parallel-screencast.md`

---
*PR created automatically by Jules for task [1447636207477759572](https://jules.google.com/task/1447636207477759572) started by @BintzGavin*