### PR TITLE
✨ RENDERER: [PERF-095] Evaluate noDisplayUpdates for DOM capture

### DIFF
--- a/.sys/plans/PERF-095-no-display-updates.md
+++ b/.sys/plans/PERF-095-no-display-updates.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-095
 slug: no-display-updates
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2024-05-24"
+result: "failed"
 ---
 
 # PERF-095: noDisplayUpdates
@@ -50,3 +50,9 @@ Verify that the output video contains the correct frames and is not a black/blan
 
 ## Prior Art
 - Chromium CDP documentation for `HeadlessExperimental.beginFrame` mentions the `noDisplayUpdates` parameter.
+
+## Results Summary
+- **Best render time**: 0.000s (crash vs baseline 33.840s)
+- **Improvement**: N/A
+- **Kept experiments**:
+- **Discarded experiments**: noDisplayUpdates optimization on beginFrameParams (causes crash due to empty 1x1 screenshots)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -47,6 +47,9 @@ Last updated by: PERF-092
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- Tried setting `noDisplayUpdates: true` on CDP `beginFrameParams` to reduce compositor overhead.
+  - **WHY it didn't work**: This parameter caused Chromium to output empty or 1x1 screenshots because without display updates, the pixel buffers never properly generated content for capture, resulting in ffmpeg crashing on the 1x1 buffers. (PERF-095)
+
 - [PERF-093] Attempted to preallocate Promise array when using .evaluate across frames in SeekTimeDriver.ts and CdpTimeDriver.ts. Found that this optimization was already natively implemented (const framePromises = new Array(frames.length);). Render time remained around baseline (~32.479s vs baseline 33.376s). Discarded because no code changes were necessary.
 - [PERF-090] Attempted to use native Chromium CDP `Emulation.setVirtualTimePolicy` (to `pause` and `advance`) instead of the injected WAAPI syncing script. This fundamentally breaks Playwright's `page.goto` network idle wait logic, causing timeouts. Furthermore, advancing virtual time manually does not natively synchronize Web Animations API (WAAPI) timelines correctly without complex CDP Animation Domain tracking. Did not improve times and broke the test suite. Discarded.
 - [PERF-091] Hoisted closures inside the frame capture loop in Renderer.ts. Did not yield a measurable improvement over the baseline (median 33.906s vs 33.474s baseline).

--- a/packages/renderer/.sys/perf-results-PERF-095.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-095.tsv
@@ -1,0 +1,1 @@
+1	0.000	0	0.00	0.0	crash	noDisplayUpdates optimization causes screenshot capture to fail, resulting in 1x1 buffer and ffmpeg crash.


### PR DESCRIPTION
💡 **What**: Tested `noDisplayUpdates: true` on CDP `beginFrameParams` to skip Chromium compositor display updates. The experiment failed, causing ffmpeg to crash due to empty (1x1) screenshots. The codebase change was reverted.
🎯 **Why**: To reduce compositor overhead and improve DOM render speed.
📊 **Impact**: N/A - Experiment failed.
🔬 **Verification**: FFprobe failed on 0 byte output file.
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-095-no-display-updates.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	noDisplayUpdates optimization causes screenshot capture to fail, resulting in 1x1 buffer and ffmpeg crash.
```

---
*PR created automatically by Jules for task [4071002547924605399](https://jules.google.com/task/4071002547924605399) started by @BintzGavin*