### PR TITLE
✨ RENDERER: Share CDPSession Between Strategy and TimeDriver

### DIFF
--- a/.sys/plans/PERF-152-share-cdpsession.md
+++ b/.sys/plans/PERF-152-share-cdpsession.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-152
 slug: share-cdpsession
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-10-25
 completed: ""
 result: ""
@@ -91,3 +91,8 @@ Run `npx tsx packages/renderer/tests/fixtures/benchmark.ts` to verify the DOM re
 Also run TimeDriver verification tests to ensure they are stable:
 `npx tsx packages/renderer/tests/verify-seek-driver-determinism.ts`
 `npx tsx packages/renderer/tests/verify-cdp-driver.ts`
+
+## Results Summary
+- **Best render time**: 33.949s (vs baseline 33.893s)
+- **Kept experiments**: [PERF-152]
+- **Discarded experiments**: []

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -4,6 +4,11 @@ Last updated by: PERF-136
 
 ## What Works
 
+- **Share CDPSession Between Strategy and TimeDriver (PERF-152)**:
+  - What you tried: Reusing a single `_sharedCdpSession` between `DomStrategy` and the active `TimeDriver` on the worker page.
+  - Result: Median time 33.949s vs baseline 33.893s. (Within noise margin, kept due to architectural simplicity and ensuring sequential execution)
+  - Plan ID: PERF-152
+
 - [PERF-147] Preallocated CDP parameters inside `setTime` driver loops to eliminate per-frame object allocation and reduce GC overhead. Maintained ~33.5s median render time.
 - **Optimize Renderer Promise Chain (PERF-145)**:
   - What you did: Removed the `.then(() => capturePromise)` allocation and return the `capturePromise` directly after a `.catch(noopCatch)` on the `setTimePromise`.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -244,3 +244,4 @@ peak_mem_mb:        38.3
 1	35.428	150	4.23	37.8	discard	Optimization was already implemented in PERF-129
 145	33.893	150	4.43	39.2	keep	Optimize Renderer Promise Chain
 245	0	150	0	0	crash	investigate-page-evaluate-handle
+246	33.949	300	4.42	37.6	keep	PERF-152 Share CDPSession Between Strategy and TimeDriver

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -21,11 +21,16 @@ export class CdpTimeDriver implements TimeDriver {
   }
 
   async prepare(page: Page): Promise<void> {
-    this.client = await page.context().newCDPSession(page);
+    if ((page as any)._sharedCdpSession) {
+      this.client = (page as any)._sharedCdpSession;
+    } else {
+      this.client = await page.context().newCDPSession(page);
+      (page as any)._sharedCdpSession = this.client;
+    }
     // Initialize virtual time policy to 'pause' to take control of the clock.
     // We set initialVirtualTime to Jan 1, 2024 (UTC) to ensure deterministic Date.now()
     const INITIAL_VIRTUAL_TIME = 1704067200; // 2024-01-01T00:00:00Z in seconds
-    await this.client.send('Emulation.setVirtualTimePolicy', {
+    await this.client!.send('Emulation.setVirtualTimePolicy', {
       policy: 'pause',
       initialVirtualTime: INITIAL_VIRTUAL_TIME
     });

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -44,7 +44,12 @@ export class SeekTimeDriver implements TimeDriver {
   }
 
   async prepare(page: Page): Promise<void> {
-    this.cdpSession = await page.context().newCDPSession(page);
+    if ((page as any)._sharedCdpSession) {
+      this.cdpSession = (page as any)._sharedCdpSession;
+    } else {
+      this.cdpSession = await page.context().newCDPSession(page);
+      (page as any)._sharedCdpSession = this.cdpSession;
+    }
 
     // Inject the seek script once during initialization
     // We wrap it in an IIFE to avoid polluting the global namespace with helper functions

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -82,8 +82,13 @@ export class DomStrategy implements RenderStrategy {
     this.discoveredAudioTracks = extractionResult.tracks;
     this.cleanupAudio = extractionResult.cleanup;
 
-    this.cdpSession = await page.context().newCDPSession(page);
-    await this.cdpSession.send('HeadlessExperimental.enable');
+    if ((page as any)._sharedCdpSession) {
+      this.cdpSession = (page as any)._sharedCdpSession;
+    } else {
+      this.cdpSession = await page.context().newCDPSession(page);
+      (page as any)._sharedCdpSession = this.cdpSession;
+    }
+    await this.cdpSession!.send('HeadlessExperimental.enable');
 
     // Check if the requested pixel format supports alpha
     const pixelFormat = this.options.pixelFormat || 'yuv420p';
@@ -95,7 +100,7 @@ export class DomStrategy implements RenderStrategy {
 
     // Emulate Browser.setDownloadBehavior/etc or use Emulation to set transparent background
     if (hasAlpha) {
-      await this.cdpSession.send('Emulation.setDefaultBackgroundColorOverride', {
+      await this.cdpSession!.send('Emulation.setDefaultBackgroundColorOverride', {
         color: { r: 0, g: 0, b: 0, a: 0 }
       }).catch(() => {});
     }
@@ -242,7 +247,6 @@ export class DomStrategy implements RenderStrategy {
 
   async finish(page: Page): Promise<void> {
     if (this.cdpSession) {
-      await this.cdpSession.detach().catch(() => {});
       this.cdpSession = null;
     }
   }


### PR DESCRIPTION
✨ RENDERER: Share CDPSession Between Strategy and TimeDriver

💡 What:
Reused a single `_sharedCdpSession` between `DomStrategy` and the active `TimeDriver` on the worker page instead of instantiating independent connections.

🎯 Why:
To eliminate the IPC overhead of managing redundant CDP connections in Node.js and Chromium per worker, and to guarantee strictly sequential execution of Playwright CDP commands across the pipeline.

📊 Impact:
The render time remained practically equivalent (median 33.949s vs baseline 33.893s, within noise margin), but we successfully simplified the connection architecture.

🔬 Verification:
- All compilation, verification, and smoke tests passed.
- Output deterministic frame limits matching previous performance cycles.

📎 Plan:
PERF-152 (/packages/renderer/.sys/plans/PERF-152-share-cdpsession.md)

---
*PR created automatically by Jules for task [4102894135140502703](https://jules.google.com/task/4102894135140502703) started by @BintzGavin*