### PR TITLE
✨ RENDERER: Document failed optimization for cdpSession truthiness check

### DIFF
--- a/.sys/plans/PERF-170-optimize-cdp-truthiness.md
+++ b/.sys/plans/PERF-170-optimize-cdp-truthiness.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-170
 slug: optimize-cdp-truthiness
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2025-04-05
-completed: ""
-result: ""
+completed: 2025-04-05
+result: failed
 ---
 
 # PERF-170: Remove Defensive Truthiness Checks in DOM Strategy Capture Loop
@@ -109,3 +109,9 @@ Inside `DomStrategy.capture(page: Page, frameTime: number)`, remove the `if (thi
 
 ## Correctness Check
 Verify `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` successfully renders without throwing TypeErrors about `cdpSession`.
+
+## Results Summary
+- **Best render time**: 33.840s (vs baseline 33.962s)
+- **Improvement**: ~0.3%
+- **Kept experiments**: []
+- **Discarded experiments**: [Remove defensive this.cdpSession truthiness checks in capture()]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -98,6 +98,9 @@ Last updated by: PERF-168
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- **Remove defensive truthiness checks for cdpSession directly (PERF-170)**:
+  - What you tried: Removing `if (this.cdpSession)` and `else` fallback branches in `DomStrategy.capture()`.
+  - WHY it didn't work: The micro-stalls from this branch evaluation are negligible and do not improve median render time significantly (33.84s vs 33.96s). Furthermore, removing the fallback paths creates a regression risk if the CDP session fails to attach or isn't supported, causing a crash instead of gracefully falling back to standard `page.screenshot`.
 - **Remove defensive truthiness checks for cdpSession**: Pre-resolving the capture pathway in `DomStrategy.prepare` and executing the pre-bound pathway in the hot loop actually slowed down rendering by ~5.6% (baseline: ~32.05s, experiment: ~33.84s). WHY it didn't work: Re-introducing closure allocation for the pre-resolved `_captureStrategy` negated any minor gains from removing truthiness checks (`cdpSession` and `targetElementHandle`). V8 likely optimizes these highly predictable branches effectively, while dynamic closure execution in the hot loop introduces overhead. (PERF-169)
 - **Disable Chromium Sandbox (PERF-166)**:
   - What you tried: Added `--no-sandbox` and `--disable-setuid-sandbox` to Chromium launch args to avoid zygote processes.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -265,3 +265,4 @@ PERF-162	33.663	150	4.47	37.9	failed	Median changed from 33.654 to 33.663
 PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613
 1	34.953	150	4.29	39.0	discard	Disabled Chromium sandbox (--no-sandbox, --disable-setuid-sandbox)
 117	36.046	150	4.16	38.5	keep	inline executeFrameCapture
+267	33.840	150	4.43	37.6	discard	PERF-170: Remove defensive this.cdpSession truthiness checks in capture()


### PR DESCRIPTION
Evaluated removing the `this.cdpSession` defensive checks inside `DomStrategy.capture()`. The benchmark showed an insignificant median render time improvement (33.840s vs 33.962s baseline) which does not justify the introduced regression risk (loss of the safety fallback mechanism). Thus, the experiment was logged as discarded and the code was fully reverted.

---
*PR created automatically by Jules for task [17104180418004250867](https://jules.google.com/task/17104180418004250867) started by @BintzGavin*