### PR TITLE
✨ RENDERER: Tried to eliminate closure allocation in DomStrategy.capture() (PERF-172)

### DIFF
--- a/.sys/plans/PERF-172-eliminate-closure-allocation-hot-loop.md
+++ b/.sys/plans/PERF-172-eliminate-closure-allocation-hot-loop.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-172
 slug: eliminate-closure-allocation-hot-loop
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2026-10-18
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -98,6 +98,7 @@ Last updated by: PERF-168
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- Tried pre-binding result handlers in DomStrategy.capture() (PERF-172), but the benchmark produced an impossibly fast result (3s vs 32s baseline) indicating a crash or frame skipping.
 - **Eliminate Destructuring (PERF-171)**:
   - What you tried: Removed `({ screenshotData }: any)` object destructuring in `DomStrategy.ts` hot loop.
   - WHY it didn't work: Micro-allocations from destructuring inside promise resolutions were negligible or did not improve median times. V8 optimization is already good.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -267,3 +267,4 @@ PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613
 117	36.046	150	4.16	38.5	keep	inline executeFrameCapture
 267	33.840	150	4.43	37.6	discard	PERF-170: Remove defensive this.cdpSession truthiness checks in capture()
 3	33.451	150	4.48	46.2	discard	eliminate destructuring in DomStrategy capture
+1	0.000	0	0.00	0.0	discard	Eliminated closure allocations in DomStrategy PERF-172 (caused crash/skip)


### PR DESCRIPTION
💡 **What**: Tried extracting inline closures into pre-bound class methods (`handleBeginFrameResult` and `handleFallbackResult`) to avoid per-frame function allocation in `DomStrategy.ts`.
🎯 **Why**: To reduce V8 GC pressure in the hottest rendering path.
📊 **Impact**: N/A - Failed.
🔬 **Verification**: The benchmark failed/skipped rendering completely (produced impossibly fast render time of 3s for 150 frames vs 32s baseline). Reverted code changes.
📎 **Plan**: `/.sys/plans/PERF-172-eliminate-closure-allocation-hot-loop.md`

### Results Summary
```
1	0.000	0	0.00	0.0	discard	Eliminated closure allocations in DomStrategy PERF-172 (caused crash/skip)
```

---
*PR created automatically by Jules for task [13548680980034143627](https://jules.google.com/task/13548680980034143627) started by @BintzGavin*