### PR TITLE
✨ RENDERER: [PERF-132] Verify and close already optimized capture promise

### DIFF
--- a/.sys/plans/PERF-132-optimize-capture-promise.md
+++ b/.sys/plans/PERF-132-optimize-capture-promise.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-132
 slug: optimize-capture-promise
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-03-31
 completed: ""
-result: ""
+result: "inconclusive"
 ---
 # PERF-132: Optimize `DomStrategy.capture()` by removing unnecessary `async/await` overhead
 
@@ -57,3 +57,9 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas
 
 ## Correctness Check
 Run the renderer benchmark script `npx tsx packages/renderer/tests/fixtures/benchmark.ts` to verify DOM rendering succeeds.
+
+## Results Summary
+- **Best render time**: 34.916s (vs baseline 34.916s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [optimize-capture-promise]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -177,3 +177,8 @@ Last updated by: PERF-136
   - What you tried: Pre-binding `handleBeginFrameResult` to a class property in `DomStrategy.ts` instead of using an inline `.then()` closure to reduce V8 GC pressure.
   - WHY it didn't work: Extracting the `(({ screenshotData }: any) => { ... })` inline closure logic into a pre-bound handler unexpectedly broke the `screenshotData` unpacking, leading to undefined buffers and causing a `RangeError: Invalid array length` crash during the `captureLoop` execution due to empty arrays. The V8 inline closure overhead in Playwright is negligible compared to IPC.
   - Plan ID: PERF-138
+
+- **Remove `async/await` overhead from `DomStrategy.capture()` (PERF-132)**:
+  - What you tried: Removing the `async` keyword from the `capture` method in `DomStrategy.ts` to return the Promise chain directly and avoid V8 generator overhead.
+  - WHY it didn't work: The optimization was already present in the codebase. Verified that the baseline performance remains ~34.916s. No new changes were needed.
+  - Plan ID: PERF-132

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -238,3 +238,4 @@ peak_mem_mb:        38.3
 236	34.306	300	4.37	39.0	keep	Independent Strategies per Worker
 1	33.686	150	4.45	38.9	discard	cache page.frames() array locally in SeekTimeDriver
 1	34.714	150	4.32	37.7	keep	precompile-cdp-sync-script
+240	34.916	150	4.33	39.1	inconclusive	optimize capture promise (already implemented)

--- a/packages/renderer/tests/verify-dom-strategy-capture.ts
+++ b/packages/renderer/tests/verify-dom-strategy-capture.ts
@@ -1,0 +1,43 @@
+import { DomStrategy } from '../src/strategies/DomStrategy.js';
+import { RendererOptions } from '../src/types.js';
+
+async function main() {
+  const options: RendererOptions = {
+    fps: 30,
+    videoCodec: 'libx264',
+    pixelFormat: 'yuv420p'
+  };
+
+  const strategy = new DomStrategy(options);
+
+  // Create a mock page and cdpSession
+  const mockPage: any = {
+    context: () => ({
+      newCDPSession: async () => mockCdpSession
+    }),
+    frames: () => [],
+    evaluate: async () => ({}),
+    screenshot: async () => Buffer.from('mock-fallback-buffer')
+  };
+
+  const mockCdpSession = {
+    send: async (method: string, params: any) => {
+      if (method === 'HeadlessExperimental.enable') return {};
+      if (method === 'HeadlessExperimental.beginFrame') {
+        return { screenshotData: Buffer.from('mock-buffer').toString('base64') };
+      }
+      return {};
+    },
+    detach: async () => {}
+  };
+
+  await strategy.prepare(mockPage);
+
+  const bufferPromise = strategy.capture(mockPage, 100);
+  console.log("Is Promise?", bufferPromise instanceof Promise);
+
+  const buffer = await bufferPromise;
+  console.log("Buffer returned:", buffer.toString() === 'mock-buffer');
+}
+
+main().catch(console.error);


### PR DESCRIPTION
This PR completes the autonomous performance experiment defined in `PERF-132`.

### Results Summary
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
240	34.916	150	4.33	39.1	inconclusive	optimize capture promise (already implemented)

---
*PR created automatically by Jules for task [13606816514292872656](https://jules.google.com/task/13606816514292872656) started by @BintzGavin*