### PR TITLE
📋 RENDERER: Remove CDP Session Check Overhead

### DIFF
--- a/.sys/plans/PERF-141-remove-cdp-session-check-overhead.md
+++ b/.sys/plans/PERF-141-remove-cdp-session-check-overhead.md
@@ -1,0 +1,44 @@
+---
+id: PERF-141
+slug: remove-cdp-session-check-overhead
+status: unclaimed
+claimed_by: ""
+created: 2024-05-24
+completed: ""
+result: ""
+---
+# PERF-141: Remove CDP Session Check Overhead in TimeDrivers
+
+## Focus Area
+Frame capture hot loop (`setTime` calls in `SeekTimeDriver.ts` and `CdpTimeDriver.ts`).
+
+## Background Research
+In the `setTime` method of `SeekTimeDriver.ts` and `CdpTimeDriver.ts`, there is an explicit check for `if (this.cdpSession)` or `if (this.client)` on every frame. Since the drivers are inherently initialized with these properties during the `prepare()` phase before the frame capture loop starts, repeatedly checking their truthiness inside the hot loop adds minor branch prediction overhead in V8. While V8 handles static branching efficiently, explicitly bypassing it by moving the fallback code or assuming truthiness (since an error would be caught safely by the top-level loop) reduces bytecode size for the hot path.
+
+## Benchmark Configuration
+- **Composition URL**: The standard DOM benchmark composition
+- **Render Settings**: Baseline identical settings across all runs
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~32.057s
+- **Bottleneck analysis**: Micro-optimizing execution branching inside the Node-to-Chromium IPC hot loop.
+
+## Implementation Spec
+
+### Step 1: Remove truthiness checks for cdpSession/client
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts` and `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+1. In `SeekTimeDriver.ts`, remove the `if (this.cdpSession)` blocks. We know the `cdpSession` is initialized because `prepare()` runs before `captureLoop`. We can assert it using the non-null assertion operator `this.cdpSession!` and remove the else branches that fallback to `frame.evaluate`.
+2. In `CdpTimeDriver.ts`, remove the `if (!this.client)` guard at the beginning of `setTime()` and use `this.client!.once(...)` later.
+
+**Why**: Eliminating branching inside the hot loop reduces V8 bytecode processing and execution stalls, potentially yielding minor improvements.
+**Risk**: If `setTime` is somehow called before `prepare`, it will throw a null reference error instead of a custom error or fallback, but this breaks the interface contract anyway.
+
+## Correctness Check
+Run the renderer benchmark script `npx tsx packages/renderer/tests/fixtures/benchmark.ts` to verify the DOM rendering still succeeds.
+
+## Canvas Smoke Test
+Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas mode still works properly.


### PR DESCRIPTION
📋 RENDERER: Remove CDP Session Check Overhead

💡 **What**: Proposing the removal of the repetitive explicit checks for `cdpSession`/`client` inside the hot frame capture `setTime` loop in `SeekTimeDriver.ts` and `CdpTimeDriver.ts`.
🎯 **Why**: Since `prepare()` is guaranteed to run before `setTime()`, constantly asserting truthiness in the hot path adds unnecessary V8 branching. Removing it could slightly reduce bytecode execution overhead.
🔬 **Approach**: Assert the `cdpSession`/`client` property as non-null directly and bypass the `if` and `else` blocks in the hot loop.
📎 **Plan**: `/.sys/plans/PERF-141-remove-cdp-session-check-overhead.md`

---
*PR created automatically by Jules for task [7705145944761906878](https://jules.google.com/task/7705145944761906878) started by @BintzGavin*