### PR TITLE
✨ RENDERER: Eliminate Modulo Arithmetic in Hot Capture Loop

### DIFF
--- a/.sys/plans/PERF-149-modulo-elimination.md
+++ b/.sys/plans/PERF-149-modulo-elimination.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-149
 slug: modulo-elimination
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-10-25
 completed: "2026-04-02"
-result: "failed"
+result: "discard"
 ---
 
 # PERF-149: Eliminate Modulo Arithmetic in Hot Capture Loop
@@ -59,7 +59,7 @@ None.
 Run `npx tsx packages/renderer/tests/fixtures/benchmark.ts` to verify the DOM rendering still succeeds and produces a valid output.
 
 ## Results Summary
-- **Best render time**: 33.579s (vs baseline ~32.057s)
-- **Improvement**: -4.7%
+- **Best render time**: 34.643s (vs baseline ~34.475s)
+- **Improvement**: Slower
 - **Kept experiments**: []
 - **Discarded experiments**: [Eliminate modulo in capture loop]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -90,6 +90,7 @@ Last updated by: PERF-136
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- Eliminate modulo operator `%` inside the high-frequency frame capture loop by incrementing an index and resetting. Baseline was ~34.475s, new time ~34.643 s. Discarding changes. (PERF-149)
 - **Evaluate Handle Capture API (PERF-157)**:
   - **What you tried**: Investigated using `page.evaluateHandle()` to capture screenshots directly within the browser context to avoid base64 IPC bottlenecks.
   - **WHY it didn't work**: In DOM rendering strategies, deterministic animation requires `--enable-begin-frame-control`. As previously seen in PERF-148, activating this flag causes standard `elementHandle.screenshot()` or `page.screenshot()` to hang indefinitely. Using `html2canvas` is far too slow (~311ms vs 22ms) to be viable. `HeadlessExperimental.beginFrame` string serialization remains structurally unavoidable.
@@ -111,7 +112,6 @@ Last updated by: PERF-136
   - WHY it didn't work: The direct `Runtime.evaluate` command via CDP was executed without actually awaiting the asynchronous Promise inside the page (since Playwright wraps evaluating promises transparently, but direct CDP `Runtime.evaluate` requires the `awaitPromise: true` parameter and specific result handling). This broke the timeout and stability logic, as `Runtime.evaluate` returns immediately without waiting for the page script. We verified this by adding tests, which failed.
   - Plan ID: PERF-151
 - Extracted drain event listener out of hot loop to remove events.once overhead (PERF-150). Resulted in ~34.2s (similar to baseline). The overhead of events.once is negligible compared to other bottlenecks.
-- Eliminate modulo operator `%` inside the high-frequency frame capture loop by incrementing an index and resetting. The baseline was ~32.057s. The new runs timed at ~33.9s. The overhead from variable incrementing/branching might negate the savings over standard JIT-optimized constant modulo. Discarding changes. (PERF-149)
 
 - **PERF-148: page.screenshot vs beginFrame**:
   - What you tried: Replaced `HeadlessExperimental.beginFrame` with `page.screenshot` and `targetElementHandle.screenshot`.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -256,3 +256,4 @@ peak_mem_mb:        38.3
 3	33.626	150	4.46	37.7	discard	ffmpeg thread_queue_size
 1	0.000	0	0.00	0.0	crash	forced layout screencast
 1	0.000	0	0.00	0.0	crash	Replaced beginFrame with page.evaluateHandle.screenshot, caused timeouts/hangs as expected
+1	34.643	150		37.8	discard	Eliminate modulo in capture loop


### PR DESCRIPTION
Evaluated replacing the modulo arithmetic in the hot capture loop with a counter increment and reset logic. The results were worse than the baseline, so the changes were discarded.

### Results summary:
```
1	34.643	150		37.8	discard	Eliminate modulo in capture loop
```

---
*PR created automatically by Jules for task [4299199408771742230](https://jules.google.com/task/4299199408771742230) started by @BintzGavin*