### PR TITLE
✨ RENDERER: Eliminate Modulo Arithmetic in Hot Capture Loop (PERF-149)

### DIFF
--- a/.sys/plans/PERF-149-modulo-elimination.md
+++ b/.sys/plans/PERF-149-modulo-elimination.md
@@ -4,8 +4,8 @@ slug: modulo-elimination
 status: unclaimed
 claimed_by: ""
 created: 2024-10-25
-completed: ""
-result: ""
+completed: "2026-04-02"
+result: "failed"
 ---
 
 # PERF-149: Eliminate Modulo Arithmetic in Hot Capture Loop
@@ -57,3 +57,9 @@ None.
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/fixtures/benchmark.ts` to verify the DOM rendering still succeeds and produces a valid output.
+
+## Results Summary
+- **Best render time**: 33.579s (vs baseline ~32.057s)
+- **Improvement**: -4.7%
+- **Kept experiments**: []
+- **Discarded experiments**: [Eliminate modulo in capture loop]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -80,6 +80,7 @@ Last updated by: PERF-136
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- Eliminate modulo operator `%` inside the high-frequency frame capture loop by incrementing an index and resetting. The baseline was ~32.057s. The new runs timed at ~33.9s. The overhead from variable incrementing/branching might negate the savings over standard JIT-optimized constant modulo. Discarding changes. (PERF-149)
 
 - **PERF-148: page.screenshot vs beginFrame**:
   - What you tried: Replaced `HeadlessExperimental.beginFrame` with `page.screenshot` and `targetElementHandle.screenshot`.


### PR DESCRIPTION
✨ RENDERER: Eliminate Modulo Arithmetic in Hot Capture Loop (PERF-149)

💡 **What**: Replaced the modulo operator (`%`) with a manually incremented and reset variable in `packages/renderer/src/Renderer.ts` capture loop. The experiment degraded performance and the code changes were discarded. Documented the findings in the journal.
🎯 **Why**: To test if eliminating integer division overhead in the hot loop would improve frame capture speed.
📊 **Impact**: No improvement. Render time worsened slightly from ~32.0s baseline to ~33.9s.
🔬 **Verification**: Code built and successfully benchmarked on the simple-animation example 3 times. Output correctly rejected based on median render time.
📎 **Plan**: .sys/plans/PERF-149-modulo-elimination.md

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	34.318	150	4.37	37.5	discard	modulo-elimination
2	33.579	150	4.47	37.6	discard	modulo-elimination
3	33.961	150	4.42	38.1	discard	modulo-elimination
```

---
*PR created automatically by Jules for task [9316491046436881324](https://jules.google.com/task/9316491046436881324) started by @BintzGavin*