### PR TITLE
✨ RENDERER: Resolve PERF-080 CdpTimeDriver optimization

### DIFF
--- a/.sys/plans/PERF-080-cdp-evaluate-gc.md
+++ b/.sys/plans/PERF-080-cdp-evaluate-gc.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-080
 slug: cdp-evaluate-gc
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2024-05-24"
+result: "already-implemented"
 ---
 
 **PERF-080: Eliminate micro-stalls and GC churn in CdpTimeDriver frame synchronization**
@@ -36,3 +36,9 @@ Currently, when `CdpTimeDriver.setTime` is called, it iterates over all frames a
 
 **Correctness Check**
 Verify that `npx tsx packages/renderer/tests/fixtures/benchmark.ts -m canvas` successfully completes without throwing errors related to media synchronization.
+
+## Results Summary
+- **Best render time**: 33.541s (vs baseline 33.541s)
+- **Improvement**: 0%
+- **Kept experiments**: cdp-evaluate-gc (already implemented)
+- **Discarded experiments**: none

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -76,3 +76,4 @@ Last updated by: PERF-079
 ## What Works
 - PERF-079: Removed Promise.all array allocations in CdpTimeDriver.ts for single frames (~0.3% improvement)
 - Added lightweight browser args (`--disable-dev-shm-usage`, `--disable-extensions`, `--disable-default-apps`, `--disable-sync`, `--no-first-run`, `--mute-audio`, `--disable-background-networking`, `--disable-background-timer-throttling`, `--disable-breakpad`) to `DEFAULT_BROWSER_ARGS` in `packages/renderer/src/Renderer.ts`. Render time improved from ~34.335s baseline to ~33.657s. (PERF-063)
+- PERF-080: The CdpTimeDriver.ts file already contained the single-frame Promise.all avoidance and array preallocation optimization. Verified it is present. The codebase requires no further modifications for this experiment.

--- a/packages/renderer/.sys/perf-results-PERF-080.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-080.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	33.541	150	4.47	38.3	keep	baseline


### PR DESCRIPTION
✨ RENDERER: Resolve PERF-080 CdpTimeDriver optimization

💡 **What**: Investigated the PERF-080 plan to eliminate Promise.all allocations for single-frame evaluation in CdpTimeDriver.ts. Found that the optimization was already implemented in the codebase. Established a benchmark baseline, verified no changes were required, and completed the plan.
🎯 **Why**: To reduce micro-stalls and GC churn in CdpTimeDriver frame synchronization.
📊 **Impact**: Baseline render time established at ~33.541s (0% improvement as no new changes were made).
🔬 **Verification**: Ran the `tests/fixtures/benchmark.ts -m canvas` test, ran the `tests/verify-seek-driver-stability.ts` tests.
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-080-cdp-evaluate-gc.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | 33.541 | 150 | 4.47 | 38.3 | keep | baseline |

---
*PR created automatically by Jules for task [8946877618677270577](https://jules.google.com/task/8946877618677270577) started by @BintzGavin*