### PR TITLE
✨ RENDERER: Disable Chromium Sandbox

### DIFF
--- a/.sys/plans/PERF-166-chromium-no-sandbox.md
+++ b/.sys/plans/PERF-166-chromium-no-sandbox.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-166
 slug: chromium-no-sandbox
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2023-10-25
-completed: ""
-result: ""
+completed: "2026-04-03"
+result: "failed"
 ---
 # PERF-166: Disable Chromium Sandbox
 
@@ -44,3 +44,9 @@ Run the verification suite to ensure frames are still accurately captured.
 
 ## Prior Art
 Standard Playwright and Puppeteer practices for Docker environments often recommend `--no-sandbox` to improve performance and stability.
+
+## Results Summary
+- **Best render time**: 34.953s (vs baseline 33.5s)
+- **Improvement**: 0% (discarded)
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-166]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -93,6 +93,10 @@ Last updated by: PERF-136
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **Disable Chromium Sandbox (PERF-166)**:
+  - What you tried: Added `--no-sandbox` and `--disable-setuid-sandbox` to Chromium launch args to avoid zygote processes.
+  - WHY it didn't work: Render time was 34.953s vs baseline 33.5s. In this microVM environment, the sandbox initialization and IPC overhead does not appear to be the limiting factor for layout/paint rendering, or the potential CPU savings are offset by Playwright orchestration overhead.
+  - Plan ID: PERF-166
 - **Pre-calculate execution closures (PERF-162)**:
   - What you tried: Pre-calculating closures outside hot loop in Renderer.ts.
   - WHY it didn't work: Render time degraded or unchanged (Median changed from 33.654 to 33.663). The inline closure overhead is negligible.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -263,3 +263,4 @@ peak_mem_mb:        38.3
 1	47.202	150	3.18	36.0	discard	PERF-161 inline capture and destructuring
 PERF-162	33.663	150	4.47	37.9	failed	Median changed from 33.654 to 33.663
 PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613
+1	34.953	150	4.29	39.0	discard	Disabled Chromium sandbox (--no-sandbox, --disable-setuid-sandbox)


### PR DESCRIPTION
💡 **What**: Added `--no-sandbox` and `--disable-setuid-sandbox` to the Chromium launch args in `packages/renderer/src/Renderer.ts` and ran the standard benchmark.
🎯 **Why**: To test if completely disabling the Chromium sandbox processes (zygotes, seccomp filters) reduces IPC and syscall overhead enough to improve DOM rendering speed in the CPU-bound microVM environment.
📊 **Impact**: The median render time degraded from the baseline of `33.5s` to `34.953s`. The experiment was evaluated as failed (status: `discard`).
🔬 **Verification**: The code changes were automatically reverted by the benchmark script to prevent performance degradation. The findings were correctly logged in `packages/renderer/.sys/perf-results.tsv` and appended to the `What Doesn't Work (and Why)` section of `docs/status/RENDERER-EXPERIMENTS.md`.
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-166-chromium-no-sandbox.md`.

**TSV Data**:
```tsv
155	34.953	150	4.29	39.0	discard	Disabled Chromium sandbox (--no-sandbox, --disable-setuid-sandbox)
```

---
*PR created automatically by Jules for task [13392469903315085857](https://jules.google.com/task/13392469903315085857) started by @BintzGavin*