### PR TITLE
📋 RENDERER: Disable Font Subpixel Positioning Experiment

### DIFF
--- a/.sys/plans/PERF-217-disable-font-subpixel-positioning.md
+++ b/.sys/plans/PERF-217-disable-font-subpixel-positioning.md
@@ -1,0 +1,42 @@
+---
+id: PERF-217
+slug: disable-font-subpixel-positioning
+status: unclaimed
+claimed_by: ""
+created: 2024-06-03
+completed: ""
+result: ""
+---
+
+# PERF-217: Disable Font Subpixel Positioning
+
+## Focus Area
+DOM Rendering Pipeline - Chromium Compositor overhead in `BrowserPool.ts`.
+
+## Background Research
+When generating frames in a headless, CPU-bound environment, text rendering can be a surprisingly heavy operation. Chromium by default uses font subpixel positioning, which renders text at fractional pixel coordinates for smoother appearance on LCD screens. Since our output is video and we are using software rasterization (`SwiftShader`), disabling subpixel positioning (`--disable-font-subpixel-positioning`) might significantly reduce the CPU cycles spent in the Skia text rendering paths during the `HeadlessExperimental.beginFrame` layout/paint cycle.
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark composition
+- **Render Settings**: 1280x720, 30fps, 5s duration, libx264 codec
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~32.6s
+- **Bottleneck analysis**: The Playwright/Chromium CDP frame capture (`HeadlessExperimental.beginFrame`) is CPU-bound. Reducing layout/paint complexity directly improves performance.
+
+## Implementation Spec
+
+### Step 1: Add flag to `DEFAULT_BROWSER_ARGS`
+**File**: `packages/renderer/src/core/BrowserPool.ts`
+**What to change**: Add `'--disable-font-subpixel-positioning'` to the `DEFAULT_BROWSER_ARGS` array.
+**Why**: Disabling subpixel text rendering simplifies the rendering pipeline in software mode.
+**Risk**: Text might look slightly different (e.g., aliased or differently spaced), but usually acceptable for video renders, especially if it provides a measurable speedup.
+
+## Canvas Smoke Test
+Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts`.
+
+## Correctness Check
+Run the DOM render tests to ensure no visual regressions break tests.


### PR DESCRIPTION
Created experiment plan PERF-217 to test disabling font subpixel positioning in Chromium for performance gains.

---
*PR created automatically by Jules for task [1283813045302396818](https://jules.google.com/task/1283813045302396818) started by @BintzGavin*