### PR TITLE
✨ RENDERER: Record PERF-250 experiment failure

### DIFF
--- a/.sys/plans/PERF-251-remove-closure.md
+++ b/.sys/plans/PERF-251-remove-closure.md
@@ -1,0 +1,31 @@
+---
+id: PERF-251
+slug: remove-closure
+status: unclaimed
+claimed_by: ""
+created: "2026-04-11"
+completed: ""
+result: ""
+---
+
+# PERF-251: Pre-bind Closure in CaptureLoop Worker Dispatch
+
+## Focus Area
+DOM Rendering Pipeline - Hot Loop in `packages/renderer/src/core/CaptureLoop.ts`.
+
+## Background Research
+The `CaptureLoop` uses a `.then()` closure to schedule the next frame's capture:
+```typescript
+            const framePromise = worker.activePromise
+                .catch(noopCatch)
+                .then(() => {
+                    worker.timeDriver.setTime(worker.page, compositionTimeInSeconds).then(undefined, noopCatch);
+                    return worker.strategy.capture(worker.page, time);
+                });
+```
+This anonymous closure `() => { ... }` is allocated on every frame (e.g. 150 times per 5s video), which causes V8 garbage collection overhead in memory-constrained environments. Similar anonymous closure allocations have been optimized in other hot loops (e.g. PERF-245 in CdpTimeDriver). By creating a pre-allocated bound method or static context, we can avoid this per-frame allocation.
+Wait, earlier we tried `Pre-allocated execution context ring buffer inside CaptureLoop hot loop (PERF-241)`.
+Let's check the journal.
+"Creating context objects and binding methods up front degraded performance significantly (~49.6s baseline to ~50.9s). The overhead of calling .bind() and using closure functions wrapped in objects outweighed the performance cost of anonymous closure allocation in the .then() callback."
+
+Let me check the `CaptureLoop.ts` file again.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -44,7 +44,10 @@ Last updated by: PERF-198
 
 - Moved closure logic outside CaptureLoop (~3.2% faster) [PERF-235]
 ## What Doesn't Work (and Why)
-- Increased pipeline depth to `poolLen * 8` (PERF-244). Result: 50.119s. Reason: Overhead of tracking larger base64 array in Node.js event loop outweighed buffering benefits.
+-
+- **PERF-250**: Restore Counter-Based Indexing in CaptureLoop
+  - **Why it didn't work**: Although microbenchmarks showed counter indexing as faster, the implementation regressed render time from ~2.175s to 2.768s. The added variables and bounds checking inside the deeply overlapping promise pipeline negated the benefits and resulted in slightly slower performance.
+ Increased pipeline depth to `poolLen * 8` (PERF-244). Result: 50.119s. Reason: Overhead of tracking larger base64 array in Node.js event loop outweighed buffering benefits.
 
 - Increased pipeline depth to `poolLen * 8` (PERF-244). . Reason: Overhead of tracking larger base64 array in Node.js event loop outweighed buffering benefits.
 


### PR DESCRIPTION
💡 What: Documented the failure of PERF-250, which attempted to restore counter-based indexing in `CaptureLoop.ts` on top of the parallel promise overlapping changes from PERF-249.
🎯 Why: To record that adding extra variables, counter increments, and bounds checking logic inside the deeply overlapping promise pipeline negated the benefits of counter-based array indexing, resulting in a performance regression (render time increased from ~2.17s to 2.76s).
🔬 Verification: Implemented the logic and ran `scripts/benchmark-test.js`, measuring a regression. Reverted the codebase changes and documented the results in `.sys/plans/PERF-250-restore-counter-based-indexing.md` and `docs/status/RENDERER-EXPERIMENTS.md`.
📎 Plan: `.sys/plans/PERF-250-restore-counter-based-indexing.md`

---
*PR created automatically by Jules for task [3910381063947919628](https://jules.google.com/task/3910381063947919628) started by @BintzGavin*