### PR TITLE
✨ RENDERER: Discard pre-bound closure in CaptureLoop Worker Dispatch

### DIFF
--- a/.sys/plans/PERF-251-remove-closure.md
+++ b/.sys/plans/PERF-251-remove-closure.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-251
 slug: remove-closure
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: "2026-04-11"
-completed: ""
-result: ""
+completed: "2026-04-11"
+result: "discarded"
 ---
 
 # PERF-251: Pre-bind Closure in CaptureLoop Worker Dispatch
@@ -29,3 +29,10 @@ Let's check the journal.
 "Creating context objects and binding methods up front degraded performance significantly (~49.6s baseline to ~50.9s). The overhead of calling .bind() and using closure functions wrapped in objects outweighed the performance cost of anonymous closure allocation in the .then() callback."
 
 Let me check the `CaptureLoop.ts` file again.
+
+
+## Results Summary
+- **Best render time**: 1.730s (vs baseline 1.701s)
+- **Improvement**: -1.7%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-251]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -44,6 +44,8 @@ Last updated by: PERF-198
 
 - Moved closure logic outside CaptureLoop (~3.2% faster) [PERF-235]
 ## What Doesn't Work (and Why)
+- **PERF-251**: Pre-bind Closure in CaptureLoop Worker Dispatch
+  - **Why it didn't work**: Like PERF-241, pre-allocating closures with captured state arrays (or context objects) did not improve performance. The overhead of looking up state from the closure array or the function call dispatch negated the savings of avoiding per-frame anonymous closure allocation. Render time remained around ~1.74s compared to ~1.71s baseline. V8 seems to optimize the inline arrow function allocation within the `.then()` very well.
 -
 - **PERF-250**: Restore Counter-Based Indexing in CaptureLoop
   - **Why it didn't work**: Although microbenchmarks showed counter indexing as faster, the implementation regressed render time from ~2.175s to 2.768s. The added variables and bounds checking inside the deeply overlapping promise pipeline negated the benefits and resulted in slightly slower performance.

--- a/packages/renderer/.sys/perf-results-PERF-251.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-251.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.726	150	86.88	34.5	keep	baseline
+2	1.705	150	88.00	40.2	keep	baseline
+3	1.701	150	88.20	48.9	keep	baseline
+4	1.774	150	84.54	34.6	discard	pre-bound closures
+5	1.742	150	86.12	34.7	discard	pre-bound closures
+6	1.730	150	86.71	48.8	discard	pre-bound closures


### PR DESCRIPTION
💡 **What**: Tested using pre-bound closures and pre-allocated state arrays in CaptureLoop instead of anonymous inline closures.
🎯 **Why**: To reduce V8 garbage collection overhead in the hot loop.
📊 **Impact**: Render time slightly degraded from ~1.71s baseline to ~1.74s, so experiment was discarded.
🔬 **Verification**: Code restored, tests skipped for discarded experiments.
📎 **Plan**: Reference the plan file (/.sys/plans/PERF-251-remove-closure.md)

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.726	150	86.88	34.5	keep	baseline
2	1.705	150	88.00	40.2	keep	baseline
3	1.701	150	88.20	48.9	keep	baseline
4	1.774	150	84.54	34.6	discard	pre-bound closures
5	1.742	150	86.12	34.7	discard	pre-bound closures
6	1.730	150	86.71	48.8	discard	pre-bound closures
```

---
*PR created automatically by Jules for task [17683453393145024769](https://jules.google.com/task/17683453393145024769) started by @BintzGavin*