### PR TITLE
✨ RENDERER: Disable Threaded Compositing (Crash)

### DIFF
--- a/.sys/plans/PERF-216-disable-threaded-compositing.md
+++ b/.sys/plans/PERF-216-disable-threaded-compositing.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-216
 slug: disable-threaded-compositing
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: 2024-05-24
+result: failed
 ---
 
 # PERF-216: Disable Component/Layout Resync in Chromium via Single Process Disabling Feature Flags
@@ -39,3 +39,8 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure the Ca
 
 ## Correctness Check
 Run the DOM smoke tests (`npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts`) to ensure deterministic rendering is not broken.
+## Results Summary
+- **Best render time**: N/A (baseline 32.595s)
+- **Improvement**: N/A
+- **Kept experiments**: []
+- **Discarded experiments**: [Step 1: Add `--disable-threaded-compositing` and Feature Flags]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -91,3 +91,7 @@ Last updated by: PERF-214
 - Removed `--disable-gpu` from `GPU_DISABLED_ARGS` allowing Chromium to handle software fallback automatically.
   - Slower than baseline. Explicitly disabling GPU yields better performance than native software fallback. Render time was 33.543s (-2.90842% change).
   - PERF-215
+
+## What Doesn't Work (and Why)
+- **PERF-216**: Added `--disable-threaded-compositing` and `--disable-features=PaintHolding,ThreadedCompositing` flags to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
+  - **Why it didn't work**: The renderer crashed immediately during the benchmark. Disabling threaded compositing in the headless Chromium environment resulted in a broken rendering pipeline that failed to process the `beginFrame` commands properly, outputting a 1x1 corrupted stream and throwing `FFmpeg stdin is not writable`. This approach fundamentally breaks the required rendering paths.

--- a/packages/renderer/.sys/perf-results-PERF-216.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-216.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	Adding --disable-threaded-compositing and feature flags


### PR DESCRIPTION
💡 What: The experiment ran `PERF-216` by adding `--disable-threaded-compositing` and `--disable-features=PaintHolding,ThreadedCompositing` flags to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`. The outcome was a total failure (crash).
🎯 Why: The goal was to simplify the compositing pipeline in the CPU-bound microVM to see if eliminating multithreaded layout syncing could improve render time.
📊 Impact: The benchmark crashed, unable to initialize the FFmpeg output stream.
🔬 Verification: Ran the benchmark which failed. Ran unit tests which also indicated failure. Code reverted to pre-experiment state.
📎 Plan: Reference the plan file `/.sys/plans/PERF-216-disable-threaded-compositing.md`.

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	Adding --disable-threaded-compositing and feature flags

---
*PR created automatically by Jules for task [2108689725631672211](https://jules.google.com/task/2108689725631672211) started by @BintzGavin*