### PR TITLE
✨ PLAYER: Document missing API parity members in README

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -1,6 +1,6 @@
 # Context: PLAYER
 
-**Version**: 0.77.3
+**Version**: 0.77.4
 
 ## Section A: Component Structure
 
@@ -77,6 +77,7 @@
 
 ## Section C: Attributes
 
+- `crossorigin`: CORS setting for this media element.
 - `src`: The URL of the Helios composition to load.
 - `width`: Overrides the preview width (Standard Media API parity).
 - `height`: Overrides the preview height (Standard Media API parity).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -93,6 +93,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### CLI v0.31.0
 - ✅ Completed: AWS Deployment - Implemented AWS Lambda deployment scaffolding and custom browser path support.
 
+### PLAYER v0.77.4
+- ✅ Completed: README API Parity - Documented missing HTMLMediaElement API parity properties, methods, and attributes.
+
 ### PLAYER v0.77.3
 - ✅ Completed: Expand Test Coverage - Added tests for audio metering, getAudioTracks timeout, and captureFrame timeout in controllers.ts.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,5 @@
-**Version**: 0.77.3
+**Version**: 0.77.4
+[v0.77.4] ✅ Completed: README API Parity - Documented missing HTMLMediaElement API parity properties, methods, and attributes.
 [v0.77.3] ✅ Completed: Expand Test Coverage - Added tests for audio metering, getAudioTracks timeout, and captureFrame timeout in controllers.ts.
 [v0.77.2] ✅ Completed: Expand Test Coverage - Added tests for captureFrame edge cases in DirectController.
 [v0.77.1] ✅ Completed: Bridge Coverage Expansion - Added comprehensive unit test coverage for HELIOS_CAPTURE_FRAME modes and global error handlers in bridge.ts.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -77,6 +77,7 @@ The player will automatically attempt to access `window.helios` on the iframe's 
 | `media-artist` | Artist name for OS Media Session. | - |
 | `media-album` | Album name for OS Media Session. | - |
 | `media-artwork` | URL of artwork for OS Media Session (defaults to poster). | - |
+| `crossorigin` | CORS setting for this media element. | - |
 
 ## User Interface
 
@@ -137,6 +138,7 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `requestPictureInPicture(): Promise<PictureInPictureWindow>` - Requests Picture-in-Picture mode for the player.
 - `export(options?: HeliosExportOptions): Promise<void>` - Programmatically trigger client-side export.
 - `fastSeek(time: number): void` - Seeks to the specified time as fast as possible (currently equivalent to setting `currentTime`).
+- `canPlayType(type: string): CanPlayTypeResult` - Returns whether the player can play the specified media type.
 
 ### Properties
 
@@ -162,6 +164,14 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `inputProps` (object): Get or set the input properties passed to the composition.
 - `playsInline` (boolean): Reflected playsinline attribute.
 - `disablePictureInPicture` (boolean): Hides the Picture-in-Picture button.
+- `error` (MediaError | null, read-only): The current media error.
+- `currentSrc` (string, read-only): The absolute URL of the chosen media resource.
+- `played` (TimeRanges, read-only): The ranges of the media source that the browser has played.
+- `defaultMuted` (boolean): Reflected defaultMuted attribute.
+- `defaultPlaybackRate` (number): The default rate of playback.
+- `preservesPitch` (boolean): Whether pitch should be preserved when altering playback speed.
+- `srcObject` (MediaProvider | null): The media provider object.
+- `crossOrigin` (string | null): The CORS setting for this media element.
 
 ## Events
 
@@ -179,6 +189,7 @@ The element dispatches the following custom events:
 - `loadeddata`: Fired when data for the current frame is available.
 - `canplay`: Fired when the browser can resume playback of the media.
 - `canplaythrough`: Fired when the browser estimates it can play through the media without buffering.
+- `resize`: Fired when the player dimensions change.
 
 ## Client-Side Export
 


### PR DESCRIPTION
💡 **What**: Documented missing HTMLMediaElement parity API properties, methods, attributes, and events in the README.
🎯 **Why**: To close the vision gap and provide developers with complete and accurate documentation of the Web Component's API per `2027-01-13-PLAYER-README-API-Parity-Gap.md`.
📊 **Impact**: Developers can now seamlessly integrate and understand the full capabilities of the player when using standard HTMLMediaElement wrappers.
🔬 **Verification**: Run `npm run build -w packages/player` and verify `README.md` contains the new additions (`canPlayType`, `currentSrc`, `defaultMuted`, `resize`, `crossorigin`, etc.).

---
*PR created automatically by Jules for task [2497979080167309986](https://jules.google.com/task/2497979080167309986) started by @BintzGavin*