### PR TITLE
✨ STUDIO: Asset Move (Drag and Drop)

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -69,6 +69,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### INFRASTRUCTURE v0.2.0
 - ✅ Completed: Stateless Worker Interface - Implemented WorkerAdapter and LocalWorkerAdapter.
 
+### STUDIO v0.120.3
+- ✅ Completed: STUDIO-Asset-Move - Updated effectAllowed to copyMove in AssetItem.tsx
+
 ### STUDIO v0.120.2
 - ✅ Completed: STUDIO-Asset-Move - Implemented drag-and-drop to move assets into folders
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.120.2
+**Version**: 0.120.3
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -12,6 +12,7 @@
 - [v0.119.5] ✅ Completed: Refine CLI Component Removal - Verified existing implementation of component file deletion and interactive confirmation prompts in `helios remove` command (2026-10-23-STUDIO-Refine-CLI-Component-Removal.md).
 
 ## Recent Updates
+- [v0.120.3] ✅ Completed: STUDIO-Asset-Move - Updated effectAllowed to copyMove in AssetItem.tsx.
 - [v0.120.1] ✅ Completed: STUDIO-Asset-Move - Added drag and drop for assets to folder functionality by implementing unit tests and confirming logic.
 - [v0.120.0] ✅ Completed: Asset Move - Verified and documented drag-and-drop support for moving assets into folders within the Assets Panel.
 - [v0.119.3] ✅ Completed: Asset Move - Verified existing implementation of drag-and-drop support for moving assets into folders within the Studio Assets Panel.

--- a/packages/studio/src/components/AssetsPanel/AssetItem.tsx
+++ b/packages/studio/src/components/AssetsPanel/AssetItem.tsx
@@ -135,7 +135,7 @@ export const AssetItem: React.FC<AssetItemProps> = ({ asset }) => {
     e.dataTransfer.setData('application/helios-asset', JSON.stringify(asset));
     e.dataTransfer.setData('application/helios-asset-id', asset.id);
     e.dataTransfer.setData('text/plain', asset.url);
-    e.dataTransfer.effectAllowed = 'copy';
+    e.dataTransfer.effectAllowed = 'copyMove';
   };
 
   const renderPreview = () => {


### PR DESCRIPTION
This PR addresses a vision gap by finalizing the drag and drop functionality for organizing assets in Helios Studio.

Changes:
* Updated `AssetItem.tsx` drag start handler to use `copyMove` instead of `copy` for `effectAllowed`. This allows the drop handler in `FolderItem.tsx` and `AssetsPanel.tsx` to correctly resolve drop events as move operations, completing the backend asset management integration.
* Updated `docs/status/STUDIO.md` and `docs/PROGRESS.md` with version bumps and release notes.

---
*PR created automatically by Jules for task [11962279976355422065](https://jules.google.com/task/11962279976355422065) started by @BintzGavin*