### PR TITLE
✨ RENDERER: Independent Strategies per Worker

### DIFF
--- a/.sys/plans/PERF-119-independent-strategies.md
+++ b/.sys/plans/PERF-119-independent-strategies.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-119
 slug: independent-strategies
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-24
 completed: ""
@@ -76,3 +76,8 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas
 
 ## Correctness Check
 Run the `packages/renderer/tests/fixtures/benchmark.ts` to verify DOM output is correct and measure the unlocked concurrency speedup.
+
+## Results Summary
+- **Best render time**: 34.306s
+- **Kept experiments**: Independent Strategies per Worker (PERF-119)
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -130,3 +130,6 @@ Last updated by: PERF-119
 - **Expanding Buffer Pool and Pipeline Depth (PERF-098)**: Tried increasing `maxPipelineDepth` to `poolLen * 15` and `bufferPool` size to `20`. The expected rendering time improvement was not observed, instead it hovered around ~33.9s to ~34.3s. This suggests that expanding the pipeline depth and pre-allocated buffer pool doesn't relieve any critical bottleneck, or the overhead of managing a larger buffer queue balances out the potential concurrent frame gains.
 - Tried incremental time calculation in the hot loop (PERF-117).
   - WHY it didn't work: Caused `cdpSession.send: Protocol error (HeadlessExperimental.beginFrame): Another frame is pending` crash. The accumulators likely got out of sync with the true frame offset.
+
+## What Works
+- PERF-119: Independent Strategies per Worker. It resolved the "Another frame is pending" crashes and allowed deep pipelining to safely distribute frame renders across workers, unlocking concurrency speedup. Render time reduced to 34.306s.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -235,3 +235,4 @@ peak_mem_mb:        38.3
 014-pipeline-evaluate-capture	34.814	150	4.31	35.2	keep	Pipeline Evaluate and Capture in Renderer.ts
 15	0.000	0	0.00	0.0	crash	incremental time calculation
 1	0.000	0	0.00	0.0	crash	incremental time calculation
+236	34.306	300	4.37	39.0	keep	Independent Strategies per Worker

--- a/packages/renderer/src/Renderer.ts
+++ b/packages/renderer/src/Renderer.ts
@@ -46,18 +46,9 @@ const GPU_DISABLED_ARGS = [
 
 export class Renderer {
   private options: RendererOptions;
-  private strategy: RenderStrategy;
-  private timeDriver: TimeDriver;
 
   constructor(options: RendererOptions) {
     this.options = options;
-    if (this.options.mode === 'dom') {
-      this.strategy = new DomStrategy(this.options);
-      this.timeDriver = new SeekTimeDriver(this.options.stabilityTimeout);
-    } else {
-      this.strategy = new CanvasStrategy(this.options);
-      this.timeDriver = new CdpTimeDriver(this.options.stabilityTimeout);
-    }
   }
 
   private getLaunchOptions() {
@@ -116,7 +107,8 @@ export class Renderer {
     try {
       const page = await browser.newPage();
       await page.goto('about:blank');
-      const browserDiagnostics = await this.strategy.diagnose(page);
+      const strategy = this.options.mode === 'dom' ? new DomStrategy(this.options) : new CanvasStrategy(this.options);
+      const browserDiagnostics = await strategy.diagnose(page);
 
       const ffmpegPath = this.options.ffmpegPath || ffmpeg.path;
       const ffmpegDiagnostics = FFmpegInspector.inspect(ffmpegPath);
@@ -169,7 +161,7 @@ export class Renderer {
 
       const createPage = async (index: number) => {
         const page = await context.newPage();
-        const strategy = this.strategy || (this.options.mode === 'dom' ? new DomStrategy(this.options) : new CanvasStrategy(this.options));
+        const strategy = this.options.mode === 'dom' ? new DomStrategy(this.options) : new CanvasStrategy(this.options);
         const timeDriver = this.options.mode === 'dom' ? new SeekTimeDriver(this.options.stabilityTimeout) : new CdpTimeDriver(this.options.stabilityTimeout);
 
         page.on('console', (msg: ConsoleMessage) => console.log(`PAGE LOG [${index}]: ${msg.text()}`));
@@ -215,7 +207,7 @@ export class Renderer {
       const fps = this.options.fps;
       const startFrame = this.options.startFrame || 0;
 
-      const { args, inputBuffers } = this.strategy.getFFmpegArgs(this.options, outputPath);
+      const { args, inputBuffers } = pool[0].strategy.getFFmpegArgs(this.options, outputPath);
 
       const stdio: any[] = ['pipe', 'pipe', 'pipe'];
       const maxPipeIndex = Math.max(...inputBuffers.map(b => b.index), 2);


### PR DESCRIPTION
💡 What: Refactored `Renderer.ts` to remove the shared `strategy` and `timeDriver` from class state and instantiate independent instances per worker in `createPage`. Updated `diagnose` to use its own instance and fetched FFmpeg args from `pool[0]`. Kept changes.
🎯 Why: To fix "Another frame is pending" crashes during parallel DOM capture caused by multiple Playwright pages sharing and interleaving commands on a single `DomStrategy` CDP session.
📊 Impact: Render time reduced to 34.306s
🔬 Verification: Passed canvas strategy verification (`verify-canvas-strategy.ts`) and DOM benchmark with proper visual output in `dom-animation.mp4` without CDP concurrency crashes.
📎 Plan: `.sys/plans/PERF-119-independent-strategies.md`

```
236	34.306	300	4.37	39.0	keep	Independent Strategies per Worker
```

---
*PR created automatically by Jules for task [3601385558540784560](https://jules.google.com/task/3601385558540784560) started by @BintzGavin*