### PR TITLE
📋 RENDERER: Preallocate Buffer for Base64 Decoding

### DIFF
--- a/.sys/plans/PERF-092-buffer-allocation.md
+++ b/.sys/plans/PERF-092-buffer-allocation.md
@@ -16,7 +16,7 @@ V8 Garbage Collection and memory allocation overhead during frame capture in `Do
 ## Background Research
 During the hot frame capture loop in `DomStrategy.ts` (`capture` method), the application receives base64-encoded strings representing the screenshot data over the Chromium CDP protocol. Currently, it converts this string into a binary `Buffer` using `Buffer.from(screenshotData, 'base64')`.
 This operation allocates a new `Buffer` object for every single frame. At 1080p resolution and high frame rates, this creates continuous churn of multi-megabyte objects in Node's heap, which must be subsequently garbage collected, leading to micro-stalls.
-By pre-allocating a pool of large reusable buffers per `DomStrategy` instance and using `captureBuffer.write(screenshotData, 'base64')`, we can completely eliminate these `Buffer` allocations per frame. Tests verify that Node's `Stream.write` handles this synchronously, and since the max pipeline depth in `Renderer.ts` is exactly 8 frames per worker, a pool of 8 pre-allocated buffers per worker is completely race-condition safe.
+By pre-allocating a pool of large reusable buffers per `DomStrategy` instance and using `captureBuffer.write(screenshotData, 'base64')`, we can completely eliminate these `Buffer` allocations per frame. Tests verify that Node's `Stream.write` handles this synchronously, and since the max pipeline depth in `Renderer.ts` is exactly 8 frames per worker (`const maxPipelineDepth = poolLen * 8`), a pool of 8 pre-allocated buffers per worker is completely race-condition safe.
 
 ## Benchmark Configuration
 - **Composition URL**: The standard DOM benchmark composition

--- a/plan-review.md
+++ b/plan-review.md
@@ -1,0 +1,28 @@
+# Request for Plan Review: PERF-092-buffer-allocation
+
+I propose the following plan to implement PERF-092.
+
+## Implementation details
+1. **Add a buffer pool to `DomStrategy`**
+   - File: `packages/renderer/src/strategies/DomStrategy.ts`
+   - I will add private class properties to `DomStrategy`:
+     ```typescript
+     private bufferPool: Buffer[] = Array.from({ length: 8 }, () => Buffer.allocUnsafe(1920 * 1080 * 2));
+     private bufferIndex: number = 0;
+     ```
+   - In the `capture` method, I'll replace `const buffer = Buffer.from(screenshotData, 'base64');` with logic that writes the base64 payload into the pre-allocated buffers:
+     ```typescript
+     const byteLen = Buffer.byteLength(screenshotData, 'base64');
+     let captureBuffer = this.bufferPool[this.bufferIndex];
+     if (captureBuffer.length < byteLen) {
+         captureBuffer = Buffer.allocUnsafe(Math.max(byteLen + 1024 * 1024, 1920 * 1080 * 2));
+         this.bufferPool[this.bufferIndex] = captureBuffer;
+     }
+     const bytesWritten = captureBuffer.write(screenshotData, 'base64');
+     const buffer = captureBuffer.subarray(0, bytesWritten);
+     this.bufferIndex = (this.bufferIndex + 1) % 8;
+     ```
+   - This replacement will be made in both branches of `capture()` that deal with `screenshotData` (the target element branch and the main capture branch).
+
+## Rationale
+This eliminates multi-megabyte allocations and subsequent GC sweeps on every single frame. 8 buffers align with the active pipeline depth `pool.length * 8` constraint per worker, preventing data overwrites.


### PR DESCRIPTION
Creates an experiment plan (PERF-092) for optimizing the `capture` loop in `DomStrategy.ts`. The plan details a strategy to eliminate multi-megabyte allocations and GC micro-stalls per frame by preallocating a pool of buffers and reusing them via `Buffer.write(screenshotData, 'base64')`.

---
*PR created automatically by Jules for task [17383468759858418496](https://jules.google.com/task/17383468759858418496) started by @BintzGavin*