### PR TITLE
📋 CLI: Scaffold Kubernetes Deployment Command Plan

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -124,3 +124,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.36.0] - Hardcoded Infrastructure Adapters
 **Learning:** `helios job run` was refactored to use `JobExecutor`, but it still hardcodes `LocalWorkerAdapter`, failing to expose the cloud capabilities (`AwsLambdaAdapter`, `CloudRunAdapter`) provided by the `infrastructure` package.
 **Action:** When integrating new infrastructure abstractions into the CLI, ensure that all relevant capabilities (like execution adapters) are exposed via CLI options, rather than hardcoding local defaults.
+
+## [0.41.0] - Distributed Execution Scaffold Prerequisites (Kubernetes)
+**Learning:** The Infrastructure agent completed the `KubernetesAdapter`, but the `cli` package lacked a matching `helios deploy kubernetes` command to scaffold the required Kubernetes `job.yaml` manifest. Without the manifest, users cannot easily deploy their rendering workloads to a Kubernetes cluster, preventing the adapter from being usable in production.
+**Action:** Created plan `2027-01-12-CLI-Scaffold-Kubernetes-Deployment.md` to add the `deploy kubernetes` subcommand, completing the product surface for the Kubernetes distributed rendering adapter. When adding new infrastructure adapters, always verify if a corresponding CLI deployment scaffold is required.

--- a/.sys/plans/2027-01-12-CLI-Scaffold-Kubernetes-Deployment.md
+++ b/.sys/plans/2027-01-12-CLI-Scaffold-Kubernetes-Deployment.md
@@ -1,0 +1,26 @@
+#### 1. Context & Goal
+- **Objective**: Implement `helios deploy kubernetes` to scaffold deployment configuration files for Kubernetes distributed rendering.
+- **Trigger**: The Infrastructure agent completed the `KubernetesAdapter` for distributed rendering (Tier 2 Cloud Execution Adapter), but the CLI lacks a command to easily deploy the required Kubernetes Job template, leaving a gap in the product surface for cloud deployment workflows.
+- **Impact**: Unlocks enterprise-standard distributed rendering by allowing users to easily deploy their rendering workload onto any existing Kubernetes cluster.
+
+#### 2. File Inventory
+- **Create**: `packages/cli/src/templates/kubernetes.ts` (Exports strings for `KUBERNETES_JOB_TEMPLATE` and `README_KUBERNETES_TEMPLATE`)
+- **Modify**: `packages/cli/src/commands/deploy.ts` (Add the `kubernetes` subcommand to `helios deploy` to write the files)
+- **Read-Only**: `packages/infrastructure/src/adapters/kubernetes-adapter.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Extend the existing `helios deploy` Commander.js subcommand structure. Create a new `kubernetes` command that writes a `job.yaml` (a Kubernetes `BatchV1` Job definition) and a `README-KUBERNETES.md` file to the user's current working directory.
+- **Pseudo-Code**:
+  - In `packages/cli/src/templates/kubernetes.ts`, define `KUBERNETES_JOB_TEMPLATE` with standard K8s Job yaml containing the `helios-renderer` image and basic env configurations. Define `README_KUBERNETES_TEMPLATE` with instructions to apply the job and use the CLI adapter.
+  - In `packages/cli/src/commands/deploy.ts`, import templates.
+  - Add `deploy.command('kubernetes')` action.
+  - Check if `job.yaml` and `README-KUBERNETES.md` exist. Prompt user to overwrite using `prompts` if they do.
+  - Write templates to disk.
+  - Log success message.
+- **Public API Changes**: Adds `kubernetes` subcommand to `helios deploy`.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: Run `npx tsx packages/cli/src/index.ts deploy kubernetes` in a temporary directory.
+- **Success Criteria**: The command should execute successfully, output a success message, and `job.yaml` and `README-KUBERNETES.md` should exist in the directory with the expected content.
+- **Edge Cases**: Run the command again to verify the interactive overwrite prompt works correctly (should not overwrite if "no" is selected).


### PR DESCRIPTION
Created execution plan spec file in `/.sys/plans/2027-01-12-CLI-Scaffold-Kubernetes-Deployment.md` for implementing `helios deploy kubernetes`. This will provide users with a K8s job manifest and README to properly utilize the new KubernetesAdapter. Also added a learning entry to the CLI journal.

---
*PR created automatically by Jules for task [9154398874763399848](https://jules.google.com/task/9154398874763399848) started by @BintzGavin*