### PR TITLE
✨ RENDERER: Eliminate async wrappers in DOM render hot path

### DIFF
--- a/.sys/plans/PERF-238-eliminate-async-wrappers.md
+++ b/.sys/plans/PERF-238-eliminate-async-wrappers.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-238
 slug: eliminate-async-wrappers
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-06-06
 completed: ""
-result: ""
+result: "Skipped: async wrappers already eliminated in codebase"
 ---
 # PERF-238: Eliminate `async` wrappers in DOM render hot path
 

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -7,6 +7,9 @@ Current best: 35.091s (baseline was 49.436s, -32.5%)
 Last updated by: PERF-198
 
 ## What Works
+- **PERF-238**: Eliminate `async` wrappers in DOM render hot path
+  - **Result**: SKIPPED. Codebase exploration confirmed that the `capture` method in `DomStrategy.ts` and the injected `window.__helios_seek` function in `SeekTimeDriver.ts` already lack `async` wrappers and utilize native Promise chaining or direct synchronous returns.
+
 - Caching target element bounding box in DomStrategy.prepare() instead of per-frame querying (~1.1% faster) (PERF-232)
 
 - **PERF-231**: Verified that eliminating the `async` wrapper for `captureWorkerFrame` in `CaptureLoop.ts` was already correctly implemented natively, avoiding V8 `async` context creation micro-stalls during the hot loop.


### PR DESCRIPTION
Codebase exploration confirmed that the capture method in DomStrategy.ts and the injected window.__helios_seek function in SeekTimeDriver.ts already lack async wrappers and utilize native Promise chaining or direct synchronous returns. No code changes required.

---
*PR created automatically by Jules for task [13075081505356435958](https://jules.google.com/task/13075081505356435958) started by @BintzGavin*