### PR TITLE
✨ RENDERER: Optimize SeekTimeDriver runtime via callFunctionOn

### DIFF
--- a/.sys/plans/PERF-202-sync-seek-driver.md
+++ b/.sys/plans/PERF-202-sync-seek-driver.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-202
 slug: sync-seek-driver
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-25
-completed: ""
-result: ""
+completed: "2024-05-25"
+result: "improved"
 ---
 
 # PERF-202: Eliminate Script Parsing Overhead via Runtime.callFunctionOn
@@ -79,3 +79,9 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/verify-cdp-driver.ts` (or similar seek test) to verify DOM fallback capture succeeds.
+
+## Results Summary
+- **Best render time**: 32.947s
+- **Improvement**: ~2.3%
+- **Kept experiments**: PERF-202
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -6,6 +6,7 @@ Current best: 35.091s (baseline was 49.436s, -32.5%)
 Last updated by: PERF-198
 
 ## What Works
+- PERF-202: Replaced evaluate with callFunctionOn in SeekTimeDriver to eliminate AST parsing overhead. Result: ~32.9s.
 - PERF-200: Defaulted libx264 to ultrafast preset. Reduced cpu cycles. Render time ~33.7s.
 - Removed `await` from `capturePromise` return inside `captureWorkerFrame` hot loop natively allowing V8 promise chaining (PERF-127) (~2.0% faster)
 - Stream base64 string directly to FFmpeg stdin (`PERF-195`): Avoids buffering Base64 string from CDP inside JS before writing to FFmpeg by taking advantage of Node.js string base64 write streaming. Reduced garbage collection of large `Buffer`s. Yielded 33.700s median render time (similar to baseline 33.557s). Kept for reduced GC load.
@@ -42,6 +43,7 @@ Last updated by: PERF-198
 - **Result**: Reduced contention, improved rendering speed over 34.2s baseline to 33.9s.
 
 ## What Works
+- PERF-202: Replaced evaluate with callFunctionOn in SeekTimeDriver to eliminate AST parsing overhead. Result: ~32.9s.
 - Removed `await` from `capturePromise` return inside `captureWorkerFrame` hot loop natively allowing V8 promise chaining (PERF-127) (~2.0% faster)
 - Eliminated `.then()` closure in Renderer.ts capture loop to reduce GC pressure (~1% faster, PERF-192)
 - **PERF-197**: Replaced dynamic format mapping with static image2pipe. Kept because it improved performance by eliminating demuxer probing overhead.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -284,3 +284,4 @@ PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613
 1	33.929	150	4.42	37.8	keep	Re-enabled process-per-tab
 8	35.091	150	4.27	37.3	discard	Eliminate SeekTimeDriver IPC via rAF synchronous evaluate hook
 2	33.749	150	4.44	37.8	keep	ultrafast preset for libx264
+50	32.947	150	4.55	38.6	keep	PERF-202: Sync seek driver via callFunctionOn

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -11,6 +11,13 @@ export class SeekTimeDriver implements TimeDriver {
   private cachedMainFrame: import('playwright').Frame | null = null;
   private cachedPromises: Promise<any>[] = [];
   private evaluateParams = { expression: '', awaitPromise: true };
+  private callParams: any = {
+    functionDeclaration: 'function(t, timeout) { return this.__helios_seek(t, timeout); }',
+    objectId: '',
+    arguments: [ { value: 0 }, { value: 0 } ],
+    awaitPromise: true,
+    returnByValue: false
+  };
 
   constructor(private timeout: number = 30000) {}
 
@@ -246,10 +253,22 @@ export class SeekTimeDriver implements TimeDriver {
 
     this.cachedFrames = page.frames();
     this.cachedMainFrame = page.mainFrame();
+
+    const windowRes = await this.cdpSession!.send('Runtime.evaluate', { expression: 'window' });
+    if (windowRes.result && windowRes.result.objectId) {
+      this.callParams.objectId = windowRes.result.objectId;
+    }
+    this.callParams.arguments[1].value = this.timeout;
   }
 
   setTime(page: Page, timeInSeconds: number): Promise<void> {
     const frames = this.cachedFrames;
+
+    if (frames.length === 1 && this.callParams.objectId) {
+      this.callParams.arguments[0].value = timeInSeconds;
+      return this.cdpSession!.send('Runtime.callFunctionOn', this.callParams) as Promise<any>;
+    }
+
     this.evaluateParams.expression = `window.__helios_seek(${timeInSeconds}, ${this.timeout})`;
 
     if (frames.length === 1) {


### PR DESCRIPTION
💡 **What**: Replaced `Runtime.evaluate` with `Runtime.callFunctionOn` in the SeekTimeDriver by fetching the window objectId and caching parameters.
🎯 **Why**: To eliminate dynamic V8 AST parsing and script compilation overhead on every frame, reducing V8 GC micro-stalls and accelerating rendering performance.
📊 **Impact**: Improved median DOM render time from ~33.5s to 32.947s (~2% faster).
🔬 **Verification**: Ran `verify-cdp-driver.ts` correctness tests, `verify-canvas-strategy.ts` canvas smoke test, and 3 background renders for the median metrics calculation.
📎 **Plan**: `PERF-202-sync-seek-driver`

50	32.947	150	4.55	38.6	keep	PERF-202: Sync seek driver via callFunctionOn

---
*PR created automatically by Jules for task [11249416307864169820](https://jules.google.com/task/11249416307864169820) started by @BintzGavin*