### PR TITLE
✨ RENDERER: Inline TimeDriver.setTime arguments

### DIFF
--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -258,14 +258,13 @@ export class SeekTimeDriver implements TimeDriver {
     if (windowRes.result && windowRes.result.objectId) {
       this.callParams.objectId = windowRes.result.objectId;
     }
-    this.callParams.arguments[1].value = this.timeout;
   }
 
   setTime(page: Page, timeInSeconds: number): Promise<void> {
     const frames = this.cachedFrames;
 
     if (frames.length === 1 && this.callParams.objectId) {
-      this.callParams.arguments[0].value = timeInSeconds;
+      this.callParams.arguments = [{ value: timeInSeconds }, { value: this.timeout }];
       return this.cdpSession!.send('Runtime.callFunctionOn', this.callParams) as Promise<any>;
     }
 


### PR DESCRIPTION
Inlined arguments array in SeekTimeDriver to reduce property mutation overhead. Fixed performance bottleneck PERF-203.

---
*PR created automatically by Jules for task [598466107148888521](https://jules.google.com/task/598466107148888521) started by @BintzGavin*