### PR TITLE
✨ RENDERER: Fix DOM target selector frame capture hang

### DIFF
--- a/.sys/plans/PERF-057-target-selector-beginframe.md
+++ b/.sys/plans/PERF-057-target-selector-beginframe.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-057
 slug: target-selector-beginframe
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-03-24
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 32.251s (baseline was 32.251s)
 Last updated by: PERF-038
 
 ## What Works
+- [PERF-057] Replaced `element.screenshot()` with CDP `HeadlessExperimental.beginFrame` in `DomStrategy.ts` using bounding box clipping when `targetSelector` is specified. Solves the issue where Playwright would hang indefinitely waiting for layout ticks while we ran Chromium in explicitly paused mode (`--enable-begin-frame-control`).
 - Eliminated array allocation in DOM traversal (PERF-052)
 - [PERF-050] Changed `frame.evaluate` in `SeekTimeDriver.ts` to implicitly return `undefined` rather than the serialized result of `window.__helios_seek`. This avoids V8 object serialization over IPC for non-main frames. Render time changed from ~32.1s to 31.943s.
 - [PERF-017] Discovered that the `SeekTimeDriver` script is already pre-compiled and injected via `page.addInitScript(initScript)` in `prepare()`. The `setTime` method correctly uses a lightweight `window.__helios_seek()` call over Playwright CDP, meaning this optimization was already natively implemented in the codebase. Baseline render time confirmed at 32.217s.

--- a/packages/renderer/.sys/perf-results-PERF-057.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-057.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	39.633	150	3.78	36.1	keep	Fix Playwright element screenshot hanging by using CDP HeadlessExperimental.beginFrame for target selectors

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -4,3 +4,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 3	33.472	150	4.48	4.4	keep	Fix HeadlessExperimental.beginFrame damage-driven omissions
 1	33.243	150	4.51	38.2	discard	PERF-048 skip serialization already implemented
 1	32.337	150	4.64	38.0	discard	PERF-051 skip serialization already implemented
+1	39.633	150	3.78	36.1	keep	Fix Playwright element screenshot hanging by using CDP HeadlessExperimental.beginFrame for target selectors

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -132,7 +132,45 @@ export class DomStrategy implements RenderStrategy {
       if (!element) {
         throw new Error(`Target element found but is not an element: ${this.options.targetSelector}`);
       }
-      return await element.screenshot(screenshotOptions);
+
+      if (this.cdpSession) {
+        const box = await element.boundingBox();
+        if (box) {
+          const screenshot: any = { format };
+          if ((format === 'jpeg' || format === 'webp') && quality !== undefined) {
+            screenshot.quality = quality;
+          }
+          screenshot.clip = {
+            x: box.x,
+            y: box.y,
+            width: box.width,
+            height: box.height,
+            scale: 1
+          };
+
+          const { screenshotData } = await this.cdpSession.send('HeadlessExperimental.beginFrame', {
+            screenshot
+          });
+
+          if (screenshotData) {
+            const buffer = Buffer.from(screenshotData, 'base64');
+            this.lastFrameBuffer = buffer;
+            return buffer;
+          } else if (this.lastFrameBuffer) {
+            return this.lastFrameBuffer;
+          } else {
+            // Wait for next explicit tick or fallback if damage driven logic fails
+            const res = await this.cdpSession.send('Page.captureScreenshot', { format, quality, clip: screenshot.clip } as any);
+            const buffer = Buffer.from(res.data, 'base64');
+            this.lastFrameBuffer = buffer;
+            return buffer;
+          }
+        }
+      }
+
+      const fallback = await element.screenshot(screenshotOptions);
+      this.lastFrameBuffer = fallback;
+      return fallback;
     }
 
     try {


### PR DESCRIPTION
💡 What: Switched from native `element.screenshot()` to `HeadlessExperimental.beginFrame` CDP commands with bounding box clipping when a targetSelector is defined in `DomStrategy.ts`.
🎯 Why: Native Playwright captures hung indefinitely when waiting for a compositor tick, due to Chromium being explicitly paused for damage-driven captures (`--enable-begin-frame-control`).
📊 Impact: Fixed total failure/timeout in `verify-dom-selector.ts`, enabling element-specific capture in headless new architecture.
🔬 Verification: `npm run build`, verified fixing `verify-dom-selector.ts` scripts.
📎 Plan: `/.sys/plans/PERF-057-target-selector-beginframe.md`

Results:
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	39.633	150	3.78	36.1	keep	Fix Playwright element screenshot hanging by using CDP HeadlessExperimental.beginFrame for target selectors

---
*PR created automatically by Jules for task [9887017221166558922](https://jules.google.com/task/9887017221166558922) started by @BintzGavin*