### PR TITLE
📋 RENDERER: Reintroduce Sync Compositor Flags

### DIFF
--- a/.sys/plans/PERF-219-reintroduce-sync-compositor-flags.md
+++ b/.sys/plans/PERF-219-reintroduce-sync-compositor-flags.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-219
 slug: reintroduce-sync-compositor-flags
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-03
-completed: ""
-result: ""
+completed: "2024-06-03"
+result: "keep"
 ---
 
 # PERF-219: Reintroduce Synchronous Compositor Flags
@@ -45,3 +45,8 @@ Run `npx tsx packages/renderer/tests/run-all.ts`.
 
 ## Correctness Check
 Run the DOM render tests to ensure no visual regressions break tests.
+## Results Summary
+- **Best render time**: 32.716s (vs baseline 33.303s)
+- **Improvement**: 1.8%
+- **Kept experiments**: Added synchronous compositor flags
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,11 +1,13 @@
 ## Performance Trajectory
-Current best: 32.916s (baseline was 33.6s, -2.0%)
-Last updated by: PERF-127
+Current best: 32.716s (baseline was 33.303s, -1.8%)
+Last updated by: PERF-219
+
 
 Current best: 35.091s (baseline was 49.436s, -32.5%)
 Last updated by: PERF-198
 
 ## What Works
+- **PERF-219**: Added synchronous compositor flags (`--disable-threaded-animation`, `--disable-threaded-scrolling`, `--disable-checker-imaging`, `--disable-image-animation-resync`) to `DEFAULT_BROWSER_ARGS`. Reduced render time from ~33.303s to ~32.716s (-1.8%).
 - Disabled LCD text antialiasing in Chromium args (`--disable-lcd-text`), avoiding expensive Skia text rasterization paths in SwiftShader. Improved from 43.200s to 33.270s (PERF-218)
 - PERF-202: Replaced evaluate with callFunctionOn in SeekTimeDriver to eliminate AST parsing overhead. Result: ~32.9s.
 - PERF-200: Defaulted libx264 to ultrafast preset. Reduced cpu cycles. Render time ~33.7s.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -289,3 +289,4 @@ PERF-158	33.613	150	4.45	0	keep	Median changed from 33.859 to 33.613
 1	33.156	150	4.52	38.1	discard	Shared BrowserContext
 1	47.938	150	3.13	40.4	discard	PERF-211-disable-chromium-features
 218	33.270	150	4.51	37.9	keep	PERF-218: disable LCD text antialiasing
+289	32.716	150	4.58	37.9	keep	Reintroduce synchronous compositor flags

--- a/packages/renderer/src/core/BrowserPool.ts
+++ b/packages/renderer/src/core/BrowserPool.ts
@@ -24,7 +24,11 @@ const DEFAULT_BROWSER_ARGS = [
   '--enable-begin-frame-control',
   '--run-all-compositor-stages-before-draw',
   '--process-per-tab',
-  '--disable-lcd-text'
+  '--disable-lcd-text',
+  '--disable-threaded-animation',
+  '--disable-threaded-scrolling',
+  '--disable-checker-imaging',
+  '--disable-image-animation-resync'
 ];
 
 const GPU_DISABLED_ARGS = [


### PR DESCRIPTION
Added `--disable-threaded-animation`, `--disable-threaded-scrolling`, `--disable-checker-imaging`, and `--disable-image-animation-resync` to `DEFAULT_BROWSER_ARGS`.

---
*PR created automatically by Jules for task [14640826917674887521](https://jules.google.com/task/14640826917674887521) started by @BintzGavin*