### PR TITLE
📋 RENDERER: Remove --disable-gpu (Discarded)

### DIFF
--- a/.sys/plans/PERF-215-remove-disable-gpu.md
+++ b/.sys/plans/PERF-215-remove-disable-gpu.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-215
 slug: remove-disable-gpu
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2024-05-24"
+result: "no-improvement"
 ---
 
 # PERF-215: Remove `--disable-gpu` to Evaluate Hardware Acceleration Fallback
@@ -37,3 +37,9 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure the Ca
 
 ## Correctness Check
 Run the `verify-cdp-driver.ts` and `verify-cdp-determinism.ts` scripts to ensure frame capture timing remains accurate. Run the main suite with `npx tsx packages/renderer/tests/run-all.ts` to catch any regressions.
+
+## Results Summary
+- **Best render time**: 33.543s (vs baseline 32.595s)
+- **Improvement**: -2.91%
+- **Kept experiments**: none
+- **Discarded experiments**: PERF-215

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -86,3 +86,8 @@ Last updated by: PERF-210
 ## Performance Trajectory
 Current best: 32.595s (baseline was ~33.156s, -1.7%)
 Last updated by: PERF-214
+
+## What Doesn't Work (and Why)
+- Removed `--disable-gpu` from `GPU_DISABLED_ARGS` allowing Chromium to handle software fallback automatically.
+  - Slower than baseline. Explicitly disabling GPU yields better performance than native software fallback. Render time was 33.543s (-2.90842% change).
+  - PERF-215

--- a/packages/renderer/.sys/perf-results-PERF-215.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-215.tsv
@@ -1,0 +1,1 @@
+1	33.543	150	4.47	37.9	keep	remove disable-gpu


### PR DESCRIPTION
💡 **What**: Evaluated removing `--disable-gpu` from Chromium launch args.
🎯 **Why**: To test if Chromium could handle software fallback better natively without explicitly disabling GPU, based on findings from PERF-214.
📊 **Impact**: Render time regressed from 32.595s to 33.543s (-2.91%). Experiment discarded. Code changes reverted.
🔬 **Verification**: Ran benchmark and verification tests.
📎 **Plan**: `/.sys/plans/PERF-215-remove-disable-gpu.md`

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	33.543	150	4.47	37.9	discard	remove disable-gpu

---
*PR created automatically by Jules for task [1503126424978687896](https://jules.google.com/task/1503126424978687896) started by @BintzGavin*