### PR TITLE
✨ PLAYER: Expose Missing Export Attributes

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -89,6 +89,15 @@
 - `poster`: Image URL to display while connecting or loading.
 - `preload`: Indicates caching behavior (`none`, `metadata`, `auto`).
 - `controlslist`: Allows hiding specific UI elements (e.g., `nodownload`, `nofullscreen`).
+- `exportMode`
+- `exportFormat`
+- `exportFilename`
+- `exportWidth`
+- `exportHeight`
+- `exportBitrate`
+- `exportCaptionMode`
+- `canvasSelector`
+- `controlsList`
 - `sandbox`: Overrides the default iframe sandbox flags.
 - `disablepictureinpicture`: If present, hides the PiP button.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -105,6 +105,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### CLI v0.31.0
 - ✅ Completed: AWS Deployment - Implemented AWS Lambda deployment scaffolding and custom browser path support.
 
+### PLAYER v0.77.7
+- ✅ Completed: Expose Missing Export Attributes - Added missing properties (exportMode, exportFormat, exportFilename, exportWidth, exportHeight, exportBitrate, exportCaptionMode, canvasSelector, controlsList) to HeliosPlayer to match the documented attributes.
+
 ### PLAYER v0.77.6
 - ✅ Completed: Improve Test Coverage - Added test coverage for onremovetrack and onchange properties in audio and video track lists.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,6 @@
-**Version**: 0.77.6
+**Version**: 0.77.7
+[v0.77.7] ✅ Completed: Expose Missing Export Attributes - Added missing properties (exportMode, exportFormat, exportFilename, exportWidth, exportHeight, exportBitrate, exportCaptionMode, canvasSelector, controlsList) to HeliosPlayer to match the documented attributes.
+
 [v0.77.6] ✅ Completed: Improve Test Coverage - Added test coverage for onremovetrack and onchange properties in audio and video track lists.
 [v0.77.5] ✅ Completed: Document getSchema API Parity - Added missing getSchema method to README documentation.
 [v0.77.4] ✅ Completed: README API Parity - Documented missing HTMLMediaElement API parity properties, methods, and attributes.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -173,6 +173,16 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `preservesPitch` (boolean): Whether pitch should be preserved when altering playback speed.
 - `srcObject` (MediaProvider | null): The media provider object.
 - `crossOrigin` (string | null): The CORS setting for this media element.
+- `exportMode` (string): Reflected export-mode attribute.
+- `exportFormat` (string): Reflected export-format attribute.
+- `exportFilename` (string): Reflected export-filename attribute.
+- `exportWidth` (number | null): Reflected export-width attribute.
+- `exportHeight` (number | null): Reflected export-height attribute.
+- `exportBitrate` (number | null): Reflected export-bitrate attribute.
+- `exportCaptionMode` (string): Reflected export-caption-mode attribute.
+- `canvasSelector` (string): Reflected canvas-selector attribute.
+- `controlsList` (string): Reflected controlslist attribute.
+
 
 ## Events
 

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1142,6 +1142,58 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     console.warn("HeliosPlayer does not support srcObject");
   }
 
+
+  public get exportMode(): string { return this.getAttribute("export-mode") || "auto"; }
+  public set exportMode(val: string) { this.setAttribute("export-mode", val); }
+
+  public get exportFormat(): string { return this.getAttribute("export-format") || "mp4"; }
+  public set exportFormat(val: string) { this.setAttribute("export-format", val); }
+
+  public get exportFilename(): string { return this.getAttribute("export-filename") || "video"; }
+  public set exportFilename(val: string) { this.setAttribute("export-filename", val); }
+
+  public get exportCaptionMode(): string { return this.getAttribute("export-caption-mode") || "burn-in"; }
+  public set exportCaptionMode(val: string) { this.setAttribute("export-caption-mode", val); }
+
+  public get exportWidth(): number | null {
+      const val = this.getAttribute("export-width");
+      if (!val) return null;
+      const num = parseInt(val, 10);
+      return isNaN(num) ? null : num;
+  }
+  public set exportWidth(val: number | null) {
+      if (val === null) this.removeAttribute("export-width");
+      else this.setAttribute("export-width", val.toString());
+  }
+
+  public get exportHeight(): number | null {
+      const val = this.getAttribute("export-height");
+      if (!val) return null;
+      const num = parseInt(val, 10);
+      return isNaN(num) ? null : num;
+  }
+  public set exportHeight(val: number | null) {
+      if (val === null) this.removeAttribute("export-height");
+      else this.setAttribute("export-height", val.toString());
+  }
+
+  public get exportBitrate(): number | null {
+      const val = this.getAttribute("export-bitrate");
+      if (!val) return null;
+      const num = parseInt(val, 10);
+      return isNaN(num) ? null : num;
+  }
+  public set exportBitrate(val: number | null) {
+      if (val === null) this.removeAttribute("export-bitrate");
+      else this.setAttribute("export-bitrate", val.toString());
+  }
+
+  public get canvasSelector(): string { return this.getAttribute("canvas-selector") || "canvas"; }
+  public set canvasSelector(val: string) { this.setAttribute("canvas-selector", val); }
+
+  public get controlsList(): string { return this.getAttribute("controlslist") || ""; }
+  public set controlsList(val: string) { this.setAttribute("controlslist", val); }
+
   public get crossOrigin(): string | null {
     return this.getAttribute("crossorigin");
   }


### PR DESCRIPTION
✨ PLAYER: Expose Missing Export Attributes

💡 What: Added missing properties (`exportMode`, `exportFormat`, `exportFilename`, `exportWidth`, `exportHeight`, `exportBitrate`, `exportCaptionMode`, `canvasSelector`, `controlsList`) to the `HeliosPlayer` class, mapping them directly to their respective HTML attributes via getters and setters. Also updated the documentation accordingly.
🎯 Why: The README stated that `<helios-player>` supports various `export-*` configuration attributes, but these were not exposed as JavaScript properties on the class instance, causing an API parity gap.
📊 Impact: Allows developers to programmatically access and modify these configuration options, improving parity with standard Web Component practices.
🔬 Verification: Ran `npm run test -w packages/player` to ensure no regressions occurred.

---
*PR created automatically by Jules for task [4755421927071999392](https://jules.google.com/task/4755421927071999392) started by @BintzGavin*