### PR TITLE
✨ RENDERER: Inline frame capture logic and remove destructuring overhead (PERF-161)

### DIFF
--- a/.sys/plans/PERF-161-inline-capture-and-destructuring.md
+++ b/.sys/plans/PERF-161-inline-capture-and-destructuring.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-161
 slug: inline-capture-and-destructuring
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-26
 completed: ""
-result: ""
+result: no-improvement
 ---
 
 # PERF-161: Inline Frame Capture Logic and Remove Destructuring Overhead
@@ -66,3 +66,9 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to ensure DOM frames remain correct.
+
+## Results Summary
+- **Best render time**: 47.202s
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [Inline capture and destructuring]

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -260,3 +260,4 @@ peak_mem_mb:        38.3
 259	33.950	150	4.42	37.7	discard	remove anonymous closure inside capture hot loop
 260	33.950	150	4.42	37.7	keep	remove anonymous closure inside capture hot loop
 1	33.890	150	4.42	37.7	keep	inline closure instead of bind
+1	47.202	150	3.18	36.0	discard	PERF-161 inline capture and destructuring


### PR DESCRIPTION
Attempted to improve DOM render times by inlining frame capture logic in `Renderer.ts` and removing destructuring overhead in `DomStrategy.ts`. The changes severely degraded performance (render time jumped to ~47.2s vs the baseline of ~32s). Following the performance experiment protocol, the code changes were discarded and reverted, and the negative result was logged into tracking files.

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	47.202	150	3.18	36.0	discard	PERF-161 inline capture and destructuring

---
*PR created automatically by Jules for task [8072197430648995102](https://jules.google.com/task/8072197430648995102) started by @BintzGavin*