### PR TITLE
📋 RENDERER: Fix Shared DomStrategy Instance and Enable Concurrency

### DIFF
--- a/.sys/plans/PERF-118-fix-shared-strategy.md
+++ b/.sys/plans/PERF-118-fix-shared-strategy.md
@@ -1,0 +1,66 @@
+---
+id: PERF-118
+slug: fix-shared-strategy
+status: unclaimed
+claimed_by: ""
+created: 2024-05-31
+completed: ""
+result: ""
+---
+# PERF-118: Fix Shared DomStrategy Instance and Enable Concurrency
+
+## Focus Area
+`packages/renderer/src/Renderer.ts`, specifically the worker pool initialization logic.
+
+## Background Research
+Currently, the codebase instantiates `this.strategy` in the `Renderer` constructor. Inside the `captureLoop` pool creation, the code reads:
+```typescript
+const strategy = this.strategy || (this.options.mode === 'dom' ? new DomStrategy(this.options) : new CanvasStrategy(this.options));
+```
+Because `this.strategy` is truthy, all workers are assigned the EXACT SAME instance of `DomStrategy`!
+
+When `strategy.prepare(page)` is called, it mutates the shared instance:
+```typescript
+this.cdpSession = await page.context().newCDPSession(page);
+```
+As a result, all concurrent `capture()` calls from the worker pool mistakenly route their `HeadlessExperimental.beginFrame` CDP commands to the **last worker's** CDP session. Chromium's main thread receives multiple concurrent `beginFrame` requests for the same page, crashing the pipeline with the error:
+`Protocol error (HeadlessExperimental.beginFrame): Another frame is pending`.
+
+This hidden shared-state bug completely destroyed multi-core scalability. PERF-115 observed an 11-second regression when attempting to use concurrency, incorrectly blaming it on layout/paint locking. In reality, it was just the workers tripping over each other's CDP sessions.
+
+## Benchmark Configuration
+- **Composition URL**: Standard simple-animation HTML fixture
+- **Render Settings**: 1280x720, 30fps, 5 seconds (150 frames)
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: 35.867s (with concurrency=1 due to this bug)
+- **Bottleneck analysis**: DOM capture was single-threaded because concurrency caused a crash.
+
+## Implementation Spec
+
+### Step 1: Fix Shared Strategy Instance in Worker Pool
+**File**: `packages/renderer/src/Renderer.ts`
+**What to change**:
+In the `createPage` function:
+Replace:
+```typescript
+const strategy = this.strategy || (this.options.mode === 'dom' ? new DomStrategy(this.options) : new CanvasStrategy(this.options));
+```
+With:
+```typescript
+// Worker 0 can reuse the class-level strategy instance since we use it for diagnostics/finish,
+// but subsequent workers MUST instantiate their own isolated RenderStrategy instance to avoid sharing CDP sessions.
+const strategy = index === 0 ? this.strategy : (this.options.mode === 'dom' ? new DomStrategy(this.options) : new CanvasStrategy(this.options));
+```
+
+**Why**: By ensuring each worker gets its own isolated `DomStrategy` instance, their CDP sessions remain properly scoped to their respective Playwright pages. This allows true concurrent rendering without `Another frame is pending` crashes.
+
+## Canvas Smoke Test
+Run `npx tsx packages/renderer/tests/verify-codecs.ts` and `npm run test -w packages/renderer`.
+
+## Correctness Check
+Run the DOM verification script to ensure frames are sequenced correctly without crashing:
+`npx tsx packages/renderer/tests/verify-dom-selector.ts`


### PR DESCRIPTION
This pull request adds the execution plan `PERF-118-fix-shared-strategy.md` to `.sys/plans/`. 

The plan outlines an optimization for the DOM rendering pipeline: isolating `RenderStrategy` instances (specifically `DomStrategy`) for each Playwright worker page during concurrent rendering. Currently, a single strategy instance is instantiated and shared across all workers, which leads to overlapping CDP `HeadlessExperimental.beginFrame` calls to the same underlying CDP session, resulting in fatal `Another frame is pending` crashes. The plan proposes instantiating new strategy instances per worker to ensure each possesses its own isolated CDP session, enabling proper concurrency and unblocking significant multi-core performance gains.

---
*PR created automatically by Jules for task [9603584211789812480](https://jules.google.com/task/9603584211789812480) started by @BintzGavin*