### PR TITLE
📋 RENDERER: Test removing background networking flags (discarded)

### DIFF
--- a/.sys/plans/PERF-220-disable-background-networking.md
+++ b/.sys/plans/PERF-220-disable-background-networking.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-220
 slug: test-remove-background-networking
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-04
-completed: ""
-result: ""
+completed: "2026-04-08"
+result: "no-improvement"
 ---
 
 # PERF-220: Test removing background networking flags
@@ -43,3 +43,9 @@ Run `npx tsx packages/renderer/tests/run-all.ts`.
 
 ## Correctness Check
 Run the DOM render tests to ensure no visual regressions break tests.
+
+## Results Summary
+- **Best render time**: 32.552s (baseline)
+- **Improvement**: 0%
+- **Kept experiments**: None
+- **Discarded experiments**: Remove background networking flags (no meaningful improvement)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -26,6 +26,9 @@ Last updated by: PERF-198
 - **Replace startScreencast with beginFrame in DomStrategy** (PERF-184): Replaced the damage-driven `Page.startScreencast` capture approach with synchronous `HeadlessExperimental.beginFrame` for the full-page DOM fallback. Improved render time to ~6.6s.
 
 ## What Doesn't Work (and Why)
+- Discarded `PERF-220` (remove background networking flags)
+  - Time: 32.547s (baseline: 32.552s). The difference is well within the margin of error (less than 0.1%).
+  - Conclusion: Allowing background networking and background timer throttling did not yield a tangible performance improvement.
 - **Eliminate SeekTimeDriver IPC** (PERF-199): Hooked rAF to evaluate __helios_seek inline in browser rather than Node CDP per frame. Render time was 35.091s, which is slower than the 33.331s baseline, so it was discarded.
 - Replace image2pipe (`PERF-197`): Update the -f flag for the video input from image2pipe to the format dynamically corresponding to this.cdpScreenshotParams.format. Did not improve render time, actually degraded from ~33.5s to 34.2s. Bypassing FFmpeg probing heuristics dynamically provided no real-world gain, suggesting pipe format parsing overhead in FFmpeg is not the bottleneck or node writable stream handles image2pipe identically well.
 - PERF-180: Inline parameters in SeekTimeDriver. Inlined parameters in the cdpSession.send. Did not improve performance over the baseline, resulting in 14.631s vs baseline 3.993s. The reason is likely due to V8 having already cached object types efficiently in earlier optimization phases or the difference being imperceptible against IPC overhead, coupled with unexpected regression overhead from garbage collection handling of intermediate anonymous objects in `Promises[i]`.

--- a/packages/renderer/.sys/perf-results-PERF-220.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-220.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.552	150	4.61	37.9	keep	baseline
+2	32.547	150	4.61	37.9	discard	remove background networking flags


### PR DESCRIPTION
📋 RENDERER: Test removing background networking flags (discarded)

💡 What: Tested removing --disable-background-networking and --disable-background-timer-throttling. The experiment was discarded because it didn't provide any meaningful render time improvement.
🎯 Why: To see if allowing background networking and background timer throttling might improve performance by accelerating asset loading during the setup phase.
📊 Impact: 32.547s (experiment) vs 32.552s (baseline). Difference is less than 0.1%, no improvement.
🔬 Verification: 4-gate verification + benchmark test.
📎 Plan: /.sys/plans/PERF-220-disable-background-networking.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.552	150	4.61	37.9	keep	baseline
2	32.547	150	4.61	37.9	discard	remove background networking flags

---
*PR created automatically by Jules for task [11882006935941016928](https://jules.google.com/task/11882006935941016928) started by @BintzGavin*