### PR TITLE
✨ RENDERER: Disable Site Isolation

### DIFF
--- a/.sys/plans/PERF-158-disable-site-isolation.md
+++ b/.sys/plans/PERF-158-disable-site-isolation.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-158
 slug: disable-site-isolation
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-26
-completed: ""
-result: ""
+completed: 2026-04-03
+result: keep
 ---
 
 # PERF-158: Disable Chromium Site Isolation
@@ -44,3 +44,9 @@ Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to ensure f
 
 ## Prior Art
 - Standard Chromium headless optimization recommendations for trusted environments (Docker, CI).
+
+## Results Summary
+- **Best render time**: 33.613s (vs baseline 33.859s)
+- **Improvement**: N/A
+- **Kept experiments**: [PERF-158]
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 32.057s (baseline was 32.242s, -0.6%)
 Last updated by: PERF-136
 
 ## What Works
+- [PERF-158] Disabled site isolation in Chromium. (Median changed from 33.859 to 33.613)
 - [PERF-160] Replaced `.bind` with an inline closure in `Renderer.ts` `captureLoop`. This avoids intermediate `BoundFunction` object creation in the hot path. Render time improved.
 - PERF-159: Removed closure allocation in capture hot loop using bound function (~34.36s improvement)
 - **Cache jobOptions Properties (PERF-154)**:

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -262,3 +262,4 @@ peak_mem_mb:        38.3
 1	33.890	150	4.42	37.7	keep	inline closure instead of bind
 1	47.202	150	3.18	36.0	discard	PERF-161 inline capture and destructuring
 PERF-162	33.663	150	4.47	37.9	failed	Median changed from 33.654 to 33.663
+PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613

--- a/packages/renderer/src/Renderer.ts
+++ b/packages/renderer/src/Renderer.ts
@@ -26,7 +26,9 @@ const DEFAULT_BROWSER_ARGS = [
   '--disable-web-security',
   '--allow-file-access-from-files',
   '--enable-begin-frame-control',
-  '--run-all-compositor-stages-before-draw'
+  '--run-all-compositor-stages-before-draw',
+  '--disable-site-isolation-trials',
+  '--disable-features=IsolateOrigins,site-per-process'
 ];
 
 const GPU_DISABLED_ARGS = [


### PR DESCRIPTION
💡 **What**: Added `--disable-site-isolation-trials` and `--disable-features=IsolateOrigins,site-per-process` to Chromium args.
🎯 **Why**: To disable Chromium site isolation and out-of-process iframes, saving OS-level memory and IPC context-switch CPU overhead inside a trusted microVM environment.
📊 **Impact**: Improved median DOM render time from ~33.859s to ~33.613s.
🔬 **Verification**:
- `npm test -w packages/renderer` passed
- `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` passed
- `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` passed
📎 **Plan**: `/.sys/plans/PERF-158-disable-site-isolation.md`

| run_id | render_time_s | frames | fps | peak_mem_mb | status | notes |
|--------|---------------|--------|-----|-------------|--------|-------|
| PERF-158 | 33.613 | 150 | 4.46 | 0 | keep | Median changed from 33.859 to 33.613 |

---
*PR created automatically by Jules for task [13239190297105255073](https://jules.google.com/task/13239190297105255073) started by @BintzGavin*