### PR TITLE
✨ RENDERER: Document failed PERF-041 experiment (async Runtime.evaluate)

### DIFF
--- a/.sys/plans/PERF-041-evaluate-async-capture.md
+++ b/.sys/plans/PERF-041-evaluate-async-capture.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-041
 slug: evaluate-async-capture
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-03-31
-completed: ""
-result: ""
+completed: 2026-03-31
+result: no-improvement
 ---
 
 # PERF-041: Asynchronous Runtime.evaluate for Pipelined Frame Capture
@@ -52,3 +52,9 @@ Verify that the resulting MP4 from the `dom` mode benchmark does not contain tea
 
 ## Prior Art
 - PERF-035: Pipelined `Runtime.evaluate` and `Page.captureScreenshot` CDP commands in the worker execution loop.
+
+## Results Summary
+- **Best render time**: 32.248s (vs baseline 32.680s)
+- **Improvement**: ~1.3% (within noise margin)
+- **Kept experiments**: none
+- **Discarded experiments**: Setting `awaitPromise: false` on `Runtime.evaluate`. It causes `tests/verify-seek-driver-offsets.ts` to fail because the seek script doesn't initialize fast enough for the tests to pass. The performance improvement was also non-existent or statistically insignificant.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -42,3 +42,5 @@ Last updated by: PERF-016
 ## What Works
 - [PERF-016] Changed the default intermediate image format to 'webp' when an alpha channel is needed. It reduces IPC overhead and is faster to encode/decode than 'png'.
 - [PERF-015] Instantiating a pool of multiple Playwright pages based on CPU concurrency and dividing frames between them using a sliding window. It allows concurrent evaluation of `strategy.capture()` across workers, cutting ~23% off render time.
+## What Doesn't Work (and Why)
+- Setting `awaitPromise: false` on `Runtime.evaluate` in `SeekTimeDriver.ts`. This resulted in `TypeError: window.__helios_seek is not a function` in the verification tests (`tests/verify-seek-driver-offsets.ts`). It causes the driver's `setTime` to fail, and the benchmark times did not improve regardless (32.25s). Root cause is likely that without `awaitPromise: true`, the evaluation script isn't guaranteed to have run synchronously and properly initialized state before the subsequent test logic or frame captures try to proceed, failing stability tests.

--- a/packages/renderer/.sys/perf-results-PERF-041.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-041.tsv
@@ -1,0 +1,5 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.680	150	4.59	38.3	keep	baseline
+2	32.253	150	4.65	38.2	discard	awaitPromise: false
+3	32.248	150	4.65	38.4	discard	awaitPromise: false
+4	32.248	150	4.65	38.3	discard	awaitPromise: false


### PR DESCRIPTION
💡 **What**: Executed PERF-041 to test if setting `awaitPromise: false` on `Runtime.evaluate` in `SeekTimeDriver.ts` would improve pipelined frame capture speed by reducing Node.js event loop and Playwright IPC overhead. The experiment was discarded.
🎯 **Why**: Node.js and Playwright IPC latency dominate CPU-bound rendering time, and the hypothesis was that utilizing Chromium's sequential CDP queueing would remove unnecessary sequential gaps.
📊 **Impact**: Baseline render time was 32.68s. Modified render time was 32.25s. The improvement (~1.3%) was within the noise margin and therefore statistically insignificant.
🔬 **Verification**: The change failed `tests/verify-seek-driver-offsets.ts` with `TypeError: window.__helios_seek is not a function`, indicating that the evaluation script did not complete initialization synchronously before the tests or subsequent capture commands executed.
📎 **Plan**: `/.sys/plans/PERF-041-evaluate-async-capture.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.680	150	4.59	38.3	keep	baseline
2	32.253	150	4.65	38.2	discard	awaitPromise: false
3	32.248	150	4.65	38.4	discard	awaitPromise: false
4	32.248	150	4.65	38.3	discard	awaitPromise: false
```

---
*PR created automatically by Jules for task [3147140199355330453](https://jules.google.com/task/3147140199355330453) started by @BintzGavin*