### PR TITLE
✨ RENDERER: Discard Native Headless Mode experiment

### DIFF
--- a/.sys/plans/PERF-038-new-headless-mode.md
+++ b/.sys/plans/PERF-038-new-headless-mode.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-038
 slug: new-headless-mode
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-03-23
-completed: ""
-result: ""
+completed: 2025-03-23
+result: no-improvement
 ---
 # PERF-038: Enable Native Headless Mode (headless: true, --headless=new)
 
@@ -62,3 +62,9 @@ Run the DOM benchmark and verify that the output `out.mp4` contains visually cor
 ## Prior Art
 - Chromium Blog: "Chrome's new headless mode"
 - Playwright release notes on `--headless=new`
+
+## Results Summary
+- **Best render time**: 32.280s (vs baseline 32.251s)
+- **Improvement**: 0%
+- **Kept experiments**: None
+- **Discarded experiments**: Native Headless Mode (`--headless=new`)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,6 +1,6 @@
 ## Performance Trajectory
-Current best: 33.823s (baseline was 32.324s)
-Last updated by: PERF-035
+Current best: 32.251s (baseline was 32.251s)
+Last updated by: PERF-038
 
 ## What Works
 - [PERF-017] Discovered that the `SeekTimeDriver` script is already pre-compiled and injected via `page.addInitScript(initScript)` in `prepare()`. The `setTime` method correctly uses a lightweight `window.__helios_seek()` call over Playwright CDP, meaning this optimization was already natively implemented in the codebase. Baseline render time confirmed at 32.217s.
@@ -19,6 +19,7 @@ Last updated by: PERF-035
 - Defaulting intermediate image format to jpeg when no alpha channel is needed (~2.2% faster) (PERF-011)
 
 ## What Doesn't Work (and Why)
+- **PERF-038: Native Headless Mode (`--headless=new`)**: Changing Playwright's default arguments to use `--headless=new` instead of the legacy headless shell did not meaningfully improve performance in the microVM. The render times were nearly identical (median ~32.4s). This suggests that the headless implementation (native vs shell) is not the dominant bottleneck for our CPU-bound layout/paint and CDP screenshot capture loop in this specific environment. It might even be slightly slower on some runs, likely because the new mode spins up more full-browser infrastructure. Discarding to maintain simplicity and stick with the known-stable legacy headless.
 - [PERF-034] Adding `fromSurface: true`, `optimizeForSpeed: true`, and an explicit `clip` bounding box to `Page.captureScreenshot` CDP parameters. The render time remained identical within noise margins (35.086s vs 35.156s baseline). In this CPU-only microVM with GPU disabled, forcing surface capture via the internal software rasterizer compositor cache did not yield any meaningful layout/paint latency reduction compared to the standard DOM-to-bitmap copy operation.
 - [PERF-032] Replacing polling CDP screenshots with continuous `Page.startScreencast`. Attempted to buffer `ScreencastFrame` events in `DomStrategy` and pull from this buffer in `Renderer.ts`, triggering forced layout/paint in the browser after each `timeDriver.setTime()` evaluation to overcome the "damage-driven" limitation of screencast. Failed because the screencast mechanism still caused hangs in the strictly synchronized sequential loop.
 - [entries]

--- a/packages/renderer/.sys/perf-results-PERF-038.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-038.tsv
@@ -1,0 +1,6 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.593	150	4.60	39.0	discard	baseline
+2	32.251	150	4.65	38.8	discard	baseline
+3	32.433	150	4.62	39.3	discard	native headless
+4	32.834	150	4.57	38.8	discard	native headless
+5	32.280	150	4.65	38.9	discard	native headless


### PR DESCRIPTION
✨ RENDERER: Discard Native Headless Mode experiment

💡 **What**: Evaluated `--headless=new` instead of legacy headless shell.
🎯 **Why**: PERF-038 plan to test Chromium's native headless mode.
📊 **Impact**: Render times identical (32.28s vs baseline 32.25s). Discarded to maintain known stable environment.
🔬 **Verification**: 4-gate verification via benchmark script. Code changes reverted.
📎 **Plan**: PERF-038-new-headless-mode.md

Results summary:
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.593	150	4.60	39.0	discard	baseline
2	32.251	150	4.65	38.8	discard	baseline
3	32.433	150	4.62	39.3	discard	native headless
4	32.834	150	4.57	38.8	discard	native headless
5	32.280	150	4.65	38.9	discard	native headless
```

---
*PR created automatically by Jules for task [6023066539669038873](https://jules.google.com/task/6023066539669038873) started by @BintzGavin*