### PR TITLE
📋 RENDERER: Cache jobOptions Properties in Hot Loop

### DIFF
--- a/.sys/plans/PERF-154-cache-joboptions.md
+++ b/.sys/plans/PERF-154-cache-joboptions.md
@@ -1,0 +1,49 @@
+---
+id: PERF-154
+slug: cache-joboptions
+status: unclaimed
+claimed_by: ""
+created: 2024-10-25
+completed: ""
+result: ""
+---
+# PERF-154: Cache jobOptions Properties in Hot Loop
+
+## Focus Area
+`packages/renderer/src/Renderer.ts` hot capture loop.
+
+## Background Research
+Inside the `captureLoop` of `Renderer.ts`, the optional chaining properties `jobOptions?.signal?.aborted` and `jobOptions?.onProgress` are accessed repeatedly in the `while` loop condition `while (nextFrameToWrite < totalFrames)`. Optional chaining compiles to multiple conditional checks in Javascript, increasing V8 branch evaluations. By caching these properties (e.g., `const signal = jobOptions?.signal`, `const onProgress = jobOptions?.onProgress`) immediately before the `while` loop, we can eliminate redundant optional property evaluations and reduce micro-stalls within the frame capture hot loop.
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark fixture (`output/example-build/examples/simple-animation/composition.html`)
+- **Render Settings**: Standard benchmark settings
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~33.400s
+- **Bottleneck analysis**: Property access overhead and branch evaluations within the hot loop.
+
+## Implementation Spec
+
+### Step 1: Cache jobOptions properties
+**File**: `packages/renderer/src/Renderer.ts`
+**What to change**:
+Before `while (nextFrameToWrite < totalFrames)`, cache the variables:
+```typescript
+const signal = jobOptions?.signal;
+const onProgress = jobOptions?.onProgress;
+```
+Inside the `while` loop, replace `if (jobOptions?.signal?.aborted)` with `if (signal && signal.aborted)`.
+Replace the `if (jobOptions?.onProgress)` check with `if (onProgress)` and execute the `onProgress` call directly.
+
+**Why**: To eliminate repetitive property access and branch evaluation overhead for static options across every frame iteration.
+**Risk**: Negligible risk. Logic remains identical.
+
+## Variations
+None.
+
+## Correctness Check
+Run `npx tsx packages/renderer/tests/fixtures/benchmark.ts` to verify the DOM rendering still succeeds and produces a valid output.


### PR DESCRIPTION
💡 What: Cache jobOptions properties in the Renderer hot loop.\n🎯 Why: Reduce property access and branch evaluation overhead per frame.\n🔬 Approach: Store jobOptions.signal and jobOptions.onProgress in local variables outside the loop.\n📎 Plan: .sys/plans/PERF-154-cache-joboptions.md

---
*PR created automatically by Jules for task [12161184624631370874](https://jules.google.com/task/12161184624631370874) started by @BintzGavin*