### PR TITLE
✨ RENDERER: [Discarded] Cache boundingBox

### DIFF
--- a/.sys/plans/PERF-164-cache-boundingbox.md
+++ b/.sys/plans/PERF-164-cache-boundingbox.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-164
 slug: cache-boundingbox
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-04-03
-completed: ""
-result: ""
+completed: 2024-04-03
+result: discarded
 ---
 # PERF-164: Cache targetElementHandle boundingBox to avoid per-frame IPC
 
@@ -90,3 +90,9 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` and verify output.
+
+## Results Summary
+- **Best render time**: 33.912s (baseline)
+- **Improvement**: 0%
+- **Kept experiments**: None
+- **Discarded experiments**: Cache targetElementHandle boundingBox in DomStrategy.prepare (PERF-164)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -247,6 +247,10 @@ Last updated by: PERF-136
 
 ## What Doesn't Work (and Why)
 
+- **Cache targetElementHandle boundingBox (PERF-164)**:
+  - What you tried: Caching the `boundingBox()` of the target element in `DomStrategy.prepare()` to avoid calling it on every frame inside `capture()`.
+  - WHY it didn't work: Render time was practically unchanged (~33.936s vs baseline ~33.912s), indicating that the asynchronous `.boundingBox()` IPC overhead is completely negligible compared to `HeadlessExperimental.beginFrame` and FFmpeg. The optimization is not worth the potential risk of breaking animations where the target element changes position.
+
 - **Fix Shared Strategy Instance in Worker Pool (PERF-118)**:
   - What you tried: Instantiating a new \`DomStrategy\` instance for every worker page in the pool instead of sharing the class-level instance to avoid CDP session collisions during concurrent rendering.
   - WHY it didn't work: The codebase was already updated to instantiate a new \`DomStrategy\` per worker in \`createPage\` (via \`const strategy = this.options.mode === 'dom' ? new DomStrategy(this.options) : new CanvasStrategy(this.options);\`). Attempting to "fix" it by reusing \`this.strategy\` for index 0 caused TypeScript errors because \`strategy\` is not a property of \`Renderer\`. The underlying issue of shared state was already resolved previously. The baseline performance remains ~34.5s.

--- a/packages/renderer/.sys/perf-results-PERF-164.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-164.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	33.912	150	4.42	39.2	keep	baseline
+2	33.936	150	4.42	39.8	discard	cache targetElementHandle boundingBox


### PR DESCRIPTION
💡 **What**: Evaluated caching `targetElementHandle.boundingBox()` in `DomStrategy.prepare()` to bypass calling it per frame in `capture()`. The experiment was discarded and code changes reverted.
🎯 **Why**: To test if removing the asynchronous Playwright `.boundingBox()` IPC round trip per frame would speed up the DOM rendering pipeline for targeted selectors.
📊 **Impact**: Render time was practically unchanged (~33.936s vs baseline ~33.912s), proving that `.boundingBox()` overhead is negligible compared to the underlying `HeadlessExperimental.beginFrame` and encoding pipeline.
🔬 **Verification**: Four-gate validation completed via manual benchmark runs and test suite (`verify-dom-strategy-capture.ts`). Tests passed successfully.
📎 **Plan**: `/.sys/plans/PERF-164-cache-boundingbox.md`

### Benchmark Results
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	33.912	150	4.42	39.2	keep	baseline
2	33.936	150	4.42	39.8	discard	cache targetElementHandle boundingBox
```

---
*PR created automatically by Jules for task [8056955128514719032](https://jules.google.com/task/8056955128514719032) started by @BintzGavin*