### PR TITLE
📋 RENDERER: Eliminate Serialization for Frame Evaluate Fallback

### DIFF
--- a/.sys/plans/PERF-050-page-evaluate-serialization.md
+++ b/.sys/plans/PERF-050-page-evaluate-serialization.md
@@ -1,0 +1,50 @@
+---
+id: PERF-050
+slug: page-evaluate-serialization
+status: unclaimed
+claimed_by: ""
+created: 2024-05-28
+completed: ""
+result: ""
+---
+# PERF-050: Eliminate Serialization for Frame Evaluate Fallback
+
+## Focus Area
+DOM Rendering Frame Capture Overhead. This extends the optimization from PERF-049 by targeting the V8 object serialization overhead occurring over Playwright's IPC layer when the fallback `frame.evaluate()` is used in `SeekTimeDriver.ts`.
+
+## Background Research
+In `SeekTimeDriver.ts`, the frame capture loop uses `frame.evaluate()` as a fallback for non-main frames. Currently, it evaluates an expression that implicitly returns the result of `window.__helios_seek()`. Although `__helios_seek` returns `undefined`, Playwright's `evaluate()` mechanism still allocates and serializes the return object over IPC. By modifying the evaluation block so it returns nothing (e.g., using curly braces without a `return` statement), we can bypass this serialization cost entirely, just like we did with `returnByValue: false` in the direct CDP path (PERF-049).
+
+## Benchmark Configuration
+- **Composition URL**: Use `ls` or `list_files` on the `examples/` directory during execution to find, build, and verify a valid composition URL (e.g., `examples/simple-animation/output/example-build/composition.html`).
+- **Render Settings**: 600x600, 30fps, 5 seconds (150 frames)
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~33.5s
+- **Bottleneck analysis**: IPC communication and V8 serialization overhead due to Playwright returning and serializing the result of `frame.evaluate()` per frame.
+
+## Implementation Spec
+
+### Step 1: Remove return value from frame.evaluate
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+In `SeekTimeDriver.ts`, locate the `frame.evaluate` call in `setTime` inside the `else` block for non-main frames. Change the evaluation callback to an explicit block that does not return a value (e.g., by wrapping the execution in curly braces).
+**Why**: Avoids serializing the return object over Playwright's IPC. We only care about executing the seek function.
+**Risk**: Minimal. We don't use the return value.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run the Canvas baseline script to ensure basic rendering still works.
+`npx tsx packages/renderer/scripts/render.ts`
+
+## Correctness Check
+Run the DOM render script and verify output exists, has valid video contents, and does not crash.
+`npx tsx packages/renderer/scripts/render-dom.ts`
+
+## Prior Art
+- PERF-049: Eliminated serialization overhead on the main frame by setting `returnByValue: false` on the `Runtime.evaluate` CDP call. This extends the same principle to Playwright's high-level `evaluate` API.


### PR DESCRIPTION
This PR introduces a new performance experiment plan (PERF-050) targeting the DOM Rendering Frame Capture Overhead.

It outlines an optimization for the fallback `frame.evaluate()` path in `SeekTimeDriver.ts`. Currently, this path implicitly returns the result of `window.__helios_seek()`, which causes Playwright to allocate and serialize the return object over IPC on every frame for non-main frames.

The plan proposes modifying the evaluation callback to return nothing (void), bypassing this serialization cost entirely. This approach mirrors the successful `returnByValue: false` optimization implemented for the direct CDP path in PERF-049.

The plan includes detailed background research, benchmark configuration, baseline metrics, a step-by-step implementation spec, and verification instructions.

---
*PR created automatically by Jules for task [3445683469490599876](https://jules.google.com/task/3445683469490599876) started by @BintzGavin*