### PR TITLE
📋 RENDERER: Eliminate Hot Loop Allocations

### DIFF
--- a/.sys/plans/PERF-086-eliminate-hot-loop-allocations.md
+++ b/.sys/plans/PERF-086-eliminate-hot-loop-allocations.md
@@ -1,0 +1,63 @@
+---
+id: PERF-086
+slug: eliminate-hot-loop-allocations
+status: unclaimed
+claimed_by: ""
+created: 2026-10-18
+completed: ""
+result: ""
+---
+
+# PERF-086: Eliminate Hot Loop Allocations
+
+## Focus Area
+Hot rendering path (`packages/renderer/src/Renderer.ts`, `packages/renderer/src/strategies/DomStrategy.ts`, `packages/renderer/src/drivers/SeekTimeDriver.ts`). We want to eliminate all remaining redundant array length lookups, math calculations, and object allocations inside the frame capture loop.
+
+## Background Research
+Profiling V8 garbage collection (GC) and micro-stalls shows that continuously allocating small objects (like parameter objects for Playwright IPC calls) and performing redundant array length lookups inside tight loops adds up over thousands of frames. While V8 is fast, explicitly hoisting constants and preallocating IPC parameter objects prevents the garbage collector from churning on short-lived objects.
+
+## Benchmark Configuration
+- **Composition URL**: Standard DOM benchmark composition
+- **Render Settings**: 1920x1080, 30 FPS, 10 seconds, libx264
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: Consult journal for latest baseline.
+- **Bottleneck analysis**: Micro-stalls in the V8 execution loop due to redundant property lookups, math operations, and object allocations for CDP commands on every iteration.
+
+## Implementation Spec
+
+### Step 1: Hoist invariant calculations in Renderer
+**File**: `packages/renderer/src/Renderer.ts`
+**What to change**:
+Locate the outer loop responsible for frame capture in `Renderer.ts`.
+1. Explicitly hoist invariant calculations (like `pool.length * 8`) completely outside the `while` frame capture loops.
+2. Avoid redundant arithmetic and property lookups inside the hot loop.
+**Why**: Avoid redundant arithmetic and property lookups inside the hot loop.
+**Risk**: Negligible.
+
+### Step 2: Preallocate CDP beginFrame parameters
+**File**: `packages/renderer/src/strategies/DomStrategy.ts`
+**What to change**:
+In `DomStrategy.ts`, locate where the CDP command for `HeadlessExperimental.beginFrame` is sent.
+Instead of allocating the screenshot parameters object on every frame when targeting an element, preallocate parameter objects for Playwright IPC calls (like `HeadlessExperimental.beginFrame`).
+Set this property once during the strategy's preparation phase and reuse it in the capture loop for the standard rendering path.
+**Why**: Eliminates creating a new object literal for every frame sent over IPC when targeting a specific element.
+**Risk**: Low.
+
+### Step 3: Remove shared evaluateParams in SeekTimeDriver (Safety)
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+Locate where the `Runtime.evaluate` CDP command is sent in the `SeekTimeDriver` time-setting logic.
+The parameter object is currently a shared class property, which causes race conditions during concurrent IPC calls.
+Remove this shared property and inline the object allocation inside the time-setting method.
+**Why**: Fixes a potential race condition. As noted in the memory: "However, do not cache parameter objects for concurrent IPC calls (like Runtime.evaluate in SeekTimeDriver.ts) as shared mutable class properties, as this causes race conditions."
+**Risk**: Fixes a bug, slightly increases allocations but ensures correctness.
+
+### Step 4: Run Canvas Smoke Test
+**What to change**: Run a basic canvas render test to ensure nothing broke.
+
+### Step 5: Correctness Check
+**What to change**: Run `npx tsx packages/renderer/tests/verify-dom-selector.ts` and ensure DOM output is still correct.


### PR DESCRIPTION
💡 **What**: Created a new execution plan to explicitly hoist invariant calculations and preallocate parameter objects.
🎯 **Why**: Micro-stalls in the V8 execution loop due to redundant property lookups, math operations, and object allocations for CDP commands on every iteration cause unnecessary overhead during frame capture.
🔬 **Approach**: Eliminate redundant array length lookups, math calculations, and object allocations inside the frame capture loop.
📎 **Plan**: /.sys/plans/PERF-086-eliminate-hot-loop-allocations.md

---
*PR created automatically by Jules for task [18174892305498091159](https://jules.google.com/task/18174892305498091159) started by @BintzGavin*