### PR TITLE
📋 STUDIO: [PERF-210] Share Browser Context (Discarded)

### DIFF
--- a/.sys/plans/PERF-210-share-browser-context.md
+++ b/.sys/plans/PERF-210-share-browser-context.md
@@ -1,12 +1,18 @@
 ---
 id: PERF-210
 slug: share-browser-context
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2024-06-03
-completed: ""
-result: ""
+completed: "2024-06-03"
+result: "discarded"
 ---
+
+## Results Summary
+- **Best render time**: 33.156s
+- **Improvement**: N/A (Failed tests)
+- **Kept experiments**: None
+- **Discarded experiments**: Shared BrowserContext across workers
 
 # PERF-210: Share Browser Context
 

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -62,3 +62,11 @@ Last updated by: PERF-200
 - Removed `--disable-software-rasterizer` from `GPU_DISABLED_ARGS` in `packages/renderer/src/core/BrowserPool.ts`. Allowed Chromium to fallback to its software rasterizer (SwiftShader) which provides significant execution speedups in the headless, CPU-bound environment. Reduced rendering time in benchmark from ~45.4s to ~32.7s (~28% improvement).
   - ID: PERF-208
 - [PERF-209] Inline virtual time budget params to reduce GC overhead
+
+## Performance Trajectory
+Current best: 33.156s (baseline was ~32.7s)
+Last updated by: PERF-210
+
+## What Doesn't Work (and Why)
+- Shared BrowserContext for all pages in BrowserPool (PERF-210)
+  - Sharing a single BrowserContext across concurrent workers causes cross-worker contamination or resource contention that breaks the tests (specifically CDP media sync timing and iframe sync tests). While benchmark render time was around 33.156s, the approach fundamentally breaks test assertions.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -286,3 +286,4 @@ PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613
 2	33.749	150	4.44	37.8	keep	ultrafast preset for libx264
 50	32.947	150	4.55	38.6	keep	PERF-202: Sync seek driver via callFunctionOn
 3	32.713	150	4.59	37.7	keep	PERF-208: Enable Chromium Software Rasterizer
+1	33.156	150	4.52	38.1	discard	Shared BrowserContext


### PR DESCRIPTION
💡 **What**: Executed and subsequently discarded the `PERF-210` experiment (Sharing BrowserContext). The code changes have been completely reverted, and only the documentation/tracking files were updated to record the failure.
🎯 **Why**: The experiment aimed to reduce the performance overhead of spinning up isolated Playwright contexts for each worker.
📊 **Impact**: N/A - The experiment was discarded because it fundamentally broke application correctness.
🔬 **Verification**: Code built successfully, but the test suite (`npm run test -w packages/renderer`) failed massively due to cross-worker context contamination. Failures were localized and confirmed via standalone tests (e.g., `verify-cdp-media-sync-timing.ts`).
📎 **Plan**: `/.sys/plans/PERF-210-share-browser-context.md`

### Benchmark Results
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	33.156	150	4.52	38.1	discard	Shared BrowserContext
```

---
*PR created automatically by Jules for task [3250752039898501858](https://jules.google.com/task/3250752039898501858) started by @BintzGavin*