### PR TITLE
✨ RENDERER: Eliminate hot-loop Promise closures with Ring Buffers and Unchained Execution

### DIFF
--- a/.sys/plans/PERF-134-eliminate-promise-closures.md
+++ b/.sys/plans/PERF-134-eliminate-promise-closures.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-134
 slug: eliminate-promise-closures
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-27
-completed: ""
-result: ""
+completed: "2024-05-27"
+result: "discard"
 ---
 # PERF-134: Eliminate hot-loop Promise closures with Ring Buffers and Unchained Execution
 
@@ -66,3 +66,9 @@ Verify rendering works by running `npx tsx packages/renderer/tests/verify-canvas
 
 ## Correctness Check
 Run the renderer benchmark script `npx tsx packages/renderer/tests/fixtures/benchmark.ts` to ensure the strategy correctly synchronizes media elements and generates valid video outputs without race conditions.
+
+## Results Summary
+- **Best render time**: 33.669s (vs baseline 33.400s)
+- **Improvement**: 0% (Regression)
+- **Kept experiments**: None
+- **Discarded experiments**: Eliminate hot-loop Promise closures with Ring Buffers and Unchained Execution

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -158,3 +158,9 @@ Last updated by: PERF-121
 - Removed async/await overhead from `setTime` in `SeekTimeDriver.ts` hot loop. Reduced V8 allocation pressure without changing execution path. Kept in PERF-131. Render time median ~34.0s vs 35.9s (variable but directionally positive).
 
 ## Open Questions
+
+## What Doesn't Work (and Why)
+- **Eliminate Promise closures with Ring Buffers and Unchained Execution (PERF-134)**:
+  - What you tried: Replaced `evaluateParamsPool` array with a Ring Buffer in `SeekTimeDriver.ts` and unchained the `setTime` and `capture` promises in `Renderer.ts` (executing them synchronously without `.then()`).
+  - WHY it didn't work: Render time regressed slightly (median ~33.669s vs baseline ~33.400s). Unchaining the commands and using a ring buffer did not reduce overhead enough to overcome the noise margin, and the strict sequential dependency of CDP commands in Chromium might still be necessary or at least not the primary bottleneck compared to IPC latency.
+  - Plan ID: PERF-134

--- a/packages/renderer/.sys/perf-results-PERF-134.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-134.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	33.400	150	4.49	37.9	keep	baseline
+2	33.669	150	4.46	39.8	discard	unchained setTime and capture with ring buffer


### PR DESCRIPTION
💡 **What**: The experiment run and its outcome: Replaced `evaluateParamsPool` array with a Ring Buffer in `SeekTimeDriver.ts` and unchained the `setTime` and `capture` promises in `Renderer.ts` (executing them synchronously without `.then()`).
🎯 **Why**: The performance bottleneck targeted: V8 Promise allocation and microtask scheduling overhead during frame evaluations in the DOM frame capture hot loop.
📊 **Impact**: Before/after render times and percentage improvement:
- Best render time: 33.669s (vs baseline 33.400s)
- Improvement: 0% (Regression)
- The experiment was discarded.
🔬 **Verification**: What was tested (4-gate verification, benchmark results): Tested functionality with `verify-canvas-strategy.ts` and benchmarked rendering performance. Code changes were reverted upon seeing a regression in render time. Results recorded.
📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-134-eliminate-promise-closures.md`)

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	33.400	150	4.49	37.9	keep	baseline
2	33.669	150	4.46	39.8	discard	unchained setTime and capture with ring buffer
```

---
*PR created automatically by Jules for task [17381603308493796182](https://jules.google.com/task/17381603308493796182) started by @BintzGavin*