### PR TITLE
✨ RENDERER: Evaluate PERF-180 Inline Parameters in SeekTimeDriver

### DIFF
--- a/.sys/plans/PERF-180-inline-seektimedriver-params.md
+++ b/.sys/plans/PERF-180-inline-seektimedriver-params.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-180
 slug: inline-seektimedriver-params
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-28
-completed: ""
-result: ""
+completed: 2024-05-28
+result: "failed"
 ---
 
 # PERF-180: Inline Parameters in SeekTimeDriver
@@ -101,3 +101,8 @@ Verify that rendering completes correctly and the output MP4 is generated.
 ## Prior Art
 - PERF-178: Inline parameters in `DomStrategy.ts`
 - PERF-179: Inline parameters in `CdpTimeDriver.ts`
+## Results Summary
+- **Best render time**: 14.631s (vs baseline 3.993s)
+- **Improvement**: -366%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-180: Inline parameters in SeekTimeDriver]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -5,7 +5,7 @@ Last updated by: PERF-178
 ## What Works
 - **Inline parameter construction for `cdpSession.send('HeadlessExperimental.beginFrame')`** (PERF-178): Inlining standard object literals for `cdpSession.send` params instead of pre-allocating an object in the loop avoided local variable overhead and further simplified byte code. The targeted parameters needed to use `as any` to compile without TS errors regarding `clip` instead of passing the object into the screenshot parameter, which V8 optimizes well.
 - Eliminated CDP destructuring and spread operator in hot loop (~X% faster) - PERF-177
-
-
-## What Works
 - PERF-179: Inlined object literal for `this.client!.send('Emulation.setVirtualTimePolicy', { ... })` in `packages/renderer/src/drivers/CdpTimeDriver.ts`. This avoids dynamic allocation of a `params` object on every frame when advancing virtual time. While CdpTimeDriver isn't the default in `dom` mode, reducing loop allocation overhead is functionally safer and follows the same optimizations in PERF-178.
+
+## What Doesn't Work (and Why)
+- PERF-180: Inline parameters in SeekTimeDriver. Inlined parameters in the cdpSession.send. Did not improve performance over the baseline, resulting in 14.631s vs baseline 3.993s. The reason is likely due to V8 having already cached object types efficiently in earlier optimization phases or the difference being imperceptible against IPC overhead, coupled with unexpected regression overhead from garbage collection handling of intermediate anonymous objects in `Promises[i]`.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -276,3 +276,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 2	3.764	150	39.42	40.8	keep	PERF-174 optimize setTime promise
 276	3.980	150	37.69	39.7	keep	PERF-175: dynamic shallow objects for CDP
 277	3.875	150	38.71	37.9	keep	eliminate destructuring and spread in capture
+278	14.631	150	10.25	38.5	discard	inline seektimedriver params


### PR DESCRIPTION
✨ RENDERER: Evaluate PERF-180 Inline Parameters in SeekTimeDriver

💡 What: Executed the single experiment proposed by PERF-180 to inline object literals in the `SeekTimeDriver`'s hot loop when making calls to `cdpSession.send`. Documented results in the results file as discarded and restored the original codebase because performance severely degraded.
🎯 Why: Followed an iterative experimentation to improve CPU-bound execution speed under DOM rendering.
📊 Impact: Degraded render times by approximately -366% (-14.631s compared to the 3.993s baseline), presumably due to excessive GC stalling overhead against anonymous parameter structures created within array mapping closures during `cdpSession.send`.
🔬 Verification: Benchmarked results over the `dom` mode correctly tracked via the 4-gate suite testing determinism and verifying DOM vs. Canvas rendering implementations were unimpeded.
📎 Plan: `/.sys/plans/PERF-180-inline-seektimedriver-params.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 278 | 14.631 | 150 | 10.25 | 38.5 | discard | inline seektimedriver params |

---
*PR created automatically by Jules for task [1839454745479446896](https://jules.google.com/task/1839454745479446896) started by @BintzGavin*