### PR TITLE
✨ CLI: Add Cloudflare Sandbox Adapter to job run

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -44,7 +44,7 @@ packages/cli/
 - `helios deploy <provider>`: Scaffolds deployment configurations for cloud providers (e.g., `aws`, `gcp`, `cloudflare`, `cloudflare-sandbox`, `kubernetes`, `fly`, `azure`, `docker`, `hetzner`, `modal`, `deno`, `vercel`).
 - `helios diff <component>`: Compares a local component against its remote registry equivalent, outputting patch diffs.
 - `helios init`: Scaffolds `helios.config.json` and base templates (or examples) for user workspaces.
-- `helios job run <spec>`: Executes a distributed execution spec using available Worker adapters. Accepts adapter-specific configurations such as `--docker-args`.
+- `helios job run <spec>`: Executes a distributed execution spec using available Worker adapters (e.g., `local`, `aws`, `gcp`, `cloudflare`, `cloudflare-sandbox`, `azure`, `fly`, `kubernetes`, `docker`, `deno`, `vercel`, `modal`, `hetzner`). Accepts adapter-specific configurations such as `--docker-args` or `--cloudflare-sandbox-account-id`.
 - `helios list`: Lists all currently tracked local components.
 - `helios merge`: Stitches together chunks from distributed execution outputs using FFmpeg.
 - `helios preview`: Previews a production build.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -100,6 +100,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 - ✅ Completed: WebCodecs Preference - Added `webCodecsPreference` configuration to Studio Renders Panel, allowing users to select Hardware, Software, or Disabled modes for rendering.
 
 
+### CLI v0.46.4
+- ✅ Completed: Add Cloudflare Sandbox Adapter support to job run - Exposes the adapter from infrastructure package
+
 ### CLI v0.46.0
 - ✅ Completed: Scaffold Docker Deployment Command - Implemented `helios deploy docker` to scaffold docker-compose.yml and README-DOCKER.md.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,8 +1,10 @@
 # CLI Status
 
-**Version**: 0.46.3
+**Version**: 0.46.4
 
 ## Recent Completions
+[v0.46.4] ✅ Completed: Add Cloudflare Sandbox Adapter support to job run - Exposes the adapter from infrastructure package
+
 [v0.46.3] ✅ Completed: Scaffold Hetzner Deployment Command - Verified existing implementation of helios deploy hetzner command fulfills the scaffolding requirements.
 [v0.45.1] ✅ Completed: Scaffold Cloudflare Sandbox Deployment - Verified `helios deploy cloudflare-sandbox` command is implemented and working.
 [v0.45.0] ✅ Completed: Scaffold Cloudflare Sandbox Deployment - Added `helios deploy cloudflare-sandbox` command to generate wrangler.toml, workflow index, and render script.

--- a/packages/cli/src/commands/__tests__/job.test.ts
+++ b/packages/cli/src/commands/__tests__/job.test.ts
@@ -3,7 +3,7 @@ import { loadJobSpec, registerJobCommand } from '../job';
 import path from 'path';
 import fs from 'fs';
 import { Command } from 'commander';
