### PR TITLE
📋 RENDERER: [Parameter Unrolling and Closure Inlining in DomStrategy & Renderer]

### DIFF
--- a/.sys/plans/PERF-186-inline-closures-and-parameters.md
+++ b/.sys/plans/PERF-186-inline-closures-and-parameters.md
@@ -1,0 +1,59 @@
+---
+id: PERF-186
+slug: inline-closures-and-parameters
+status: unclaimed
+claimed_by: ""
+created: 2026-04-05
+completed: ""
+result: ""
+---
+
+PERF-186: Parameter Unrolling and Closure Inlining in DomStrategy & Renderer
+
+Focus Area
+DOM Frame Capture Loop in packages/renderer/src/Renderer.ts and packages/renderer/src/strategies/DomStrategy.ts. The focus is on eliminating method invocation overhead (this.writeToBufferPool) and object property access overhead inside async worker loops, as well as unrolling the nested screenshot parameter in HeadlessExperimental.beginFrame.
+
+Background Research
+Based on previous memory context, inlining the screenshot parameters in cdpSession.send (PERF-178) was partially implemented but missed the nested unrolling of the screenshot object itself (it still referenced this.beginFrameParams). Fully inlining the nested literal allows V8 to optimize the entire payload as a single allocation.
+Additionally, inside Renderer.ts, the captureWorkerFrame async helper currently accesses properties on the worker object (worker.activePromise, worker.timeDriver, etc) inside its execution scope. By unrolling these into direct parameters, V8 can store these references in registers for the async state machine without needing to dereference the worker object on every tick.
+Finally, this.writeToBufferPool adds an unnecessary method invocation layer around Buffer.from in the innermost hot loop closure of DomStrategy.ts.
+
+Benchmark Configuration
+- Composition URL: file:///app/output/example-build/examples/simple-animation/composition.html
+- Render Settings: 1280x720, 30fps, 5 seconds (150 frames)
+- Mode: dom
+- Metric: Wall-clock render time in seconds
+- Minimum runs: 3 per experiment, report median
+
+Baseline
+- Current estimated render time: ~13.7s
+- Bottleneck analysis: Micro-stalls from object property reads in async generators and nested object literal referencing.
+
+Implementation Spec
+
+Step 1: Inline Nested Parameters and Buffer decoding in DomStrategy
+File: packages/renderer/src/strategies/DomStrategy.ts
+What to change:
+1. Remove private writeToBufferPool(screenshotData: string): Buffer method entirely.
+2. In capture(), inline the screenshot parameters: screenshot: { format: this.cdpScreenshotParams.format, quality: this.cdpScreenshotParams.quality } instead of using this.beginFrameParams.
+3. Inside the beginFrame .then closure, inline Buffer.from(res.screenshotData, 'base64') and flatten the fallback logic.
+
+Why: Unrolling the object literal allows V8's escape analysis to optimize the allocation, and removing the method call reduces frame overhead.
+Risk: Syntax errors or incorrect this.cdpScreenshotParams reference.
+
+Step 2: Unroll Worker Properties in captureWorkerFrame
+File: packages/renderer/src/Renderer.ts
+What to change:
+Modify the signature of captureWorkerFrame to accept explicit arguments instead of the worker object:
+`const captureWorkerFrame = async (activePromise: Promise<void>, timeDriver: TimeDriver, page: import('playwright').Page, strategy: RenderStrategy, compositionTimeInSeconds: number, time: number): Promise<Buffer> => { ... }`
+Update the invocation in the loop:
+`const framePromise = captureWorkerFrame(worker.activePromise, worker.timeDriver, worker.page, worker.strategy, compositionTimeInSeconds, time);`
+
+Why: Dereferencing worker.property inside an async function forces V8 to perform object shape checks during state machine resumption. Passing explicit arguments avoids this.
+Risk: Parameter misalignment.
+
+Canvas Smoke Test
+Run npm run test:renderer to verify Canvas is unbroken.
+
+Correctness Check
+Ensure output dom-animation.mp4 has no visual stuttering.


### PR DESCRIPTION
💡 What: Creating PERF-186 experiment plan for inline closures and parameter unrolling in capture hot loops.
🎯 Why: To avoid method invocation and object dereferencing overhead inside async state machines.
🔬 Approach: Inline \`screenshot\` parameter object creation in CDP send and pass explicit properties to \`captureWorkerFrame\`.
📎 Plan: /.sys/plans/PERF-186-inline-closures-and-parameters.md

---
*PR created automatically by Jules for task [5987541733492346138](https://jules.google.com/task/5987541733492346138) started by @BintzGavin*