### PR TITLE
✨ RENDERER: Discard CPU rasterization experiment for DOM mode

### DIFF
--- a/.sys/plans/PERF-061-force-cpu-rasterization-dom.md
+++ b/.sys/plans/PERF-061-force-cpu-rasterization-dom.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-061
 slug: force-cpu-rasterization-dom
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-03-24
-completed: ""
-result: ""
+completed: "2026-03-25"
+result: "discarded"
 ---
 
 # PERF-061: Force CPU Rasterization for DOM Mode
@@ -67,3 +67,9 @@ All tests should pass without hanging and CSS rendering should remain intact.
 
 ## Prior Art
 - PERF-006 previously identified this approach but the exact \`GPU_DISABLED_ARGS\` logic was never strictly enforced for all DOM renders by default.
+
+## Results Summary
+- **Best render time**: 41.765s (vs baseline 41.770s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [Force GPU_DISABLED_ARGS for DOM mode, Add --disable-dev-shm-usage]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -25,6 +25,10 @@ Last updated by: PERF-038
 - Defaulting intermediate image format to jpeg when no alpha channel is needed (~2.2% faster) (PERF-011)
 
 ## What Doesn't Work (and Why)
+- **Tried:** Forcing GPU_DISABLED_ARGS (`--disable-gpu`, `--disable-software-rasterizer`, `--disable-gpu-compositing`) for DOM mode rendering. Also tried with `--disable-dev-shm-usage`.
+  **Why it didn't work:** It resulted in slower render times (44s vs 41.7s baseline). The CPU rasterization overhead might actually be higher when trying to explicitly bypass SwiftShader, or SwiftShader is heavily optimized for our specific DOM structures.
+  **Plan ID:** PERF-061
+
 - [PERF-051] The proposed optimization to remove the implicit return in `frame.evaluate` to avoid V8 object serialization overhead was already present in the codebase (`([t, timeoutMs]) => { (window as any).__helios_seek(t, timeoutMs); }`). Render time remained around baseline (~32.3s). Discarded because no code changes were necessary.
 - **PERF-044: Scale Concurrency via Multiple Browser Instances**: Instantiating a new browser process for each worker rather than grouping pages in a single browser context did not meaningfully improve DOM rendering time (median 33.563s vs baseline ~32.4s). Furthermore, creating separate browser instances broke canvas mode testing completely, causing the `CdpTimeDriver` to fail to sync media properly when attempting to process multiple offscreen frames, leading to "Target page, context or browser has been closed" and EPIPE errors. Discarded to maintain a stable, single-browser pool structure.
 - **PERF-040: Asynchronous Runtime.evaluate**: Setting `awaitPromise: false` on `Runtime.evaluate` in `SeekTimeDriver.ts`. This provides no significant performance improvement (32.347s vs baseline 32.337s). Chromium's CDP queueing already allows us to pipeline `Runtime.evaluate` and `Page.captureScreenshot` efficiently via a Promise chain without needing to detach the evaluation execution entirely. Furthermore, previous tests have shown detaching this execution entirely breaks synchronous state initialization in verification tests (e.g. `window.__helios_seek is not a function`).

--- a/packages/renderer/.sys/perf-results-PERF-061.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-061.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	41.770	300	7.18	40.9	keep	baseline
+2	44.178	300	6.79	41.3	discard	force GPU_DISABLED_ARGS for dom mode
+3	41.765	300	7.18	42.4	discard	add --disable-dev-shm-usage


### PR DESCRIPTION
💡 **What**: The experiment run and its outcome
Experimented with forcing `GPU_DISABLED_ARGS` (`--disable-gpu`, `--disable-software-rasterizer`, `--disable-gpu-compositing`) and `--disable-dev-shm-usage` for `mode: 'dom'`. Reverted code changes since the performance decreased or didn't meaningfully improve.

🎯 **Why**: The performance bottleneck targeted
Attempted to reduce CPU overhead during DOM composition and rasterization by targeting Skia software rasterizer instead of SwiftShader.

📊 **Impact**: Before/after render times and percentage improvement
Baseline render time was 41.770s.
Forcing GPU_DISABLED_ARGS resulted in 44.178s.
Adding `--disable-dev-shm-usage` resulted in 41.765s.
0% improvement, discarded due to performance not meaningfully beating baseline and the added risk of breaking webgl elements inside dom renders.

🔬 **Verification**: What was tested
Ran the benchmark script sequentially with changes and reverted them. Recorded results in `.sys/perf-results-PERF-061.tsv` and `docs/status/RENDERER-EXPERIMENTS.md`.

📎 **Plan**: Reference the plan file
`/.sys/plans/PERF-061-force-cpu-rasterization-dom.md`

### TSV Results Summary
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	41.770	300	7.18	40.9	keep	baseline
2	44.178	300	6.79	41.3	discard	force GPU_DISABLED_ARGS for dom mode
3	41.765	300	7.18	42.4	discard	add --disable-dev-shm-usage
```

---
*PR created automatically by Jules for task [3763660865490752321](https://jules.google.com/task/3763660865490752321) started by @BintzGavin*