### PR TITLE
✨ RENDERER: Eliminate Serialization for Frame Evaluate Fallback

### DIFF
--- a/.sys/plans/PERF-050-page-evaluate-serialization.md
+++ b/.sys/plans/PERF-050-page-evaluate-serialization.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-050
 slug: page-evaluate-serialization
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-28
-completed: ""
-result: ""
+completed: "2024-05-28"
+result: "improved"
 ---
 # PERF-050: Eliminate Serialization for Frame Evaluate Fallback
 
@@ -48,3 +48,9 @@ Run the DOM render script and verify output exists, has valid video contents, an
 
 ## Prior Art
 - PERF-049: Eliminated serialization overhead on the main frame by setting `returnByValue: false` on the `Runtime.evaluate` CDP call. This extends the same principle to Playwright's high-level `evaluate` API.
+
+## Results Summary
+- **Best render time**: 31.943s (vs baseline ~32.1s)
+- **Improvement**: 0.6%
+- **Kept experiments**: Eliminated frame.evaluate return object serialization
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 32.251s (baseline was 32.251s)
 Last updated by: PERF-038
 
 ## What Works
+- [PERF-050] Changed `frame.evaluate` in `SeekTimeDriver.ts` to implicitly return `undefined` rather than the serialized result of `window.__helios_seek`. This avoids V8 object serialization over IPC for non-main frames. Render time changed from ~32.1s to 31.943s.
 - [PERF-017] Discovered that the `SeekTimeDriver` script is already pre-compiled and injected via `page.addInitScript(initScript)` in `prepare()`. The `setTime` method correctly uses a lightweight `window.__helios_seek()` call over Playwright CDP, meaning this optimization was already natively implemented in the codebase. Baseline render time confirmed at 32.217s.
 - [PERF-035] Pipelined `Runtime.evaluate` and `Page.captureScreenshot` CDP commands in the worker execution loop by removing the blocking `await` from the `.then` chain. This allows Node.js to fire the capture command immediately without waiting for IPC evaluation round-trip. While micro-benchmarks showed 15% lower overhead per cycle, the overall DOM render time stayed stable around 33.823s, confirming correct execution ordering without an explicit `await` due to sequential CDP queueing rules.
 - [PERF-030] Enforced worker-local sequential promise chaining for frame capture loop. While removing the concurrent queue depth of `pool.length * 8` from PERF-029 degrades render time, it guarantees that `seek` and `capture` actions on a Playwright page evaluate sequentially, fixing a critical race condition. (Render time: 32.324s vs baseline 3.696s)
@@ -39,8 +40,8 @@ Last updated by: PERF-038
 - [PERF-032] Can we overcome the damage-driven limitations of `Page.startScreencast` (which failed in PERF-026) by injecting a forced layout/paint toggle on every virtual time tick, allowing us to buffer continuous screencast frames and eliminate the IPC latency of polling `Page.captureScreenshot`?
 
 ## Performance Trajectory
-Current best: 32.161s (baseline was 33.258s, -3.3%)
-Last updated by: PERF-049
+Current best: 31.943s (baseline was ~32.1s, -0.6%)
+Last updated by: PERF-050
 
 ## What Works
 - [PERF-049] Disabled `returnByValue` in `Runtime.evaluate` to skip object serialization over CDP IPC since the script `window.__helios_seek` returns `undefined`. In combination with commenting out synchronous console spam when GSAP timelines aren't found, this cut down idle IPC traffic during the frame capture loop and improved render time (from 33.258s to 32.161s, ~3.3% improvement).

--- a/packages/renderer/.sys/perf-results-PERF-050.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-050.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	31.943	150	4.70	37.7	keep	eliminated frame.evaluate return object serialization

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -229,7 +229,7 @@ export class SeekTimeDriver implements TimeDriver {
         promises.push(promise);
       } else {
         const promise = frame.evaluate(
-          ([t, timeoutMs]) => (window as any).__helios_seek(t, timeoutMs),
+          ([t, timeoutMs]) => { (window as any).__helios_seek(t, timeoutMs); },
           [timeInSeconds, this.timeout]
         );
         promises.push(promise);


### PR DESCRIPTION
✨ RENDERER: Eliminate Serialization for Frame Evaluate Fallback

💡 What: Changed `frame.evaluate` in `SeekTimeDriver.ts` to implicitly return `undefined` rather than the serialized result of `window.__helios_seek`. This avoids V8 object serialization over IPC for non-main frames.
🎯 Why: DOM Rendering Frame Capture Overhead. This extends the optimization from PERF-049 by targeting the V8 object serialization overhead occurring over Playwright's IPC layer when the fallback `frame.evaluate()` is used in `SeekTimeDriver.ts`.
📊 Impact: Render time changed from ~32.1s to 31.943s (0.6% improvement).
🔬 Verification: Ran Canvas smoke test and DOM test suite.
📎 Plan: Reference the plan file `/.sys/plans/PERF-050-page-evaluate-serialization.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	31.943	150	4.70	37.7	keep	eliminated frame.evaluate return object serialization
```

---
*PR created automatically by Jules for task [8018859384574975938](https://jules.google.com/task/8018859384574975938) started by @BintzGavin*