### PR TITLE
✨ RENDERER: [Discarded] Incremental Time Calculation (PERF-116)

### DIFF
--- a/.sys/plans/PERF-116-incremental-time-calculation.md
+++ b/.sys/plans/PERF-116-incremental-time-calculation.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-116
 slug: incremental-time-calculation
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-10-18
 completed: ""
-result: ""
+result: "failed"
 ---
 # PERF-116: Incremental Time Calculation in Hot Loop
 
@@ -65,3 +65,7 @@ Run `npx tsx packages/renderer/tests/verify-codecs.ts` to ensure the CanvasStrat
 Run the DOM verification scripts to ensure frames are still sequenced correctly:
 `npx tsx packages/renderer/tests/verify-frame-count.ts`
 `npx tsx packages/renderer/tests/verify-seek-driver-determinism.ts`
+
+## Results Summary
+- **Kept experiments**: none
+- **Discarded experiments**: PERF-116

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -56,6 +56,8 @@ Last updated by: PERF-114
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **Incremental time calculation (PERF-116)**: Replaced multiplication with incremental addition for `time` and `compositionTimeInSeconds` inside the hot capture loop. This caused a synchronization error (`Another frame is pending`) from Chromium's `HeadlessExperimental.beginFrame`, indicating that altering the exact timing of variable assignments disrupted the delicate asynchronous pipelining and synchronization between worker evaluations, resulting in a crash.
+
 - **PERF-115: Restore Page Pool Concurrency**: Restored page pool concurrency (`os.cpus().length`) and scaled `maxPipelineDepth` to `poolLen * 2`. Render time regressed to 44.102s (vs baseline 34.584s). The expected multi-core scaling was not realized. Running multiple Playwright pages concurrently caused layout/paint locking in the single Chromium instance, destroying pipeline throughput.
 - PERF-085: Eliminate hot loop allocations. **WHY**: Already implemented by previous cycles.
 - **PERF-100**: Attempted to use Playwright's `pipe: true` IPC transport.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -233,3 +233,4 @@ peak_mem_mb:        38.3
 2	35.175	150	4.29	35.4	keep	PERF-110 Sequential CDP Capture
 3	36.684	150	4.09	35.8	discard	PERF-085: Already implemented
 014-pipeline-evaluate-capture	34.814	150	4.31	35.2	keep	Pipeline Evaluate and Capture in Renderer.ts
+15	0.000	0	0.00	0.0	crash	incremental time calculation


### PR DESCRIPTION
💡 **What**: Attempted to replace multiplication with incremental addition for time calculation in the hot loop.
🎯 **Why**: To reduce V8 micro-stalls and overhead during frame capture.
📊 **Impact**: The change caused a synchronization error (`Another frame is pending`) from Chromium's `HeadlessExperimental.beginFrame`, indicating that altering the exact timing of variable assignments disrupted the delicate asynchronous pipelining and synchronization between worker evaluations. The experiment was recorded as a failure and the changes were reverted.
🔬 **Verification**: Code built successfully but the application crashed during test/render runs.
📎 **Plan**: Reference the plan file (`.sys/plans/PERF-116-incremental-time-calculation.md`)

```
15	0.000	0	0.00	0.0	crash	incremental time calculation
```

---
*PR created automatically by Jules for task [4250441286926774277](https://jules.google.com/task/4250441286926774277) started by @BintzGavin*