### PR TITLE
📋 RENDERER: Fix EPIPE crashes on FFmpeg stdin (#3038)

### DIFF
--- a/packages/cli/src/utils/ffmpeg.ts
+++ b/packages/cli/src/utils/ffmpeg.ts
@@ -95,6 +95,14 @@ export async function transcodeMerge(
       reject(err);
     });
 
+    process.stdin.on('error', (err: any) => {
+      if (err && err.code === 'EPIPE') {
+        console.warn('FFmpeg stdin closed prematurely (EPIPE). Ignoring error to allow graceful exit.');
+      } else {
+        reject(err);
+      }
+    });
+
     // Write file list to stdin
     process.stdin.write(listContent);
     process.stdin.end();

--- a/packages/renderer/src/concat.ts
+++ b/packages/renderer/src/concat.ts
@@ -71,6 +71,14 @@ export async function concatenateVideos(inputPaths: string[], outputPath: string
       reject(err);
     });
 
+    process.stdin.on('error', (err: any) => {
+      if (err && err.code === 'EPIPE') {
+        console.warn('FFmpeg stdin closed prematurely (EPIPE). Ignoring error to allow graceful exit.');
+      } else {
+        reject(err);
+      }
+    });
+
     // Write file list to stdin
     process.stdin.write(listContent);
     process.stdin.end();


### PR DESCRIPTION
Fixes issue #3038 by adding error handling to `process.stdin` streams during FFmpeg processing (transcoding and concatenation). This prevents Node.js process crashes due to 'EPIPE' errors when FFmpeg closes stdin prematurely.

Note: The `data-helios-no-audio` fix for DomScanner (Option B) was already implemented in `packages/renderer/src/utils/dom-scanner.ts` in a previous commit.

---
*PR created automatically by Jules for task [6451504071129156108](https://jules.google.com/task/6451504071129156108) started by @BintzGavin*