### PR TITLE
📋 CLI: Scaffold Cloudflare Sandbox Adapter Job Command Spec

### DIFF
--- a/.sys/plans/0.46.4-CLI-Job-Run-Cloudflare-Sandbox.md
+++ b/.sys/plans/0.46.4-CLI-Job-Run-Cloudflare-Sandbox.md
@@ -1,0 +1,49 @@
+# Context & Goal
+- **Objective**: Expose the Cloudflare Sandbox execution adapter in the `helios job run` command.
+- **Trigger**: The Cloudflare Sandbox adapter was implemented in `packages/infrastructure`, but the CLI's `job run` command does not yet expose it, preventing users from executing jobs via the Sandbox adapter.
+- **Impact**: Unblocks distributed rendering via Cloudflare Sandboxes by providing the necessary CLI integration.
+
+# File Inventory
+- **Create**: (None)
+- **Modify**: `packages/cli/src/commands/job.ts`
+- **Read-Only**: `packages/infrastructure/src/adapters/cloudflare-sandbox-adapter.ts`
+
+# Implementation Spec
+- **Architecture**:
+  - In `packages/cli/src/commands/job.ts`, update the `adapter` option in `registerJobCommand` to include `cloudflare-sandbox` as a valid choice.
+  - Add new options specific to the Cloudflare Sandbox adapter: `--cloudflare-sandbox-account-id`, `--cloudflare-sandbox-api-token`, and `--cloudflare-sandbox-namespace`.
+  - In the action handler, if `options.adapter === 'cloudflare-sandbox'`, validate that `--cloudflare-sandbox-account-id`, `--cloudflare-sandbox-api-token`, and `--cloudflare-sandbox-namespace` are provided.
+  - If they are missing, throw an error.
+  - If they are provided, instantiate the `CloudflareSandboxAdapter` from `@helios-project/infrastructure` passing the config.
+- **Pseudo-Code**:
+  ```typescript
+  // In packages/cli/src/commands/job.ts
+  jobCommand
+    // ... existing options ...
+    .option('--adapter <type>', 'Adapter to use (local, aws, gcp, cloudflare, cloudflare-sandbox, azure, fly, kubernetes, docker, deno, vercel, modal, hetzner)', 'local')
+    .option('--cloudflare-sandbox-account-id <id>', 'Cloudflare Account ID for Sandbox adapter')
+    .option('--cloudflare-sandbox-api-token <token>', 'Cloudflare API Token for Sandbox adapter')
+    .option('--cloudflare-sandbox-namespace <namespace>', 'Sandbox namespace for Sandbox adapter')
+    // ...
+
+  // In action handler:
+  } else if (options.adapter === 'cloudflare-sandbox') {
+    if (!options.cloudflareSandboxAccountId || !options.cloudflareSandboxApiToken || !options.cloudflareSandboxNamespace) {
+      throw new Error('Cloudflare Sandbox adapter requires --cloudflare-sandbox-account-id, --cloudflare-sandbox-api-token, and --cloudflare-sandbox-namespace');
+    }
+    adapter = new CloudflareSandboxAdapter({
+      accountId: options.cloudflareSandboxAccountId,
+      apiToken: options.cloudflareSandboxApiToken,
+      namespace: options.cloudflareSandboxNamespace,
+    });
+  }
+  ```
+- **Public API Changes**:
+  - Adds `cloudflare-sandbox` to the `--adapter` argument of the `job run` command.
+  - Adds `--cloudflare-sandbox-account-id`, `--cloudflare-sandbox-api-token`, and `--cloudflare-sandbox-namespace` options.
+- **Dependencies**: The `CloudflareSandboxAdapter` must be exported by `@helios-project/infrastructure`.
+
+# Test Plan
+- **Verification**: Run `npm install && npx vitest packages/cli/src/commands/__tests__/job.test.ts`. Execute `node packages/cli/bin/helios.js job run dummy.json --adapter cloudflare-sandbox` and verify it throws the correct missing-args error.
+- **Success Criteria**: The `--adapter cloudflare-sandbox` argument is parsed correctly and the adapter is initialized when given correct arguments.
+- **Edge Cases**: Verify behavior when only one of the required arguments is provided.


### PR DESCRIPTION
Adds the specification for exposing the Cloudflare Sandbox execution adapter in the helios job run command.

---
*PR created automatically by Jules for task [11112429122575588017](https://jules.google.com/task/11112429122575588017) started by @BintzGavin*