### PR TITLE
✨ CLI: Scaffold Modal, Deno, and Vercel Deployments

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -41,7 +41,7 @@ packages/cli/
 - `helios add <component>`: Adds a component from the remote registry.
 - `helios build`: Builds the user project via Vite for production usage.
 - `helios components [query]`: Lists available components in the registry (filterable by query, framework, or all).
-- `helios deploy <provider>`: Scaffolds deployment configurations for cloud providers (e.g., `aws`, `gcp`, `cloudflare`, `kubernetes`, `fly`, `azure`, `hetzner`).
+- `helios deploy <provider>`: Scaffolds deployment configurations for cloud providers (e.g., `aws`, `gcp`, `cloudflare`, `kubernetes`, `fly`, `azure`, `hetzner`, `modal`, `deno`, `vercel`).
 - `helios diff <component>`: Compares a local component against its remote registry equivalent, outputting patch diffs.
 - `helios init`: Scaffolds `helios.config.json` and base templates (or examples) for user workspaces.
 - `helios job run <spec>`: Executes a distributed execution spec using available Worker adapters.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -1,3 +1,6 @@
+## CLI v0.44.0
+- ✅ Completed: Tier 3 Scaffold Deployment Commands - Implemented `helios deploy modal`, `helios deploy deno`, and `helios deploy vercel`.
+
 ## CLI v0.43.0
 - ✅ Completed: Scaffold Hetzner Deployment Command - Implemented `helios deploy hetzner` to scaffold README-HETZNER.md for the Hetzner Cloud adapter.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,9 +1,11 @@
-**Version**: 0.43.0
+**Version**: 0.44.0
 
 # CLI Status
 
 ## Current State
 The Helios CLI is the primary user interface for component registry, project scaffolding, distributed rendering, and deployment.
+
+[v0.44.0] ✅ Completed: Tier 3 Scaffold Deployment Commands - Implemented `helios deploy modal`, `helios deploy deno`, and `helios deploy vercel`.
 
 ## Next Steps
 - Implement regression tests for remaining commands (e.g. `job.ts`, `render.ts`, `merge.ts`).

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -12,6 +12,9 @@ import { KUBERNETES_JOB_TEMPLATE, README_KUBERNETES_TEMPLATE } from '../template
 import { README_HETZNER_TEMPLATE } from '../templates/hetzner.js';
 
 import { AZURE_FUNCTION_JSON_TEMPLATE, AZURE_HOST_JSON_TEMPLATE, AZURE_LOCAL_SETTINGS_JSON_TEMPLATE, AZURE_INDEX_JS_TEMPLATE, README_AZURE_TEMPLATE } from '../templates/azure.js';
