### PR TITLE
📋 RENDERER: Eliminate Script Parsing Overhead via Runtime.callFunctionOn

### DIFF
--- a/.sys/plans/PERF-202-sync-seek-driver.md
+++ b/.sys/plans/PERF-202-sync-seek-driver.md
@@ -1,0 +1,81 @@
+---
+id: PERF-202
+slug: sync-seek-driver
+status: unclaimed
+claimed_by: ""
+created: 2024-05-25
+completed: ""
+result: ""
+---
+
+# PERF-202: Eliminate Script Parsing Overhead via Runtime.callFunctionOn
+
+## Focus Area
+DOM Rendering Pipeline - Frame Capture Loop Hot Path (Phase 4)
+
+## Background Research
+Currently, `SeekTimeDriver.setTime` evaluates a dynamically interpolated script string on every frame using `Runtime.evaluate`:
+`window.__helios_seek(${timeInSeconds}, ${this.timeout})`
+Because the string literal changes constantly as time advances, V8 cannot cache the parsed Abstract Syntax Tree (AST) or byte code. This forces the browser to allocate a new string, parse it, compile it, and execute it 60 times per second for every parallel worker, resulting in unnecessary CPU overhead and V8 garbage collection micro-stalls.
+By refactoring this to use `Runtime.callFunctionOn` with a static `functionDeclaration` and dynamic `arguments`, V8 will cache the compiled function after the first invocation.
+
+## Benchmark Configuration
+- **Composition URL**: The standard DOM benchmark composition
+- **Render Settings**: Baseline identical settings across all runs
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~33.7s
+- **Bottleneck analysis**: IPC string serialization and continuous V8 AST parsing/compilation overhead in the hot loop.
+
+## Implementation Spec
+
+### Step 1: Pre-allocate static parameters for callFunctionOn
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+Replace the existing `evaluateParams` class property with `callParams`:
+```typescript
+  private callParams: any = {
+    functionDeclaration: 'function(t, timeout) { return this.__helios_seek(t, timeout); }',
+    objectId: '',
+    arguments: [ { value: 0 }, { value: 0 } ],
+    awaitPromise: true,
+    returnByValue: false
+  };
+```
+Keep `evaluateParams` as a fallback since `callFunctionOn` requires an `objectId`.
+
+### Step 2: Fetch window objectId during prepare
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+In the `prepare()` method, after `this.cdpSession` is initialized and scripts are injected:
+```typescript
+    const windowRes = await this.cdpSession!.send('Runtime.evaluate', { expression: 'window' });
+    if (windowRes.result && windowRes.result.objectId) {
+        this.callParams.objectId = windowRes.result.objectId;
+    }
+    this.callParams.arguments[1].value = this.timeout;
+```
+
+### Step 3: Use callFunctionOn in hot loop
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+In `setTime()`, check if `this.callParams.objectId` is populated. If it is and `frames.length === 1`, use `Runtime.callFunctionOn`:
+```typescript
+    if (frames.length === 1 && this.callParams.objectId) {
+      this.callParams.arguments[0].value = timeInSeconds;
+      return this.cdpSession!.send('Runtime.callFunctionOn', this.callParams) as Promise<any>;
+    }
+```
+Otherwise, fallback to the existing `evaluateParams.expression` loop.
+
+## Variations
+- **Variation A**: Attempt to pass the function via `Runtime.evaluate` by evaluating a closure generator once, storing the `objectId` of the returned function, and then calling `Runtime.callFunctionOn` on that function directly without `window` binding.
+
+## Canvas Smoke Test
+Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas mode still works properly.
+
+## Correctness Check
+Run `npx tsx packages/renderer/tests/verify-cdp-driver.ts` (or similar seek test) to verify DOM fallback capture succeeds.


### PR DESCRIPTION
💡 What: Replace SeekTimeDriver Runtime.evaluate with Runtime.callFunctionOn.
🎯 Why: Avoids re-parsing the seek function string on every frame, reducing V8 GC micro-stalls.
🔬 Approach: Fetch window objectId and call a static function declaration dynamically.
📎 Plan: /.sys/plans/PERF-202-sync-seek-driver.md

---
*PR created automatically by Jules for task [10309122560071856449](https://jules.google.com/task/10309122560071856449) started by @BintzGavin*