### PR TITLE
✨ RENDERER: Conditionally return Promise in __helios_seek

### DIFF
--- a/.sys/plans/PERF-067-conditionally-async-seek.md
+++ b/.sys/plans/PERF-067-conditionally-async-seek.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-067
 slug: conditionally-async-seek
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2024-05-24"
+result: "failed"
 ---
 
 # PERF-067: Bypass V8 Microtask Queue in SeekTimeDriver
@@ -58,3 +58,9 @@ In the `initScript` string:
 
 ## Correctness Check
 Instruct the Executor to run the offset verification tests (`npx tsx packages/renderer/tests/verify-seek-driver-offsets.ts`) to ensure time synchronization is not broken, particularly for frames that *do* require waiting.
+
+## Results Summary
+- **Best render time**: 41.215s (vs baseline ~32.100s)
+- **Improvement**: -28.4% (Regression)
+- **Kept experiments**: []
+- **Discarded experiments**: [Removed async keyword from window.__helios_seek and conditionally returned a Promise]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -70,6 +70,7 @@ Last updated by: PERF-050
 - [PERF-046] Avoided allocating un-cleared `setTimeout` floating promises and looping over empty arrays in `SeekTimeDriver.ts` when no media elements exist. While best practice, the benchmark execution time was mostly bounded by IPC and Playwright frame captures, so this optimization resulted in a negligible -0.5% (33.615s median vs 33.657s) improvement within noise margins. Kept for stability.
 
 ## What Doesn't Work (and Why)
+- [PERF-067] Attempted to conditionally return a Promise in `SeekTimeDriver`'s `window.__helios_seek` function, to bypass V8 Promise allocation and microtask queue scheduling. Render time regressed significantly (41.215s vs baseline 32.100s). The `async` keyword and returning `undefined` through `awaitPromise: true` is deeply optimized in V8/CDP, and manually returning promises adds unexpected overhead, possibly stalling the evaluation pipeline.
 - **Adding Aggressive CPU Saving Flags to Chromium**: I attempted to add `--disable-features=IsolateOrigins,site-per-process`, `--disable-site-isolation-trials`, and `--disable-ipc-flooding-protection` to `DEFAULT_BROWSER_ARGS` to reduce CPU load since site isolation is unnecessary for local file rendering. This resulted in Chromium immediately hanging during initialization in the headless mode, particularly in conjunction with the required `--enable-begin-frame-control` flag.
 
 ## What Works

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -7,3 +7,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	39.633	150	3.78	36.1	keep	Fix Playwright element screenshot hanging by using CDP HeadlessExperimental.beginFrame for target selectors
 1	33.592	15	0.45	36.8	keep	Native beginFrame for targetSelector
 70	32.015	150	4.68	0.0	keep	use standalone headless shell binary if available
+71	41.215	30	0.73	7.6	discard	conditionally return Promise in __helios_seek


### PR DESCRIPTION
💡 **What**: Evaluated removing the `async` keyword from `window.__helios_seek` and conditionally returning a Promise only when `promises.length > 0`.
🎯 **Why**: Attempted to eliminate V8 native Promise allocation and microtask queue scheduling overhead for the vast majority of frames where no internal `await` happens.
📊 **Impact**: Render time regressed from ~32.100s to 41.215s. Experiment discarded and code reverted.
🔬 **Verification**: Ran `verify-seek-driver-offsets.ts` and 4-gate verification with standard benchmark.
📎 **Plan**: Reference the plan file (`.sys/plans/PERF-067-conditionally-async-seek.md`)

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
71	41.215	30	0.73	7.6	discard	conditionally return Promise in __helios_seek
```

---
*PR created automatically by Jules for task [3044215467830054982](https://jules.google.com/task/3044215467830054982) started by @BintzGavin*