### PR TITLE
✨ RENDERER: [Discard] Optimize events.once

### DIFF
--- a/.sys/plans/PERF-150-optimize-events-once.md
+++ b/.sys/plans/PERF-150-optimize-events-once.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-150
 slug: optimize-events-once
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-28
-completed: ""
-result: ""
+completed: "2026-04-02"
+result: "no-improvement"
 ---
 
 # PERF-150: Optimize FFmpeg Backpressure Handling by Eliminating events.once Overhead
@@ -76,3 +76,9 @@ Remember to remove these listeners in the cleanup phase of the renderer.
 
 ## Correctness Check
 Run the benchmark suite `npx tsx packages/renderer/tests/fixtures/benchmark.ts` to ensure rendering still completes successfully.
+
+## Results Summary
+- **Best render time**: 34.224s (vs baseline 34.119s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-150]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -80,6 +80,7 @@ Last updated by: PERF-136
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- Extracted drain event listener out of hot loop to remove events.once overhead (PERF-150). Resulted in ~34.2s (similar to baseline). The overhead of events.once is negligible compared to other bottlenecks.
 - Eliminate modulo operator `%` inside the high-frequency frame capture loop by incrementing an index and resetting. The baseline was ~32.057s. The new runs timed at ~33.9s. The overhead from variable incrementing/branching might negate the savings over standard JIT-optimized constant modulo. Discarding changes. (PERF-149)
 
 - **PERF-148: page.screenshot vs beginFrame**:

--- a/packages/renderer/.sys/perf-results-PERF-150.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-150.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	34.224	150	4.38	37.8	discard	eliminate events.once overhead (no significant improvement)


### PR DESCRIPTION
💡 What: Attempted to extract drain event listener out of hot loop to remove events.once overhead.
🎯 Why: events.once allocations inside the capture loop backpressure handling cause V8 memory churn.
📊 Impact: 34.224s (vs baseline 34.119s) - 0% improvement.
🔬 Verification: 4-gate verification, benchmark results.
📎 Plan: .sys/plans/PERF-150-optimize-events-once.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	34.224	150	4.38	37.8	discard	eliminate events.once overhead (no significant improvement)


---
*PR created automatically by Jules for task [13402140635298191604](https://jules.google.com/task/13402140635298191604) started by @BintzGavin*