### PR TITLE
✨ CLI: Scaffold Hetzner Deployment Command

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -41,7 +41,7 @@ packages/cli/
 - `helios add <component>`: Adds a component from the remote registry.
 - `helios build`: Builds the user project via Vite for production usage.
 - `helios components [query]`: Lists available components in the registry (filterable by query, framework, or all).
-- `helios deploy <provider>`: Scaffolds deployment configurations for cloud providers (e.g., `aws`, `gcp`, `cloudflare`, `kubernetes`, `fly`, `azure`).
+- `helios deploy <provider>`: Scaffolds deployment configurations for cloud providers (e.g., `aws`, `gcp`, `cloudflare`, `kubernetes`, `fly`, `azure`, `hetzner`).
 - `helios diff <component>`: Compares a local component against its remote registry equivalent, outputting patch diffs.
 - `helios init`: Scaffolds `helios.config.json` and base templates (or examples) for user workspaces.
 - `helios job run <spec>`: Executes a distributed execution spec using available Worker adapters.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -1,3 +1,6 @@
+## CLI v0.43.0
+- ✅ Completed: Scaffold Hetzner Deployment Command - Implemented `helios deploy hetzner` to scaffold README-HETZNER.md for the Hetzner Cloud adapter.
+
 ### CLI v0.40.2
 - ✅ Completed: Scaffold Kubernetes Deployment Command - Implemented `helios deploy kubernetes` to scaffold job.yaml and README-KUBERNETES.md for Kubernetes Job clusters.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,4 +1,4 @@
-**Version**: 0.41.1
+**Version**: 0.43.0
 
 # CLI Status
 
@@ -19,6 +19,7 @@ The Helios CLI is the primary user interface for component registry, project sca
 5. **Merge Command** - `helios merge` for stitching distributed render chunks
 
 ## History
+[v0.43.0] ✅ Completed: Scaffold Hetzner Deployment Command - Implemented `helios deploy hetzner` to scaffold README-HETZNER.md for the Hetzner Cloud adapter.
 [v0.42.0] ✅ Completed: CLI Scaffold Hetzner Deployment Plan - Created plan to implement `helios deploy hetzner` for the Hetzner Cloud adapter.
 [v0.41.1] ✅ Completed: Verify Scaffold Azure Deployment Command - Verified that helios deploy azure is correctly implemented.
 [v0.41.0] ✅ Completed: Add Diff Command Regression Tests - Implemented comprehensive unit tests for `helios diff`.

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -9,6 +9,8 @@ import { AWS_DOCKERFILE_TEMPLATE, AWS_LAMBDA_HANDLER_TEMPLATE, AWS_SAM_TEMPLATE,
 import { WRANGLER_TOML_TEMPLATE, CLOUDFLARE_WORKER_TEMPLATE, README_CLOUDFLARE_TEMPLATE } from '../templates/cloudflare.js';
 import { FLY_TOML_TEMPLATE, FLY_DOCKERFILE_TEMPLATE, README_FLY_TEMPLATE } from '../templates/fly.js';
 import { KUBERNETES_JOB_TEMPLATE, README_KUBERNETES_TEMPLATE } from '../templates/kubernetes.js';
+import { README_HETZNER_TEMPLATE } from '../templates/hetzner.js';
+
 import { AZURE_FUNCTION_JSON_TEMPLATE, AZURE_HOST_JSON_TEMPLATE, AZURE_LOCAL_SETTINGS_JSON_TEMPLATE, AZURE_INDEX_JS_TEMPLATE, README_AZURE_TEMPLATE } from '../templates/azure.js';
 
 
@@ -644,5 +646,42 @@ export function registerDeployCommand(program: Command) {
 
       console.log(chalk.blue('\nKubernetes setup complete!'));
       console.log('See README-KUBERNETES.md for deployment instructions.');
+    });
+
+  deploy
+    .command('hetzner')
+    .description('Scaffold Hetzner Cloud deployment configuration')
+    .action(async () => {
+      const cwd = process.cwd();
+      const readmePath = path.join(cwd, 'README-HETZNER.md');
+
+      console.log(chalk.blue('Scaffolding Hetzner Cloud deployment files...'));
+
+      let writeReadme = true;
+      if (fs.existsSync(readmePath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'README-HETZNER.md already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeReadme = response.value;
+      }
+
+      if (writeReadme) {
+        fs.writeFileSync(readmePath, README_HETZNER_TEMPLATE);
+        console.log(chalk.green('✔ Created README-HETZNER.md'));
+      } else {
+        console.log(chalk.gray('Skipped README-HETZNER.md'));
+      }
+
+      console.log(chalk.blue('\nHetzner Cloud setup complete!'));
+      console.log('See README-HETZNER.md for deployment instructions.');
     });
 }

--- a/packages/cli/src/templates/hetzner.ts
+++ b/packages/cli/src/templates/hetzner.ts
@@ -1,0 +1,33 @@
+export const README_HETZNER_TEMPLATE = `# Hetzner Cloud Deployment
+
+This directory contains the configuration to deploy your Helios rendering jobs to Hetzner Cloud.
+
+## Prerequisites
+
+1. A [Hetzner Cloud account](https://www.hetzner.com/cloud/).
+2. An API Token generated from your Hetzner Cloud Console (Security > API Tokens). The token requires Read & Write permissions.
+
+## Environment Setup
+
+You need to provide your API token and optional server configuration to the Helios CLI. Set the following environment variables:
+
+\`\`\`bash
+# Required
+export HETZNER_API_TOKEN="your-api-token-here"
+
+# Optional (Defaults shown)
+export HETZNER_SERVER_TYPE="cpx11"
+export HETZNER_IMAGE="ubuntu-24.04"
+export HETZNER_LOCATION="fsn1"
+\`\`\`
+
+## Running Jobs
+
+To execute a distributed rendering job on Hetzner Cloud, use the \`helios job run\` command and specify the \`hetzner\` adapter:
+
+\`\`\`bash
+helios job run render-job.json --adapter hetzner
+\`\`\`
+
+The adapter will automatically provision a VM for each job chunk, execute the render, and terminate the VM upon completion.
+`;


### PR DESCRIPTION
Implemented `helios deploy hetzner` to generate necessary instructions for deploying and running jobs via the Tier 3 `HetznerCloudAdapter`. Added new template, hooked it into `deploy.ts`, updated status, progress logs, and CLI context files to reflect the v0.43.0 release. Tested successfully.

---
*PR created automatically by Jules for task [10255874083995572434](https://jules.google.com/task/10255874083995572434) started by @BintzGavin*