### PR TITLE
📋 RENDERER: Browser Launch & Compositing Pipeline

### DIFF
--- a/.sys/plans/PERF-038-new-headless-mode.md
+++ b/.sys/plans/PERF-038-new-headless-mode.md
@@ -1,0 +1,64 @@
+---
+id: PERF-038
+slug: new-headless-mode
+status: unclaimed
+claimed_by: ""
+created: 2024-03-23
+completed: ""
+result: ""
+---
+# PERF-038: Enable Native Headless Mode (headless: true, --headless=new)
+
+## Focus Area
+Browser Launch & Compositing Pipeline
+
+## Background Research
+Playwright historically used an older headless mode for Chromium (`--headless`). Chromium recently introduced a completely new headless implementation (`--headless=new` or passing `headless: true` with `'--headless=new'` in args) which is built directly on the native Chrome browser architecture rather than a separate headless shell.
+
+This new native headless mode has different performance characteristics. Because it uses the full Chrome rendering pipeline, it may handle DOM layouts, paint operations, and the internal `Page.captureScreenshot` CDP command more efficiently or with different locking semantics than the legacy headless mode. Given that our rendering is heavily CPU-bound on layout and paint within the microVM, switching the underlying browser engine architecture is a high-leverage architectural change. (Attempting to use `headless: "new"` incorrectly causes an error due to boolean typing, but providing `--headless=new` in the args array resolves this while preserving functionality).
+
+## Benchmark Configuration
+- **Composition URL**: `file://${process.cwd()}/output/example-build/examples/simple-animation/composition.html`
+- **Render Settings**: 600x600, 30fps, 150 frames (5 seconds), JPEG intermediate format
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: Baseline is approx 33.641s based on current benchmarks.
+- **Bottleneck analysis**: The dominant cost is the per-frame `Page.captureScreenshot` call via CDP, which blocks on the browser's internal layout/paint and PNG/JPEG encoding pipeline.
+
+## Implementation Spec
+
+### Step 1: Update Browser Launch Args
+**File**: `packages/renderer/src/Renderer.ts`
+**What to change**:
+Modify `DEFAULT_BROWSER_ARGS` to use the new headless mode. Note that Playwright's `headless` option strictly accepts a boolean, so we must explicitly add `'--headless=new'` to the `args` array while keeping `headless: true`.
+
+```typescript
+// Replace:
+const DEFAULT_BROWSER_ARGS = [
+  '--disable-web-security',
+  '--allow-file-access-from-files',
+];
+
+// With:
+const DEFAULT_BROWSER_ARGS = [
+  '--disable-web-security',
+  '--allow-file-access-from-files',
+  '--headless=new',
+];
+```
+
+**Why**: This forces Chromium to use the native browser architecture for headless rendering instead of the legacy headless shell. This fundamentally changes how the compositor and render thread operate.
+**Risk**: The new headless mode might have higher memory overhead or behave differently with our disabled GPU flags, potentially causing crashes or slowdowns if it relies more heavily on hardware acceleration that isn't present in the microVM.
+
+## Canvas Smoke Test
+Run a simple canvas render to ensure the canvas rendering mode still correctly instantiates the browser and captures frames.
+
+## Correctness Check
+Run the DOM benchmark and verify that the output `out.mp4` contains visually correct frames of the simple animation and is not blank or distorted.
+
+## Prior Art
+- Chromium Blog: "Chrome's new headless mode"
+- Playwright release notes on `--headless=new`


### PR DESCRIPTION
💡 What: Creating a new experiment plan (PERF-038) to enable the new native Chromium headless mode.
🎯 Why: The current legacy headless mode uses a separate headless shell. Switching to `--headless=new` leverages the native Chromium rendering architecture, potentially offering improved efficiency and lower overhead per frame capture, specifically for DOM layout and paint operations.
🔬 Approach: Modify `DEFAULT_BROWSER_ARGS` in `Renderer.ts` to include `--headless=new` while keeping `headless: true`.
📎 Plan: `/.sys/plans/PERF-038-new-headless-mode.md`

---
*PR created automatically by Jules for task [12173754039051922908](https://jules.google.com/task/12173754039051922908) started by @BintzGavin*