### PR TITLE
✨ STUDIO: Add JKL Playback Shortcuts

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -472,6 +472,9 @@ Each agent should update **their own dedicated progress file** instead of this f
 ### PLAYER v0.77.9
 - ✅ Verified: getSchema API method is already documented in README.md.
 
+### STUDIO v0.121.0
+- ✅ Completed: Add JKL Playback Shortcuts - Implemented standard J, K, L keyboard shortcuts for variable playback speed and reverse.
+
 ### STUDIO v0.120.5
 - ✅ Completed: Timeline Drag & Drop - Verified existing handleDrop implementation and added unit test for asset drop functionality.
 ### PLAYER v0.77.10

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.120.5
+**Version**: 0.121.0
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
@@ -12,6 +12,7 @@
 - [v0.119.5] ✅ Completed: Refine CLI Component Removal - Verified existing implementation of component file deletion and interactive confirmation prompts in `helios remove` command (2026-10-23-STUDIO-Refine-CLI-Component-Removal.md).
 
 ## Recent Updates
+- [v0.121.0] ✅ Completed: Add JKL Playback Shortcuts - Implemented standard J, K, L keyboard shortcuts for variable playback speed and reverse.
 - [v0.120.5] ✅ Completed: Timeline Drag & Drop - Verified existing handleDrop implementation and added unit test for asset drop functionality.
 - [v0.120.3] ✅ Completed: STUDIO-Asset-Move - Updated effectAllowed to copyMove in AssetItem.tsx.
 - [v0.120.1] ✅ Completed: STUDIO-Asset-Move - Added drag and drop for assets to folder functionality by implementing unit tests and confirming logic.

