### PR TITLE
✨ RENDERER: Eliminate SeekTimeDriver IPC Overhead

### DIFF
--- a/.sys/plans/PERF-199-eliminate-seek-ipc.md
+++ b/.sys/plans/PERF-199-eliminate-seek-ipc.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-199
 slug: eliminate-seek-ipc
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-30
-completed: ""
-result: ""
+completed: "2024-05-30"
+result: "discarded"
 ---
 
 # PERF-199: Eliminate SeekTimeDriver IPC Overhead
@@ -56,3 +56,9 @@ Run the standard benchmark and manually inspect the output mp4 to ensure the ani
 ## Prior Art
 - PERF-194 (Preallocate evaluate objects) targeted this exact same bottleneck.
 - PERF-184 (Replace startScreencast with beginFrame) established synchronous DOM frame captures.
+
+## Results Summary
+- **Best render time**: 35.091s (vs baseline 33.331s)
+- **Improvement**: -5.2%
+- **Kept experiments**: []
+- **Discarded experiments**: [Eliminate SeekTimeDriver IPC via rAF synchronous evaluate hook]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -2,7 +2,7 @@
 Current best: 32.916s (baseline was 33.6s, -2.0%)
 Last updated by: PERF-127
 
-Current best: 33.331s (baseline was 49.436s, -32.5%)
+Current best: 35.091s (baseline was 49.436s, -32.5%)
 Last updated by: PERF-198
 
 ## What Works
@@ -21,6 +21,7 @@ Last updated by: PERF-198
 - **Replace startScreencast with beginFrame in DomStrategy** (PERF-184): Replaced the damage-driven `Page.startScreencast` capture approach with synchronous `HeadlessExperimental.beginFrame` for the full-page DOM fallback. Improved render time to ~6.6s.
 
 ## What Doesn't Work (and Why)
+- **Eliminate SeekTimeDriver IPC** (PERF-199): Hooked rAF to evaluate __helios_seek inline in browser rather than Node CDP per frame. Render time was 35.091s, which is slower than the 33.331s baseline, so it was discarded.
 - Replace image2pipe (`PERF-197`): Update the -f flag for the video input from image2pipe to the format dynamically corresponding to this.cdpScreenshotParams.format. Did not improve render time, actually degraded from ~33.5s to 34.2s. Bypassing FFmpeg probing heuristics dynamically provided no real-world gain, suggesting pipe format parsing overhead in FFmpeg is not the bottleneck or node writable stream handles image2pipe identically well.
 - PERF-180: Inline parameters in SeekTimeDriver. Inlined parameters in the cdpSession.send. Did not improve performance over the baseline, resulting in 14.631s vs baseline 3.993s. The reason is likely due to V8 having already cached object types efficiently in earlier optimization phases or the difference being imperceptible against IPC overhead, coupled with unexpected regression overhead from garbage collection handling of intermediate anonymous objects in `Promises[i]`.
 - PERF-181: Streamlined screencast capture (hangs on beginFrame substitution). `startScreencast` does not provide synchronous, deterministic frame guarantees like `beginFrame`. The reliance on `window.__helios_damage` to force screencast emissions fails to reliably queue frames, causing the pipeline to starve and deadlock while waiting for the next pushed frame in `capture()`.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -282,3 +282,4 @@ PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613
 1	35.690	150	4.20	38.0	discard	remove CDP session check overhead
 30	33.700	150	4.45	37.7	keep	stream base64 string directly to FFmpeg stdin
 1	33.929	150	4.42	37.8	keep	Re-enabled process-per-tab
+8	35.091	150	4.27	37.3	discard	Eliminate SeekTimeDriver IPC via rAF synchronous evaluate hook


### PR DESCRIPTION
💡 **What**: Evaluated an experiment to hook `__helios_seek` directly in `requestAnimationFrame` and removed the IPC per-frame evaluate call. The code was reverted because it resulted in a degraded performance.
🎯 **Why**: SeekTimeDriver `Runtime.evaluate` IPC overhead was thought to be a bottleneck.
📊 **Impact**: Degraded. The performance was 35.091s, versus baseline 33.331s.
🔬 **Verification**: Ran `packages/renderer/tests/verify-canvas-strategy.ts` and `benchmark.ts`. Tests confirmed functionality, but benchmark confirmed regression. Code reverted.
📎 **Plan**: `/.sys/plans/PERF-199-eliminate-seek-ipc.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 8 | 35.091 | 150 | 4.27 | 37.3 | discard | Eliminate SeekTimeDriver IPC via rAF synchronous evaluate hook |

---
*PR created automatically by Jules for task [6941104353725178565](https://jules.google.com/task/6941104353725178565) started by @BintzGavin*