### PR TITLE
✨ CLI: All Worker Execution - Added missing --docker-args to Docker execution adapter

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -44,7 +44,7 @@ packages/cli/
 - `helios deploy <provider>`: Scaffolds deployment configurations for cloud providers (e.g., `aws`, `gcp`, `cloudflare`, `cloudflare-sandbox`, `kubernetes`, `fly`, `azure`, `docker`, `hetzner`, `modal`, `deno`, `vercel`).
 - `helios diff <component>`: Compares a local component against its remote registry equivalent, outputting patch diffs.
 - `helios init`: Scaffolds `helios.config.json` and base templates (or examples) for user workspaces.
-- `helios job run <spec>`: Executes a distributed execution spec using available Worker adapters.
+- `helios job run <spec>`: Executes a distributed execution spec using available Worker adapters. Accepts adapter-specific configurations such as `--docker-args`.
 - `helios list`: Lists all currently tracked local components.
 - `helios merge`: Stitches together chunks from distributed execution outputs using FFmpeg.
 - `helios preview`: Previews a production build.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -1,3 +1,6 @@
+## CLI v0.46.1
+- ✅ Completed: All Worker Execution - Added missing --docker-args to Docker execution adapter
+
 ## CLI v0.45.0
 - ✅ Completed: Scaffold Cloudflare Sandbox Deployment - Added `helios deploy cloudflare-sandbox` command to generate wrangler.toml, workflow index, and render script.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,9 +1,11 @@
-**Version**: 0.46.0
+**Version**: 0.46.1
 
 # CLI Status
 
 ## Current State
 The Helios CLI is the primary user interface for component registry, project scaffolding, distributed rendering, and deployment.
+
+[v0.46.1] ✅ Completed: All Worker Execution - Added missing --docker-args to Docker execution adapter
 
 [v0.46.0] ✅ Completed: Scaffold Docker Deployment Command - Implemented `helios deploy docker` to scaffold docker-compose.yml and README-DOCKER.md for running distributed rendering workloads via Docker Swarm/Compose.
 

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -44,6 +44,7 @@ export function registerJobCommand(program: Command) {
     .option('--k8s-job-name-prefix <prefix>', 'Kubernetes job name prefix')
     .option('--k8s-service-account-name <name>', 'Kubernetes service account name')
     .option('--docker-image <image>', 'Docker image to use')
+    .option('--docker-args <args>', 'Comma-separated additional arguments for docker run')
     .option('--aws-region <region>', 'AWS Region for Lambda adapter')
     .option('--aws-function-name <name>', 'AWS Lambda function name')
     .option('--aws-job-def-url <url>', 'URL of the job definition for AWS Lambda')
@@ -158,7 +159,8 @@ export function registerJobCommand(program: Command) {
             throw new Error('Docker adapter requires --docker-image');
           }
           adapter = new DockerAdapter({
-            image: options.dockerImage
+            image: options.dockerImage,
+            dockerArgs: options.dockerArgs ? options.dockerArgs.split(',') : undefined
           });
         } else if (options.adapter === 'deno') {
           if (!options.denoServiceUrl) {


### PR DESCRIPTION
Added `--docker-args` flag to the `helios job run` command, enabling users to pass arbitrary CLI arguments (e.g. `--gpus all`, `--shm-size 2gb`) to the underlying `docker run` command when executing rendering jobs using the Docker execution adapter.

---
*PR created automatically by Jules for task [17785246638333921340](https://jules.google.com/task/17785246638333921340) started by @BintzGavin*