### PR TITLE
📋 STUDIO: Timeline Drag Drop Plan

### DIFF
--- a/.sys/plans/2026-02-18-STUDIO-TimelineDragDrop.md
+++ b/.sys/plans/2026-02-18-STUDIO-TimelineDragDrop.md
@@ -1,27 +1,38 @@
 #### 1. Context & Goal
-- **Objective**: Implement drag-and-drop support on the Timeline to map dropped assets to input props based on schema constraints.
-- **Trigger**: Vision gap identified in `.jules/STUDIO.md` where dropping assets directly onto the timeline to auto-fill inputs is missing.
-- **Impact**: Enhances the "WYSIWYG" editing experience by allowing users to rapidly swap video/audio/image assets visually.
+- **Objective**: Implement drag-and-drop support in the Timeline component to update the composition when an asset is dropped onto it.
+- **Trigger**: The README specifies "Timeline Drag & Drop - auto-detecting audio/video and updating the composition when an asset is dragged to the timeline". This is currently missing from `Timeline.tsx` according to `.jules/STUDIO.md` and codebase review.
+- **Impact**: Enhances WYSIWYG editing, making it intuitive to assign assets to a composition's props by dropping them directly on the timeline track.
 
 #### 2. File Inventory
-- **Create**: []
-- **Modify**:
-  - `packages/studio/src/components/Timeline.tsx`: Add `onDragOver` and `onDrop` handlers to the main timeline track area to intercept asset drops, validate against the `playerState.schema`, and update `playerState.inputProps`.
-- **Read-Only**:
-  - `packages/studio/src/context/StudioContext.tsx`: To understand how `setInputProps` is accessed via the controller.
-  - `packages/studio/src/components/AssetsPanel/AssetItem.tsx`: To understand the payload structure of `'application/helios-asset'`.
+- **Create**: None
+- **Modify**: `packages/studio/src/components/Timeline.tsx` (Add drag event handlers to `.timeline-track-area` to parse `application/helios-asset` payload and update `controller.setInputProps`).
+- **Read-Only**: `packages/studio/src/components/AssetsPanel/AssetItem.tsx` (to understand drag payload format), `packages/studio/src/context/StudioContext.tsx` (to understand `playerState.schema` and `controller`).
 
 #### 3. Implementation Spec
-- **Architecture**: The `Timeline.tsx` component will listen for drag events over its `timeline-track-area`. When an asset is dropped, it parses the `application/helios-asset` data payload. It then iterates through `playerState.schema` to find the first input prop of type `'asset'` that accepts the dropped asset's `type` (e.g., `'video'`, `'audio'`, `'image'`). If a matching prop is found, it calls `controller.setInputProps({ [propKey]: asset.relativePath })`.
+- **Architecture**:
+  - Add a state variable `isDragOver` to visually highlight the `.timeline-track-area` when an item is dragged over it.
+  - Implement `onDragOver` and `onDragLeave` to manage the visual state.
+  - Implement `onDrop`:
+    - Parse the asset JSON payload from the data transfer.
+    - Inspect the composition's `schema` to find a suitable property that accepts the dragged asset's URL. The heuristic should look for `string` types that might represent URIs or whose keys match the asset type (e.g. 'audio' or 'video').
+    - If a suitable property is found, update the composition state by calling `controller.setInputProps` with the new asset URL.
 - **Pseudo-Code**:
-  - Add `onDragOver` to `timeline-track-area` to `e.preventDefault()` if the data transfer contains `application/helios-asset`.
-  - Add `onDrop` handler to parse the asset JSON.
-  - Find matching schema key: `Object.entries(schema).find(([key, def]) => def.type === 'asset' && def.accept?.includes(asset.type))`.
-  - If found, `controller.setInputProps({ [key]: asset.relativePath })`.
+  - Initialize `isDragOver` state to false
+  - Define handleDragOver: prevent default, set `isDragOver` to true
+  - Define handleDragLeave: set `isDragOver` to false
+  - Define handleDrop:
+    - prevent default, set `isDragOver` to false
+    - extract 'application/helios-asset' data
+    - if data exists, parse JSON to asset object
+    - find a target property in `schema` where:
+      - property type is string
+      - AND (property key includes asset.type OR property format is 'uri'/'url')
+    - if target property found, call `controller.setInputProps` mapping target property to `asset.url`
+  - Attach handlers to the timeline track area container
 - **Public API Changes**: None.
 - **Dependencies**: None.
 
 #### 4. Test Plan
-- **Verification**: Run `npm run test -w packages/studio` to ensure no regressions. Then, run `npx helios studio` and test dragging an asset from the Assets Panel onto the Timeline to verify it updates the composition props.
-- **Success Criteria**: Dropping a valid asset onto the timeline correctly updates the corresponding input prop in the composition.
-- **Edge Cases**: Dropping an asset type that is not accepted by any schema prop should be ignored.
+- **Verification**: Run `npm run dev` and test dropping an audio/video asset from the Assets panel onto the Timeline to see if the timeline track updates and the composition's `inputProps` change. Also, verify with a component test that the drop handler correctly identifies a schema prop and calls the update method.
+- **Success Criteria**: Dropping a valid asset applies its URL to an applicable property in the composition and updates the player. Visual feedback (`drag-over` class) works.
+- **Edge Cases**: Dropping non-asset items (should be ignored), dropping an asset when no matching property exists in the schema (should be ignored or show a toast).


### PR DESCRIPTION
Created a detailed spec file (`.sys/plans/2026-02-18-STUDIO-TimelineDragDrop.md`) to plan the implementation of drag-and-drop support in the Timeline component, addressing a vision gap where users cannot drag assets onto the timeline to update the composition. The plan outlines the necessary architectural changes, pseudo-code for the event handlers, and a test plan.

---
*PR created automatically by Jules for task [3760560170502042416](https://jules.google.com/task/3760560170502042416) started by @BintzGavin*