### PR TITLE
✨ RENDERER: Pre-calculate worker capture closure

### DIFF
--- a/.sys/plans/PERF-162-worker-capture-closure.md
+++ b/.sys/plans/PERF-162-worker-capture-closure.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-162
 slug: worker-capture-closure
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-30
-completed: ""
-result: ""
+completed: 2026-04-03
+result: failed
 ---
 
 # PERF-162: Optimize worker capture closure binding
@@ -121,3 +121,9 @@ Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to verify D
 - PERF-160 (Replaced bind with inline closure)
 - PERF-159 (Removed closure allocation)
 - PERF-134 (Failed unchained execution)
+
+## Results Summary
+- **Best render time**: 33.663s (vs baseline 33.654s)
+- **Improvement**: 0%
+- **Kept experiments**: None
+- **Discarded experiments**: Pre-calculating execution closures in Renderer.ts captureLoop outside hot loop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -92,6 +92,10 @@ Last updated by: PERF-136
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **Pre-calculate execution closures (PERF-162)**:
+  - What you tried: Pre-calculating closures outside hot loop in Renderer.ts.
+  - WHY it didn't work: Render time degraded or unchanged (Median changed from 33.654 to 33.663). The inline closure overhead is negligible.
+  - Plan ID: PERF-162
 - Eliminate modulo operator `%` inside the high-frequency frame capture loop by incrementing an index and resetting. Baseline was ~34.475s, new time ~34.643 s. Discarding changes. (PERF-149)
 - **Evaluate Handle Capture API (PERF-157)**:
   - **What you tried**: Investigated using `page.evaluateHandle()` to capture screenshots directly within the browser context to avoid base64 IPC bottlenecks.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -261,3 +261,4 @@ peak_mem_mb:        38.3
 260	33.950	150	4.42	37.7	keep	remove anonymous closure inside capture hot loop
 1	33.890	150	4.42	37.7	keep	inline closure instead of bind
 1	47.202	150	3.18	36.0	discard	PERF-161 inline capture and destructuring
+PERF-162	33.663	150	4.47	37.9	failed	Median changed from 33.654 to 33.663


### PR DESCRIPTION
💡 What: Pre-calculated execution closures in Renderer.ts captureLoop outside hot loop.
🎯 Why: Eliminate closure allocations on every frame iteration.
📊 Impact: Reduced micro-allocations but degraded time (33.654s -> 33.663s). Discarded.
🔬 Verification: Verified via benchmarks and verification scripts.
📎 Plan: PERF-162

```
PERF-162	33.663	150	30	0	failed	Median changed from 33.654 to 33.663
```

---
*PR created automatically by Jules for task [12035341531373942037](https://jules.google.com/task/12035341531373942037) started by @BintzGavin*