### PR TITLE
✨ RENDERER: Inline frame capture and remove object destructuring

### DIFF
--- a/.sys/plans/PERF-161-inline-capture-and-destructuring.md
+++ b/.sys/plans/PERF-161-inline-capture-and-destructuring.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-161
 slug: inline-capture-and-destructuring
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-26
 completed: ""
 result: ""
@@ -66,3 +66,9 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to ensure DOM frames remain correct.
+
+## Results Summary
+- **Best render time**: 33.866 s (baseline unchanged)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-161]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -92,6 +92,11 @@ Last updated by: PERF-136
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **Inline Capture and Destructuring (PERF-161)**:
+  - What you tried: Inlined executeFrameCapture and replaced Promise destructuring in DomStrategy.
+  - Why it didn't work: No improvement, median time 34.054s vs baseline 33.866s.
+  - Plan ID: PERF-161
+
 - Eliminate modulo operator `%` inside the high-frequency frame capture loop by incrementing an index and resetting. Baseline was ~34.475s, new time ~34.643 s. Discarding changes. (PERF-149)
 - **Evaluate Handle Capture API (PERF-157)**:
   - **What you tried**: Investigated using `page.evaluateHandle()` to capture screenshots directly within the browser context to avoid base64 IPC bottlenecks.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -260,3 +260,5 @@ peak_mem_mb:        38.3
 259	33.950	150	4.42	37.7	discard	remove anonymous closure inside capture hot loop
 260	33.950	150	4.42	37.7	keep	remove anonymous closure inside capture hot loop
 1	33.890	150	4.42	37.7	keep	inline closure instead of bind
+PERF-161	34.054	150	4.40	37.7	discard	inline executeFrameCapture and remove dom strategy destructuring
+PERF-161	34.054	150	4.40	37.7	discard	inline executeFrameCapture and remove dom strategy destructuring


### PR DESCRIPTION
💡 **What**: Inlined the `executeFrameCapture` function in the hot capture loop and replaced object destructuring in `DomStrategy.ts` with direct property access.
🎯 **Why**: To reduce V8 function invocation, parameter passing overhead, and property wrapper allocations during high-frequency frame capture.
📊 **Impact**: No improvement. Median render time 34.054s vs baseline 33.866s. Changes were discarded.
🔬 **Verification**: Passed 4-gate verification (build, verify tests, canvas smoke tests, benchmarking). Codebase restored to baseline.
📎 **Plan**: `/.sys/plans/PERF-161-inline-capture-and-destructuring.md`

Results:
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
PERF-161	34.054	150	4.40	37.7	discard	inline executeFrameCapture and remove dom strategy destructuring

---
*PR created automatically by Jules for task [17587564926304634546](https://jules.google.com/task/17587564926304634546) started by @BintzGavin*