### PR TITLE
✨ RENDERER: Fix HeadlessExperimental.beginFrame damage-driven omissions

### DIFF
--- a/.sys/plans/PERF-047-fix-beginframe.md
+++ b/.sys/plans/PERF-047-fix-beginframe.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-047
 slug: fix-beginframe
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-28
-completed: ""
-result: ""
+completed: "2024-05-28"
+result: "improved"
 ---
 # PERF-047: Fix HeadlessExperimental.beginFrame error and Ensure Damage-Driven Capture
 
@@ -71,3 +71,9 @@ Run the DOM render script and verify output exists, has valid video contents, an
 ## Prior Art
 - PERF-045: Introduced `HeadlessExperimental.beginFrame` but failed to account for damage-driven omissions.
 - PERF-033: Explored `Page.startScreencast`, which suffered from similar damage-driven starvation issues.
+
+## Results Summary
+- **Best render time**: 33.472s (vs baseline Fails)
+- **Improvement**: N/A (Fixed Crash)
+- **Kept experiments**: Handled damage-driven `screenshotData` omission in `HeadlessExperimental.beginFrame` by reusing previous frame buffer.
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -43,6 +43,7 @@ Current best: 32.038s (baseline was 32.691s, -2.0%)
 Last updated by: PERF-045
 
 ## What Works
+- [PERF-047] Handled damage-driven frame omissions in `HeadlessExperimental.beginFrame` by reusing the previous frame buffer when Chromium detects no visual damage. Resolves the `screenshotData` omission crashes while preserving the layout/paint optimizations of PERF-045.
 - [PERF-045] Switched to `HeadlessExperimental.beginFrame` for explicit compositor synchronization instead of using Playwright's default `Page.captureScreenshot`. Required passing `--enable-begin-frame-control` and `--run-all-compositor-stages-before-draw` on browser launch. Reduced DOM rendering time to 32.038s (-2.0%) by avoiding asynchronous layout/paint pipeline delays in the rasterizer.
 - [PERF-043] Optimized `captureLoop` array allocations by replacing O(N) `shift()` with index access and reduced micro-task queue overhead by conditionally creating Promises only when FFmpeg stream writes indicate backpressure. Reduced rendering time by ~4%.
 - [PERF-016] Changed the default intermediate image format to 'webp' when an alpha channel is needed. It reduces IPC overhead and is faster to encode/decode than 'png'.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -1,3 +1,4 @@
 run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	3.696	150	40.58	150.0	keep	PERF-029 deepen pipeline to pool.length * 8
 2	32.324	150	4.64	37.1	keep	worker-local sequential promise chain
+3	33.472	150	4.48	4.4	keep	Fix HeadlessExperimental.beginFrame damage-driven omissions

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -146,13 +146,22 @@ export class DomStrategy implements RenderStrategy {
           screenshot
         });
 
-        if (!screenshotData) {
-           throw new Error("HeadlessExperimental.beginFrame did not return screenshotData");
+        if (screenshotData) {
+          const buffer = Buffer.from(screenshotData, 'base64');
+          this.lastFrameBuffer = buffer;
+          return buffer;
+        } else if (this.lastFrameBuffer) {
+          // Chromium detected no visual damage and omitted the screenshot.
+          // Reuse the last successfully captured frame for the video stream.
+          return this.lastFrameBuffer;
+        } else {
+          // If no damage was detected but we don't have a previous frame (e.g., frame 0),
+          // fallback to a standard CDP capture to guarantee an initial frame buffer.
+          const res = await this.cdpSession.send('Page.captureScreenshot', { format, quality } as any);
+          const buffer = Buffer.from(res.data, 'base64');
+          this.lastFrameBuffer = buffer;
+          return buffer;
         }
-
-        const fallback = Buffer.from(screenshotData, 'base64');
-        this.lastFrameBuffer = fallback;
-        return fallback;
       } else {
         const fallback = await page.screenshot(screenshotOptions);
         this.lastFrameBuffer = fallback;


### PR DESCRIPTION
✨ RENDERER: Fix HeadlessExperimental.beginFrame error and Ensure Damage-Driven Capture

💡 **What**: Handled damage-driven frame omissions in `HeadlessExperimental.beginFrame` by safely reusing the last successfully captured frame buffer (`this.lastFrameBuffer`) or falling back to a standard CDP capture for the initial frame.
🎯 **Why**: Chromium's `beginFrame` optimization is damage-driven and will omit `screenshotData` if it detects no visual changes. Since we produce a continuous video stream for FFmpeg, we must always provide a frame buffer, even if identical to the previous one, to avoid "did not return screenshotData" crashes.
📊 **Impact**: Fixed crash on static frames while preserving the layout/paint optimizations from PERF-045. Render time is ~33.472s.
🔬 **Verification**: Ran local DOM render benchmark script successfully without crash. Output validated via test logs. Passed canvas smoke test. Ran targeted `CdpTimeDriver` tests locally.
📎 **Plan**: `PERF-047-fix-beginframe.md`

### Results Summary
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
3	33.472	150	4.48	4.4	keep	Fix HeadlessExperimental.beginFrame damage-driven omissions
```

---
*PR created automatically by Jules for task [1175835219869963064](https://jules.google.com/task/1175835219869963064) started by @BintzGavin*