### PR TITLE
✨ RENDERER: Discard Incremental Time Calculation (PERF-117)

### DIFF
--- a/.sys/plans/PERF-117-incremental-time-calculation.md
+++ b/.sys/plans/PERF-117-incremental-time-calculation.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-117
 slug: incremental-time-calculation
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-31
-completed: ""
-result: ""
+completed: "2026-03-30"
+result: failed
 ---
 # PERF-117: Incremental Time Calculation in Hot Loop
 
@@ -64,3 +64,9 @@ Run `npx tsx packages/renderer/tests/verify-codecs.ts` to ensure the CanvasStrat
 ## Correctness Check
 Run the DOM verification script to ensure frames are still sequenced correctly:
 `npx tsx packages/renderer/tests/verify-codecs.ts`
+
+## Results Summary
+- **Best render time**: 0.000s
+- **Improvement**: 0%
+- **Kept experiments**:
+- **Discarded experiments**: [PERF-117 Incremental Time Calculation (Crashed)]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -127,3 +127,5 @@ Last updated by: PERF-114
 - Increased maxPipelineDepth to poolLen * 10 and used bitwise shift buffer allocation. Improved from 35.462 to 33.394. (PERF-097)
 ## What Doesn't Work (and Why)
 - **Expanding Buffer Pool and Pipeline Depth (PERF-098)**: Tried increasing `maxPipelineDepth` to `poolLen * 15` and `bufferPool` size to `20`. The expected rendering time improvement was not observed, instead it hovered around ~33.9s to ~34.3s. This suggests that expanding the pipeline depth and pre-allocated buffer pool doesn't relieve any critical bottleneck, or the overhead of managing a larger buffer queue balances out the potential concurrent frame gains.
+- Tried incremental time calculation in the hot loop (PERF-117).
+  - WHY it didn't work: Caused `cdpSession.send: Protocol error (HeadlessExperimental.beginFrame): Another frame is pending` crash. The accumulators likely got out of sync with the true frame offset.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -234,3 +234,4 @@ peak_mem_mb:        38.3
 3	36.684	150	4.09	35.8	discard	PERF-085: Already implemented
 014-pipeline-evaluate-capture	34.814	150	4.31	35.2	keep	Pipeline Evaluate and Capture in Renderer.ts
 15	0.000	0	0.00	0.0	crash	incremental time calculation
+1	0.000	0	0.00	0.0	crash	incremental time calculation


### PR DESCRIPTION
✨ RENDERER: Discard Incremental Time Calculation (PERF-117)

💡 **What**: Tried to replace multiplication with scalar addition accumulators for virtual time calculation (`currentTime`, `currentCompTime`) in the hot loop of `Renderer.ts`.

🎯 **Why**: To eliminate floating-point multiplication overhead per frame and reduce V8 execution micro-stalls inside the critical frame capture loop.

📊 **Impact**: The experiment failed and caused a crash (`cdpSession.send: Protocol error (HeadlessExperimental.beginFrame): Another frame is pending`). The accumulators got out of sync with the true frame offset when pipelining concurrent promises across multiple workers, leading to sequence corruption. Render time dropped to `0.000s` as it failed immediately.

🔬 **Verification**:
- Ran tests with `verify-codecs.ts` which successfully passed after reverting code.
- Tested compilation (`npm run build -w packages/renderer`).
- Benchmarking resulted in a failure and immediate error logs from Playwright/CDP.

📎 **Plan**: Reference `.sys/plans/PERF-117-incremental-time-calculation.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	incremental time calculation
```

---
*PR created automatically by Jules for task [16277233732609374293](https://jules.google.com/task/16277233732609374293) started by @BintzGavin*