### PR TITLE
✨ RENDERER: Optimize frame capture pipeline depth loop condition

### DIFF
--- a/.sys/plans/PERF-083-optimize-loop-condition.md
+++ b/.sys/plans/PERF-083-optimize-loop-condition.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-083
 slug: optimize-loop-condition
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2026-03-27"
+result: "improved"
 ---
 # PERF-083: Optimize Renderer Hot Loop Condition Variables
 
@@ -44,3 +44,9 @@ Run `tests/fixtures/benchmark.ts` script to ensure frames are still output corre
 
 ## Prior Art
 - PERF-082 (Cached array lengths in hot loops)
+
+## Results Summary
+- **Best render time**: 33.664s (vs baseline 34.096s)
+- **Improvement**: 1.27%
+- **Kept experiments**: [cache pipeline depth limit]
+- **Discarded experiments**: []

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 33.696s (baseline was 33.780s, ~0.25% improvement)
 Last updated by: PERF-083
 
 ## What Works
+- Cached the active pipeline depth limit (`poolLen * 8`) outside the inner `while` loop condition in `Renderer.ts` to prevent repeated arithmetic and V8 micro-stalls during frame capture. (PERF-083, ~1.27% improvement, 33.664s vs 34.096s).
 - Cached array lengths in hot loops (`SeekTimeDriver.ts` and `Renderer.ts`) to avoid redundant `.length` property lookups. Minimal improvement but slightly reduces V8 overhead per-frame. (PERF-082)
 - PERF-079: Removed Promise.all array allocations in CdpTimeDriver.ts for single frames (~0.3% improvement)
 - **Avoid Promise.all array allocations for single frames in SeekTimeDriver.ts**: Evaluates single frames directly without `Promise.all()` and dynamic array pushes (~1.5% faster, PERF-078).

--- a/packages/renderer/.sys/perf-results-PERF-083.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-083.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	34.096	150	4.4	38.2	keep	baseline
+2	33.664	150	4.46	37.6	keep	cache pipeline depth limit

--- a/packages/renderer/src/Renderer.ts
+++ b/packages/renderer/src/Renderer.ts
@@ -300,7 +300,8 @@ export class Renderer {
 
               // Refill the active pipeline up to the pool size
               const poolLen = pool.length;
-              while (nextFrameToSubmit < totalFrames && (nextFrameToSubmit - nextFrameToWrite) < poolLen * 8) {
+              const maxPipelineDepth = poolLen * 8;
+              while (nextFrameToSubmit < totalFrames && (nextFrameToSubmit - nextFrameToWrite) < maxPipelineDepth) {
                   const frameIndex = nextFrameToSubmit;
                   const worker = pool[frameIndex % poolLen];
                   const time = (frameIndex / fps) * 1000;


### PR DESCRIPTION
💡 **What**: Extracted the `poolLen * 8` calculation out of the innermost `while` loop condition in `packages/renderer/src/Renderer.ts` into a cached `maxPipelineDepth` variable.
🎯 **Why**: To reduce repeated arithmetic and V8 micro-stalls during the hot frame capture loop.
📊 **Impact**: Evaluated the change against baseline render times (improved to 33.664s vs 34.096s).
🔬 **Verification**: 4-gate verification (Compilation, Test Suite, Benchmark Consistency, Canvas Smoke Test).

📎 **Plan**: `/.sys/plans/PERF-083-optimize-loop-condition.md`

**Results:**
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	34.096	150	4.4	38.2	keep	baseline
2	33.664	150	4.46	37.6	keep	cache pipeline depth limit
```

---
*PR created automatically by Jules for task [12422146249816208171](https://jules.google.com/task/12422146249816208171) started by @BintzGavin*