### PR TITLE
📋 RENDERER: Disable Threaded Animations and Scrolling in Chromium

### DIFF
--- a/.sys/plans/PERF-101-disable-threaded-animations.md
+++ b/.sys/plans/PERF-101-disable-threaded-animations.md
@@ -1,5 +1,5 @@
 ---
-id: PERF-099
+id: PERF-101
 slug: disable-threaded-animations
 status: unclaimed
 claimed_by: ""
@@ -8,7 +8,7 @@ completed: ""
 result: ""
 ---
 
-# PERF-099: Disable Threaded Animations and Scrolling in Chromium
+# PERF-101: Disable Threaded Animations and Scrolling in Chromium
 
 ## Focus Area
 Chromium Engine - Layout/Paint Synchronization Overhead
@@ -17,8 +17,8 @@ Chromium Engine - Layout/Paint Synchronization Overhead
 In a headless, CPU-bound, deterministic rendering environment where animations and time are manually advanced frame-by-frame, Chromium's multi-threaded architecture for compositing and animations (e.g., compositor thread vs. main thread) can introduce unnecessary IPC synchronization and thread-hopping overhead. By passing flags such as `--disable-threaded-animation`, `--disable-threaded-scrolling`, `--disable-checker-imaging`, and `--disable-image-animation-resync`, we force the engine into a more synchronous execution model on the main thread. This might align better with our explicit `HeadlessExperimental.beginFrame` layout/paint ticks and reduce micro-stalls per frame capture.
 
 ## Benchmark Configuration
-- **Composition URL**: The standard DOM benchmark composition.
-- **Render Settings**: Standard benchmark settings (must be identical across all runs).
+- **Composition URL**: The standard DOM benchmark composition
+- **Render Settings**: Standard benchmark settings (must be identical across all runs)
 - **Mode**: `dom`
 - **Metric**: Wall-clock render time in seconds
 - **Minimum runs**: 3 per experiment, report median
@@ -31,16 +31,20 @@ In a headless, CPU-bound, deterministic rendering environment where animations a
 
 ### Step 1: Add experimental Chromium flags
 **File**: `packages/renderer/src/Renderer.ts`
-**What to change**:
-Add the following strings to the `DEFAULT_BROWSER_ARGS` array:
+**What to change**: Add the following strings to the `DEFAULT_BROWSER_ARGS` array:
 - `'--disable-threaded-animation'`
 - `'--disable-threaded-scrolling'`
 - `'--disable-checker-imaging'`
 - `'--disable-image-animation-resync'`
 **Why**: Forces synchronous main-thread execution for these subsystems, potentially reducing IPC wait times during manual layout/paint cycles.
+**Risk**: Disabling threaded animations might break or alter the behavior of some specific CSS animations or Web Animations API features if Chromium relies on them being off-main-thread, although headless tests usually run synchronously anyway.
 
 ## Canvas Smoke Test
-Run a standard canvas render to ensure nothing breaks.
+Run a standard canvas render to ensure nothing breaks in the canvas pipeline.
 
 ## Correctness Check
 Run the DOM render verify scripts. Watch the generated video output to ensure the frames are still correctly rendered and visual quality remains acceptable.
+
+## Prior Art
+- Chromium command line switches: https://peter.sh/experiments/chromium-command-line-switches/
+- Previous attempts to disable background processes and GPU optimizations (PERF-061, PERF-064) showed varying results in this CPU-only microVM, but forcing synchronous animation processing hasn't been directly tested yet.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -102,7 +102,6 @@ Last updated by: PERF-100
   **Why it didn't work**: In Playwright contexts, the V8 array length property lookup is already highly optimized. The bottleneck is inherently constrained by IPC overhead and Playwright screenshot orchestration (yielding a median ~33.773s vs the baseline of 33.657s), so this micro-optimization provides negligible, if any, benefit.
   **Plan ID**: PERF-081
 ## Open Questions
-- Can we disable threaded animations and scrolling (`--disable-threaded-animation`, etc.) in Chromium to force synchronous main-thread execution and reduce layout/paint IPC synchronization overhead during `beginFrame` capture?
 - Would switching to `page.evaluateHandle()` or another more direct API for capturing DOM screenshots be faster than `HeadlessExperimental.beginFrame`?
 - [PERF-093] Attempted to replace `Buffer.byteLength(data, 'base64')` with arithmetic `(data.length * 3) >>> 2` in `DomStrategy.ts` `writeToBufferPool`. Mathematical length calculation is faster, but `Buffer.byteLength` in Node.js handles base64 padding correctly automatically and taking padding into account in JS arithmetic requires inspecting the last few characters, negating performance benefits.
 - [PERF-093] Also experimented with replacing `Array.from({ length: totalFrames })` or `new Array(totalFrames)` array allocations in `Renderer.ts`. V8 optimizes pre-allocated arrays exceptionally well, so micro-optimizing it to `new Array(totalFrames)` (already present) is the best pattern.


### PR DESCRIPTION
This PR contains the performance experiment plan PERF-101.

💡 What: The experiment targets Chromium's multi-threaded compositing and animation architecture.
🎯 Why: By forcing synchronous main-thread execution, we hypothesize a reduction in layout/paint micro-stalls during HeadlessExperimental.beginFrame CDP captures, which currently dominates DOM rendering time.
🔬 Approach: Add `--disable-threaded-animation`, `--disable-threaded-scrolling`, `--disable-checker-imaging`, and `--disable-image-animation-resync` to `DEFAULT_BROWSER_ARGS` in `Renderer.ts`.
📎 Plan: `/.sys/plans/PERF-101-disable-threaded-animations.md`

---
*PR created automatically by Jules for task [2331415951889179806](https://jules.google.com/task/2331415951889179806) started by @BintzGavin*