### PR TITLE
✨ RENDERER: Document discard of buffer pool expansion experiment (PERF-098)

### DIFF
--- a/.sys/plans/PERF-098-buffer-pool-expansion.md
+++ b/.sys/plans/PERF-098-buffer-pool-expansion.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-098
 slug: buffer-pool-expansion
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-03-29
-completed: ""
-result: ""
+completed: "2026-03-29"
+result: "discard"
 ---
 
 # PERF-098: Expand Buffer Pool and Pipeline Depth
@@ -46,3 +46,11 @@ Currently, `maxPipelineDepth` in `Renderer.ts` is set to `poolLen * 10`, but the
 
 ## Correctness Check
 Run benchmark and verify video output is not corrupted.
+
+## Results Summary
+- **Best render time**: 33.895s (vs baseline ~33.394s)
+- **Improvement**: 0% (Worse)
+- **Kept experiments**: None
+- **Discarded experiments**:
+  - Hoist catch closure and expand maxPipelineDepth (Renderer.ts)
+  - Expand buffer pool in DomStrategy (DomStrategy.ts)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -108,3 +108,5 @@ Last updated by: PERF-092
 - [PERF-093] Also experimented with replacing `Array.from({ length: totalFrames })` or `new Array(totalFrames)` array allocations in `Renderer.ts`. V8 optimizes pre-allocated arrays exceptionally well, so micro-optimizing it to `new Array(totalFrames)` (already present) is the best pattern.
 
 - Increased maxPipelineDepth to poolLen * 10 and used bitwise shift buffer allocation. Improved from 35.462 to 33.394. (PERF-097)
+## What Doesn't Work (and Why)
+- **Expanding Buffer Pool and Pipeline Depth (PERF-098)**: Tried increasing `maxPipelineDepth` to `poolLen * 15` and `bufferPool` size to `20`. The expected rendering time improvement was not observed, instead it hovered around ~33.9s to ~34.3s. This suggests that expanding the pipeline depth and pre-allocated buffer pool doesn't relieve any critical bottleneck, or the overhead of managing a larger buffer queue balances out the potential concurrent frame gains.

--- a/packages/renderer/.sys/perf-results-PERF-098.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-098.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	34.349	150	4.37	38.5	discard	Expand Buffer Pool and Pipeline Depth
+2	33.978	150	4.41	38.0	discard	Expand Buffer Pool and Pipeline Depth
+3	33.895	150	4.43	37.7	discard	Expand Buffer Pool and Pipeline Depth


### PR DESCRIPTION
💡 **What**: Executed and discarded PERF-098 (expanding `maxPipelineDepth` to 15x and `bufferPool` to 20). The code changes resulted in worse performance and were reverted. Documentation was updated to reflect the discarded experiment.
🎯 **Why**: Attempted to increase parallel worker saturation by deepening the processing pipeline and allowing a larger buffer array, aiming to reduce hot loop stalls when workers get ahead of ffmpeg writing.
📊 **Impact**: No improvement (Regressed). Median render time increased from baseline ~33.39s to ~33.89s - ~34.34s. 
🔬 **Verification**: 4-gate verification process run. 3 iterations of `benchmark.ts` performed. `Renderer.ts` and `DomStrategy.ts` were restored to their pre-experiment state.
📎 **Plan**: `/.sys/plans/PERF-098-buffer-pool-expansion.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	34.349	150	4.37	38.5	discard	Expand Buffer Pool and Pipeline Depth
2	33.978	150	4.41	38.0	discard	Expand Buffer Pool and Pipeline Depth
3	33.895	150	4.43	37.7	discard	Expand Buffer Pool and Pipeline Depth
```

---
*PR created automatically by Jules for task [539046753134371513](https://jules.google.com/task/539046753134371513) started by @BintzGavin*