### PR TITLE
📋 RENDERER: Eliminate activePromise .then() closure allocation in Renderer loop

### DIFF
--- a/.sys/plans/PERF-192-refactor-promise-chaining.md
+++ b/.sys/plans/PERF-192-refactor-promise-chaining.md
@@ -1,0 +1,59 @@
+---
+id: PERF-192
+slug: refactor-promise-chaining
+status: unclaimed
+claimed_by: ""
+created: 2024-05-30
+completed: ""
+result: ""
+---
+
+PERF-192: Eliminate activePromise .then() closure allocation in Renderer loop
+
+Focus Area
+DOM Rendering Pipeline hot loop inside packages/renderer/src/Renderer.ts and SeekTimeDriver.ts.
+
+Background Research
+In packages/renderer/src/Renderer.ts, the loop that refilis the frame pipeline constructs a promise chain for each frame to ensure sequential processing by the same worker. It does this by appending a .then() closure (`worker.activePromise = framePromise.then(undefined, noopCatch) as Promise<void>;`). Since this happens on every frame per worker, it allocates numerous Promise objects and closures, placing pressure on V8's Garbage Collector. We can eliminate the .then() closure entirely by catching rejections inside the captureWorkerFrame async function itself and assigning framePromise directly to activePromise.
+Additionally, in packages/renderer/src/drivers/SeekTimeDriver.ts, the slow path for setTime (`promises[i] = frame.evaluate(...)`) dynamically allocates a new `Array(frames.length)` per frame. Caching this array will further reduce micro-allocations.
+
+Benchmark Configuration
+- Composition URL: file:///app/examples/simple-animation/composition.html
+- Render Settings: 1280x720, 30fps, 5 seconds (150 frames)
+- Mode: dom
+- Metric: Wall-clock render time in seconds
+- Minimum runs: 3 per experiment, report median
+
+Baseline
+- Current estimated render time: ~33.6s
+- Bottleneck analysis: GC pressure from dynamic promise chaining in the hot loop.
+
+Implementation Spec
+
+Step 1: Eliminate .then() closure in Renderer.ts
+File: packages/renderer/src/Renderer.ts
+What to change:
+1. In the captureWorkerFrame async function, replace `await activePromise;` with a try-catch block to handle previous rejections gracefully:
+`try { await activePromise; } catch (e) { /* ignore */ }`
+2. In the captureLoop where `worker.activePromise` is assigned, change:
+`worker.activePromise = framePromise.then(undefined, noopCatch) as Promise<void>;`
+to:
+`worker.activePromise = framePromise as unknown as Promise<void>;`
+
+Why: Eliminating the .then() closure significantly reduces V8 Garbage Collection pressure.
+Risk: Mismanagement of promise rejections if the catch block is incorrectly implemented.
+
+Step 2: Cache promises array in SeekTimeDriver.ts
+File: packages/renderer/src/drivers/SeekTimeDriver.ts
+What to change:
+1. Add `private cachedPromises: Promise<any>[] = [];` to the class properties.
+2. In setTime, replace `const promises: Promise<any>[] = new Array(frames.length);` with logic to reuse the cached array:
+`if (this.cachedPromises.length !== frames.length) { this.cachedPromises = new Array(frames.length); }`
+`const promises = this.cachedPromises;`
+
+Why: Avoids allocating a new Array object on every frame when the frame tree size is stable.
+Risk: Array elements from previous frames might linger, though Promise.all consumes them immediately and they are overwritten.
+
+Correctness Check
+Run npx tsx packages/renderer/tests/verify-cdp-driver.ts to verify DOM rendering still functions properly.
+Run npx tsx packages/renderer/tests/fixtures/benchmark.ts to verify the DOM rendering still succeeds and produces a valid output.


### PR DESCRIPTION
📋 RENDERER: Eliminate activePromise .then() closure allocation in Renderer loop

💡 What: Update captureWorkerFrame to handle await try/catch to drop the .then() chain, and cache promises array in SeekTimeDriver.
🎯 Why: Eliminating .then() closures inside the synchronous hot loop significantly reduces V8 Garbage Collection pressure.
🔬 Approach: Modify Renderer.ts to assign framePromise directly and handle promise catching inside captureWorkerFrame, and cache multi-frame array in SeekTimeDriver.ts.
📏 Plan: /.sys/plans/PERF-192-refactor-promise-chaining.md

---
*PR created automatically by Jules for task [16928852523178581125](https://jules.google.com/task/16928852523178581125) started by @BintzGavin*