### PR TITLE
✨ RENDERER: [PERF-206] Remove Worker IPC Serialization (Crashed)

### DIFF
--- a/.sys/plans/PERF-206-remove-active-promise-await.md
+++ b/.sys/plans/PERF-206-remove-active-promise-await.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-206
 slug: remove-active-promise-await
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: "2026-10-18"
+result: "failed"
 ---
 # PERF-206: Remove Worker IPC Serialization
 
@@ -29,3 +29,9 @@ Currently, the `captureLoop` limits in-flight frames using a sliding window. How
 
 ## Correctness Check
 Run the DOM verification scripts to ensure frames are still sequenced correctly: `npx tsx packages/renderer/tests/verify-cdp-driver.ts`
+
+## Results Summary
+- **Best render time**: 0.000s (vs baseline 33.7s)
+- **Improvement**: N/A
+- **Kept experiments**: none
+- **Discarded experiments**: Remove `await activePromise` (crashed with `Another frame is pending` protocol error)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -52,3 +52,5 @@ Last updated by: PERF-198
 ## Performance Trajectory
 Current best: 33.749s (baseline was 33.6s, -2.0%)
 Last updated by: PERF-200
+- **PERF-206**: Removed `await activePromise;` inside the `captureWorkerFrame` loop.
+  - **Why it didn't work**: The renderer crashed immediately with `Protocol error (HeadlessExperimental.beginFrame): Another frame is pending`. Playwright and Chromium do not allow sending multiple `beginFrame` commands concurrently on the same CDP session. Explicit sequencing must be maintained per worker.

--- a/packages/renderer/.sys/perf-results-PERF-206.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-206.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	Remove activePromise await


### PR DESCRIPTION
💡 **What**: Removed `await activePromise;` inside the `captureWorkerFrame` loop, causing the renderer to crash immediately with `Protocol error (HeadlessExperimental.beginFrame): Another frame is pending`. Code changes were discarded.
🎯 **Why**: Attempted to pipeline CDP commands to Chromium directly to avoid Node-side serialization overhead, but Playwright and Chromium do not allow sending multiple `beginFrame` commands concurrently on the same CDP session.
📊 **Impact**: N/A (Experiment failed and was reverted). Best render time was 0.000s (vs baseline 33.7s).
🔬 **Verification**: Code changes were reverted. RENDERER-EXPERIMENTS.md, .sys/plans/PERF-206-remove-active-promise-await.md, and .sys/perf-results-PERF-206.tsv were updated. Tests verified successfully.
📎 **Plan**: `/.sys/plans/PERF-206-remove-active-promise-await.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	Remove activePromise await
```

---
*PR created automatically by Jules for task [5812310941843682619](https://jules.google.com/task/5812310941843682619) started by @BintzGavin*