### PR TITLE
📋 PLAYER: Fix Duplicate getSchema README Entry

### DIFF
--- a/.sys/plans/2026-11-26-PLAYER-Fix-Duplicate-README-Entry.md
+++ b/.sys/plans/2026-11-26-PLAYER-Fix-Duplicate-README-Entry.md
@@ -1,0 +1,28 @@
+#### 1. Context & Goal
+- **Objective**: Remove the duplicated `getSchema` documentation from the `README.md`.
+- **Trigger**: The method `getSchema` is listed twice consecutively in the `README.md` file.
+- **Impact**: Improves documentation readability and accuracy by removing duplicate entries.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**: `packages/player/README.md`
+- **Read-Only**: None
+
+#### 3. Implementation Spec
+- **Architecture**: Plaintext markdown updates.
+- **Pseudo-Code**:
+  - Open `packages/player/README.md`
+  - Locate the `### Methods` section.
+  - Find the duplicate lines:
+    ```markdown
+    - `getSchema(): Promise<HeliosSchema | undefined>` - Retrieves the input properties schema from the composition.
+    - `getSchema(): Promise<HeliosSchema | undefined>` - Retrieves the input properties schema from the composition.
+    ```
+  - Remove one of the lines so only one instance remains.
+- **Public API Changes**: None
+- **Dependencies**: None
+
+#### 4. Test Plan
+- **Verification**: `grep -c "getSchema(): Promise<HeliosSchema" packages/player/README.md`
+- **Success Criteria**: The output is exactly 1.
+- **Edge Cases**: None.


### PR DESCRIPTION
Created plan file .sys/plans/2026-11-26-PLAYER-Fix-Duplicate-README-Entry.md to fix a duplicated documentation entry in the packages/player/README.md.

---
*PR created automatically by Jules for task [4924963327659708314](https://jules.google.com/task/4924963327659708314) started by @BintzGavin*