### PR TITLE
✨ RENDERER: Document failed PERF-033 experiment

### DIFF
--- a/.sys/plans/PERF-033-screencast-buffer.md
+++ b/.sys/plans/PERF-033-screencast-buffer.md
@@ -1,10 +1,11 @@
 ---
 id: PERF-033
 slug: screencast-buffer
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
+result: failed
 created: 2026-03-22
-completed: ""
+completed: "2026-03-22"
 result: ""
 ---
 
@@ -53,3 +54,10 @@ Run `npx tsx packages/renderer/scripts/render.ts` to ensure Canvas mode remains 
 
 ## Correctness Check
 Run the DOM rendering tests: `npx tsx packages/renderer/tests/verify-codecs.ts` and ensure `DomStrategy` captures correctly. Ensure no hangs occur on static scenes (the primary reason PERF-026 failed).
+
+
+## Results Summary
+- **Best render time**: 35.577s (vs baseline 32.324s)
+- **Improvement**: -10.06%
+- **Kept experiments**: []
+- **Discarded experiments**: [Screencast buffer approach]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,6 +1,6 @@
 ## Performance Trajectory
 Current best: 32.324s (baseline was 3.696s)
-Last updated by: PERF-030
+Last updated by: PERF-033
 
 ## What Works
 - [PERF-030] Enforced worker-local sequential promise chaining for frame capture loop. While removing the concurrent queue depth of `pool.length * 8` from PERF-029 degrades render time, it guarantees that `seek` and `capture` actions on a Playwright page evaluate sequentially, fixing a critical race condition. (Render time: 32.324s vs baseline 3.696s)
@@ -18,6 +18,7 @@ Last updated by: PERF-030
 
 ## What Doesn't Work (and Why)
 - [entries]
+- [PERF-033] Replaced sequential `Page.captureScreenshot` with buffered `Page.startScreencast` combined with forced CSS transform toggling to guarantee damage events. Render time regressed to 35.577s (vs baseline 32.324s). The overhead of constantly pushing frames from Chromium, buffering them in Node, and coordinating the async queue across the worker pool negates any IPC latency savings from avoiding explicit capture requests. The asynchronous nature also introduces jitter in frame alignment when multiple pages are in flight.
 - [PERF-031] Replaced `CDPSession` string `Runtime.evaluate` with a pre-compiled function using `Runtime.callFunctionOn` in the `SeekTimeDriver`'s frame capture loop. Render time was virtually identical to baseline (32.494s vs baseline 32.324s, +0.5% regression within noise margins). It seems Chromium V8 caching for small, repeated string evaluations via CDP is already highly optimized, rendering manual function injection and `callFunctionOn` object targeting redundant and potentially fragile due to context IDs expiring.
 - [PERF-026] Replaced sequential `Page.captureScreenshot` with push-based `Page.startScreencast` in `DomStrategy`. This architectural change fundamentally breaks the frame-by-frame synchronization required for rendering video because Chrome's `Page.startScreencast` is damage-driven (only emits frames on visual changes). This results in indefinite hangs during static scenes or when target selectors are missing. It is fundamentally incompatible with the renderer's strict sequential capture loop.
 - Explicitly specifying the video input codec (`-vcodec mjpeg` or `webp`) for FFmpeg `image2pipe` to bypass probing. The render time did not improve and remained identical within noise margins (36.605s vs 36.547s baseline). The CPU overhead in `image2pipe` probing is negligible compared to Playwright IPC and frame capture overhead in this microVM. (PERF-020)

--- a/packages/renderer/.sys/perf-results-PERF-033.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-033.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	35.577	300	8.43	38.4	discard	screencast buffer approach


### PR DESCRIPTION
💡 **What**: Executed and reverted the `PERF-033` experiment, which attempted to use buffered `Page.startScreencast` combined with forced CSS transform toggling to replace polling `Page.captureScreenshot`.
🎯 **Why**: To test if streaming damage-driven screencast frames would be faster than sequentially polling for screenshots via IPC.
📊 **Impact**: The approach regressed render time to 35.577s (vs baseline 32.324s), marking a -10.06% slowdown. The overhead of pushing frames from Chromium, buffering them in Node, and coordinating the async queue across the worker pool negates any IPC latency savings.
🔬 **Verification**: Code was fully reverted and DOM verification tests passed successfully via `npx tsx packages/renderer/tests/verify-codecs.ts`.
📎 **Plan**: `/.sys/plans/PERF-033-screencast-buffer.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 35.577 | 300 | 8.43 | 38.4 | discard | screencast buffer approach |

---
*PR created automatically by Jules for task [14050990400378695703](https://jules.google.com/task/14050990400378695703) started by @BintzGavin*