### PR TITLE
✨ RENDERER: Document failed PERF-130 promise.all batching experiment

### DIFF
--- a/.sys/plans/PERF-130-promise-all-frames.md
+++ b/.sys/plans/PERF-130-promise-all-frames.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-130
 slug: promise-all-frames
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-03-31
 completed: ""
-result: ""
+result: "discarded"
 ---
 # PERF-130: Optimize capture loop with Promise.all for workers
 

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -58,6 +58,7 @@ Last updated by: PERF-121
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **PERF-130**: Tried batching `processWorkerFrame` calls using `Promise.all` in the `captureLoop` to optimize V8 promise scheduling. It did not improve performance (median render time ~35.3s, worse than baseline ~33.6s). The overhead of creating arrays for batching and waiting for all frames in a batch to resolve actually increased the sequential stall time before writing to the FFmpeg pipe.
 - **PERF-124: Cache page.frames()**:
   **What you tried**: Caching `page.frames()` in a local property to bypass array allocations per frame in `SeekTimeDriver.ts`.
   **Why it didn't work**: The overhead of Playwright's array creation for frames is negligible and does not cause significant GC pressure compared to IPC and rendering bottlenecks. Render time remained equivalent or slightly worse than the baseline (33.686s).

--- a/packages/renderer/.sys/perf-results-PERF-130.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-130.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	35.309	150	4.25	38.9	discard	Promise.all batching in capture loop
+2	35.458	150	4.23	36.1	discard	Promise.all batching in capture loop
+3	34.846	150	4.30	36.0	discard	Promise.all batching in capture loop


### PR DESCRIPTION
💡 **What**: The experiment run and its outcome
Tried batching `processWorkerFrame` calls using `Promise.all` in the `captureLoop` to optimize V8 promise scheduling. It was discarded.

🎯 **Why**: The performance bottleneck targeted
To reduce the overhead of constant event loop ticks and sequential `await` state management in Node.js.

📊 **Impact**: Before/after render times and percentage improvement
It degraded performance (median render time ~35.3s, worse than baseline ~33.6s). The overhead of creating arrays for batching and waiting for all frames in a batch to resolve increased the sequential stall time before writing to the FFmpeg pipe.

🔬 **Verification**: What was tested (4-gate verification, benchmark results)
Ran 3 benchmarks using the `dom` animation fixture.

📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-130-promise-all-frames.md`)

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	35.309	150	4.25	38.9	discard	Promise.all batching in capture loop
2	35.458	150	4.23	36.1	discard	Promise.all batching in capture loop
3	34.846	150	4.30	36.0	discard	Promise.all batching in capture loop
```

---
*PR created automatically by Jules for task [14684514028763375505](https://jules.google.com/task/14684514028763375505) started by @BintzGavin*