--- a/packages/studio/src/components/GlobalShortcuts.test.tsx
+++ b/packages/studio/src/components/GlobalShortcuts.test.tsx
@@ -13,6 +13,7 @@ describe('GlobalShortcuts', () => {
   const mockSeek = vi.fn();
   const mockPlay = vi.fn();
   const mockPause = vi.fn();
+  const mockSetPlaybackRate = vi.fn();
   const mockSetInPoint = vi.fn();
   const mockSetOutPoint = vi.fn();
   const mockToggleLoop = vi.fn();
@@ -24,6 +25,7 @@ describe('GlobalShortcuts', () => {
     duration: 10, // 10 seconds
     fps: 30,
     isPlaying: false,
+    playbackRate: 1,
   };
 
   const defaultContext = {
@@ -31,6 +33,7 @@ describe('GlobalShortcuts', () => {
       seek: mockSeek,
       play: mockPlay,
       pause: mockPause,
+      setPlaybackRate: mockSetPlaybackRate,
     },
     playerState: defaultPlayerState,
     inPoint: 0,
@@ -48,7 +51,7 @@ describe('GlobalShortcuts', () => {
   });
 
   it('toggles play/pause with Space', () => {
-    render(<GlobalShortcuts />);
+    const { rerender } = render(<GlobalShortcuts />);
     fireEvent.keyDown(window, { key: ' ' });
     expect(mockPlay).toHaveBeenCalled();
 
@@ -57,14 +60,7 @@ describe('GlobalShortcuts', () => {
         ...defaultContext,
         playerState: { ...defaultPlayerState, isPlaying: true }
     });
-    // Re-render to pick up new state (or just fire event again if effect depends on state)
-    // In our implementation, the effect depends on controller/state in callback.
-    // The hook refs the callback, so it should see fresh state.
-    // But we need to make sure the hook updates.
-
-    // Easier to just re-render cleanly for second assertion or rely on ref mechanism
-    // Let's re-render
-    render(<GlobalShortcuts />);
+    rerender(<GlobalShortcuts />);
     fireEvent.keyDown(window, { key: ' ' });
     expect(mockPause).toHaveBeenCalled();
   });
@@ -99,10 +95,58 @@ describe('GlobalShortcuts', () => {
     expect(mockSeek).toHaveBeenCalledWith(50);
   });
 
-  it('toggles loop with L', () => {
-    render(<GlobalShortcuts />);
+  it('speeds up playback with L', () => {
+    (StudioContext.useStudio as any).mockReturnValue({
+      ...defaultContext,
+      playerState: { ...defaultPlayerState, isPlaying: false, playbackRate: 1 }
+    });
+    const { rerender } = render(<GlobalShortcuts />);
+
     fireEvent.keyDown(window, { key: 'l' });
-    expect(mockToggleLoop).toHaveBeenCalled();
+    expect(mockSetPlaybackRate).toHaveBeenCalledWith(1);
+    expect(mockPlay).toHaveBeenCalled();
+
+    mockSetPlaybackRate.mockClear();
+
+    (StudioContext.useStudio as any).mockReturnValue({
+      ...defaultContext,
+      playerState: { ...defaultPlayerState, isPlaying: true, playbackRate: 1 }
+    });
+
+    rerender(<GlobalShortcuts />);
+
+    fireEvent.keyDown(window, { key: 'l' });
+    expect(mockSetPlaybackRate).toHaveBeenCalledWith(2);
+  });
+
+  it('reverses playback with J', () => {
+    (StudioContext.useStudio as any).mockReturnValue({
+      ...defaultContext,
+      playerState: { ...defaultPlayerState, isPlaying: false, playbackRate: 1 }
+    });
+    const { rerender } = render(<GlobalShortcuts />);
+
+    fireEvent.keyDown(window, { key: 'j' });
+    expect(mockSetPlaybackRate).toHaveBeenCalledWith(-1);
+    expect(mockPlay).toHaveBeenCalled();
+
+    mockSetPlaybackRate.mockClear();
+
+    (StudioContext.useStudio as any).mockReturnValue({
+      ...defaultContext,
+      playerState: { ...defaultPlayerState, isPlaying: true, playbackRate: -1 }
+    });
+
+    rerender(<GlobalShortcuts />);
+
+    fireEvent.keyDown(window, { key: 'j' });
+    expect(mockSetPlaybackRate).toHaveBeenCalledWith(-2);
+  });
+
+  it('pauses with K', () => {
+    render(<GlobalShortcuts />);
+    fireEvent.keyDown(window, { key: 'k' });
+    expect(mockPause).toHaveBeenCalled();
   });
 
   it('sets In point with I (clamped)', () => {

--- a/packages/studio/src/components/GlobalShortcuts.tsx
+++ b/packages/studio/src/components/GlobalShortcuts.tsx
@@ -11,8 +11,7 @@ export const GlobalShortcuts: React.FC = () => {
     inPoint,
     setInPoint,
     outPoint,
-    setOutPoint,
-    toggleLoop
+    setOutPoint
   } = useStudio();
 
   const { currentFrame, duration, fps } = playerState;
@@ -72,9 +71,38 @@ export const GlobalShortcuts: React.FC = () => {
     setOutPoint(newOut);
   }, { ignoreInput: true });
 
-  // L: Toggle Loop
+  // J: Play Reverse / Speed Up Reverse
+  useKeyboardShortcut('j', () => {
+    if (!controller) return;
+    const currentRate = playerState.playbackRate || 1;
+    if (!playerState.isPlaying || currentRate > -0.25) {
+      controller.setPlaybackRate(-1);
+      controller.play();
+    } else {
+      const newRate = Math.max(-4, currentRate === -0.25 ? -0.5 : (currentRate === -0.5 ? -1 : currentRate * 2));
+      controller.setPlaybackRate(newRate);
+      if (!playerState.isPlaying) controller.play();
+    }
+  }, { ignoreInput: true });
+
+  // K: Pause
+  useKeyboardShortcut('k', () => {
+    if (!controller) return;
+    controller.pause();
+  }, { ignoreInput: true });
+
+  // L: Play Forward / Speed Up
   useKeyboardShortcut('l', () => {
-    toggleLoop();
+    if (!controller) return;
+    const currentRate = playerState.playbackRate || 1;
+    if (!playerState.isPlaying || currentRate < 0.25) {
+      controller.setPlaybackRate(1);
+      controller.play();
+    } else {
+      const newRate = Math.min(4, currentRate === 0.25 ? 0.5 : (currentRate === 0.5 ? 1 : currentRate * 2));
+      controller.setPlaybackRate(newRate);
+      if (!playerState.isPlaying) controller.play();
+    }
   }, { ignoreInput: true });
 
   return null;


### PR DESCRIPTION
Implemented standard JKL keyboard shortcuts for variable playback speed and reverse in Helios Studio. Removes the previous `L` (Toggle Loop) shortcut in favor of the standard NLE forward/speed-up mapping.

---
*PR created automatically by Jules for task [11425447302228356239](https://jules.google.com/task/11425447302228356239) started by @BintzGavin*