### PR TITLE
📋 RENDERER: Disable Threaded Animations and Scrolling in Chromium

### DIFF
--- a/.sys/plans/PERF-099-disable-threaded-animations.md
+++ b/.sys/plans/PERF-099-disable-threaded-animations.md
@@ -1,0 +1,46 @@
+---
+id: PERF-099
+slug: disable-threaded-animations
+status: unclaimed
+claimed_by: ""
+created: 2024-05-25
+completed: ""
+result: ""
+---
+
+# PERF-099: Disable Threaded Animations and Scrolling in Chromium
+
+## Focus Area
+Chromium Engine - Layout/Paint Synchronization Overhead
+
+## Background Research
+In a headless, CPU-bound, deterministic rendering environment where animations and time are manually advanced frame-by-frame, Chromium's multi-threaded architecture for compositing and animations (e.g., compositor thread vs. main thread) can introduce unnecessary IPC synchronization and thread-hopping overhead. By passing flags such as `--disable-threaded-animation`, `--disable-threaded-scrolling`, `--disable-checker-imaging`, and `--disable-image-animation-resync`, we force the engine into a more synchronous execution model on the main thread. This might align better with our explicit `HeadlessExperimental.beginFrame` layout/paint ticks and reduce micro-stalls per frame capture.
+
+## Benchmark Configuration
+- **Composition URL**: The standard DOM benchmark composition.
+- **Render Settings**: Standard benchmark settings (must be identical across all runs).
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~33.376s
+- **Bottleneck analysis**: Micro-stalls during frame layout, paint, and CDP frame captures.
+
+## Implementation Spec
+
+### Step 1: Add experimental Chromium flags
+**File**: `packages/renderer/src/Renderer.ts`
+**What to change**:
+Add the following strings to the `DEFAULT_BROWSER_ARGS` array:
+- `'--disable-threaded-animation'`
+- `'--disable-threaded-scrolling'`
+- `'--disable-checker-imaging'`
+- `'--disable-image-animation-resync'`
+**Why**: Forces synchronous main-thread execution for these subsystems, potentially reducing IPC wait times during manual layout/paint cycles.
+
+## Canvas Smoke Test
+Run a standard canvas render to ensure nothing breaks.
+
+## Correctness Check
+Run the DOM render verify scripts. Watch the generated video output to ensure the frames are still correctly rendered and visual quality remains acceptable.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,6 +1,6 @@
 ## Performance Trajectory
 Current best: 33.376s (baseline was 33.561s, ~0.55% improvement)
-Last updated by: PERF-092
+Last updated by: PERF-099
 
 ## What Works
 - Reduced default intermediate image quality from 90 to 75 to optimize IPC payload sizes and reduce node.js base64 decode overhead (~0.1% improvement). (PERF-096)
@@ -102,6 +102,7 @@ Last updated by: PERF-092
   **Why it didn't work**: In Playwright contexts, the V8 array length property lookup is already highly optimized. The bottleneck is inherently constrained by IPC overhead and Playwright screenshot orchestration (yielding a median ~33.773s vs the baseline of 33.657s), so this micro-optimization provides negligible, if any, benefit.
   **Plan ID**: PERF-081
 ## Open Questions
+- Can we disable threaded animations and scrolling (`--disable-threaded-animation`, etc.) in Chromium to force synchronous main-thread execution and reduce layout/paint IPC synchronization overhead during `beginFrame` capture?
 - Can we further optimize base64 decoding in `DomStrategy.ts` by pre-allocating an array of buffers that we fill via indexing rather than allocating new objects at all? Or perhaps `Buffer.write()` is fast enough and we should focus on Playwright API?
 - Would switching to `page.evaluateHandle()` or another more direct API for capturing DOM screenshots be faster than `HeadlessExperimental.beginFrame`?
 - [PERF-093] Attempted to replace `Buffer.byteLength(data, 'base64')` with arithmetic `(data.length * 3) >>> 2` in `DomStrategy.ts` `writeToBufferPool`. Mathematical length calculation is faster, but `Buffer.byteLength` in Node.js handles base64 padding correctly automatically and taking padding into account in JS arithmetic requires inspecting the last few characters, negating performance benefits.


### PR DESCRIPTION
📋 RENDERER: Disable Threaded Animations and Scrolling in Chromium

💡 What: Creating a new performance experiment plan to disable threaded animations and scrolling in Chromium.
🎯 Why: Chromium's multi-threaded architecture can introduce unnecessary IPC synchronization overhead. By disabling it, we force synchronous main-thread execution for these subsystems, potentially reducing IPC wait times during manual layout/paint cycles.
🔬 Approach: Append `--disable-threaded-animation`, `--disable-threaded-scrolling`, `--disable-checker-imaging`, and `--disable-image-animation-resync` to DEFAULT_BROWSER_ARGS in Renderer.ts.
📎 Plan: .sys/plans/PERF-099-disable-threaded-animations.md

---
*PR created automatically by Jules for task [13586351227903701363](https://jules.google.com/task/13586351227903701363) started by @BintzGavin*