### PR TITLE
📋 PLAYER: Fix API Parity for srcObject property

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -16,3 +16,6 @@
 ## [v0.77.1] - Add Missing Plan
 **Learning:** The previous plan was missing from `/.sys/plans/`, violating the protocol.
 **Action:** Always create a plan file when instructed as Planner.
+## [v0.77.10] - Identifying minor API Parity Gaps
+**Learning:** During review of API parity tests, `srcObject` only returns null and warns on assignment. While `srcObject` stream rendering isn't supported, assigning the property should persist the value to match standard `HTMLMediaElement` wrapper expectations.
+**Action:** When creating plans for API Parity, ensure getters and setters interact coherently with internal state even if the underlying functionality is deferred or partially supported.

--- a/.sys/plans/2026-11-25-PLAYER-Fix-API-Parity-srcObject.md
+++ b/.sys/plans/2026-11-25-PLAYER-Fix-API-Parity-srcObject.md
@@ -1,0 +1,23 @@
+#### 1. Context & Goal
+- **Objective**: Fix `srcObject` getter/setter to store the assigned value internally.
+- **Trigger**: The current implementation of `srcObject` only returns null, violating HTMLMediaElement parity expectations where assigned properties should be readable.
+- **Impact**: Improves compatibility with third-party wrappers that expect `srcObject` to persist values.
+
+#### 2. File Inventory
+- **Create**: []
+- **Modify**: [`packages/player/src/index.ts`, `packages/player/src/api_parity.test.ts`]
+- **Read-Only**: [`packages/player/README.md`]
+
+#### 3. Implementation Spec
+- **Architecture**: Update `srcObject` getter and setter to store the value internally instead of just returning null and warning.
+- **Pseudo-Code**:
+  - Add private `_srcObject: MediaProvider | null = null;` to `HeliosPlayer`.
+  - Update `get srcObject()` to return `this._srcObject`.
+  - Update `set srcObject(val)` to `this._srcObject = val; console.warn("HeliosPlayer does not currently render srcObject streams, but value is stored.");`
+- **Public API Changes**: `HeliosPlayer.srcObject` will now correctly reflect assigned values.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm test -w packages/player`
+- **Success Criteria**: The `api_parity.test.ts` test for `srcObject` passes, verifying that getting the property returns the set value, and a console warning is emitted.
+- **Edge Cases**: Verify setting to null works correctly.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -195,3 +195,5 @@
 [v0.77.0] ✅ Completed: Expand Test Coverage - Added test coverage to `DirectController` and `BridgeController` to improve edge case handling and error branches, achieving 100% coverage on `controllers.ts`.
 [v0.77.1] 🚫 Blocked: The current active plan is for RENDERER optimizations. No new implementation plan found in /.sys/plans/ for the PLAYER domain. Waiting for Planner.
 [v0.77.9] ✅ Verified: getSchema API method is already documented in README.md.
+
+[v0.77.10] ✅ Completed: Discovered missing `srcObject` parity logic. Created plan `.sys/plans/2026-11-25-PLAYER-Fix-API-Parity-srcObject.md` to persist assigned `srcObject` values.


### PR DESCRIPTION
Created the implementation spec for `srcObject` property parity to persist assigned values internally and updated relevant status/journal logs.

---
*PR created automatically by Jules for task [14587527985450229443](https://jules.google.com/task/14587527985450229443) started by @BintzGavin*