### PR TITLE
✨ RENDERER: Discard worker concurrency reduction to 1

### DIFF
--- a/.sys/plans/PERF-243-reduce-worker-concurrency.md
+++ b/.sys/plans/PERF-243-reduce-worker-concurrency.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-243
 slug: reduce-worker-concurrency
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: "2026-04-11"
-completed: ""
-result: ""
+completed: "2026-04-11"
+result: "failed"
 ---
 
 # PERF-243: Evaluate Minimal Worker Concurrency (Single Page)
@@ -57,3 +57,9 @@ Run the DOM render tests to ensure 1 worker correctly processes all frames in or
 
 ## Prior Art
 - PERF-237: Optimize BrowserPool Concurrency Heuristic (halved cores).
+
+## Results Summary
+- **Best render time**: 53.825s (vs baseline 48.336s)
+- **Improvement**: -11%
+- **Kept experiments**: []
+- **Discarded experiments**: [Reduce worker concurrency to 1]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -41,6 +41,9 @@ Last updated by: PERF-198
 
 - Moved closure logic outside CaptureLoop (~3.2% faster) [PERF-235]
 ## What Doesn't Work (and Why)
+- Reduced worker concurrency to 1. Resulted in ~54s render time vs ~49s baseline. Running multiple pages in parallel is faster even if it causes some context switching overhead.
+  (Plan: PERF-243)
+
 - PERF-222: Added `--disable-renderer-backgrounding` and `--disable-backgrounding-occluded-windows` to `DEFAULT_BROWSER_ARGS`. Resulted in 32.839s (-0.2% change). Status: discard.
 - Discarded `PERF-220` (remove background networking flags)
   - Time: 32.547s (baseline: 32.552s). The difference is well within the margin of error (less than 0.1%).

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -310,3 +310,4 @@ PERF-224-run	32.807	150			keep	mutate callParams.arguments instead of reallocati
 309	48.777	600	12.30	46.3	keep	Bypass writeToStdin async wrapper (PERF-239)
 310	48.082	600	12.48	38.3	keep	Inline captureWorkerFrame
 1	59.793	300	10.03	37.3	keep	Eliminated closure allocation in DomStrategy capture (PERF-242)
+311	53.825	600	11.15	36.2	discard	Reduce worker concurrency to 1


### PR DESCRIPTION
✨ RENDERER: Discard worker concurrency reduction to 1

💡 **What**: Ran an experiment (PERF-243) to reduce BrowserPool worker concurrency to 1 to see if eliminating inter-page contention improved wall-clock throughput on the CPU-bound VM. The experiment failed and the code was reverted to use the dynamic concurrency heuristic.

🎯 **Why**: Profiling indicated significant context switching and thrashing when running multiple headless Playwright pages alongside Node.js and FFmpeg on limited CPU.

📊 **Impact**: The render time regressed from a baseline of ~48.336s to 53.825s (-11% regression). Running multiple pages concurrently allows for better overall throughput despite the context switching overhead.

🔬 **Verification**:
- Ran tests/fixtures/benchmark.ts directly.
- Baseline median: 48.336s
- Exp median: 53.825s
- The code change was discarded. `perf-results.tsv`, `.sys/plans/PERF-243-reduce-worker-concurrency.md`, and `docs/status/RENDERER-EXPERIMENTS.md` were updated to reflect the discarded experiment.

📎 **Plan**: Reference the plan file `/.sys/plans/PERF-243-reduce-worker-concurrency.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|-----|---------------|--------|---------------|-------------|--------|-------------|
| 311 | 53.825        | 600    | 11.15         | 36.2        | discard | Reduce worker concurrency to 1 |

---
*PR created automatically by Jules for task [15390537534668091741](https://jules.google.com/task/15390537534668091741) started by @BintzGavin*