### PR TITLE
✨ CLI: Tier 3 Cloud Execution Adapters

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -82,7 +82,7 @@ packages/cli/
 - `helios render <input>`: Render a composition.
   - Options: `--output`, `--width`, `--height`, `--fps`, `--duration`, `--quality`, `--mode`, `--emit-job`
 - `helios job run <spec>`: Run a distributed render job from a local file or remote URL.
-  - Options: `--concurrency`, `--chunks`, `--adapter`, `--aws-region`, `--aws-function-name`, `--aws-job-def-url`, `--gcp-service-url`, `--gcp-job-def-url`, `--cloudflare-service-url`, `--cloudflare-auth-token`, `--cloudflare-job-def-url`, `--azure-service-url`, `--azure-function-key`, `--azure-job-def-url`, `--fly-api-token`, `--fly-app-name`, `--fly-image-ref`, `--fly-region`, `--k8s-kubeconfig-path`, `--k8s-namespace`, `--k8s-job-image`, `--k8s-job-name-prefix`, `--k8s-service-account-name`, `--docker-image`
+  - Options: `--concurrency`, `--chunks`, `--adapter`, `--aws-region`, `--aws-function-name`, `--aws-job-def-url`, `--gcp-service-url`, `--gcp-job-def-url`, `--cloudflare-service-url`, `--cloudflare-auth-token`, `--cloudflare-job-def-url`, `--azure-service-url`, `--azure-function-key`, `--azure-job-def-url`, `--fly-api-token`, `--fly-app-name`, `--fly-image-ref`, `--fly-region`, `--k8s-kubeconfig-path`, `--k8s-namespace`, `--k8s-job-image`, `--k8s-job-name-prefix`, `--k8s-service-account-name`, `--docker-image`, `--deno-service-url`, `--deno-auth-token`, `--vercel-service-url`, `--vercel-auth-token`, `--vercel-job-def-url`, `--modal-endpoint-url`, `--modal-auth-token`, `--hetzner-api-token`, `--hetzner-server-type`, `--hetzner-image`, `--hetzner-ssh-key-id`, `--hetzner-location`
 - `helios merge <output> <inputs...>`: Merge video files.
 - `helios build`: Build the project for production.
 - `helios preview`: Preview the production build.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -81,6 +81,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### STUDIO v0.115.0
 - ✅ Completed: WebCodecs Preference - Added `webCodecsPreference` configuration to Studio Renders Panel, allowing users to select Hardware, Software, or Disabled modes for rendering.
 
+### CLI v0.40.0
+- ✅ Completed: Tier 3 Cloud Execution Adapters - Added support for Deno Deploy, Vercel, Modal, and Hetzner Cloud to the job run command.
+
 ### CLI v0.32.0
 - ✅ Completed: Remote Job Spec - Implemented support for executing distributed render jobs from remote HTTP/HTTPS URLs in `helios job run`.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.39.1
+**Version**: 0.40.0
 
 ## Current State
 
@@ -41,6 +41,7 @@ Per AGENTS.md, the CLI is "ACTIVELY EXPANDING FOR V2" with focus on:
 
 ## History
 
+[v0.40.0] ✅ Completed: Tier 3 Cloud Execution Adapters - Added support for Deno Deploy, Vercel, Modal, and Hetzner Cloud to the job run command.
 [v0.37.4] ✅ Completed: Add Command Regression Tests - Implemented comprehensive unit tests for helios add.
 [v0.37.3] ✅ Completed: CLI Merge Regression Tests - Verified existing regression tests for helios merge command
 [v0.37.2] ✅ Merge Command Regression Tests Complete - Added missing regression test for `transcodeMerge` error handling in the `helios merge` command.

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
 import { JobSpec } from '../types/job.js';
