### PR TITLE
✨ RENDERER: Discard PERF-123 chunked stdin writes experiment

### DIFF
--- a/.sys/plans/PERF-123-optimize-ffmpeg-stdin-pipe-writes.md
+++ b/.sys/plans/PERF-123-optimize-ffmpeg-stdin-pipe-writes.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-123
 slug: optimize-ffmpeg-stdin-pipe-writes
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-03-31
-completed: ""
-result: ""
+completed: "2026-03-31"
+result: "no-improvement"
 ---
 # PERF-123: Optimize FFmpeg stdin Pipeline Block Size
 
@@ -60,3 +60,9 @@ Verify that the output video plays correctly and doesn't exhibit tearing or miss
 
 ## Canvas Smoke Test
 Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to make sure Canvas mode isn't negatively affected since both strategies share the FFmpeg encoding pipeline in `Renderer.ts`.
+
+## Results Summary
+- **Best render time**: 34.088s (vs baseline ~33.66s)
+- **Improvement**: -1.27% (Regression)
+- **Kept experiments**: None
+- **Discarded experiments**: [Step 1: Implement chunked writes for FFmpeg stdin]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -142,3 +142,6 @@ Last updated by: PERF-121
 
 ## What Works
 - PERF-120: Replaced module-level `evaluateParamsPool` with an instance-level pool inside `SeekTimeDriver.ts`. This successfully decoupled Playwright worker pages and eliminated a major concurrency race condition (preventing corrupted evaluation parameters during overlapping `setTime` calls), keeping render time at ~33.4s but guaranteeing safe multi-worker scaling.
+
+## What Doesn't Work (and Why)
+- **Batching chunks for ffmpeg.stdin.write**: PERF-123. Tried aggregating frame buffers into 1MB chunks before calling \`stdin.write()\` to reduce IPC system calls. The result was slightly slower than baseline (~34.088s vs ~33.66s baseline). While batching saves IPC context switches, `Buffer.concat` introduces heavy CPU synchronous overhead for memory copying in Node.js which negates the benefits of fewer writes in this specific microVM environment.

--- a/packages/renderer/.sys/perf-results-PERF-123.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-123.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	34.088	150	4.40	40.0	discard	chunked stdin writes


### PR DESCRIPTION
💡 **What**: Executed PERF-123 to batch Buffer chunks for FFmpeg `stdin.write()`. The performance regressed and the experiment was discarded. All code changes were successfully reverted and results logged.
🎯 **Why**: Attempted to reduce IPC system calls and V8 context-switching overhead by aggregating small frame chunks into 1MB batches before sending to FFmpeg pipe.
📊 **Impact**: Render time regressed slightly to ~34.088s vs the baseline of ~33.66s. The CPU synchronous overhead of `Buffer.concat` copying memory in Node.js negated the benefits of fewer writes in this specific microVM environment.
🔬 **Verification**:
- Output verified with benchmark runner (4.40 fps, 150 frames, 34.088s)
- Discard verified by `git restore packages/renderer/src/Renderer.ts`
- Canvas smoke test passed via `verify-canvas-strategy.ts`
📎 **Plan**: Reference `PERF-123-optimize-ffmpeg-stdin-pipe-writes.md`

### TSV Results:
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	34.088	150	4.40	40.0	discard	chunked stdin writes
```

---
*PR created automatically by Jules for task [3407768603754219155](https://jules.google.com/task/3407768603754219155) started by @BintzGavin*