### PR TITLE
📋 RENDERER: Preallocate Runtime.evaluate Parameters in SeekTimeDriver

### DIFF
--- a/.sys/plans/PERF-194-preallocate-seek-evaluate.md
+++ b/.sys/plans/PERF-194-preallocate-seek-evaluate.md
@@ -1,0 +1,26 @@
+---
+id: PERF-194
+slug: preallocate-seek-evaluate
+status: unclaimed
+claimed_by: ""
+created: 2024-06-01
+completed: ""
+result: ""
+---
+# PERF-194: Preallocate Runtime.evaluate Parameters in SeekTimeDriver
+
+## Focus Area
+packages/renderer/src/drivers/SeekTimeDriver.ts - setTime method.
+
+## Background Research
+The SeekTimeDriver constructs a new object literal { expression: ..., awaitPromise: true } on every invocation. We can pre-allocate an object as a class property to reduce allocations.
+
+## Benchmark Configuration
+- Composition URL: file:///app/output/example-build/examples/simple-animation/composition.html
+- Render Settings: 1280x720, 30fps, 5 seconds
+- Mode: dom
+- Metric: Wall-clock render time in seconds
+- Minimum runs: 3 per experiment, report median
+
+## Implementation Spec
+Cache evaluateParams in SeekTimeDriver and reuse it.

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -10,6 +10,7 @@ export class SeekTimeDriver implements TimeDriver {
   private cachedFrames: import('playwright').Frame[] = [];
   private cachedMainFrame: import('playwright').Frame | null = null;
   private cachedPromises: Promise<any>[] = [];
+  private evaluateParams = { expression: '', awaitPromise: true };
 
   constructor(private timeout: number = 30000) {}
 
@@ -249,12 +250,10 @@ export class SeekTimeDriver implements TimeDriver {
 
   setTime(page: Page, timeInSeconds: number): Promise<void> {
     const frames = this.cachedFrames;
+    this.evaluateParams.expression = `window.__helios_seek(${timeInSeconds}, ${this.timeout})`;
 
     if (frames.length === 1) {
-      return this.cdpSession!.send('Runtime.evaluate', {
-        expression: `window.__helios_seek(${timeInSeconds}, ${this.timeout})`,
-        awaitPromise: true
-      }) as Promise<any>;
+      return this.cdpSession!.send('Runtime.evaluate', this.evaluateParams) as Promise<any>;
     }
 
     if (this.cachedPromises.length !== frames.length) {
@@ -265,10 +264,7 @@ export class SeekTimeDriver implements TimeDriver {
     for (let i = 0; i < frames.length; i++) {
       const frame = frames[i];
       if (frame === this.cachedMainFrame) {
-        promises[i] = this.cdpSession!.send('Runtime.evaluate', {
-          expression: `window.__helios_seek(${timeInSeconds}, ${this.timeout})`,
-          awaitPromise: true
-        });
+        promises[i] = this.cdpSession!.send('Runtime.evaluate', this.evaluateParams);
       } else {
         promises[i] = frame.evaluate(
           ([t, timeoutMs]) => { (window as any).__helios_seek(t, timeoutMs); },


### PR DESCRIPTION
💡 What: Cached the evaluate params object as a class property in SeekTimeDriver.
🎯 Why: To reduce object allocation micro-stalls during Playwright IPC payload construction inside the hot loop.
🔬 Approach: Mutate the expression string of a pre-allocated params object rather than creating `{ expression, awaitPromise }` every frame.
📏 Plan: /.sys/plans/PERF-194-preallocate-seek-evaluate.md

---
*PR created automatically by Jules for task [8935542082446246858](https://jules.google.com/task/8935542082446246858) started by @BintzGavin*