### PR TITLE
📋 RENDERER: Optimize GC overhead by preallocating framePromises

### DIFF
--- a/.sys/plans/PERF-076-preallocate-framepromises.md
+++ b/.sys/plans/PERF-076-preallocate-framepromises.md
@@ -1,0 +1,42 @@
+---
+id: PERF-076
+slug: preallocate-framepromises
+status: unclaimed
+claimed_by: ""
+created: 2024-05-24
+completed: ""
+result: ""
+---
+
+**PERF-076: Optimize GC overhead by preallocating framePromises**
+
+**Focus Area**
+The central captureLoop in packages/renderer/src/Renderer.ts currently pushes promises into the framePromises array on every frame iteration. Since totalFrames is known ahead of time, we can avoid dynamic array resizing and memory reallocation overhead by preallocating the framePromises array to its exact final size.
+
+**Background Research**
+When allocating arrays in hot loops in JavaScript (and specifically V8), continuously .push()ing items into a dynamically sized array forces the engine to repeatedly allocate larger backing buffers and copy the data over. Since we calculate totalFrames prior to starting the captureLoop, we can instantiate framePromises as new Array(totalFrames) to entirely bypass reallocation churn. The framePromises array elements are already garbage collected via framePromises[nextFrameToWrite] = null as any; once written, but the initial dynamic allocation sizing during the .push() loop remains unoptimized.
+
+**Benchmark Configuration**
+- Composition URL: Standard benchmark composition
+- Render Settings: 1920x1080, 60 FPS, 5 seconds duration
+- Mode: dom
+- Metric: Wall-clock render time in seconds
+- Minimum runs: 3 per experiment, report median
+
+**Baseline**
+- Current estimated render time: 33.594s
+- Bottleneck analysis: Micro-allocations and continuous array resizing during the while loops that push generated frame capture promises onto the framePromises array.
+
+**Implementation Spec**
+
+**Step 1: Preallocate framePromises array**
+**File**: packages/renderer/src/Renderer.ts
+**What to change**:
+1. Find `let framePromises: Promise<Buffer>[] = [];` in captureLoop.
+2. Change it to `let framePromises: Promise<Buffer>[] = new Array(totalFrames);`.
+3. In the inner while loop (`while (nextFrameToSubmit < totalFrames ...)`), change `framePromises.push(framePromise);` to `framePromises[nextFrameToSubmit] = framePromise;`.
+**Why**: Preallocating the array prevents V8 from needing to resize and copy the array buffer dynamically under the hood as nextFrameToSubmit scales into the thousands, thus reducing memory pressure and micro-stalls during the capture loop.
+**Risk**: Negligible. Array bounds are strictly bounded by nextFrameToSubmit < totalFrames.
+
+**Correctness Check**
+Run the DOM verification tests to ensure the sequence of frames output to FFmpeg correctly executes and renders.


### PR DESCRIPTION
💡 **What**: Preallocate `framePromises` array to `totalFrames` in `Renderer.ts`.
🎯 **Why**: Avoids dynamic array resizing and memory reallocation overhead during the hot frame capture loop.
🔬 **Approach**: Replace `[]` with `new Array(totalFrames)` and use index assignment instead of `.push()`.
📎 **Plan**: `.sys/plans/PERF-076-preallocate-framepromises.md`

---
*PR created automatically by Jules for task [18365686552227468904](https://jules.google.com/task/18365686552227468904) started by @BintzGavin*