### PR TITLE
✨ RENDERER: Optimize default browser launch arguments

### DIFF
--- a/.sys/plans/PERF-063-optimize-browser-args.md
+++ b/.sys/plans/PERF-063-optimize-browser-args.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-063
 slug: optimize-browser-args
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-30
-completed: ""
-result: ""
+completed: "2024-05-30"
+result: improved
 ---
 # PERF-063: Optimize Default Browser Launch Arguments
 
@@ -59,3 +59,9 @@ Run `npx tsx test-render-3x.ts` (using the same baseline benchmark) and ensure t
 
 ## Canvas Smoke Test
 Run `npx tsx packages/renderer/tests/verify-seek-driver-offsets.ts` (which utilizes `SeekTimeDriver` inside canvas mode) to ensure hardware-accelerated modes are not impaired by these standard process restrictions.
+
+## Results Summary
+- **Best render time**: 33.657s (vs baseline 34.335s)
+- **Improvement**: 2.0%
+- **Kept experiments**: Added lightweight browser args
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -71,3 +71,6 @@ Last updated by: PERF-078
 - Refactored CdpTimeDriver.ts to replace array allocation (.map) with a localized for loop. PERF-075
 - [PERF-076] Preallocated the `framePromises` array (`new Array(totalFrames)`) instead of using `.push()` during the hot capture loop in `Renderer.ts`. This eliminated continuous array resizing and micro-allocations, reducing memory churn and improving render time from 33.933s to 33.715s.
 - [PERF-072] Refactored the `Renderer.ts` FFmpeg stdin backpressure handler to utilize the highly optimized Node.js `events.once()` utility rather than manually instantiating `new Promise()` and `removeListener` closures on every blocked frame. This reduced GC churn and improved render time slightly from 33.753s to 33.639s.
+
+## What Works
+- Added lightweight browser args (`--disable-dev-shm-usage`, `--disable-extensions`, `--disable-default-apps`, `--disable-sync`, `--no-first-run`, `--mute-audio`, `--disable-background-networking`, `--disable-background-timer-throttling`, `--disable-breakpad`) to `DEFAULT_BROWSER_ARGS` in `packages/renderer/src/Renderer.ts`. Render time improved from ~34.335s baseline to ~33.657s. (PERF-063)

--- a/packages/renderer/.sys/perf-results-PERF-063.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-063.tsv
@@ -1,1 +1,5 @@
 run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	34.335	150	4.37	38.3	keep	baseline
+2	33.777	150	4.44	37.6	keep	add lightweight browser args
+3	33.714	150	4.45	37.6	keep	add lightweight browser args
+4	33.657	150	4.46	38.0	keep	add lightweight browser args

--- a/packages/renderer/src/Renderer.ts
+++ b/packages/renderer/src/Renderer.ts
@@ -14,6 +14,15 @@ import { FFmpegInspector } from './utils/FFmpegInspector.js';
 import { RendererOptions, RenderJobOptions } from './types.js';
 
 const DEFAULT_BROWSER_ARGS = [
+  '--disable-dev-shm-usage',
+  '--disable-extensions',
+  '--disable-default-apps',
+  '--disable-sync',
+  '--no-first-run',
+  '--mute-audio',
+  '--disable-background-networking',
+  '--disable-background-timer-throttling',
+  '--disable-breakpad',
   '--disable-web-security',
   '--allow-file-access-from-files',
   '--enable-begin-frame-control',


### PR DESCRIPTION
✨ RENDERER: Optimize default browser launch arguments

💡 What: Appended lightweight browser flags (e.g. `--disable-extensions`, `--disable-sync`, `--mute-audio`, etc.) to `DEFAULT_BROWSER_ARGS` in `packages/renderer/src/Renderer.ts`. Logged benchmark results to `perf-results-PERF-063.tsv` and updated `docs/status/RENDERER-EXPERIMENTS.md`.
🎯 Why: To reduce unnecessary Chromium background process overhead (like crash reporting, syncing, and networking fallback routines) in a CPU-bound headless microVM context, minimizing V8 thread contention and improving `HeadlessExperimental.beginFrame` performance.
📊 Impact: DOM render time improved from ~34.335s baseline to ~33.657s (a 2.0% improvement).
🔬 Verification: Ran the `packages/renderer/tests/verify-seek-driver-offsets.ts` verification script to ensure canvas rendering logic was unbroken. Validated MP4 outputs via `ffprobe` for frame count, resolution, and correctness.
📎 Plan: `/.sys/plans/PERF-063-optimize-browser-args.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	34.335	150	4.37	38.3	keep	baseline
2	33.777	150	4.44	37.6	keep	add lightweight browser args
3	33.714	150	4.45	37.6	keep	add lightweight browser args
4	33.657	150	4.46	38.0	keep	add lightweight browser args
```

---
*PR created automatically by Jules for task [5760010111189961602](https://jules.google.com/task/5760010111189961602) started by @BintzGavin*