### PR TITLE
✨ PLAYER: Fix Observed Attributes

### DIFF
--- a/.sys/plans/2026-03-22-PLAYER-Fix-Observed-Attributes.md
+++ b/.sys/plans/2026-03-22-PLAYER-Fix-Observed-Attributes.md
@@ -1,0 +1,21 @@
+#### 1. Context & Goal
+- **Objective**: Add `canvas-selector`, `playsinline`, and `crossorigin` to `observedAttributes` in `packages/player/src/index.ts`.
+- **Trigger**: The player implemented these attributes (e.g., `crossorigin` added in v0.41.0, `canvas-selector` documented), but they are missing from `observedAttributes`, preventing them from being correctly observed for changes.
+- **Impact**: Ensures that when these attributes change, the component can react properly if needed, bringing the component behavior into alignment with its implementation and standard Media Element parity.
+
+#### 2. File Inventory
+- **Create**: (None)
+- **Modify**: `packages/player/src/index.ts` - Update `observedAttributes` array.
+- **Read-Only**: None
+
+#### 3. Implementation Spec
+- **Architecture**: Standard Web Component `observedAttributes` pattern.
+- **Pseudo-Code**:
+  - Add `"canvas-selector"`, `"playsinline"`, and `"crossorigin"` to the array returned by `static get observedAttributes()`.
+- **Public API Changes**: No structural changes, just additional observed attributes for consistency.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm run build -w packages/player`
+- **Success Criteria**: The code compiles and builds successfully with the updated attributes list.
+- **Edge Cases**: None.

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1560,7 +1560,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   }
 
   static get observedAttributes() {
-    return ["src", "width", "height", "autoplay", "loop", "controls", "export-format", "input-props", "poster", "muted", "interactive", "preload", "controlslist", "sandbox", "export-caption-mode", "disablepictureinpicture", "export-width", "export-height", "export-bitrate", "export-filename", "media-title", "media-artist", "media-album", "media-artwork", "export-mode"];
+    return ["src", "width", "height", "autoplay", "loop", "controls", "export-format", "input-props", "poster", "muted", "interactive", "preload", "controlslist", "sandbox", "export-caption-mode", "disablepictureinpicture", "export-width", "export-height", "export-bitrate", "export-filename", "media-title", "media-artist", "media-album", "media-artwork", "export-mode", "canvas-selector", "playsinline", "crossorigin"];
   }
 
   constructor() {

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,20 @@
+1. **Context & Goal**
+   - **Objective**: Add `canvas-selector`, `playsinline`, and `crossorigin` to `observedAttributes` in `packages/player/src/index.ts`.
+   - **Trigger**: The player implemented these attributes (e.g., `crossorigin` added in v0.41.0, `canvas-selector` documented), but they are missing from `observedAttributes`, preventing them from being correctly observed for changes.
+   - **Impact**: Ensures that when these attributes change, the component can react properly if needed, bringing the component behavior into alignment with its implementation and standard Media Element parity.
+
+2. **File Inventory**
+   - **Create**: `/.sys/plans/2026-03-22-PLAYER-Fix-Observed-Attributes.md`
+   - **Read-Only**: `packages/player/src/index.ts`
+
+3. **Implementation Spec**
+   - **Architecture**: Standard Web Component `observedAttributes` pattern.
+   - **Pseudo-Code**:
+     - Add `"canvas-selector"`, `"playsinline"`, and `"crossorigin"` to the array returned by `static get observedAttributes()`.
+   - **Public API Changes**: No structural changes, just additional observed attributes for consistency.
+   - **Dependencies**: None.
+
+4. **Test Plan**
+   - **Verification**: `npm run build -w packages/player`
+   - **Success Criteria**: The code compiles and builds successfully with the updated attributes list.
+   - **Edge Cases**: None.


### PR DESCRIPTION
💡 What: Added `canvas-selector`, `playsinline`, and `crossorigin` to `observedAttributes` in the `<helios-player>` Web Component (`packages/player/src/index.ts`). Also created an implementation spec document.
🎯 Why: These attributes were implemented and documented previously (e.g., `crossorigin` added in v0.41.0, `canvas-selector` used for export mode configurations, and `playsinline` used for inline playback support) but omitted from the `observedAttributes` array. This omission meant the player wouldn't react properly if these attributes were dynamically updated.
📊 Impact: Ensures standard Web Component parity and correct reactivity for the mentioned attributes.
🔬 Verification: Built `@helios-project/core` and `@helios-project/player`. Ran `npm test -w packages/player` and `npx tsx tests/e2e/verify-player.ts`, which all completed successfully.

---
*PR created automatically by Jules for task [18002523268991764846](https://jules.google.com/task/18002523268991764846) started by @BintzGavin*