### PR TITLE
✨ PLAYER: Expand bridge test coverage and verify API properties

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -473,3 +473,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 - ✅ Completed: Timeline Drag & Drop - Verified existing handleDrop implementation and added unit test for asset drop functionality.
 ### PLAYER v0.77.10
 - ✅ Verified: getSchema API method is already documented in README.md.
+
+### PLAYER v0.77.15
+- ✅ Completed: Bridge coverage for postMessage expanded and properties verified. Completed plans: 2026-12-25, 2026-12-26, 2027-01-16, 2027-01-08.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: 0.77.14
+**Version**: 0.77.15
 [v0.77.14] ✅ Completed: Document getSchema API Parity - Added missing getSchema method to README documentation.
 [v0.77.13] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner to create the next implementation spec.
 [v0.77.12] ✅ Completed: Bridge Coverage Expansion 2 - Added missing unit test coverage for `bridge.ts` message handling boundary conditions (e.g., `HELIOS_SET_PLAYBACK_RATE` invalid args), achieving 100% coverage.
@@ -201,3 +201,4 @@
 
 [v0.77.10] ✅ Completed: Discovered missing `srcObject` parity logic. Created plan `.sys/plans/2026-11-25-PLAYER-Fix-API-Parity-srcObject.md` to persist assigned `srcObject` values.
 [v0.77.11] ✅ Completed: Fix API Parity srcObject - Updated srcObject getter and setter to persist assigned values internally, improving compatibility with third-party wrappers.
+[v0.77.15] ✅ Verified: Bridge coverage for postMessage expanded and properties verified. Completed plans: 2026-12-25, 2026-12-26, 2027-01-16, 2027-01-08.

--- a/packages/player/src/bridge.test.ts
+++ b/packages/player/src/bridge.test.ts
@@ -339,6 +339,81 @@ describe('connectToParent', () => {
         expect(mockHelios.setDuration).not.toHaveBeenCalled();
     });
 
+    it('should handle property update commands', () => {
+        connectToParent(mockHelios);
+        triggerMessage({ type: 'HELIOS_PAUSE' }, window.parent);
+        expect(mockHelios.pause).toHaveBeenCalled();
+
+        triggerMessage({ type: 'HELIOS_SET_PLAYBACK_RATE', rate: 2.0 }, window.parent);
+        expect(mockHelios.setPlaybackRate).toHaveBeenCalledWith(2.0);
+
+        triggerMessage({ type: 'HELIOS_SET_PLAYBACK_RANGE', start: 10, end: 50 }, window.parent);
+        expect(mockHelios.setPlaybackRange).toHaveBeenCalledWith(10, 50);
+
+        triggerMessage({ type: 'HELIOS_CLEAR_PLAYBACK_RANGE' }, window.parent);
+        expect(mockHelios.clearPlaybackRange).toHaveBeenCalled();
+
+        triggerMessage({ type: 'HELIOS_SET_VOLUME', volume: 0.5 }, window.parent);
+        expect(mockHelios.setAudioVolume).toHaveBeenCalledWith(0.5);
+
+        triggerMessage({ type: 'HELIOS_SET_MUTED', muted: true }, window.parent);
+        expect(mockHelios.setAudioMuted).toHaveBeenCalledWith(true);
+
+        triggerMessage({ type: 'HELIOS_SET_AUDIO_TRACK_VOLUME', trackId: 'test', volume: 0.8 }, window.parent);
+        expect(mockHelios.setAudioTrackVolume).toHaveBeenCalledWith('test', 0.8);
+
+        triggerMessage({ type: 'HELIOS_SET_AUDIO_TRACK_MUTED', trackId: 'test', muted: true }, window.parent);
+        expect(mockHelios.setAudioTrackMuted).toHaveBeenCalledWith('test', true);
+
+        triggerMessage({ type: 'HELIOS_SET_LOOP', loop: true }, window.parent);
+        expect(mockHelios.setLoop).toHaveBeenCalledWith(true);
+
+        triggerMessage({ type: 'HELIOS_SET_PROPS', props: { a: 1 } }, window.parent);
+        expect(mockHelios.setInputProps).toHaveBeenCalledWith({ a: 1 });
+
+        triggerMessage({ type: 'HELIOS_SET_CAPTIONS', captions: [{ start: 0, end: 1, text: 'a' }] }, window.parent);
+        expect(mockHelios.setCaptions).toHaveBeenCalledWith([{ start: 0, end: 1, text: 'a' }]);
+    });
+
+    it('should handle HELIOS_GET_AUDIO_TRACKS', async () => {
+        connectToParent(mockHelios);
+
+        // Ensure promise resolves and pushes HELIOS_AUDIO_DATA to postMessage
+        parentPostMessage.mockClear();
+        triggerMessage({ type: 'HELIOS_GET_AUDIO_TRACKS' }, window.parent);
+        await new Promise(r => setTimeout(r, 0));
+
+        expect(parentPostMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'HELIOS_AUDIO_DATA' }),
+            '*',
+            expect.any(Array)
+        );
+    });
+
+    it('should handle HELIOS_SEEK message', async () => {
+        const originalRaf = window.requestAnimationFrame;
+        let cbs: Function[] = [];
+        window.requestAnimationFrame = (cb) => { cbs.push(cb); return 0; };
+
+        connectToParent(mockHelios);
+        parentPostMessage.mockClear();
+
+        triggerMessage({ type: 'HELIOS_SEEK', frame: 50 }, window.parent);
+        expect(mockHelios.seek).toHaveBeenCalledWith(50);
+
+        // requestAnimationFrame(() => requestAnimationFrame(() => postMessage))
+        cbs.forEach(cb => cb(0));
+        cbs.shift(); // The outer raf cb fired and registered an inner one.
+        cbs.forEach(cb => cb(0)); // Second frame
+
+        expect(parentPostMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'HELIOS_SEEK_DONE', frame: 50 }),
+            '*'
+        );
+
+        window.requestAnimationFrame = originalRaf;
+    });
+
     it('should handle HELIOS_GET_SCHEMA message', () => {
         connectToParent(mockHelios);
         triggerMessage({ type: 'HELIOS_GET_SCHEMA' }, window.parent);


### PR DESCRIPTION
Implemented test coverage for HELIOS_SEEK, HELIOS_SET_*, etc. in bridge.test.ts (addresses plan 2027-01-08-PLAYER-Bridge-Coverage-Expansion-2.md). Verified that export-mode, media-title etc., properties were already correctly defined in src/index.ts. Removed test coverage artifacts before committing.

---
*PR created automatically by Jules for task [16741223371328857001](https://jules.google.com/task/16741223371328857001) started by @BintzGavin*