### PR TITLE
✨ CLI: Add Deploy Command Regression Tests

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -8,6 +8,9 @@
 - ✅ Completed: Documentation Orchestration - Updated README.md to document Orchestration, Job Management, Cloud Execution Adapters, and Worker Runtime abstractions.
 # Helios Project Progress Log
 
+## CLI v0.46.7
+- ✅ Completed: Deploy Command Regression Tests - Implemented unit tests for all remaining deploy subcommands.
+
 ## STUDIO v0.121.1
 - ✅ Completed: STUDIO-Timeline-Drag-Drop - Verified existing implementation for timeline drag and drop support to accept assets (2026-11-13-STUDIO-Timeline-Drag-Drop.md).
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,8 +1,9 @@
 # CLI Status
 
-**Version**: 0.46.6
+**Version**: 0.46.7
 
 ## Recent Completions
+[v0.46.7] ✅ Completed: Deploy Command Regression Tests - Implemented unit tests for all remaining deploy subcommands.
 [v0.46.6] ✅ Completed: Add Cloudflare Sandbox Adapter support to job run - Verified implementation and tests for Cloudflare Sandbox adapter support in the job run command.
 [v0.46.5] ✅ Completed: Implement job command regression tests - Add unit tests for job run and adapters.
 [v0.46.4] ✅ Completed: Add Cloudflare Sandbox Adapter support to job run - Exposes the adapter from infrastructure package

--- a/packages/cli/src/commands/__tests__/deploy.test.ts
+++ b/packages/cli/src/commands/__tests__/deploy.test.ts
@@ -8,6 +8,15 @@ import { DOCKERFILE_TEMPLATE, DOCKER_COMPOSE_TEMPLATE } from '../../templates/do
 import { CLOUD_RUN_JOB_TEMPLATE, README_GCP_TEMPLATE } from '../../templates/gcp.js';
 import { AWS_DOCKERFILE_TEMPLATE, AWS_LAMBDA_HANDLER_TEMPLATE, AWS_SAM_TEMPLATE, README_AWS_TEMPLATE } from '../../templates/aws.js';
 import { DOCKER_COMPOSE_ADAPTER_TEMPLATE, README_DOCKER_TEMPLATE } from '../../templates/docker-adapter.js';
+import { WRANGLER_TOML_TEMPLATE, CLOUDFLARE_WORKER_TEMPLATE, README_CLOUDFLARE_TEMPLATE } from '../../templates/cloudflare.js';
+import { WRANGLER_TOML_TEMPLATE as CF_SANDBOX_WRANGLER_TOML_TEMPLATE, WORKFLOW_INDEX_TS_TEMPLATE, WORKFLOW_RENDER_TS_TEMPLATE, README_CLOUDFLARE_SANDBOX_TEMPLATE } from '../../templates/cloudflare-sandbox.js';
+import { FLY_TOML_TEMPLATE, FLY_DOCKERFILE_TEMPLATE, README_FLY_TEMPLATE } from '../../templates/fly.js';
+import { AZURE_FUNCTION_JSON_TEMPLATE, AZURE_HOST_JSON_TEMPLATE, AZURE_LOCAL_SETTINGS_JSON_TEMPLATE, AZURE_INDEX_JS_TEMPLATE, README_AZURE_TEMPLATE } from '../../templates/azure.js';
+import { KUBERNETES_JOB_TEMPLATE, README_KUBERNETES_TEMPLATE } from '../../templates/kubernetes.js';
+import { README_HETZNER_TEMPLATE } from '../../templates/hetzner.js';
+import { README_MODAL_TEMPLATE } from '../../templates/modal.js';
+import { README_DENO_TEMPLATE } from '../../templates/deno.js';
+import { README_VERCEL_TEMPLATE } from '../../templates/vercel.js';
 
 // Mock fs and prompts
 vi.mock('fs');
