### PR TITLE
✨ RENDERER: Execute PERF-124 cache page.frames() array

### DIFF
--- a/.sys/plans/PERF-124-cache-page-frames.md
+++ b/.sys/plans/PERF-124-cache-page-frames.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-124
 slug: cache-page-frames
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2026-03-31
-completed: ""
-result: ""
+completed: "2026-03-31"
+result: "discarded"
 ---
 # PERF-124: Optimize Playwright Page Object Model overhead by bypassing `page.frames()` array allocation
 
@@ -52,3 +52,9 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/verify-frame-count.ts` to ensure DOM frames render properly.
+
+## Results Summary
+- **Best render time**: 33.686s (vs baseline ~33.4s)
+- **Improvement**: -0.8%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-124]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -58,6 +58,12 @@ Last updated by: PERF-121
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **PERF-124: Cache page.frames()**:
+  **What you tried**: Caching `page.frames()` in a local property to bypass array allocations per frame in `SeekTimeDriver.ts`.
+  **Why it didn't work**: The overhead of Playwright's array creation for frames is negligible and does not cause significant GC pressure compared to IPC and rendering bottlenecks. Render time remained equivalent or slightly worse than the baseline (33.686s).
+  **Plan ID**: PERF-124
+
+
 - **PERF-122: Increase maxPipelineDepth to poolLen * 8**:
   **What you tried**: Modifying `maxPipelineDepth` from `poolLen * 2` to `poolLen * 8` to increase concurrent frames in-flight.
   **Why it didn't work**: The performance improvement was negligible (around 33.6s, matching baseline noise margins). Deeper pipelines in the Node-Chromium IPC model reach a diminishing returns ceiling due to CPU scheduling constraints.

--- a/packages/renderer/.sys/perf-results-PERF-124.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-124.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	33.686	150	4.45	38.9	discard	cache page.frames() array locally in SeekTimeDriver

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -236,3 +236,4 @@ peak_mem_mb:        38.3
 15	0.000	0	0.00	0.0	crash	incremental time calculation
 1	0.000	0	0.00	0.0	crash	incremental time calculation
 236	34.306	300	4.37	39.0	keep	Independent Strategies per Worker
+1	33.686	150	4.45	38.9	discard	cache page.frames() array locally in SeekTimeDriver

--- a/packages/renderer/tests/verify-frame-count.ts
+++ b/packages/renderer/tests/verify-frame-count.ts
@@ -35,36 +35,25 @@ async function verifyFrameCount() {
 
   const renderer = new Renderer(options);
 
-  // Mock the strategy
-  const strategy = (renderer as any).strategy as CanvasStrategy;
-
-  // Override the renderer's internal strategy creation so it uses our mocked instance
-
-
-
   let capturedFrames = 0;
+  let generatedArgs: string[] = [];
 
+  // Create a mock strategy instance
+  const strategy = new CanvasStrategy(options) as any;
   strategy.prepare = async (page) => {
     console.log('Mock strategy.prepare called');
   };
-
   strategy.diagnose = async (page) => {
     return {};
   };
-
   strategy.capture = async (page, time) => {
     capturedFrames++;
     return Buffer.from('dummy-frame-data');
   };
-
   strategy.finish = async (page) => {
     return Buffer.alloc(0);
   };
-
   const realGetArgs = strategy.getFFmpegArgs.bind(strategy);
-  let generatedArgs: string[] = [];
-
-  // Mock getFFmpegArgs to return args for our dummy script
   strategy.getFFmpegArgs = (opts, outPath) => {
     // Generate real args to verify them later
     const config = FFmpegBuilder.getArgs(opts, outPath, []);
@@ -82,9 +71,27 @@ async function verifyFrameCount() {
   };
 
   try {
+    // Actually, just intercepting CanvasStrategy constructor would be better, but we can't easily.
+    // Let's monkey-patch the prototype of CanvasStrategy since this is a test.
+    const origPrepare = CanvasStrategy.prototype.prepare;
+    const origCapture = CanvasStrategy.prototype.capture;
+    const origFinish = CanvasStrategy.prototype.finish;
+    const origGetArgs = CanvasStrategy.prototype.getFFmpegArgs;
+
+    CanvasStrategy.prototype.prepare = strategy.prepare;
+    CanvasStrategy.prototype.capture = strategy.capture;
+    CanvasStrategy.prototype.finish = strategy.finish;
+    CanvasStrategy.prototype.getFFmpegArgs = strategy.getFFmpegArgs;
+
     // Run render
     // Use about:blank to minimize browser overhead
     await renderer.render('about:blank', outputPath);
+
+    // Restore
+    CanvasStrategy.prototype.prepare = origPrepare;
+    CanvasStrategy.prototype.capture = origCapture;
+    CanvasStrategy.prototype.finish = origFinish;
+    CanvasStrategy.prototype.getFFmpegArgs = origGetArgs;
 
     console.log(`Captured ${capturedFrames} frames.`);
 


### PR DESCRIPTION
Executed the `PERF-124` performance experiment for the renderer to cache the `page.frames()` array.

**Results Summary:**
- **Best render time**: 33.686s (vs baseline ~33.4s)
- **Improvement**: -0.8%
- **Kept experiments**: []
- **Discarded experiments**: [PERF-124]

The experiment was discarded as the optimization yielded no significant improvements. Code changes have been reverted to maintain a clean codebase. Status tracking files (`RENDERER-EXPERIMENTS.md`, `PERF-124-cache-page-frames.md`, and TSV results files) have been appropriately updated. The `verify-frame-count.ts` test was also fixed to properly mock the canvas strategy since the renderer instantiation refactor.

---
*PR created automatically by Jules for task [6004877367945773685](https://jules.google.com/task/6004877367945773685) started by @BintzGavin*