### PR TITLE
✨ RENDERER: Test page.evaluateHandle vs beginFrame

### DIFF
--- a/.sys/plans/PERF-148-evaluate-handle.md
+++ b/.sys/plans/PERF-148-evaluate-handle.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-148
 slug: evaluate-handle
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-10-25
 completed: ""
-result: ""
+result: "crash"
 ---
 
 # PERF-148: Investigate `page.evaluateHandle()` vs `HeadlessExperimental.beginFrame` for DOM Screen Capture

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -90,6 +90,7 @@ Last updated by: PERF-136
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **page.evaluateHandle() screenshot**: Replaced `beginFrame` with `page.evaluateHandle().screenshot()`. It caused timeouts/hangs during rendering due to being incompatible with `--enable-begin-frame-control`. `HeadlessExperimental.beginFrame` remains strictly necessary. (PERF-148)
 - **Forced layout screencast (PERF-156)**:
   - What you tried: `Page.startScreencast` with forced layout damage via `--helios-force-layout`.
   - WHY it didn't work: Crashed with `Protocol error (Target.disposeBrowserContext)`. The screencast pushes base64 strings so fast it likely overloads IPC or hits a race condition on cleanup.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -255,3 +255,4 @@ peak_mem_mb:        38.3
 2	33.905	150	4.42	37.8	discard	ffmpeg thread_queue_size
 3	33.626	150	4.46	37.7	discard	ffmpeg thread_queue_size
 1	0.000	0	0.00	0.0	crash	forced layout screencast
+1	0.000	0	0.00	0.0	crash	Replaced beginFrame with page.evaluateHandle.screenshot, caused timeouts/hangs as expected


### PR DESCRIPTION
Tested whether `page.evaluateHandle().screenshot()` is faster than `HeadlessExperimental.beginFrame` for DOM capture (PERF-148). The experiment resulted in a crash/timeout as `elementHandle.screenshot` is incompatible with the `--enable-begin-frame-control` flag active during rendering. The code was cleanly reverted and results documented.

---
*PR created automatically by Jules for task [171190966110843636](https://jules.google.com/task/171190966110843636) started by @BintzGavin*