### PR TITLE
✨ CLI: Mark domain as blocked waiting for plan

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -134,3 +134,5 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] **Documentation**: Add Quickstart guide.
 - [x] ⛔ Renderer Verification Blocked: packages/studio dependency mismatch
 
+## Blocked Items
+- [ ] [v0.46.2] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,6 @@
 # CLI Status
 
-**Version**: 0.45.1
+**Version**: 0.46.2
 
 ## Recent Completions
 [v0.45.1] ✅ Completed: Scaffold Cloudflare Sandbox Deployment - Verified `helios deploy cloudflare-sandbox` command is implemented and working.
@@ -18,7 +18,7 @@ The Helios CLI is the primary user interface for component registry, project sca
 - Implement regression tests for remaining commands (e.g. `job.ts`, `render.ts`, `merge.ts`).
 
 ## Blocked Items
-- None
+- [v0.46.2] Blocked: Waiting for a new, valid plan in /.sys/plans/
 
 ## Available Commands
 1. **Studio Command** - `helios studio` for launching dev server


### PR DESCRIPTION
💡 **What**: Marked the CLI domain as blocked.
🎯 **Why**: No valid, uncompleted execution plans remain in `/.sys/plans/` that map to the CLI. All tier 3 adapters, docker adapters, add commands, etc., are fully implemented in `packages/cli/src/commands/deploy.ts` and others. Following EXECUTOR rules, execution has stopped until a new plan is available.
📊 **Impact**: Safely halts automated execution to prevent hallucinations.
🔬 **Verification**: Ran `helios --help` and tested build integrity. Checked `deploy.ts` source confirming completion of `Scaffold-Hetzner-Deployment`, `Tier3-Deployment` etc.

---
*PR created automatically by Jules for task [12559890201425559645](https://jules.google.com/task/12559890201425559645) started by @BintzGavin*