### PR TITLE
📋 RENDERER: Disable Font Subpixel Positioning Experiment (Discarded)

### DIFF
--- a/.sys/plans/PERF-217-disable-font-subpixel-positioning.md
+++ b/.sys/plans/PERF-217-disable-font-subpixel-positioning.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-217
 slug: disable-font-subpixel-positioning
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2024-06-03
-completed: ""
-result: ""
+completed: 2024-06-03
+result: "discarded"
 ---
 
 # PERF-217: Disable Font Subpixel Positioning
@@ -40,3 +40,8 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts`.
 
 ## Correctness Check
 Run the DOM render tests to ensure no visual regressions break tests.
+## Results Summary
+- **Best render time**: 43.842s (vs baseline ~32.6s)
+- **Improvement**: Regressed
+- **Kept experiments**: None
+- **Discarded experiments**: Adding `--disable-font-subpixel-positioning` to BrowserPool.ts

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -84,7 +84,6 @@ Last updated by: PERF-210
 ## What Works
 - **PERF-211**: Disabled `AudioServiceOutOfProcess` and `PaintHolding` to reduce Chromium memory/context switching footprint.
   - **Why it didn't work**: Did not improve render time (regressed from ~32.7s to 47.938s). The change may have removed optimizations built into Chromium's default multiprocess architecture or caused unexpected stalling in the CPU-bound environment.
-## What Doesn't Work (and Why)
 - **PERF-213**: Added `--single-process` flag to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
   - **Why it didn't work**: The renderer crashed because Chrome headless shell cannot load the audio output devices when falling back to single-process mode, causing tests and benchmarks to fail immediately (`Target page, context or browser has been closed`).
 - Removed `--disable-gpu-compositing` from `GPU_DISABLED_ARGS` in `packages/renderer/src/core/BrowserPool.ts`. Allowed Chromium to fallback to its software rasterizer (SwiftShader) which provides significant execution speedups in the headless, CPU-bound environment. Reduced rendering time in benchmark from ~33.156s to ~32.595s (~1.7% improvement).
@@ -98,7 +97,7 @@ Last updated by: PERF-214
 - Removed `--disable-gpu` from `GPU_DISABLED_ARGS` allowing Chromium to handle software fallback automatically.
   - Slower than baseline. Explicitly disabling GPU yields better performance than native software fallback. Render time was 33.543s (-2.90842% change).
   - PERF-215
-
-## What Doesn't Work (and Why)
 - **PERF-216**: Added `--disable-threaded-compositing` and `--disable-features=PaintHolding,ThreadedCompositing` flags to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
   - **Why it didn't work**: The renderer crashed immediately during the benchmark. Disabling threaded compositing in the headless Chromium environment resulted in a broken rendering pipeline that failed to process the `beginFrame` commands properly, outputting a 1x1 corrupted stream and throwing `FFmpeg stdin is not writable`. This approach fundamentally breaks the required rendering paths.
+- **PERF-217**: Disabled Font Subpixel Positioning using `--disable-font-subpixel-positioning` flag in `BrowserPool.ts`.
+  - **Why it didn't work**: The renderer performance regressed significantly from ~32.6s to ~43.8s and tests failed. The change caused unexpected stalling in the CPU-bound environment, likely due to rendering path incompatibility or increased software rasterization overhead.

--- a/packages/renderer/.sys/perf-results-PERF-217.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-217.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	43.842	150	3.42	39.6	discard	disable-font-subpixel-positioning


### PR DESCRIPTION
Run experiment PERF-217 to measure the performance impact of adding `--disable-font-subpixel-positioning` to the Chromium launch arguments in `BrowserPool.ts`.

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	43.842	150	3.42	39.6	discard	disable-font-subpixel-positioning

---
*PR created automatically by Jules for task [14671344153499154732](https://jules.google.com/task/14671344153499154732) started by @BintzGavin*