### PR TITLE
📋 PLAYER: Document Media Session Properties

### DIFF
--- a/.sys/plans/2026-11-25-PLAYER-Document-MediaSession-Properties.md
+++ b/.sys/plans/2026-11-25-PLAYER-Document-MediaSession-Properties.md
@@ -1,0 +1,23 @@
+#### 1. Context & Goal
+- **Objective**: Document the `mediaTitle`, `mediaArtist`, `mediaAlbum`, and `mediaArtwork` properties in the `README.md`.
+- **Trigger**: The properties were recently added to `<helios-player>` to achieve Media Session parity (`v0.77.0`), but are missing from the "Standard Media API - Properties" section in `README.md`.
+- **Impact**: Improves API parity documentation and makes the properties discoverable to users.
+
+#### 2. File Inventory
+- **Create**: []
+- **Modify**: [`packages/player/README.md`]
+- **Read-Only**: [`packages/player/src/index.ts`]
+
+#### 3. Implementation Spec
+- **Architecture**: N/A - Documentation update
+- **Pseudo-Code**:
+  - Edit `packages/player/README.md`
+  - Locate the `### Properties` list under `## Standard Media API`.
+  - Append entries for `mediaTitle`, `mediaArtist`, `mediaAlbum`, and `mediaArtwork`, indicating they correspond to their respective reflected attributes.
+- **Public API Changes**: Documentation only.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `cat packages/player/README.md | grep -i "mediaTitle"`
+- **Success Criteria**: The properties are correctly listed in the README's properties section.
+- **Edge Cases**: N/A


### PR DESCRIPTION
Creates a plan to document the recently added `mediaTitle`, `mediaArtist`, `mediaAlbum`, and `mediaArtwork` properties in the README's Standard Media API section.

---
*PR created automatically by Jules for task [6237220127052453690](https://jules.google.com/task/6237220127052453690) started by @BintzGavin*