### PR TITLE
📋 RENDERER: Eliminate Array.map in PRELOAD_SCRIPT Execution

### DIFF
--- a/.sys/plans/PERF-112-eliminate-array-map.md
+++ b/.sys/plans/PERF-112-eliminate-array-map.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-112
 slug: eliminate-array-map
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-30
 completed: ""
-result: ""
+result: "improved"
 ---
 
 # PERF-112: Eliminate Array.map in PRELOAD_SCRIPT Execution

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 33.394s (baseline was 34.631s, -3.5%)
 Last updated by: PERF-111
 
 ## What Works
+- [PERF-112] Eliminated `Array.map` allocation in `DomStrategy.ts` `prepare` method by replacing it with a localized `for` loop, marginally reducing GC overhead during strategy preparation.
 - Sequential CDP Capture (concurrency=1, maxPipelineDepth=50) improved render time from 46.493s to 35.175s [PERF-110]
 - [PERF-109] Removed the previously added flags `--disable-threaded-animation`, `--disable-threaded-scrolling`, `--disable-checker-imaging`, and `--disable-image-animation-resync` from `DEFAULT_BROWSER_ARGS` in `Renderer.ts`. This reverts a regression that occurred when these flags forced operations onto the main thread, negating concurrent execution benefits and slowing down DOM rendering.
 - [PERF-107] Replaced the static array of 10 buffers (`bufferPool`) in `DomStrategy.ts` with dynamically allocated buffers using `Buffer.allocUnsafe` per frame. This resolves a severe memory race condition and crash that occurs when the worker pipeline depth outpaces the static pool size, allowing deep pipelining to function reliably. Render time improved to ~33.459s.

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -69,9 +69,12 @@ export class DomStrategy implements RenderStrategy {
     const script = `${PRELOAD_SCRIPT}(${timeout})`;
 
     // Execute preloading script in all frames
-    await Promise.all(page.frames().map(frame =>
-      frame.evaluate(script)
-    ));
+    const frames = page.frames();
+    const framePromises = new Array(frames.length);
+    for (let i = 0; i < frames.length; i++) {
+        framePromises[i] = frames[i].evaluate(script);
+    }
+    await Promise.all(framePromises);
 
     // Scan for audio tracks using the shared utility
     const initialTracks = await scanForAudioTracks(page, timeout);


### PR DESCRIPTION
Implemented PERF-112:
- Refactored `Array.map` in `packages/renderer/src/strategies/DomStrategy.ts` to use a localized `for` loop with a pre-allocated array.
- Updated `PERF-112-eliminate-array-map.md` plan status.
- Logged result in `docs/status/RENDERER-EXPERIMENTS.md`.
- Verified changes with DOM strategy tests.

---
*PR created automatically by Jules for task [9434212931727858813](https://jules.google.com/task/9434212931727858813) started by @BintzGavin*