### PR TITLE
📋 RENDERER: Bypass CDP IPC Object Serialization Overhead

### DIFF
--- a/.sys/plans/PERF-066-cdp-evaluate-serialization.md
+++ b/.sys/plans/PERF-066-cdp-evaluate-serialization.md
@@ -3,47 +3,39 @@ id: PERF-066
 slug: cdp-evaluate-serialization
 status: unclaimed
 claimed_by: ""
-created: 2024-05-27
+created: 2024-05-24
 completed: ""
 result: ""
 ---
 
-# PERF-066: Eliminate V8 Object Serialization in CDP Evaluate
+# PERF-066: Bypass CDP IPC Object Serialization Overhead
 
 ## Focus Area
-The `setTime` execution loop in `packages/renderer/src/drivers/SeekTimeDriver.ts`. Specifically, the CDP command `Runtime.evaluate` used to trigger `window.__helios_seek` on the main frame. Disabling `returnByValue` will skip the expensive and unnecessary process of serializing the evaluation's return value (which is `undefined`) and transmitting it back to Node.js over the IPC boundary.
+Frame Capture Loop in DOM Mode (`packages/renderer/src/drivers/SeekTimeDriver.ts`). This targets the execution of the `window.__helios_seek` function within Chromium via the CDP `Runtime.evaluate` command.
 
 ## Background Research
-When Node.js communicates with headless Chromium via Playwright's CDP session, calling `Runtime.evaluate` with `returnByValue: true` instructs the V8 engine to serialize the returned JavaScript object into JSON before sending it back across the IPC pipe. `window.__helios_seek` performs synchronous DOM operations and explicitly returns nothing (`undefined`). Therefore, retaining the default (or true) `returnByValue` incurs micro-latency per frame by pointlessly spinning up V8 serialization routines for an empty result. Prior experiments (`PERF-049` and `PERF-050`) have successfully proven that minimizing IPC chat by removing implicit returns or turning off `returnByValue` trims rendering latency for high-throughput frame loops.
+Currently, `SeekTimeDriver.ts` calls `Runtime.evaluate` for the `window.__helios_seek` script on every frame in the main execution loop. By default, CDP `Runtime.evaluate` attempts to serialize and return the result of the evaluated script back to Node.js. Even if the script implicitly returns `undefined`, there is non-zero overhead in V8 evaluating the return type and sending the result object over the IPC layer.
+
+By explicitly setting `returnByValue: false` in the CDP `Runtime.evaluate` payload for the main frame, we can instruct Chromium to bypass this serialization entirely. This reduces V8 IPC serialization overhead on the browser side and string decoding on the Node.js side for the hot loop. The equivalent fix was previously implemented for non-main frames (via Playwright's `frame.evaluate` in PERF-050) but was missed for the direct CDP call on the main frame.
 
 ## Benchmark Configuration
-- **Composition URL**: `file://packages/renderer/scripts/fixtures/index.html` (or standard test fixture)
-- **Render Settings**: 1280x720, 30 FPS, 3 seconds duration, `libx264` codec.
+- **Composition URL**: Standard benchmark (e.g. `tests/fixtures/benchmark.html`)
+- **Render Settings**: Baseline resolution and framerate
 - **Mode**: `dom`
 - **Metric**: Wall-clock render time in seconds
 - **Minimum runs**: 3 per experiment, report median
 
 ## Baseline
-- **Current estimated render time**: 32.100s
-- **Bottleneck analysis**: Micro-latency accumulating from V8 IPC object serialization over thousands of frames in the active CDP pipeline.
+- **Current estimated render time**: ~32.100s
+- **Bottleneck analysis**: The execution of `__helios_seek` via CDP incurs IPC serialization overhead. By explicitly disabling value return, we reduce the communication payload for time synchronization.
 
 ## Implementation Spec
 
-### Step 1: Disable `returnByValue` in CDP `Runtime.evaluate`
+### Step 1: Set returnByValue for CDP Evaluate
 **File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
 **What to change**:
-Locate the `setTime(page: Page, timeInSeconds: number)` method. Look for the `this.cdpSession.send('Runtime.evaluate', ...)` call. Ensure the parameters object explicitly sets `returnByValue: false`.
-**Why**: Tells Chromium's V8 engine to skip JSON serialization of the execution result, returning only a lightweight RemoteObjectId (or nothing), saving CPU cycles and IPC bandwidth for every single frame capture cycle.
-**Risk**: Low. The renderer does not capture or utilize the returned value of `__helios_seek` (only checking for `exceptionDetails`).
-
-## Canvas Smoke Test
-Run `npx tsx packages/renderer/scripts/render.ts` with canvas mode settings. This change strictly modifies the `SeekTimeDriver` used for DOM rendering, so canvas behavior remains unaffected.
+In the `setTime` function, locate the `this.cdpSession.send('Runtime.evaluate', { ... })` call. Add the property `returnByValue: false` to the payload object alongside `expression` and `awaitPromise`.
+**Why**: Instructs V8 to skip serializing the result of the script evaluation, eliminating unnecessary IPC overhead during the frame capture loop.
 
 ## Correctness Check
-Run the DOM synchronization tests:
-`npx tsx packages/renderer/tests/verify-seek-driver-offsets.ts`
-Confirm the script outputs `SUCCESS: SeekTimeDriver respects offsets and seeks.` Ensure `__helios_seek` still accurately updates the DOM states without failure.
-
-## Prior Art
-- PERF-049: Disabled `returnByValue` to skip object serialization over CDP IPC.
-- PERF-050: Changed `frame.evaluate` in `SeekTimeDriver.ts` to implicitly return `undefined`.
+Instruct the Executor to run the WAAPI offset verification tests (`npx tsx packages/renderer/tests/verify-seek-driver-offsets.ts`) to ensure time synchronization is not broken.


### PR DESCRIPTION
💡 What: PERF-066 Bypass CDP IPC Object Serialization Overhead.
🎯 Why: explicitly setting returnByValue: false in the CDP Runtime.evaluate payload for the main frame instructs Chromium to bypass serialization entirely, reducing V8 IPC serialization overhead on the browser side and string decoding on the Node.js side for the hot loop.
🔬 Approach: Add returnByValue: false to Runtime.evaluate in SeekTimeDriver.ts
📎 Plan: .sys/plans/PERF-066-cdp-evaluate-serialization.md

---
*PR created automatically by Jules for task [16670380958106037820](https://jules.google.com/task/16670380958106037820) started by @BintzGavin*