### PR TITLE
✨ RENDERER: Discard PERF-081 cache frames.length experiment

### DIFF
--- a/.sys/plans/PERF-081-cache-frames-length.md
+++ b/.sys/plans/PERF-081-cache-frames-length.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-081
 slug: cache-frames-length
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-03-27
-completed: ""
-result: ""
+completed: "2026-03-28"
+result: no-improvement
 ---
 
 # PERF-081: Cache `frames.length` in TimeDrivers to avoid redundant access
@@ -68,3 +68,9 @@ to:
 ## Correctness Check
 1. The DOM verification tests (`npm run test -w packages/renderer`) should pass.
 2. The renderer benchmark should execute without errors and produce valid video output.
+
+## Results Summary
+- **Best render time**: 33.773s (median vs baseline 33.657s)
+- **Improvement**: none (within noise margin)
+- **Kept experiments**: None
+- **Discarded experiments**: Cache frames.length in TimeDrivers

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -81,3 +81,7 @@ Last updated by: PERF-083
 - PERF-079: Removed Promise.all array allocations in CdpTimeDriver.ts for single frames (~0.3% improvement)
 - Added lightweight browser args (`--disable-dev-shm-usage`, `--disable-extensions`, `--disable-default-apps`, `--disable-sync`, `--no-first-run`, `--mute-audio`, `--disable-background-networking`, `--disable-background-timer-throttling`, `--disable-breakpad`) to `DEFAULT_BROWSER_ARGS` in `packages/renderer/src/Renderer.ts`. Render time improved from ~34.335s baseline to ~33.657s. (PERF-063)
 - PERF-080: The CdpTimeDriver.ts file already contained the single-frame Promise.all avoidance and array preallocation optimization. Verified it is present. The codebase requires no further modifications for this experiment.
+- **PERF-081: Cache `frames.length` in TimeDrivers**:
+  **What you tried**: Caching `frames.length` to a local `numFrames` variable inside `SeekTimeDriver.ts` and `CdpTimeDriver.ts` to avoid redundant property lookups in hot loop conditions.
+  **Why it didn't work**: In Playwright contexts, the V8 array length property lookup is already highly optimized. The bottleneck is inherently constrained by IPC overhead and Playwright screenshot orchestration (yielding a median ~33.773s vs the baseline of 33.657s), so this micro-optimization provides negligible, if any, benefit.
+  **Plan ID**: PERF-081

--- a/packages/renderer/.sys/perf-results-PERF-081.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-081.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	33.850	150	4.43	37.4	discard	cache frames.length in TimeDrivers
+2	33.773	150	4.44	38.7	discard	cache frames.length in TimeDrivers
+3	33.662	150	4.46	37.4	discard	cache frames.length in TimeDrivers


### PR DESCRIPTION
💡 **What**: The experiment run and its outcome (discarded caching `frames.length`).
🎯 **Why**: The performance bottleneck targeted (redundant array length lookups).
📊 **Impact**: Before/after render times and percentage improvement (none, 33.77s vs 33.65s).
🔬 **Verification**: What was tested (4-gate verification, benchmark results).
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-081-cache-frames-length.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	33.850	150	4.43	37.4	discard	cache frames.length in TimeDrivers
2	33.773	150	4.44	38.7	discard	cache frames.length in TimeDrivers
3	33.662	150	4.46	37.4	discard	cache frames.length in TimeDrivers
```

---
*PR created automatically by Jules for task [2707358653117288599](https://jules.google.com/task/2707358653117288599) started by @BintzGavin*