@@ -305,6 +314,309 @@ describe('deploy command', () => {
       expect(prompts).toHaveBeenCalledTimes(2);
 
       // Check if files were NOT overwritten
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cloudflare subcommand', () => {
+    it('should create Cloudflare files when they do not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'cloudflare']);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('wrangler.toml'), WRANGLER_TOML_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('src/worker.ts'), CLOUDFLARE_WORKER_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('README-CLOUDFLARE.md'), README_CLOUDFLARE_TEMPLATE);
+    });
+
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: true });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'cloudflare']);
+
+      expect(prompts).toHaveBeenCalledTimes(3);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('wrangler.toml'), WRANGLER_TOML_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('src/worker.ts'), CLOUDFLARE_WORKER_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('README-CLOUDFLARE.md'), README_CLOUDFLARE_TEMPLATE);
+    });
+
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: false });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'cloudflare']);
+
+      expect(prompts).toHaveBeenCalledTimes(3);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cloudflare-sandbox subcommand', () => {
+    it('should create Cloudflare Sandbox files when they do not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'cloudflare-sandbox']);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('wrangler.toml'), CF_SANDBOX_WRANGLER_TOML_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('src/index.ts'), WORKFLOW_INDEX_TS_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('src/render-workflow.ts'), WORKFLOW_RENDER_TS_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('README-CLOUDFLARE-SANDBOX.md'), README_CLOUDFLARE_SANDBOX_TEMPLATE);
+    });
+
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: true });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'cloudflare-sandbox']);
+
+      expect(prompts).toHaveBeenCalledTimes(4);
+    });
+
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: false });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'cloudflare-sandbox']);
+
+      expect(prompts).toHaveBeenCalledTimes(4);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fly subcommand', () => {
+    it('should create Fly files when they do not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'fly']);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('fly.toml'), FLY_TOML_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('Dockerfile'), FLY_DOCKERFILE_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('README-FLY.md'), README_FLY_TEMPLATE);
+    });
+
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: true });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'fly']);
+
+      expect(prompts).toHaveBeenCalledTimes(3);
+    });
+
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: false });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'fly']);
+
+      expect(prompts).toHaveBeenCalledTimes(3);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('azure subcommand', () => {
+    it('should create Azure files when they do not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'azure']);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('host.json'), AZURE_HOST_JSON_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('local.settings.json'), AZURE_LOCAL_SETTINGS_JSON_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('function.json'), AZURE_FUNCTION_JSON_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('index.js'), AZURE_INDEX_JS_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('README-AZURE.md'), README_AZURE_TEMPLATE);
+    });
+
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: true });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'azure']);
+
+      expect(prompts).toHaveBeenCalledTimes(5);
+    });
+
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: false });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'azure']);
+
+      expect(prompts).toHaveBeenCalledTimes(5);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('kubernetes subcommand', () => {
+    it('should create Kubernetes files when they do not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'kubernetes']);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('job.yaml'), KUBERNETES_JOB_TEMPLATE);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('README-KUBERNETES.md'), README_KUBERNETES_TEMPLATE);
+    });
+
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: true });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'kubernetes']);
+
+      expect(prompts).toHaveBeenCalledTimes(2);
+    });
+
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: false });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'kubernetes']);
+
+      expect(prompts).toHaveBeenCalledTimes(2);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hetzner subcommand', () => {
+    it('should create Hetzner files when they do not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'hetzner']);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('README-HETZNER.md'), README_HETZNER_TEMPLATE);
+    });
+
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: true });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'hetzner']);
+
+      expect(prompts).toHaveBeenCalledTimes(1);
+    });
+
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: false });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'hetzner']);
+
+      expect(prompts).toHaveBeenCalledTimes(1);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('modal subcommand', () => {
+    it('should create Modal files when they do not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'modal']);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('README-MODAL.md'), README_MODAL_TEMPLATE);
+    });
+
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: true });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'modal']);
+
+      expect(prompts).toHaveBeenCalledTimes(1);
+    });
+
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: false });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'modal']);
+
+      expect(prompts).toHaveBeenCalledTimes(1);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deno subcommand', () => {
+    it('should create Deno files when they do not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'deno']);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('README-DENO.md'), README_DENO_TEMPLATE);
+    });
+
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: true });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'deno']);
+
+      expect(prompts).toHaveBeenCalledTimes(1);
+    });
+
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: false });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'deno']);
+
+      expect(prompts).toHaveBeenCalledTimes(1);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('vercel subcommand', () => {
+    it('should create Vercel files when they do not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'vercel']);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('README-VERCEL.md'), README_VERCEL_TEMPLATE);
+    });
+
+    it('should prompt if files exist and overwrite if confirmed', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: true });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'vercel']);
+
+      expect(prompts).toHaveBeenCalledTimes(1);
+    });
+
+    it('should prompt if files exist and NOT overwrite if declined', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(prompts).mockResolvedValue({ value: false });
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+
+      await program.parseAsync(['node', 'test', 'deploy', 'vercel']);
+
+      expect(prompts).toHaveBeenCalledTimes(1);
       expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/commands/__tests__/job.test.ts
+++ b/packages/cli/src/commands/__tests__/job.test.ts
@@ -51,7 +51,7 @@ vi.mock('fs', async (importOriginal) => {
   return {
     ...actual,
     default: {
-      ...actual.default,
+      ...actual,
       existsSync: vi.fn(),
       readFileSync: vi.fn(),
     },


### PR DESCRIPTION
💡 What: Implemented unit tests for the remaining tier 1-3 deployment scaffold commands (cloudflare, cloudflare-sandbox, fly, azure, kubernetes, hetzner, modal, deno, vercel).
🎯 Why: The previous test suite only covered setup, docker, aws, and gcp subcommands, leaving the rest vulnerable to regressions.
📊 Impact: Ensures all deploy scaffolding commands are robust against regressions and behave correctly with the file system.
🔬 Verification: Run `npx vitest run packages/cli/src/commands/__tests__/deploy.test.ts` to see 100% test completion for all subcommands.

---
*PR created automatically by Jules for task [15551482385460152036](https://jules.google.com/task/15551482385460152036) started by @BintzGavin*