### PR TITLE
✨ PLAYER: Document getSchema API parity

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -1,6 +1,6 @@
 # Context: PLAYER
 
-**Version**: 0.77.4
+**Version**: 0.77.5
 
 ## Section A: Component Structure
 
@@ -105,6 +105,7 @@
 ## Section D: Methods
 
 - `play(): Promise<void>`
+- `getSchema(): Promise<HeliosSchema | undefined>`
 - `pause(): void`
 - `load(): void`
 - `export(options?: HeliosExportOptions): Promise<void>`

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -1,3 +1,6 @@
+## PLAYER v0.77.5
+- ✅ Completed: Document getSchema API Parity - Added missing getSchema method to README documentation.
+
 ## PLAYER v0.76.23
 - ✅ Completed: Bridge Coverage Completeness - Added test coverage for HELIOS_GET_SCHEMA, HELIOS_START_METERING, HELIOS_STOP_METERING, HELIOS_DIAGNOSE, helios subscribe callbacks, and timeout logic for getSchema and diagnose in BridgeController.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,5 @@
-**Version**: 0.77.4
+**Version**: 0.77.5
+[v0.77.5] ✅ Completed: Document getSchema API Parity - Added missing getSchema method to README documentation.
 [v0.77.4] ✅ Completed: README API Parity - Documented missing HTMLMediaElement API parity properties, methods, and attributes.
 [v0.77.3] ✅ Completed: Expand Test Coverage - Added tests for audio metering, getAudioTracks timeout, and captureFrame timeout in controllers.ts.
 [v0.77.2] ✅ Completed: Expand Test Coverage - Added tests for captureFrame edge cases in DirectController.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -131,6 +131,7 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 ### Methods
 
 - `play(): Promise<void>` - Starts playback.
+- `getSchema(): Promise<HeliosSchema | undefined>` - Retrieves the input properties schema from the composition.
 - `pause(): void` - Pauses playback.
 - `load(): void` - Reloads the iframe (useful if `src` changed or to retry connection).
 - `addTextTrack(kind: string, label?: string, language?: string): TextTrack` - Adds a new text track to the media element.


### PR DESCRIPTION
💡 What: Added getSchema to the Methods section of the player README and context file.
🎯 Why: To close the API Parity Gap and provide complete documentation for developers.
📊 Impact: Developers can now properly retrieve the composition schema using documented API.
🔬 Verification: Ran build and verified README content.

---
*PR created automatically by Jules for task [1351633228288159307](https://jules.google.com/task/1351633228288159307) started by @BintzGavin*