### PR TITLE
✨ RENDERER: Record crashed screencast forced layout experiment

### DIFF
--- a/.sys/plans/PERF-156-screencast-forced-layout.md
+++ b/.sys/plans/PERF-156-screencast-forced-layout.md
@@ -1,11 +1,17 @@
 ---
 id: PERF-156
 slug: screencast-forced-layout
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-04-02
-completed: ""
-result: ""
+completed: "2024-04-03"
+result: "crashed"
+
+## Results Summary
+- **Best render time**: N/A (crash)
+- **Improvement**: N/A
+- **Kept experiments**: none
+- **Discarded experiments**: Forced layout screencast (crashed, Protocol error Target.disposeBrowserContext)
 ---
 # PERF-156: Screencast with Forced Layout Damage
 

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -90,6 +90,11 @@ Last updated by: PERF-136
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **Forced layout screencast (PERF-156)**:
+  - What you tried: `Page.startScreencast` with forced layout damage via `--helios-force-layout`.
+  - WHY it didn't work: Crashed with `Protocol error (Target.disposeBrowserContext)`. The screencast pushes base64 strings so fast it likely overloads IPC or hits a race condition on cleanup.
+  - Plan ID: PERF-156
+
 - **Optimize FFmpeg Ingestion via thread_queue_size (PERF-155)**:
   - What you tried: Added `-thread_queue_size 1024` to FFmpeg input args.
   - WHY it didn't work: Render time degraded or unchanged (median 33.905s). The overhead of managing a larger buffer queue balances out the potential concurrent frame gains, or FFmpeg input thread backpressure is not the critical bottleneck compared to IPC.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -254,3 +254,4 @@ peak_mem_mb:        38.3
 1	34.590	150	4.34	37.7	discard	ffmpeg thread_queue_size
 2	33.905	150	4.42	37.8	discard	ffmpeg thread_queue_size
 3	33.626	150	4.46	37.7	discard	ffmpeg thread_queue_size
+1	0.000	0	0.00	0.0	crash	forced layout screencast


### PR DESCRIPTION
✨ RENDERER: Record crashed screencast forced layout experiment

💡 What: Implemented ScreencastDomStrategy and injected forced layout damage, but the experiment crashed with Target.disposeBrowserContext. Reverted code changes.
🎯 Why: Attempted to bypass Playwright IPC overhead by using Page.startScreencast instead of frame-by-frame capture.
📊 Impact: Crashed (N/A).
🔬 Verification: Ran benchmark, evaluated logs, ran typecheck.
📎 Plan: PERF-156

```tsv
1	0.000	0	0.00	0.0	crash	forced layout screencast
```

---
*PR created automatically by Jules for task [11314777731298233981](https://jules.google.com/task/11314777731298233981) started by @BintzGavin*