### PR TITLE
✨ RENDERER: Mark PERF-118 as already implemented

### DIFF
--- a/.sys/plans/PERF-118-fix-shared-strategy.md
+++ b/.sys/plans/PERF-118-fix-shared-strategy.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-118
 slug: fix-shared-strategy
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-31
-completed: ""
-result: ""
+completed: "2024-03-24"
+result: "discard"
 ---
 # PERF-118: Fix Shared DomStrategy Instance and Enable Concurrency
 
@@ -64,3 +64,9 @@ Run `npx tsx packages/renderer/tests/verify-codecs.ts` and `npm run test -w pack
 ## Correctness Check
 Run the DOM verification script to ensure frames are sequenced correctly without crashing:
 `npx tsx packages/renderer/tests/verify-dom-selector.ts`
+
+## Results Summary
+- **Best render time**: 34.5s (vs baseline 34.5s)
+- **Improvement**: 0%
+- **Kept experiments**:
+- **Discarded experiments**: All alternatives. Codebase remains unchanged.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -164,3 +164,9 @@ Last updated by: PERF-121
   - What you tried: Replaced `evaluateParamsPool` array with a Ring Buffer in `SeekTimeDriver.ts` and unchained the `setTime` and `capture` promises in `Renderer.ts` (executing them synchronously without `.then()`).
   - WHY it didn't work: Render time regressed slightly (median ~33.669s vs baseline ~33.400s). Unchaining the commands and using a ring buffer did not reduce overhead enough to overcome the noise margin, and the strict sequential dependency of CDP commands in Chromium might still be necessary or at least not the primary bottleneck compared to IPC latency.
   - Plan ID: PERF-134
+
+## What Doesn't Work (and Why)
+- **Fix Shared Strategy Instance in Worker Pool (PERF-118)**:
+  - What you tried: Instantiating a new \`DomStrategy\` instance for every worker page in the pool instead of sharing the class-level instance to avoid CDP session collisions during concurrent rendering.
+  - WHY it didn't work: The codebase was already updated to instantiate a new \`DomStrategy\` per worker in \`createPage\` (via \`const strategy = this.options.mode === 'dom' ? new DomStrategy(this.options) : new CanvasStrategy(this.options);\`). Attempting to "fix" it by reusing \`this.strategy\` for index 0 caused TypeScript errors because \`strategy\` is not a property of \`Renderer\`. The underlying issue of shared state was already resolved previously. The baseline performance remains ~34.5s.
+  - Plan ID: PERF-118

--- a/packages/renderer/.sys/perf-results-PERF-118.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-118.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	34.584	150	4.34	37.8	discard	Baseline from PERF-118


### PR DESCRIPTION
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	34.584	150	4.34	37.8	discard	Baseline from PERF-118

---
*PR created automatically by Jules for task [11991347543090564043](https://jules.google.com/task/11991347543090564043) started by @BintzGavin*