### PR TITLE
✨ RENDERER: Inline Frame Capture Logic and Remove Destructuring Overhead

### DIFF
--- a/.sys/plans/PERF-161-inline-capture-and-destructuring.md
+++ b/.sys/plans/PERF-161-inline-capture-and-destructuring.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-161
 slug: inline-capture-and-destructuring
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-26
-completed: ""
-result: ""
+completed: 2026-04-03
+result: no-improvement
 ---
 
 # PERF-161: Inline Frame Capture Logic and Remove Destructuring Overhead

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -260,3 +260,5 @@ peak_mem_mb:        38.3
 259	33.950	150	4.42	37.7	discard	remove anonymous closure inside capture hot loop
 260	33.950	150	4.42	37.7	keep	remove anonymous closure inside capture hot loop
 1	33.890	150	4.42	37.7	keep	inline closure instead of bind
+262	34.123	150	4.40	38.0	discard	inline-capture-and-destructuring
+263	34.123	150	4.40	38.0	discard	inline-capture-and-destructuring


### PR DESCRIPTION
Run 1	33.890	150	4.42	37.7	keep	inline closure instead of bind
Run 263	34.123	150	4.40	38.0	discard	inline-capture-and-destructuring

---
*PR created automatically by Jules for task [4165853916255905303](https://jules.google.com/task/4165853916255905303) started by @BintzGavin*