### PR TITLE
📋 RENDERER: Cache Page Frames Array in Time Drivers to Eliminate Per-Frame Allocation Overhead

### DIFF
--- a/.sys/plans/PERF-188-cache-page-frames.md
+++ b/.sys/plans/PERF-188-cache-page-frames.md
@@ -1,0 +1,66 @@
+---
+id: PERF-188
+slug: cache-page-frames
+status: unclaimed
+claimed_by: ""
+created: 2026-04-05
+completed: ""
+result: ""
+---
+# PERF-188: Cache Page Frames Array in Time Drivers to Eliminate Per-Frame Allocation Overhead
+
+## Focus Area
+The hot loops in `SeekTimeDriver.setTime` and `CdpTimeDriver.setTime` within `packages/renderer/src/drivers/`.
+
+## Background Research
+Currently, `page.frames()` is invoked on every single frame inside the `setTime()` method of the time drivers. In the Playwright Node.js client, `page.frames()` is not a simple property getter; it constructs and returns a new Array of all frames in the page hierarchy by traversing its internal frame tree. Calling this method repeatedly (e.g., 60 times per second per parallel worker) forces continuous Array allocation and subsequent garbage collection, contributing to micro-stalls. Additionally, `page.mainFrame()` is also called in `SeekTimeDriver` per frame, which incurs a method invocation overhead.
+
+Since the page hierarchy (number of iframes) is static after the composition is loaded and initialized during the `prepare()` phase, we can cache the `frames` array and the `mainFrame` reference once and reuse them safely in the hot loop.
+
+## Benchmark Configuration
+- **Composition URL**: `file:///app/output/example-build/examples/simple-animation/composition.html`
+- **Render Settings**: 1280x720, 30fps, 5 seconds (150 frames)
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~3.49s
+- **Bottleneck analysis**: Micro-stalls from Playwright internal tree traversals and Array allocations (`page.frames()`) on every frame tick.
+
+## Implementation Spec
+
+### Step 1: Cache `frames` and `mainFrame` in `SeekTimeDriver`
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+1. Add `private cachedFrames: import('playwright').Frame[] = [];` to the `SeekTimeDriver` class properties.
+2. Add `private cachedMainFrame: import('playwright').Frame | null = null;` to the class properties.
+3. In `prepare(page: Page)`, append to the end of the method:
+   ```typescript
+   this.cachedFrames = page.frames();
+   this.cachedMainFrame = page.mainFrame();
+   ```
+4. In `setTime(page: Page, timeInSeconds: number)`, replace `const frames = page.frames();` with `const frames = this.cachedFrames;`.
+5. In the `setTime` for loop, replace `if (frame === page.mainFrame())` with `if (frame === this.cachedMainFrame)`.
+
+**Why**: Eliminates the overhead of Array instantiation, garbage collection, and internal tree traversal on every frame capture tick.
+**Risk**: If the DOM dynamically injects new `<iframe>` elements during the render, the new iframes wouldn't receive time synchronization. However, Helios compositions rely on deterministic, ahead-of-time DOM trees, making this a safe trade-off for performance.
+
+### Step 2: Cache `frames` in `CdpTimeDriver`
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+1. Add `private cachedFrames: import('playwright').Frame[] = [];` to the `CdpTimeDriver` class.
+2. In `prepare(page: Page)`, append to the end of the method:
+   ```typescript
+   this.cachedFrames = page.frames();
+   ```
+3. In `setTime(page: Page, timeInSeconds: number)`, replace `const frames = page.frames();` with `const frames = this.cachedFrames;`.
+
+**Why**: Provides the same performance benefit and GC reduction for the CDP fallback time driver.
+**Risk**: Same as Step 1.
+
+## Correctness Check
+Run the renderer benchmark script `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to verify the DOM rendering still succeeds and produces a valid output file.
+
+## Prior Art
+Builds upon previous GC reduction experiments like PERF-185, PERF-186, and PERF-187 by targeting Node.js array allocation overhead inside the innermost Playwright automation loops.


### PR DESCRIPTION
💡 What: Cache page.frames() array and page.mainFrame() reference in SeekTimeDriver and CdpTimeDriver.
🎯 Why: Eliminates Node.js Array allocation and Playwright tree traversal overhead on every frame tick in the hot loop.
🔬 Approach: Store frames array once during prepare() and reuse it in setTime().
📎 Plan: .sys/plans/PERF-188-cache-page-frames.md

---
*PR created automatically by Jules for task [7058436770613314338](https://jules.google.com/task/7058436770613314338) started by @BintzGavin*