+import { README_MODAL_TEMPLATE } from '../templates/modal.js';
+import { README_DENO_TEMPLATE } from '../templates/deno.js';
+import { README_VERCEL_TEMPLATE } from '../templates/vercel.js';
 
 
 export function registerDeployCommand(program: Command) {
@@ -683,5 +686,117 @@ export function registerDeployCommand(program: Command) {
 
       console.log(chalk.blue('\nHetzner Cloud setup complete!'));
       console.log('See README-HETZNER.md for deployment instructions.');
+    });
+
+
+  deploy
+    .command('modal')
+    .description('Scaffold Modal deployment configuration')
+    .action(async () => {
+      const cwd = process.cwd();
+      const readmePath = path.join(cwd, 'README-MODAL.md');
+
+      console.log(chalk.blue('Scaffolding Modal deployment files...'));
+
+      let writeReadme = true;
+      if (fs.existsSync(readmePath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'README-MODAL.md already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeReadme = response.value;
+      }
+
+      if (writeReadme) {
+        fs.writeFileSync(readmePath, README_MODAL_TEMPLATE);
+        console.log(chalk.green('✔ Created README-MODAL.md'));
+      } else {
+        console.log(chalk.gray('Skipped README-MODAL.md'));
+      }
+
+      console.log(chalk.blue('\nModal setup complete!'));
+      console.log('See README-MODAL.md for deployment instructions.');
+    });
+
+  deploy
+    .command('deno')
+    .description('Scaffold Deno Deploy deployment configuration')
+    .action(async () => {
+      const cwd = process.cwd();
+      const readmePath = path.join(cwd, 'README-DENO.md');
+
+      console.log(chalk.blue('Scaffolding Deno Deploy files...'));
+
+      let writeReadme = true;
+      if (fs.existsSync(readmePath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'README-DENO.md already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeReadme = response.value;
+      }
+
+      if (writeReadme) {
+        fs.writeFileSync(readmePath, README_DENO_TEMPLATE);
+        console.log(chalk.green('✔ Created README-DENO.md'));
+      } else {
+        console.log(chalk.gray('Skipped README-DENO.md'));
+      }
+
+      console.log(chalk.blue('\nDeno setup complete!'));
+      console.log('See README-DENO.md for deployment instructions.');
+    });
+
+  deploy
+    .command('vercel')
+    .description('Scaffold Vercel deployment configuration')
+    .action(async () => {
+      const cwd = process.cwd();
+      const readmePath = path.join(cwd, 'README-VERCEL.md');
+
+      console.log(chalk.blue('Scaffolding Vercel deployment files...'));
+
+      let writeReadme = true;
+      if (fs.existsSync(readmePath)) {
+        const response = await prompts({
+          type: 'confirm',
+          name: 'value',
+          message: 'README-VERCEL.md already exists. Overwrite?',
+          initial: false
+        });
+
+        if (typeof response.value === 'undefined') {
+          console.log(chalk.yellow('\nOperation cancelled.'));
+          process.exit(0);
+        }
+
+        writeReadme = response.value;
+      }
+
+      if (writeReadme) {
+        fs.writeFileSync(readmePath, README_VERCEL_TEMPLATE);
+        console.log(chalk.green('✔ Created README-VERCEL.md'));
+      } else {
+        console.log(chalk.gray('Skipped README-VERCEL.md'));
+      }
+
+      console.log(chalk.blue('\nVercel setup complete!'));
+      console.log('See README-VERCEL.md for deployment instructions.');
     });
 }

--- a/packages/cli/src/templates/deno.ts
+++ b/packages/cli/src/templates/deno.ts
@@ -1,0 +1,23 @@
+export const README_DENO_TEMPLATE = `# Deno Deploy Guide
+
+This document provides instructions for deploying Helios using Deno Deploy.
+
+## Prerequisites
+
+1.  A Deno Deploy account.
+2.  Install the \`deployctl\` CLI: \`npm install -g deployctl\`
+3.  A valid Deno entrypoint (e.g. \`main.ts\`).
+
+## Setup
+
+1.  Authenticate with Deno Deploy: \`deployctl login\`
+2.  Ensure you have your \`DENO_DEPLOY_TOKEN\` available if deploying from CI/CD.
+
+## Deployment
+
+Deploy your project to Deno Deploy:
+
+\`\`\`bash
+deployctl deploy --project=<your-project-name> ./main.ts
+\`\`\`
+`;

--- a/packages/cli/src/templates/modal.ts
+++ b/packages/cli/src/templates/modal.ts
@@ -1,0 +1,25 @@
+export const README_MODAL_TEMPLATE = `# Modal Deployment Guide
+
+This document provides instructions for deploying Helios using Modal.
+
+## Prerequisites
+
+1.  A Modal account and Modal token.
+2.  Install the Modal CLI: \`pip install modal\`
+3.  Authenticate: \`modal token new\`
+
+## Setup
+
+1.  Ensure your Modal secret (if needed) is configured in your Modal dashboard or via CLI.
+2.  Set the environment variable \`MODAL_TOKEN_ID\` and \`MODAL_TOKEN_SECRET\` if running outside a pre-authenticated environment.
+
+## Deployment
+
+Deploy your Helios application to Modal:
+
+\`\`\`bash
+modal deploy your_modal_app_script.py
+\`\`\`
+
+*(Note: Ensure you have a valid python entrypoint script configured for your specific application requirements. See Modal documentation for advanced configurations).*
+`;

--- a/packages/cli/src/templates/vercel.ts
+++ b/packages/cli/src/templates/vercel.ts
@@ -1,0 +1,23 @@
+export const README_VERCEL_TEMPLATE = `# Vercel Deployment Guide
+
+This document provides instructions for deploying Helios using Vercel.
+
+## Prerequisites
+
+1.  A Vercel account.
+2.  Install the Vercel CLI: \`npm i -g vercel\`
+3.  Authenticate with Vercel: \`vercel login\`
+
+## Setup
+
+1.  Set the required environment variable \`VERCEL_TOKEN\` if running in an automated environment (CI/CD).
+2.  Configure any other required secrets in your Vercel project settings.
+
+## Deployment
+
+Deploy your Helios application to Vercel:
+
+\`\`\`bash
+vercel --prod
+\`\`\`
+`;


### PR DESCRIPTION
This PR implements the scaffolding commands for Modal, Deno, and Vercel deployments in the CLI workspace, fulfilling the requirements specified in `2027-04-02-CLI-Scaffold-Tier3-Deployment.md`.

It adds three new template files:
* `packages/cli/src/templates/modal.ts`
* `packages/cli/src/templates/deno.ts`
* `packages/cli/src/templates/vercel.ts`

And modifies `packages/cli/src/commands/deploy.ts` to expose `helios deploy modal`, `helios deploy deno`, and `helios deploy vercel`, writing the template files securely with overwrite protection.

The implementation is verified via `npm test -w packages/cli` and local execution verification. Version bumped to `0.44.0` in the CLI context, progress, and status logs.

---
*PR created automatically by Jules for task [15756235434453340002](https://jules.google.com/task/15756235434453340002) started by @BintzGavin*