### PR TITLE
📋 RENDERER: Eliminate micro-stalls and GC churn in CdpTimeDriver frame synchronization

### DIFF
--- a/.sys/plans/PERF-080-cdp-evaluate-gc.md
+++ b/.sys/plans/PERF-080-cdp-evaluate-gc.md
@@ -1,0 +1,38 @@
+---
+id: PERF-080
+slug: cdp-evaluate-gc
+status: unclaimed
+claimed_by: ""
+created: 2024-05-24
+completed: ""
+result: ""
+---
+
+**PERF-080: Eliminate micro-stalls and GC churn in CdpTimeDriver frame synchronization**
+
+**Focus Area**
+Garbage Collection overhead and continuous memory allocations inside the hot frame capture loop, specifically within the `CdpTimeDriver` synchronization step for multi-frame support.
+
+**Background Research**
+Currently, when `CdpTimeDriver.setTime` is called, it iterates over all frames and allocates an array of Promises (`frames.map(...)` or pushing to `framePromises`) before calling `Promise.all()`. Since the overwhelming majority of renders are single-frame (just the main frame), avoiding the array allocation and `Promise.all` machinery completely can reduce latency per frame loop execution in Canvas mode as well.
+
+**Benchmark Configuration**
+- **Composition URL**: `file:///app/output/example-build/examples/simple-animation/composition.html`
+- **Render Settings**: width 1280, height 720, 30fps, 5 seconds duration
+- **Mode**: `canvas` (since CdpTimeDriver is used here)
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+**Baseline**
+- **Bottleneck analysis**: Continuous memory allocation in the microtask queue and object serialization layer between Playwright CDP calls during `setTime`.
+
+**Implementation Spec**
+
+**Step 1: Avoid Promise.all array allocations for single frames in CdpTimeDriver.ts**
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**: Inside the time sync method (where we evaluate the `mediaSyncScript` across frames), check if the length of the frames collection is exactly `1`. If true, directly execute and await the evaluation on `frames[0]` instead of allocating an array and using `Promise.all`. For the fallback case (multiple frames), instantiate the array with a fixed size (`new Array(frames.length)`) and assign to indices instead of using implicit array allocations.
+**Why**: Avoids creating an array object and invoking V8's `Promise.all` logic for >99% of render cycles, decreasing microtask latency and GC churn in the Canvas rendering path.
+**Risk**: If the `length` logic is incorrect, multiple frames (iframes) may not sync their media appropriately.
+
+**Correctness Check**
+Verify that `npx tsx packages/renderer/tests/fixtures/benchmark.ts -m canvas` successfully completes without throwing errors related to media synchronization.


### PR DESCRIPTION
💡 What: Proposes eliminating the Promise.all allocation overhead inside CdpTimeDriver.ts when processing single-frame documents.
🎯 Why: Avoids creating an array object and invoking V8's Promise.all logic for >99% of render cycles, decreasing microtask latency and GC churn in the Canvas rendering path.
🔬 Approach: Check if the length of the frames collection is exactly 1 and bypass Promise.all.
📎 Plan: .sys/plans/PERF-080-cdp-evaluate-gc.md

---
*PR created automatically by Jules for task [10745690649253399030](https://jules.google.com/task/10745690649253399030) started by @BintzGavin*