### PR TITLE
✨ RENDERER: Inline executeFrameCapture in Renderer loop (PERF-167)

### DIFF
--- a/.sys/plans/PERF-167-inline-execute-frame-capture.md
+++ b/.sys/plans/PERF-167-inline-execute-frame-capture.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-167
 slug: inline-execute-frame-capture
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-04-03
-completed: ""
-result: ""
+completed: 2026-04-03
+result: keep
 ---
 # PERF-167: Inline executeFrameCapture function
 
@@ -61,3 +61,9 @@ Review the output `dom-animation.mp4` from the benchmark to ensure frames are su
 ## Prior Art
 - PERF-160: Replaced `.bind` with an inline closure in `Renderer.ts`.
 - PERF-161: Inline capture and destructuring.
+
+## Results Summary
+- **Best render time**: 36.046s (vs baseline 36.167s)
+- **Improvement**: 0.33%
+- **Kept experiments**: PERF-167
+- **Discarded experiments**:

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 32.057s (baseline was 32.242s, -0.6%)
 Last updated by: PERF-136
 
 ## What Works
+- Inline executeFrameCapture function: Improved performance from 36.167s to 36.046s (PERF-167)
 - [PERF-158] Disabled site isolation in Chromium. (Median changed from 33.859 to 33.613)
 - [PERF-160] Replaced `.bind` with an inline closure in `Renderer.ts` `captureLoop`. This avoids intermediate `BoundFunction` object creation in the hot path. Render time improved.
 - PERF-159: Removed closure allocation in capture hot loop using bound function (~34.36s improvement)

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -264,3 +264,4 @@ peak_mem_mb:        38.3
 PERF-162	33.663	150	4.47	37.9	failed	Median changed from 33.654 to 33.663
 PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613
 1	34.953	150	4.29	39.0	discard	Disabled Chromium sandbox (--no-sandbox, --disable-setuid-sandbox)
+117	36.046	150	4.16	38.5	keep	inline executeFrameCapture

--- a/packages/renderer/src/Renderer.ts
+++ b/packages/renderer/src/Renderer.ts
@@ -291,11 +291,6 @@ export class Renderer {
           const signal = jobOptions?.signal;
           const onProgress = jobOptions?.onProgress;
 
-          const executeFrameCapture = function(this: any, worker: any, compositionTimeInSeconds: number, time: number) {
-              worker.timeDriver.setTime(worker.page, compositionTimeInSeconds).catch(noopCatch);
-              return worker.strategy.capture(worker.page, time);
-          };
-
           while (nextFrameToWrite < totalFrames) {
               if (capturedErrors.length > 0) {
                   throw capturedErrors[0];
@@ -311,9 +306,10 @@ export class Renderer {
                   const time = frameIndex * timeStep;
                   const compositionTimeInSeconds = (startFrame + frameIndex) * compTimeStep;
 
-                  const framePromise = worker.activePromise.then(
-                      () => executeFrameCapture(worker, compositionTimeInSeconds, time)
-                  );
+                  const framePromise = worker.activePromise.then(() => {
+                      worker.timeDriver.setTime(worker.page, compositionTimeInSeconds).catch(noopCatch);
+                      return worker.strategy.capture(worker.page, time);
+                  });
 
                   // Add a no-op catch handler to prevent unhandled promise rejections on abort/error
                   worker.activePromise = framePromise.catch(noopCatch) as Promise<void>;


### PR DESCRIPTION
✨ RENDERER: Inline executeFrameCapture in Renderer loop (PERF-167)

💡 What: Removed the intermediate `executeFrameCapture` closure from the `captureLoop` and inlined its functionality directly into the `worker.activePromise.then()` block.
🎯 Why: To reduce function invocation stack overhead and V8 execution stalls per-frame inside the primary render loop.
📊 Impact: Render time improved slightly from the 36.167s baseline to 36.046s.
🔬 Verification: Ran the baseline DOM benchmark and verified expected frame counts and Canvas behavior using existing tests.
📎 Plan: `.sys/plans/PERF-167-inline-execute-frame-capture.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 117 | 36.046 | 150 | 4.16 | 38.5 | keep | inline executeFrameCapture |

---
*PR created automatically by Jules for task [16532097813567015872](https://jules.google.com/task/16532097813567015872) started by @BintzGavin*