-import { JobExecutor, LocalWorkerAdapter, AwsLambdaAdapter, CloudRunAdapter, CloudflareWorkersAdapter, AzureFunctionsAdapter, FlyMachinesAdapter, KubernetesAdapter, DockerAdapter, WorkerAdapter } from '@helios-project/infrastructure';
+import { JobExecutor, LocalWorkerAdapter, AwsLambdaAdapter, CloudRunAdapter, CloudflareWorkersAdapter, AzureFunctionsAdapter, FlyMachinesAdapter, KubernetesAdapter, DockerAdapter, DenoDeployAdapter, VercelAdapter, ModalAdapter, HetznerCloudAdapter, WorkerAdapter } from '@helios-project/infrastructure';
 
 export async function loadJobSpec(file: string): Promise<{ jobSpec: JobSpec, jobDir: string }> {
   if (file.startsWith('http://') || file.startsWith('https://')) {
@@ -33,7 +33,7 @@ export function registerJobCommand(program: Command) {
     .option('--chunk <id>', 'Execute only the chunk with the specified ID')
     .option('--concurrency <number>', 'Number of concurrent chunks to run locally', '1')
     .option('--no-merge', 'Skip the final merge step')
-    .option('--adapter <type>', 'Adapter to use (local, aws, gcp, cloudflare, azure, fly, kubernetes, docker)', 'local')
+    .option('--adapter <type>', 'Adapter to use (local, aws, gcp, cloudflare, azure, fly, kubernetes, docker, deno, vercel, modal, hetzner)', 'local')
     .option('--fly-api-token <token>', 'Fly.io API token')
     .option('--fly-app-name <name>', 'Fly.io app name')
     .option('--fly-image-ref <ref>', 'Fly.io image ref')
@@ -55,6 +55,18 @@ export function registerJobCommand(program: Command) {
     .option('--azure-service-url <url>', 'Azure Functions service URL')
     .option('--azure-function-key <key>', 'Azure Functions function key')
     .option('--azure-job-def-url <url>', 'URL of the job definition for Azure Functions')
+    .option('--deno-service-url <url>', 'Deno Deploy service URL')
+    .option('--deno-auth-token <token>', 'Deno Deploy authorization token')
+    .option('--vercel-service-url <url>', 'Vercel Serverless Function service URL')
+    .option('--vercel-auth-token <token>', 'Vercel authorization token')
+    .option('--vercel-job-def-url <url>', 'Static job definition URL for Vercel')
+    .option('--modal-endpoint-url <url>', 'Modal endpoint URL')
+    .option('--modal-auth-token <token>', 'Modal authorization token')
+    .option('--hetzner-api-token <token>', 'Hetzner Cloud API token')
+    .option('--hetzner-server-type <type>', 'Hetzner Cloud server type')
+    .option('--hetzner-image <image>', 'Hetzner Cloud server image')
+    .option('--hetzner-ssh-key-id <id>', 'Hetzner Cloud SSH Key ID')
+    .option('--hetzner-location <loc>', 'Hetzner Cloud location')
     .action(async (file, options) => {
       try {
         const { jobSpec, jobDir } = await loadJobSpec(file);
@@ -147,6 +159,42 @@ export function registerJobCommand(program: Command) {
           }
           adapter = new DockerAdapter({
             image: options.dockerImage
+          });
+        } else if (options.adapter === 'deno') {
+          if (!options.denoServiceUrl) {
+            throw new Error('Deno adapter requires --deno-service-url');
+          }
+          adapter = new DenoDeployAdapter({
+            serviceUrl: options.denoServiceUrl,
+            authToken: options.denoAuthToken
+          });
+        } else if (options.adapter === 'vercel') {
+          if (!options.vercelServiceUrl) {
+            throw new Error('Vercel adapter requires --vercel-service-url');
+          }
+          adapter = new VercelAdapter({
+            serviceUrl: options.vercelServiceUrl,
+            authToken: options.vercelAuthToken,
+            jobDefUrl: options.vercelJobDefUrl || file
+          });
+        } else if (options.adapter === 'modal') {
+          if (!options.modalEndpointUrl) {
+            throw new Error('Modal adapter requires --modal-endpoint-url');
+          }
+          adapter = new ModalAdapter({
+            endpointUrl: options.modalEndpointUrl,
+            authToken: options.modalAuthToken
+          });
+        } else if (options.adapter === 'hetzner') {
+          if (!options.hetznerApiToken || !options.hetznerServerType || !options.hetznerImage) {
+            throw new Error('Hetzner adapter requires --hetzner-api-token, --hetzner-server-type, and --hetzner-image');
+          }
+          adapter = new HetznerCloudAdapter({
+            apiToken: options.hetznerApiToken,
+            serverType: options.hetznerServerType,
+            image: options.hetznerImage,
+            sshKeyId: options.hetznerSshKeyId ? parseInt(options.hetznerSshKeyId, 10) : undefined,
+            location: options.hetznerLocation
           });
         } else {
           adapter = new LocalWorkerAdapter();


### PR DESCRIPTION
💡 **What**: Added command line options and instantiation logic in `helios job run` for Deno Deploy, Vercel, Modal, and Hetzner Cloud adapters.
🎯 **Why**: To expose the Tier 3 cloud execution adapters implemented in the infrastructure package through the CLI, allowing users to orchestrate jobs across these platforms.
📊 **Impact**: Makes the CLI the primary orchestrator for all supported cloud execution environments, fulfilling the vision of distributed rendering capabilities.
🔬 **Verification**: Ran `packages/cli/src/commands/__tests__/job.test.ts` to ensure no regressions and verified `--help` output includes the new options.

---
*PR created automatically by Jules for task [5007060947859875307](https://jules.google.com/task/5007060947859875307) started by @BintzGavin*