### PR TITLE
✨ RENDERER: Graceful FFmpeg EPIPE handling

### DIFF
--- a/packages/renderer/src/core/FFmpegManager.ts
+++ b/packages/renderer/src/core/FFmpegManager.ts
@@ -21,6 +21,16 @@ export class FFmpegManager {
     this.process = spawn(this.ffmpegPath, args, { stdio });
     console.log(`Spawning FFmpeg: ${this.ffmpegPath} ${args.join(' ')}`);
 
+    if (this.process.stdin) {
+      this.process.stdin.on('error', (err: any) => {
+        if (err && err.code === 'EPIPE') {
+          console.warn('FFmpeg stdin closed prematurely (EPIPE). Ignoring error to allow graceful exit.');
+        } else {
+          console.error('Error writing to FFmpeg stdin:', err);
+        }
+      });
+    }
+
     inputBuffers.forEach(({ index, buffer }) => {
       const pipe = this.process!.stdio[index] as any;
       if (pipe) {


### PR DESCRIPTION
Implements Option D by adding an error listener to stdin to prevent crashes. Option B was already implemented in a prior commit.

---
*PR created automatically by Jules for task [17937618441896632256](https://jules.google.com/task/17937618441896632256) started by @BintzGavin*