### PR TITLE
✨ RENDERER: Optimize FFmpeg Ingestion via thread_queue_size (Discarded)

### DIFF
--- a/.sys/plans/PERF-155-ffmpeg-thread-queue-size.md
+++ b/.sys/plans/PERF-155-ffmpeg-thread-queue-size.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-155
 slug: ffmpeg-thread-queue-size
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-01-20
 completed: ""
-result: ""
+result: no-improvement
 ---
 
 # PERF-155: Optimize FFmpeg Ingestion via thread_queue_size
@@ -60,3 +60,6 @@ Run benchmark tests via `npx tsx packages/renderer/tests/fixtures/benchmark.ts` 
 
 ## Prior Art
 No previous attempts documented for `thread_queue_size` in the microVM.
+
+## Results Summary
+- **Discarded experiments**: [Optimize FFmpeg Ingestion via thread_queue_size]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -90,6 +90,11 @@ Last updated by: PERF-136
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **Optimize FFmpeg Ingestion via thread_queue_size (PERF-155)**:
+  - What you tried: Added `-thread_queue_size 1024` to FFmpeg input args.
+  - WHY it didn't work: Render time degraded or unchanged (median 33.905s). The overhead of managing a larger buffer queue balances out the potential concurrent frame gains, or FFmpeg input thread backpressure is not the critical bottleneck compared to IPC.
+  - Plan ID: PERF-155
+
 
 - **Timeout Handling Logic bug in CdpTimeDriver (PERF-151)**:
   - What you tried: Updating CdpTimeDriver.ts to replace Playwright's `page.evaluate()` stability check with a pre-allocated CDP `Runtime.evaluate` command to bypass closure allocation overhead.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -248,3 +248,9 @@ peak_mem_mb:        38.3
 4	34.794	150	4.31	37.8	keep	Cache jobOptions in hot loop run 1
 5	33.511	150	4.48	38.9	keep	Cache jobOptions in hot loop run 2
 6	33.769	150	4.44	37.8	keep	Cache jobOptions in hot loop run 3
+1					discard	ffmpeg thread_queue_size
+2					discard	ffmpeg thread_queue_size
+3					discard	ffmpeg thread_queue_size
+1	34.590	150	4.34	37.7	discard	ffmpeg thread_queue_size
+2	33.905	150	4.42	37.8	discard	ffmpeg thread_queue_size
+3	33.626	150	4.46	37.7	discard	ffmpeg thread_queue_size


### PR DESCRIPTION
Attempted PERF-155 by adding `-thread_queue_size 1024` to FFmpeg's video input args in `packages/renderer/src/strategies/DomStrategy.ts`.
This caused a regression (median render time degraded from the baseline of ~32.057s to ~33.905s).
The code was safely reverted, and the negative result was accurately recorded in `docs/status/RENDERER-EXPERIMENTS.md`, `packages/renderer/.sys/perf-results.tsv`, and the plan file `.sys/plans/PERF-155-ffmpeg-thread-queue-size.md`.

---
*PR created automatically by Jules for task [7285632595922980198](https://jules.google.com/task/7285632595922980198) started by @BintzGavin*