-import { JobExecutor, LocalWorkerAdapter, AwsLambdaAdapter, CloudRunAdapter } from '@helios-project/infrastructure';
+import { JobExecutor, LocalWorkerAdapter, AwsLambdaAdapter, CloudRunAdapter, CloudflareSandboxAdapter } from '@helios-project/infrastructure';
 
 vi.mock('@helios-project/infrastructure', () => {
   return {
@@ -13,6 +13,7 @@ vi.mock('@helios-project/infrastructure', () => {
     LocalWorkerAdapter: vi.fn(),
     AwsLambdaAdapter: vi.fn(),
     CloudRunAdapter: vi.fn(),
+    CloudflareSandboxAdapter: vi.fn(),
   };
 });
 
@@ -124,6 +125,27 @@ describe('loadJobSpec', () => {
     it('should error if gcp adapter is used without service url', async () => {
       await program.parseAsync(['node', 'test', 'job', 'run', 'job.json', '--adapter', 'gcp']);
       expect(mockConsoleError).toHaveBeenCalledWith('Job execution failed:', 'GCP adapter requires --gcp-service-url');
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it('should instantiate CloudflareSandboxAdapter when --adapter cloudflare-sandbox is used', async () => {
+      await program.parseAsync([
+        'node', 'test', 'job', 'run', 'job.json',
+        '--adapter', 'cloudflare-sandbox',
+        '--cloudflare-sandbox-account-id', 'test-account',
+        '--cloudflare-sandbox-api-token', 'test-token',
+        '--cloudflare-sandbox-namespace', 'test-namespace'
+      ]);
+      expect(CloudflareSandboxAdapter).toHaveBeenCalledWith(expect.objectContaining({
+        accountId: 'test-account',
+        apiToken: 'test-token',
+        namespace: 'test-namespace'
+      }));
+    });
+
+    it('should error if cloudflare-sandbox adapter is used without required options', async () => {
+      await program.parseAsync(['node', 'test', 'job', 'run', 'job.json', '--adapter', 'cloudflare-sandbox']);
+      expect(mockConsoleError).toHaveBeenCalledWith('Job execution failed:', 'Cloudflare Sandbox adapter requires --cloudflare-sandbox-account-id, --cloudflare-sandbox-api-token, and --cloudflare-sandbox-namespace');
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
 import { JobSpec } from '../types/job.js';
-import { JobExecutor, LocalWorkerAdapter, AwsLambdaAdapter, CloudRunAdapter, CloudflareWorkersAdapter, AzureFunctionsAdapter, FlyMachinesAdapter, KubernetesAdapter, DockerAdapter, DenoDeployAdapter, VercelAdapter, ModalAdapter, HetznerCloudAdapter, WorkerAdapter } from '@helios-project/infrastructure';
+import { JobExecutor, LocalWorkerAdapter, AwsLambdaAdapter, CloudRunAdapter, CloudflareWorkersAdapter, AzureFunctionsAdapter, FlyMachinesAdapter, KubernetesAdapter, DockerAdapter, DenoDeployAdapter, VercelAdapter, ModalAdapter, HetznerCloudAdapter, CloudflareSandboxAdapter, WorkerAdapter } from '@helios-project/infrastructure';
 
 export async function loadJobSpec(file: string): Promise<{ jobSpec: JobSpec, jobDir: string }> {
   if (file.startsWith('http://') || file.startsWith('https://')) {
@@ -33,7 +33,7 @@ export function registerJobCommand(program: Command) {
     .option('--chunk <id>', 'Execute only the chunk with the specified ID')
     .option('--concurrency <number>', 'Number of concurrent chunks to run locally', '1')
     .option('--no-merge', 'Skip the final merge step')
-    .option('--adapter <type>', 'Adapter to use (local, aws, gcp, cloudflare, azure, fly, kubernetes, docker, deno, vercel, modal, hetzner)', 'local')
+    .option('--adapter <type>', 'Adapter to use (local, aws, gcp, cloudflare, cloudflare-sandbox, azure, fly, kubernetes, docker, deno, vercel, modal, hetzner)', 'local')
     .option('--fly-api-token <token>', 'Fly.io API token')
     .option('--fly-app-name <name>', 'Fly.io app name')
     .option('--fly-image-ref <ref>', 'Fly.io image ref')
@@ -53,6 +53,9 @@ export function registerJobCommand(program: Command) {
     .option('--cloudflare-service-url <url>', 'Cloudflare Workers service URL')
     .option('--cloudflare-auth-token <token>', 'Cloudflare Workers bearer token')
     .option('--cloudflare-job-def-url <url>', 'URL of the job definition for Cloudflare Workers')
+    .option('--cloudflare-sandbox-account-id <id>', 'Cloudflare Account ID for Sandbox adapter')
+    .option('--cloudflare-sandbox-api-token <token>', 'Cloudflare API Token for Sandbox adapter')
+    .option('--cloudflare-sandbox-namespace <namespace>', 'Sandbox namespace for Sandbox adapter')
     .option('--azure-service-url <url>', 'Azure Functions service URL')
     .option('--azure-function-key <key>', 'Azure Functions function key')
     .option('--azure-job-def-url <url>', 'URL of the job definition for Azure Functions')
@@ -123,6 +126,15 @@ export function registerJobCommand(program: Command) {
             serviceUrl: options.cloudflareServiceUrl,
             authToken: options.cloudflareAuthToken,
             jobDefUrl: options.cloudflareJobDefUrl || file
+          });
+        } else if (options.adapter === 'cloudflare-sandbox') {
+          if (!options.cloudflareSandboxAccountId || !options.cloudflareSandboxApiToken || !options.cloudflareSandboxNamespace) {
+            throw new Error('Cloudflare Sandbox adapter requires --cloudflare-sandbox-account-id, --cloudflare-sandbox-api-token, and --cloudflare-sandbox-namespace');
+          }
+          adapter = new CloudflareSandboxAdapter({
+            accountId: options.cloudflareSandboxAccountId,
+            apiToken: options.cloudflareSandboxApiToken,
+            namespace: options.cloudflareSandboxNamespace,
           });
         } else if (options.adapter === 'azure') {
           if (!options.azureServiceUrl) {


### PR DESCRIPTION
💡 **What**: Add support for the Cloudflare Sandbox execution adapter to the `helios job run` command.
🎯 **Why**: To expose the adapter implemented in the infrastructure package, allowing users to run distributed renders in Cloudflare Sandboxes.
📊 **Impact**: Unblocks distributed rendering workloads on Cloudflare Sandboxes.
🔬 **Verification**: Running `npm install && npx vitest packages/cli/src/commands/__tests__/job.test.ts` succeeds and covers required argument validation and adapter instantiation.

---
*PR created automatically by Jules for task [9726729822123881040](https://jules.google.com/task/9726729822123881040) started by @BintzGavin*