### PR TITLE
✨ RENDERER: Sequential CDP Capture (concurrency=1)

### DIFF
--- a/.sys/plans/PERF-110-sequential-cdp-capture.md
+++ b/.sys/plans/PERF-110-sequential-cdp-capture.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-110
 slug: sequential-cdp-capture
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-30
 completed: ""
 result: ""
@@ -48,3 +48,8 @@ Run `npx tsx packages/renderer/tests/fixtures/benchmark.ts`.
 
 ## Correctness Check
 Run the `npx tsx packages/renderer/tests/fixtures/benchmark.ts` test or check the output video visually.
+
+## Results Summary
+- **Best render time**: 35.175s (vs baseline 46.493s)
+- **Kept experiments**: PERF-110
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 33.394s (baseline was 34.631s, -3.5%)
 Last updated by: PERF-109
 
 ## What Works
+- Sequential CDP Capture (concurrency=1, maxPipelineDepth=50) improved render time from 46.493s to 35.175s [PERF-110]
 - [PERF-109] Removed the previously added flags `--disable-threaded-animation`, `--disable-threaded-scrolling`, `--disable-checker-imaging`, and `--disable-image-animation-resync` from `DEFAULT_BROWSER_ARGS` in `Renderer.ts`. This reverts a regression that occurred when these flags forced operations onto the main thread, negating concurrent execution benefits and slowing down DOM rendering.
 - [PERF-107] Replaced the static array of 10 buffers (`bufferPool`) in `DomStrategy.ts` with dynamically allocated buffers using `Buffer.allocUnsafe` per frame. This resolves a severe memory race condition and crash that occurs when the worker pipeline depth outpaces the static pool size, allowing deep pipelining to function reliably. Render time improved to ~33.459s.
 - Pass explicit timing parameters to HeadlessExperimental.beginFrame to synchronize Chromium compositor clock (~2.0% faster) [PERF-102]
@@ -115,4 +116,3 @@ Last updated by: PERF-109
 - Increased maxPipelineDepth to poolLen * 10 and used bitwise shift buffer allocation. Improved from 35.462 to 33.394. (PERF-097)
 ## What Doesn't Work (and Why)
 - **Expanding Buffer Pool and Pipeline Depth (PERF-098)**: Tried increasing `maxPipelineDepth` to `poolLen * 15` and `bufferPool` size to `20`. The expected rendering time improvement was not observed, instead it hovered around ~33.9s to ~34.3s. This suggests that expanding the pipeline depth and pre-allocated buffer pool doesn't relieve any critical bottleneck, or the overhead of managing a larger buffer queue balances out the potential concurrent frame gains.
-- [PERF-110] Would a strictly sequential capture pipeline with a single Playwright page (\`concurrency = 1\`) eliminate V8 context-switching overhead and IPC delays enough to outperform the current over-subscribed multi-page worker pool?

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -229,3 +229,5 @@ peak_mem_mb:        38.3
 
 101	33.760	150	4.44	38.0	keep	disable threaded animations and scrolling
 107	33.459	150	4.48	38.5	keep	PERF-107 Replace static buffer pool with dynamic allocUnsafe
+1	46.493	150	3.23	38.6	keep	baseline
+2	35.175	150	4.29	35.4	keep	PERF-110 Sequential CDP Capture

--- a/packages/renderer/src/Renderer.ts
+++ b/packages/renderer/src/Renderer.ts
@@ -162,7 +162,7 @@ export class Renderer {
     let pool: { page: import('playwright').Page, strategy: RenderStrategy, timeDriver: TimeDriver, activePromise: Promise<void> }[] = [];
     try {
       const cpus = os.cpus().length || 4;
-      const concurrency = Math.min(Math.ceil(cpus * 1.5), 8);
+      const concurrency = 1;
       console.log(`Initializing pool of ${concurrency} pages...`);
 
       const capturedErrors: Error[] = [];
@@ -301,7 +301,7 @@ export class Renderer {
 
           let nextFrameToWrite = 0;
           const poolLen = pool.length;
-          const maxPipelineDepth = poolLen * 10;
+          const maxPipelineDepth = 50;
           const timeStep = 1000 / fps;
           const compTimeStep = 1 / fps;
 


### PR DESCRIPTION
Executed `PERF-110-sequential-cdp-capture.md`. 
By changing `concurrency = 1` and `maxPipelineDepth = 50` in `Renderer.ts`, we avoid the V8 context switching and IPC overhead associated with parallel Playwright pages, allowing the single loop to heavily pipeline Chromium screenshot requests. The result was a ~24% performance increase in render times.

Results have been logged in `perf-results.tsv` and `RENDERER-EXPERIMENTS.md`.

```
2	35.175	150	4.29	35.4	keep	PERF-110 Sequential CDP Capture
```

---
*PR created automatically by Jules for task [3326306161857707413](https://jules.google.com/task/3326306161857707413) started by @BintzGavin*