### PR TITLE
✨ RENDERER: Explicit Compositor Stages & HeadlessExperimental Capture

### DIFF
--- a/.sys/plans/PERF-045-headless-capture.md
+++ b/.sys/plans/PERF-045-headless-capture.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-045
 slug: headless-capture
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-28
-completed: ""
-result: ""
+completed: 2024-05-28
+result: "improved"
 ---
 # PERF-045: Explicit Compositor Stages & HeadlessExperimental Capture
 
@@ -59,3 +59,9 @@ Verify that the output video looks visually correct, animations are progressing,
 
 ## Prior Art
 Headless beginFrame control is documented in Chrome's headless rendering architecture (`https://goo.gle/chrome-headless-rendering`).
+
+## Results Summary
+- **Best render time**: 32.038s (vs baseline 32.691s)
+- **Improvement**: ~2.0%
+- **Kept experiments**: replaced `Page.captureScreenshot` with `HeadlessExperimental.beginFrame` and `--run-all-compositor-stages-before-draw` / `--enable-begin-frame-control` browser args.
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -39,10 +39,11 @@ Last updated by: PERF-038
 - [PERF-032] Can we overcome the damage-driven limitations of `Page.startScreencast` (which failed in PERF-026) by injecting a forced layout/paint toggle on every virtual time tick, allowing us to buffer continuous screencast frames and eliminate the IPC latency of polling `Page.captureScreenshot`?
 
 ## Performance Trajectory
-Current best: 32.408s (baseline was 33.696s, -3.8%)
-Last updated by: PERF-043
+Current best: 32.038s (baseline was 32.691s, -2.0%)
+Last updated by: PERF-045
 
 ## What Works
+- [PERF-045] Switched to `HeadlessExperimental.beginFrame` for explicit compositor synchronization instead of using Playwright's default `Page.captureScreenshot`. Required passing `--enable-begin-frame-control` and `--run-all-compositor-stages-before-draw` on browser launch. Reduced DOM rendering time to 32.038s (-2.0%) by avoiding asynchronous layout/paint pipeline delays in the rasterizer.
 - [PERF-043] Optimized `captureLoop` array allocations by replacing O(N) `shift()` with index access and reduced micro-task queue overhead by conditionally creating Promises only when FFmpeg stream writes indicate backpressure. Reduced rendering time by ~4%.
 - [PERF-016] Changed the default intermediate image format to 'webp' when an alpha channel is needed. It reduces IPC overhead and is faster to encode/decode than 'png'.
 - [PERF-015] Instantiating a pool of multiple Playwright pages based on CPU concurrency and dividing frames between them using a sliding window. It allows concurrent evaluation of `strategy.capture()` across workers, cutting ~23% off render time.

--- a/packages/renderer/.sys/perf-results-PERF-045.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-045.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.691	150	4.59	34.2	keep	baseline
+2	32.038	150	4.68	35.7	keep	headlessExperimental beginFrame

--- a/packages/renderer/scripts/benchmark-test.js
+++ b/packages/renderer/scripts/benchmark-test.js
@@ -1,0 +1,32 @@
+import { Renderer } from '../dist/Renderer.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function run() {
+  const options = {
+    mode: 'dom',
+    width: 600,
+    height: 600,
+    fps: 30,
+    durationInSeconds: 5, // 150 frames
+  };
+  const renderer = new Renderer(options);
+  const start = performance.now();
+  try {
+    const compUrl = 'file://' + path.resolve(__dirname, '../../../examples/simple-canvas-animation/examples/simple-canvas-animation/output/example-build/composition.html');
+    await renderer.render(compUrl, 'test-output.mp4');
+  } catch (err) {
+    console.error(err);
+  }
+  const elapsed = (performance.now() - start) / 1000;
+  console.log('---');
+  console.log(`render_time_s:      ${elapsed.toFixed(3)}`);
+  console.log(`total_frames:       150`);
+  console.log(`fps_effective:      ${(150 / elapsed).toFixed(2)}`);
+  console.log(`peak_mem_mb:        ${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(1)}`);
+}
+
+run();

--- a/packages/renderer/src/Renderer.ts
+++ b/packages/renderer/src/Renderer.ts
@@ -14,6 +14,8 @@ import { RendererOptions, RenderJobOptions } from './types.js';
 const DEFAULT_BROWSER_ARGS = [
   '--disable-web-security',
   '--allow-file-access-from-files',
+  '--enable-begin-frame-control',
+  '--run-all-compositor-stages-before-draw'
 ];
 
 const GPU_DISABLED_ARGS = [

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -64,6 +64,7 @@ export class DomStrategy implements RenderStrategy {
     this.cleanupAudio = extractionResult.cleanup;
 
     this.cdpSession = await page.context().newCDPSession(page);
+    await this.cdpSession.send('HeadlessExperimental.enable');
 
     // Check if the requested pixel format supports alpha
     const pixelFormat = this.options.pixelFormat || 'yuv420p';
@@ -136,12 +137,20 @@ export class DomStrategy implements RenderStrategy {
 
     try {
       if (this.cdpSession) {
-        const captureParams: any = { format };
+        const screenshot: any = { format };
         if ((format === 'jpeg' || format === 'webp') && quality !== undefined) {
-          captureParams.quality = quality;
+          screenshot.quality = quality;
         }
-        const { data } = await this.cdpSession.send('Page.captureScreenshot', captureParams);
-        const fallback = Buffer.from(data, 'base64');
+
+        const { screenshotData } = await this.cdpSession.send('HeadlessExperimental.beginFrame', {
+          screenshot
+        });
+
+        if (!screenshotData) {
+           throw new Error("HeadlessExperimental.beginFrame did not return screenshotData");
+        }
+
+        const fallback = Buffer.from(screenshotData, 'base64');
         this.lastFrameBuffer = fallback;
         return fallback;
       } else {


### PR DESCRIPTION
💡 **What**: Switched to `HeadlessExperimental.beginFrame` for explicit compositor synchronization instead of using Playwright's default `Page.captureScreenshot` and enabled relevant Chromium flags.
🎯 **Why**: DOM Rendering frame capture via the standard Playwright API was introducing asynchronous layout and paint pipeline delays. Using explicit compositor synchronization controls reduces the per-frame capture time.
📊 **Impact**: Baseline render time 32.691s -> 32.038s (-2.0%)
🔬 **Verification**: Code built successfully. Verification and test suites passed successfully. Output visually identical and file size within threshold.
📎 **Plan**: `/.sys/plans/PERF-045-headless-capture.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.691	150	4.59	34.2	keep	baseline
2	32.038	150	4.68	35.7	keep	headlessExperimental beginFrame
```

---
*PR created automatically by Jules for task [13789579404469225022](https://jules.google.com/task/13789579404469225022) started by @BintzGavin*