### PR TITLE
📋 RENDERER: Disable unused Chromium features

### DIFF
--- a/.sys/plans/PERF-211-disable-chromium-features.md
+++ b/.sys/plans/PERF-211-disable-chromium-features.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-211
 slug: disable-chromium-features
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-06-03
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -70,3 +70,7 @@ Last updated by: PERF-210
 ## What Doesn't Work (and Why)
 - Shared BrowserContext for all pages in BrowserPool (PERF-210)
   - Sharing a single BrowserContext across concurrent workers causes cross-worker contamination or resource contention that breaks the tests (specifically CDP media sync timing and iframe sync tests). While benchmark render time was around 33.156s, the approach fundamentally breaks test assertions.
+
+## What Works
+- **PERF-211**: Disabled `AudioServiceOutOfProcess` and `PaintHolding` to reduce Chromium memory/context switching footprint.
+  - **Why it didn't work**: Did not improve render time (regressed from ~32.7s to 47.938s). The change may have removed optimizations built into Chromium's default multiprocess architecture or caused unexpected stalling in the CPU-bound environment.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -287,3 +287,4 @@ PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613
 50	32.947	150	4.55	38.6	keep	PERF-202: Sync seek driver via callFunctionOn
 3	32.713	150	4.59	37.7	keep	PERF-208: Enable Chromium Software Rasterizer
 1	33.156	150	4.52	38.1	discard	Shared BrowserContext
+1	47.938	150	3.13	40.4	discard	PERF-211-disable-chromium-features


### PR DESCRIPTION
📋 RENDERER: Disable unused Chromium features

Plan: .sys/plans/PERF-211-disable-chromium-features.md
Experiment discarded: Disabling AudioServiceOutOfProcess and PaintHolding caused a performance regression (~32s -> ~48s).

```tsv
1	47.938	150	3.13	40.4	discard	PERF-211-disable-chromium-features
```

---
*PR created automatically by Jules for task [7440702023704886827](https://jules.google.com/task/7440702023704886827) started by @BintzGavin*