### PR TITLE
✨ RENDERER: Test Playwright pipe IPC transport

### DIFF
--- a/.sys/plans/PERF-100-playwright-pipe-ipc.md
+++ b/.sys/plans/PERF-100-playwright-pipe-ipc.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-100
 slug: playwright-pipe-ipc
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-25
-completed: ""
-result: ""
+completed: "2026-03-30"
+result: "no-improvement"
 ---
 
 # PERF-100: Playwright Pipe IPC Transport
@@ -46,3 +46,10 @@ Run the standalone canvas verification script `npx tsx packages/renderer/tests/v
 
 ## Correctness Check
 Run the full verification suite `npx tsx packages/renderer/tests/run-all.ts` to confirm the renderer connects to Playwright correctly in both DOM and Canvas modes.
+
+
+## Results Summary
+- **Best render time**: 35.374s (vs baseline ~35.208s without pipe)
+- **Improvement**: 0% (within noise margin)
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-100]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -54,6 +54,10 @@ Last updated by: PERF-111
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **PERF-100**: Attempted to use Playwright's `pipe: true` IPC transport.
+  **What you tried**: Launching Chromium with `pipe: true` instead of the default WebSocket connection.
+  **Why it didn't work**: The `pipe: true` option is already present in the codebase. Benchmarking its removal showed no significant latency difference in this environment, with median render times remaining practically identical (~35.3s vs ~35.2s). The Playwright IPC transport mechanism is not the critical bottleneck for DOM rendering under this microVM setup.
+  **Plan ID**: PERF-100
 - [PERF-111] Replaced events.once and explicit AbortController instantiations for FFmpeg stdin backpressure handling in Renderer.ts with a direct Promise allocation. This reduces V8 GC pressure in the hot capture loop. The render time changed from ~35.089s to ~35.384s (median of test runs), which is effectively identical within noise margins. Marking as discarded since the GC overhead of AbortController here was not the dominant bottleneck.
 - **PERF-106: Disable Site Isolation Trials**: Added `--single-process` and `--in-process-gpu` flags to `DEFAULT_BROWSER_ARGS` in `Renderer.ts`. The render times either remained identical or degraded slightly (33.54s and 33.43s vs 33.42s baseline). In modern Chromium versions running in this CPU-bound microVM, forcing a single process or in-process GPU does not yield any IPC latency savings and likely introduces more thread contention within the single main process. Discarded to maintain stability.
 - Tried setting `noDisplayUpdates: true` on CDP `beginFrameParams` to reduce compositor overhead.

--- a/packages/renderer/.sys/perf-results-PERF-100.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-100.tsv
@@ -1,0 +1,10 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	35.744	150	4.20	35.4	discard	baseline (with pipe)
+2	35.374	150	4.24	35.3	discard	baseline (with pipe)
+3	35.295	150	4.25	35.9	discard	baseline (with pipe)
+4	35.300	150	4.25	35.4	discard	experiment (without pipe)
+5	36.442	150	4.12	35.3	discard	experiment (without pipe)
+6	35.116	150	4.27	35.5	discard	experiment (without pipe)
+7	35.058	150	4.28	35.5	discard	experiment (without pipe)
+8	36.029	150	4.16	35.4	discard	restoring to baseline
+9	34.984	150	4.29	35.4	discard	restoring to baseline


### PR DESCRIPTION
✨ RENDERER: Test Playwright pipe IPC transport

💡 **What**: Executed PERF-100 to evaluate if using `pipe: true` for Playwright's IPC transport reduces latency. Discovered that the option was already present in the codebase. Benchmarking verified that its removal yields no significant performance difference (~35.3s vs ~35.2s), suggesting IPC is not the primary bottleneck in this microVM environment.
🎯 **Why**: To reduce Playwright Chromium IPC Transport Overhead.
📊 **Impact**: No significant improvement (0% within noise margin), the codebase has been left in its pre-experiment state.
🔬 **Verification**: Canvas strategy verification passed. Benchmark results logged.
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-100-playwright-pipe-ipc.md`

### Results Summary
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	35.744	150	4.20	35.4	discard	baseline (with pipe)
2	35.374	150	4.24	35.3	discard	baseline (with pipe)
3	35.295	150	4.25	35.9	discard	baseline (with pipe)
4	35.300	150	4.25	35.4	discard	experiment (without pipe)
5	36.442	150	4.12	35.3	discard	experiment (without pipe)
6	35.116	150	4.27	35.5	discard	experiment (without pipe)
7	35.058	150	4.28	35.5	discard	experiment (without pipe)
8	36.029	150	4.16	35.4	discard	restoring to baseline
9	34.984	150	4.29	35.4	discard	restoring to baseline

---
*PR created automatically by Jules for task [13104380815295046442](https://jules.google.com/task/13104380815295046442) started by @BintzGavin*