### PR TITLE
✨ RENDERER: [Failed] Increase Pipeline Depth

### DIFF
--- a/.sys/plans/PERF-182-pipeline-depth.md
+++ b/.sys/plans/PERF-182-pipeline-depth.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-182
 slug: pipeline-depth
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-04-05
-completed: ""
-result: ""
+completed: 2026-04-05
+result: failed
 ---
 
 # PERF-182: Increase Pipeline Depth to Improve Frame Capture Throughput
@@ -48,3 +48,8 @@ Run the `benchmark.ts` to ensure rendering still completes successfully with the
 
 ## Canvas Smoke Test
 No changes are being made to canvas-specific APIs, but we will ensure standard imports and logic compiles correctly by running `npm run test -w packages/renderer`.
+## Results Summary
+- **Best render time**: 0.000s (vs baseline 3.800s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-182-pipeline-depth]

--- a/packages/renderer/.sys/perf-results-PERF-182.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-182.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	keep	baseline
+2	0.000	0	0.00	0.0	discard	maxPipelineDepth=poolLen*8


### PR DESCRIPTION
💡 **What**: The experiment run and its outcome: Increased maxPipelineDepth to poolLen * 8, but it timed out and failed.
🎯 **Why**: The performance bottleneck targeted: IPC latency between Node.js and Chromium leading to FFmpeg stdin starvation.
📊 **Impact**: Before/after render times and percentage improvement: 0.00s vs baseline, 0% improvement.
🔬 **Verification**: What was tested (4-gate verification, benchmark results): Ran tests, but the benchmark timeout failed.
📎 **Plan**: Reference the plan file (/.sys/plans/PERF-182-pipeline-depth.md)

---
*PR created automatically by Jules for task [17724634790018757712](https://jules.google.com/task/17724634790018757712) started by @BintzGavin*