### PR TITLE
✨ RENDERER: Evaluate Promise Chaining in Hot Loop (PERF-173)

### DIFF
--- a/.sys/plans/PERF-173-promise-chaining.md
+++ b/.sys/plans/PERF-173-promise-chaining.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-173
 slug: promise-chaining
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2025-05-18
-completed: ""
-result: ""
+completed: 2025-05-18
+result: "failed"
 ---
 # PERF-173: Optimize Promise Chaining in Hot Loop
 
@@ -52,3 +52,9 @@ To:
 
 ## Correctness Check
 Run the `verify-dom-strategy-capture.ts` test script to ensure screenshots are captured.
+
+## Results Summary
+- **Best render time**: 123.588s (vs baseline ~33.6s)
+- **Improvement**: -268%
+- **Kept experiments**: None
+- **Discarded experiments**: Flatten Promise Chain (PERF-173)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -98,6 +98,8 @@ Last updated by: PERF-168
 - Hoisted worker frame execution async IIFE in Renderer.ts outside of hot loop. ~0.1s improvement. [PERF-089]
 
 ## What Doesn't Work (and Why)
+- Tried flattening `.then()` promise chains instead of synchronous block closures in `Renderer.ts` hot loop. \n  - **Why it didn't work**: Made rendering time significantly slower (~123s vs ~33s baseline). Reverted as this indicates either excessive chained tick allocations or issues with evaluation execution order. (PERF-173)
+
 - Tried pre-binding result handlers in DomStrategy.capture() (PERF-172), but the benchmark produced an impossibly fast result (3s vs 32s baseline) indicating a crash or frame skipping.
 - **Eliminate Destructuring (PERF-171)**:
   - What you tried: Removed `({ screenshotData }: any)` object destructuring in `DomStrategy.ts` hot loop.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -268,3 +268,7 @@ PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613
 267	33.840	150	4.43	37.6	discard	PERF-170: Remove defensive this.cdpSession truthiness checks in capture()
 3	33.451	150	4.48	46.2	discard	eliminate destructuring in DomStrategy capture
 1	0.000	0	0.00	0.0	discard	Eliminated closure allocations in DomStrategy PERF-172 (caused crash/skip)
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	34.336	150	4.36	39.1	discard	baseline
+2	123.588	150	1.21	36.8	discard	baseline
+3	123.660	150	1.21	37.1	discard	baseline


### PR DESCRIPTION
Evaluated flattening `.then()` promise chain in `Renderer.ts` hot loop (PERF-173). The experiment failed, producing a slower render time (~123s vs ~33s baseline), indicating potential issues with Playwright execution queue limits. The codebase was reverted, results written to `perf-results.tsv`, and `.sys/plans/PERF-173-promise-chaining.md` and `docs/status/RENDERER-EXPERIMENTS.md` updated.

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 34.336 | 150 | 4.36 | 39.1 | discard | baseline |
| 2 | 123.588 | 150 | 1.21 | 36.8 | discard | baseline |
| 3 | 123.660 | 150 | 1.21 | 37.1 | discard | baseline |


---
*PR created automatically by Jules for task [7783914825001881343](https://jules.google.com/task/7783914825001881343) started by @BintzGavin*