### PR TITLE
✨ RENDERER: Discard --single-process and --in-process-gpu flags

### DIFF
--- a/.sys/plans/PERF-106-single-process-chromium.md
+++ b/.sys/plans/PERF-106-single-process-chromium.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-106
 slug: single-process-chromium
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-03-29
-completed: ""
-result: ""
+completed: "2026-03-29"
+result: "discarded"
 ---
 
 # PERF-106: Disable Site Isolation Trials
@@ -52,3 +52,9 @@ Run a canvas render test to ensure Canvas mode is unaffected.
 
 ## Correctness Check
 Run the DOM benchmark. Ensure output video is correct.
+
+## Results Summary
+- **Best render time**: 33.423s (baseline)
+- **Improvement**: 0%
+- **Kept experiments**: None
+- **Discarded experiments**: `--single-process`, `--in-process-gpu`

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -50,6 +50,7 @@ Last updated by: PERF-100
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **PERF-106: Disable Site Isolation Trials**: Added `--single-process` and `--in-process-gpu` flags to `DEFAULT_BROWSER_ARGS` in `Renderer.ts`. The render times either remained identical or degraded slightly (33.54s and 33.43s vs 33.42s baseline). In modern Chromium versions running in this CPU-bound microVM, forcing a single process or in-process GPU does not yield any IPC latency savings and likely introduces more thread contention within the single main process. Discarded to maintain stability.
 - Tried setting `noDisplayUpdates: true` on CDP `beginFrameParams` to reduce compositor overhead.
   - **WHY it didn't work**: This parameter caused Chromium to output empty or 1x1 screenshots because without display updates, the pixel buffers never properly generated content for capture, resulting in ffmpeg crashing on the 1x1 buffers. (PERF-095)
 
@@ -84,7 +85,6 @@ Last updated by: PERF-100
 - Conditionally using `jpeg_pipe` format with `mjpeg` codec for FFmpeg ingestion when intermediate image format is `jpeg`. The render time degraded (47.85s vs 46.706s). It appears that bypassing FFmpeg stream probing doesn't offset other ingestion/decoding overhead in this environment. (PERF-012)
 
 ## Open Questions
-- [PERF-106] Can we completely eliminate Chromium-internal IPC overhead by adding the `--single-process` or `--in-process-gpu` flag to `DEFAULT_BROWSER_ARGS`?
 - [PERF-089] Can we eliminate the anonymous async function allocation inside the hot loop in `Renderer.ts` by defining a static execution function outside the while loop to reduce V8 GC micro-stalls?
 - [PERF-083] Can we extract the active pipeline limit (`poolLen * 8`) calculation out of the frame loop while condition to prevent V8 micro-stalls during frame capture?
 - [PERF-032] Can we overcome the damage-driven limitations of `Page.startScreencast` (which failed in PERF-026) by injecting a forced layout/paint toggle on every virtual time tick, allowing us to buffer continuous screencast frames and eliminate the IPC latency of polling `Page.captureScreenshot`?

--- a/packages/renderer/.sys/perf-results-PERF-106.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-106.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	33.423	150	4.49	36.1	keep	baseline
+2	33.546	150	4.47	38.0	discard	--single-process
+3	33.432	150	4.49	37.6	discard	--in-process-gpu


### PR DESCRIPTION
💡 **What**: Tested `single-process` and `--in-process-gpu` Playwright options in `DEFAULT_BROWSER_ARGS` to see if rendering performance was improved. The results showed no meaningful improvement and potentially slight degradation (33.42s baseline vs ~33.5s with flags). The code changes were therefore discarded, and this PR strictly updates the required experiment tracking logs and TSV.
🎯 **Why**: To attempt to eliminate Chromium-internal IPC overhead on our CPU-bound microVM setup. 
📊 **Impact**: No improvement (0%). Experiment was aborted.
🔬 **Verification**: Ran `packages/renderer/tests/fixtures/benchmark.ts` against the flags multiple times. Compared against baseline. All verifications verified that the change did not help. 
📎 **Plan**: Reference `.sys/plans/PERF-106-single-process-chromium.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	33.423	150	4.49	36.1	keep	baseline
2	33.546	150	4.47	38.0	discard	--single-process
3	33.432	150	4.49	37.6	discard	--in-process-gpu
```

---
*PR created automatically by Jules for task [12861771944414222854](https://jules.google.com/task/12861771944414222854) started by @BintzGavin*