### PR TITLE
✨ PLAYER: Improve Test Coverage for Track Lists

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -122,3 +122,7 @@ The following standard media session metadata attributes are available as proper
 - `mediaArtist`: Maps to `media-artist` attribute
 - `mediaAlbum`: Maps to `media-album` attribute
 - `mediaArtwork`: Maps to `media-artwork` attribute
+
+## Track Lists
+- `HeliosAudioTrackList`: Implements standard HTMLMediaElement event handler properties (`onaddtrack`, `onremovetrack`, `onchange`).
+- `HeliosVideoTrackList`: Implements standard HTMLMediaElement event handler properties (`onaddtrack`, `onremovetrack`, `onchange`).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -99,6 +99,12 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### CLI v0.31.0
 - ✅ Completed: AWS Deployment - Implemented AWS Lambda deployment scaffolding and custom browser path support.
 
+### PLAYER v0.77.6
+- ✅ Completed: Improve Test Coverage - Added test coverage for onremovetrack and onchange properties in audio and video track lists.
+
+### PLAYER v0.77.5
+- ✅ Completed: Document getSchema API Parity - Added missing getSchema method to README documentation.
+
 ### PLAYER v0.77.4
 - ✅ Completed: README API Parity - Documented missing HTMLMediaElement API parity properties, methods, and attributes.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,5 @@
-**Version**: 0.77.1
+**Version**: 0.77.6
+[v0.77.6] ✅ Completed: Improve Test Coverage - Added test coverage for onremovetrack and onchange properties in audio and video track lists.
 [v0.77.5] ✅ Completed: Document getSchema API Parity - Added missing getSchema method to README documentation.
 [v0.77.4] ✅ Completed: README API Parity - Documented missing HTMLMediaElement API parity properties, methods, and attributes.
 [v0.77.3] ✅ Completed: Expand Test Coverage - Added tests for audio metering, getAudioTracks timeout, and captureFrame timeout in controllers.ts.

--- a/packages/player/src/features/audio-tracks.test.ts
+++ b/packages/player/src/features/audio-tracks.test.ts
@@ -106,4 +106,36 @@ describe('HeliosAudioTrackList', () => {
         list.addTrack(track);
         expect(spy).toHaveBeenCalled();
     });
+
+    it('should support onremovetrack property', () => {
+        const spy = vi.fn();
+        list.onremovetrack = spy;
+        expect(list.onremovetrack).toBe(spy);
+
+        const track = new HeliosAudioTrack('1', '', '', '', true, host);
+        list.addTrack(track);
+        list.removeTrack(track);
+        expect(spy).toHaveBeenCalled();
+
+        list.onremovetrack = null;
+        expect(list.onremovetrack).toBeNull();
+        const track2 = new HeliosAudioTrack('2', '', '', '', true, host);
+        list.addTrack(track2);
+        list.removeTrack(track2);
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should support onchange property', () => {
+        const spy = vi.fn();
+        list.onchange = spy;
+        expect(list.onchange).toBe(spy);
+
+        list.dispatchChangeEvent();
+        expect(spy).toHaveBeenCalled();
+
+        list.onchange = null;
+        expect(list.onchange).toBeNull();
+        list.dispatchChangeEvent();
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages/player/src/features/video-tracks.test.ts
+++ b/packages/player/src/features/video-tracks.test.ts
@@ -136,4 +136,42 @@ describe('HeliosVideoTrackList', () => {
       list.addTrack(track);
       expect(handler).toHaveBeenCalled();
   });
+
+  it('should support onremovetrack event handler property', () => {
+      const list = new HeliosVideoTrackList();
+      const handler = vi.fn();
+
+      list.onremovetrack = handler;
+      expect(list.onremovetrack).toBe(handler);
+
+      const host = { handleVideoTrackSelectedChange: vi.fn() };
+      const track = new HeliosVideoTrack('v1', 'main', 'Main Video', 'en', true, host);
+
+      list.addTrack(track);
+      list.removeTrack(track);
+      expect(handler).toHaveBeenCalled();
+
+      list.onremovetrack = null;
+      expect(list.onremovetrack).toBeNull();
+      const track2 = new HeliosVideoTrack('v2', 'main', 'Main Video', 'en', true, host);
+      list.addTrack(track2);
+      list.removeTrack(track2);
+      expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should support onchange event handler property', () => {
+      const list = new HeliosVideoTrackList();
+      const handler = vi.fn();
+
+      list.onchange = handler;
+      expect(list.onchange).toBe(handler);
+
+      list.dispatchChangeEvent();
+      expect(handler).toHaveBeenCalled();
+
+      list.onchange = null;
+      expect(list.onchange).toBeNull();
+      list.dispatchChangeEvent();
+      expect(handler).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Closes vision gap related to missing test coverage for `HeliosVideoTrackList` and `HeliosAudioTrackList` event handlers, specifically `onremovetrack` and `onchange`. Ensures `onaddtrack`, `onremovetrack`, and `onchange` correctly dispatch events to the assigned handlers. Also included the required protocol documentation updates (status, progress, context).

---
*PR created automatically by Jules for task [17977272579391080492](https://jules.google.com/task/17977272579391080492) started by @BintzGavin*