### PR TITLE
📋 RENDERER: Optimize Default Browser Launch Arguments

### DIFF
--- a/.sys/plans/PERF-064-optimize-browser-args.md
+++ b/.sys/plans/PERF-064-optimize-browser-args.md
@@ -1,0 +1,57 @@
+---
+id: PERF-064
+slug: optimize-browser-args
+status: unclaimed
+claimed_by: ""
+created: 2024-05-30
+completed: ""
+result: ""
+---
+# PERF-064: Optimize Default Browser Launch Arguments
+
+## Focus Area
+DOM Render Pipeline - Browser Launch & Process Architecture (`Renderer.ts`)
+
+## Background Research
+The `Renderer.ts` uses Chromium for DOM-to-Video capture. Headless Chromium spins up several isolated processes by default, many of which provide sandbox/security benefits or multi-site process isolation that are unnecessary in a local, single-site, local-file rendering context like the Jules microVM.
+
+After iterating through several Chromium flags designed to limit overhead, this experiment intends to combine a suite of stable, well-known puppeteer/playwright "lightweight" chromium flags into the default launch arguments to verify if we can stack multiple micro-optimizations that strip out unnecessary browser background processes.
+
+## Benchmark Configuration
+- **Composition URL**: `examples/simple-animation/output/build/composition.html`
+- **Render Settings**: 600x600, 30fps, 5 seconds
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~32.25s
+- **Bottleneck analysis**: IPC latency between Node and Chromium along with layout/paint calculation overhead in V8.
+
+## Implementation Spec
+
+### Step 1: Update Default Browser Arguments
+**File**: `packages/renderer/src/Renderer.ts`
+**What to change**:
+Append the following stable flags to `DEFAULT_BROWSER_ARGS`:
+- `--disable-dev-shm-usage`
+- `--disable-extensions`
+- `--disable-default-apps`
+- `--disable-sync`
+- `--no-first-run`
+- `--mute-audio`
+- `--disable-background-networking`
+- `--disable-background-timer-throttling`
+- `--disable-breakpad`
+
+**Why**: These flags systematically disable background synchronization, crash reporting, plugin loading, and fallback networking routines inside Chromium. In a fixed-duration headless rendering loop on a CPU-bound microVM, any unnecessary background V8 thread activity or IPC ping overhead consumes CPU cycles that could otherwise be used for `HeadlessExperimental.beginFrame` execution.
+**Risk**: Low. These flags are standard optimizations in the headless browser testing ecosystem.
+
+## Variations
+None.
+
+## Correctness Check
+Run `npx tsx packages/renderer/tests/verify-seek-driver-offsets.ts` to ensure CDP frame capture still functions normally without crashes.
+
+## Canvas Smoke Test
+Run `npx tsx packages/renderer/tests/verify-seek-driver-offsets.ts` (which utilizes `SeekTimeDriver` inside canvas mode) to ensure hardware-accelerated modes are not impaired by these standard process restrictions.


### PR DESCRIPTION
📋 RENDERER: Optimize Default Browser Launch Arguments

💡 What: An experiment to stack lightweight headless Chromium flags in DEFAULT_BROWSER_ARGS.
🎯 Why: To strip out unnecessary browser background processes and reduce V8 thread activity/IPC overhead. Expected impact is a further reduction in render time.
🔬 Approach: Append standard puppeteer/playwright "lightweight" chromium flags to DEFAULT_BROWSER_ARGS.
📎 Plan: /.sys/plans/PERF-064-optimize-browser-args.md

---
*PR created automatically by Jules for task [12905923919817379798](https://jules.google.com/task/12905923919817379798) started by @BintzGavin*