### PR TITLE
✨ PLAYER: Fix API Parity srcObject

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -1,6 +1,6 @@
 # Context: PLAYER
 
-**Version**: 0.77.5
+**Version**: 0.77.11
 
 ## Section A: Component Structure
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -105,6 +105,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### CLI v0.31.0
 - ✅ Completed: AWS Deployment - Implemented AWS Lambda deployment scaffolding and custom browser path support.
 
+### PLAYER v0.77.11
+  - ✅ Completed: Fix API Parity srcObject - Updated srcObject getter and setter to persist assigned values internally.
+
 ### PLAYER v0.77.8
 - ✅ Completed: Documented `getSchema` API Parity - Added missing getSchema method to README documentation.
 ### PLAYER v0.77.7

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -197,3 +197,4 @@
 [v0.77.9] ✅ Verified: getSchema API method is already documented in README.md.
 
 [v0.77.10] ✅ Completed: Discovered missing `srcObject` parity logic. Created plan `.sys/plans/2026-11-25-PLAYER-Fix-API-Parity-srcObject.md` to persist assigned `srcObject` values.
+[v0.77.11] ✅ Completed: Fix API Parity srcObject - Updated srcObject getter and setter to persist assigned values internally, improving compatibility with third-party wrappers.

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -388,9 +388,10 @@ describe('HeliosPlayer API Parity', () => {
     const consoleSpy = vi.spyOn(console, 'warn');
     expect(player.srcObject).toBeNull();
 
-    player.srcObject = {} as any;
-    expect(consoleSpy).toHaveBeenCalledWith("HeliosPlayer does not support srcObject");
-    expect(player.srcObject).toBeNull();
+    const mockStream = {} as any;
+    player.srcObject = mockStream;
+    expect(consoleSpy).toHaveBeenCalledWith("HeliosPlayer does not currently render srcObject streams, but value is stored.");
+    expect(player.srcObject).toBe(mockStream);
   });
 
   it('should support crossOrigin property', () => {

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -914,6 +914,7 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   private _pendingVolume: number = 1;
   private _pendingPlaybackRate: number = 1;
   private _pendingMuted: boolean | null = null;
+  private _srcObject: MediaProvider | null = null;
 
   // --- Standard Media API States ---
 
@@ -1135,11 +1136,12 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   }
 
   public get srcObject(): MediaProvider | null {
-    return null;
+    return this._srcObject;
   }
 
   public set srcObject(val: MediaProvider | null) {
-    console.warn("HeliosPlayer does not support srcObject");
+    this._srcObject = val;
+    console.warn("HeliosPlayer does not currently render srcObject streams, but value is stored.");
   }
 
 


### PR DESCRIPTION
Fixes the `srcObject` API parity issue where the getter/setter only warned and returned null instead of persisting the assigned `MediaProvider` object. This was causing problems with wrapper libraries that assume any assigned `srcObject` should remain readable. Tests have been updated and are passing successfully.

---
*PR created automatically by Jules for task [9861012160784417996](https://jules.google.com/task/9861012160784417996) started by @BintzGavin*