### PR TITLE
📋 RENDERER: PERF-221 Disable Smooth Scrolling

### DIFF
--- a/.sys/plans/PERF-221-disable-smooth-scrolling.md
+++ b/.sys/plans/PERF-221-disable-smooth-scrolling.md
@@ -1,0 +1,42 @@
+---
+id: PERF-221
+slug: disable-smooth-scrolling
+status: unclaimed
+claimed_by: ""
+created: 2024-06-05
+completed: ""
+result: ""
+---
+
+# PERF-221: Disable Smooth Scrolling
+
+## Focus Area
+DOM Rendering Pipeline - Chromium Compositor thread synchronization overhead in `BrowserPool.ts`.
+
+## Background Research
+In our headless CPU-only environment running `SwiftShader`, the synchronization and execution overhead within the Chromium Compositor thread is a key bottleneck. By default, Chromium enables smooth scrolling, which introduces additional animation frames and compositor updates when scrolling occurs or when the layout engine handles scroll-related layout shifts. Even in compositions that don't explicitly rely on scroll animations, the internal machinery for smooth scrolling remains active, consuming CPU cycles and potentially causing micro-stalls during the synchronous `HeadlessExperimental.beginFrame` loop. Passing `--disable-smooth-scrolling` disables this feature, forcing instantaneous scrolling and reducing the workload on the compositor and animation systems.
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark composition
+- **Render Settings**: 1280x720, 30fps, 5s duration, libx264 codec
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~32.552s
+- **Bottleneck analysis**: The Playwright/Chromium CDP frame capture is bound by software rasterization and compositor thread synchronization in SwiftShader. Reducing the complexity of scroll animations and layout processing directly mitigates this.
+
+## Implementation Spec
+
+### Step 1: Add flag to `DEFAULT_BROWSER_ARGS`
+**File**: `packages/renderer/src/core/BrowserPool.ts`
+**What to change**: Add `'--disable-smooth-scrolling'` to the `DEFAULT_BROWSER_ARGS` array.
+**Why**: Disabling smooth scrolling reduces CPU cycles spent on scroll animation calculations and compositor synchronization inside Chromium.
+**Risk**: If a composition explicitly depends on native smooth scrolling behavior for its visual effect, the scroll will appear instantaneous. However, since most video compositions use explicit animation libraries (like GSAP or Framer Motion) or CSS transforms rather than native scroll, the visual impact is likely negligible.
+
+## Canvas Smoke Test
+Run `npx tsx packages/renderer/tests/run-all.ts` to ensure no functionality is broken.
+
+## Correctness Check
+Run the DOM render tests to ensure no visual regressions break tests.


### PR DESCRIPTION
📋 RENDERER: Disable Smooth Scrolling

💡 What: Plan to disable Chromium's smooth scrolling in the BrowserPool
🎯 Why: Smooth scrolling relies on compositor thread synchronization which adds overhead in CPU-bound software rasterization environments. Disabling it may improve `beginFrame` capture loops.
🔬 Approach: Add `--disable-smooth-scrolling` to `DEFAULT_BROWSER_ARGS`
📎 Plan: /.sys/plans/PERF-221-disable-smooth-scrolling.md

---
*PR created automatically by Jules for task [7388987500079526810](https://jules.google.com/task/7388987500079526810) started by @BintzGavin*