### PR TITLE
✨ RENDERER: Inline frame capture logic and remove destructuring overhead

### DIFF
--- a/.sys/plans/PERF-161-inline-capture-and-destructuring.md
+++ b/.sys/plans/PERF-161-inline-capture-and-destructuring.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-161
 slug: inline-capture-and-destructuring
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-26
 completed: ""
-result: ""
+result: "discard"
 ---
 
 # PERF-161: Inline Frame Capture Logic and Remove Destructuring Overhead

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -92,6 +92,10 @@ Last updated by: PERF-136
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **PERF-161: Inline Frame Capture Logic**
+  - What you tried: Inlined `executeFrameCapture` and removed object destructuring in capture loop.
+  - WHY it didn't work: Render time was 34.001s, which did not beat the baseline. The micro-overhead saved was likely negligible compared to IPC latency.
+  - Plan ID: PERF-161
 - Eliminate modulo operator `%` inside the high-frequency frame capture loop by incrementing an index and resetting. Baseline was ~34.475s, new time ~34.643 s. Discarding changes. (PERF-149)
 - **Evaluate Handle Capture API (PERF-157)**:
   - **What you tried**: Investigated using `page.evaluateHandle()` to capture screenshots directly within the browser context to avoid base64 IPC bottlenecks.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -260,3 +260,4 @@ peak_mem_mb:        38.3
 259	33.950	150	4.42	37.7	discard	remove anonymous closure inside capture hot loop
 260	33.950	150	4.42	37.7	keep	remove anonymous closure inside capture hot loop
 1	33.890	150	4.42	37.7	keep	inline closure instead of bind
+263	34.001	150	4.41	38.8	discard	PERF-161 inline executeFrameCapture and remove destructuring


### PR DESCRIPTION
💡 **What**: Tested inlining `executeFrameCapture` and removing object destructuring in `DomStrategy.ts`.
🎯 **Why**: To attempt to reduce V8 function call boundary overhead and micro-allocations in the hot capture loop.
📊 **Impact**: Render time was 34.001s, compared to the baseline of 33.6s. The change degraded performance and was discarded.
🔬 **Verification**: Ran `npm run build`, tested capture mechanics, and benchmarked via `npx tsx packages/renderer/tests/fixtures/benchmark.ts`. Code changes were reverted.
📎 **Plan**: Reference `/.sys/plans/PERF-161-inline-capture-and-destructuring.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| X | 34.001 | 150 | 4.41 | 38.8 | discard | PERF-161 inline executeFrameCapture and remove destructuring |

---
*PR created automatically by Jules for task [4702800524182926309](https://jules.google.com/task/4702800524182926309) started by @BintzGavin*