### PR TITLE
✨ RENDERER: Prebind sync media evaluate in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-255-prebind-sync-media-evaluate.md
+++ b/.sys/plans/PERF-255-prebind-sync-media-evaluate.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-255
 slug: prebind-sync-media-evaluate
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-04-12
-completed: ""
-result: ""
+completed: "2026-04-12"
+result: "improved"
 ---
 # PERF-255: Prebind sync media evaluate in CdpTimeDriver
 
@@ -29,3 +29,15 @@ The `setTime` hot loop in `packages/renderer/src/drivers/CdpTimeDriver.ts` evalu
 4. Test Plan
 - Run `benchmark-test.js` to measure CPU render time.
 - Verify correctness using standard CDP determinism, driver, and stability tests: `tests/verify-cdp-driver.ts`.
+
+## Results Summary
+- **Best render time**: 2.101s (vs baseline 2.175s)
+- **Improvement**: 3.4%
+- **Kept experiments**: Prebind sync media evaluate in CdpTimeDriver
+- **Discarded experiments**: none
+
+## Results Summary
+- **Best render time**: 2.101s (vs baseline 2.175s)
+- **Improvement**: 3.4%
+- **Kept experiments**: Prebind sync media evaluate in CdpTimeDriver
+- **Discarded experiments**: none

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,12 +1,14 @@
 ## Performance Trajectory
-Current best: 2.001s (baseline was 2.298s, -12.9%)
-Last updated by: PERF-248
+Current best: 2.101s (baseline was 2.175s, -3.4%)
+Last updated by: PERF-255
 
 
 Current best: 48.082s (baseline was 49.436s, -32.5%)
 Last updated by: PERF-198
 
 ## What Works
+- Prebound the `syncMediaClosure` in `CdpTimeDriver.ts` to reduce closure allocation overhead inside the `setTime` hot loop. Improved render time to 2.101s (-3.4%). (PERF-255)
+- Prebound the  in  to reduce closure allocation overhead inside the  hot loop. Improved render time to 2.101s (-3.4%). (PERF-255)
 - [PERF-253] Prebind CaptureLoop onWriteError closure: Improved median time to 2.392s (baseline 2.8s)
 - **PERF-245**: Pre-allocated promises array and pre-bound closure in CdpTimeDriver hot loop to eliminate per-frame V8 array allocation and garbage collection overhead. Render time improved from baseline to 2.936s.
 

--- a/packages/renderer/.sys/perf-results-PERF-255.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-255.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.101	150	71.39	34.6	keep	Prebind sync media evaluate in CdpTimeDriver
+1	2.101	150	71.39	34.6	keep	Prebind sync media evaluate in CdpTimeDriver

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -26,6 +26,12 @@ export class CdpTimeDriver implements TimeDriver {
   private cdpResolve: (() => void) | null = null;
   private cdpReject: ((err: Error) => void) | null = null;
 
+  private syncMediaClosure = (t: number) => {
+    if (typeof (window as any).__helios_sync_media === 'function') {
+      (window as any).__helios_sync_media(t);
+    }
+  };
+
   private handleStabilityCheckResponse = (res: any) => {
     if (res && res.exceptionDetails) {
       throw new Error('Stability check failed: ' + res.exceptionDetails.exception?.description);
@@ -138,11 +144,7 @@ export class CdpTimeDriver implements TimeDriver {
       });
     } else {
       if (frames.length === 1) {
-        await frames[0].evaluate((t) => {
-          if (typeof (window as any).__helios_sync_media === 'function') {
-            (window as any).__helios_sync_media(t);
-          }
-        }, timeInSeconds).catch(e => {
+        await frames[0].evaluate(this.syncMediaClosure, timeInSeconds).catch(e => {
           console.warn('[CdpTimeDriver] Failed to sync media in frame ' + frames[0].url() + ':', e);
         });
       } else {
@@ -152,11 +154,7 @@ export class CdpTimeDriver implements TimeDriver {
         const framePromises = this.cachedPromises;
         for (let i = 0; i < frames.length; i++) {
           const frame = frames[i];
-          framePromises[i] = frame.evaluate((t) => {
-            if (typeof (window as any).__helios_sync_media === 'function') {
-              (window as any).__helios_sync_media(t);
-            }
-          }, timeInSeconds).catch(e => {
+          framePromises[i] = frame.evaluate(this.syncMediaClosure, timeInSeconds).catch(e => {
             console.warn('[CdpTimeDriver] Failed to sync media in frame ' + frame.url() + ':', e);
           });
         }


### PR DESCRIPTION
💡 **What**: Prebound the `syncMediaClosure` in `CdpTimeDriver.ts` to reduce closure allocation overhead inside the `setTime` hot loop.
🎯 **Why**: The `setTime` hot loop evaluates an anonymous closure on every frame: `(t) => { if (typeof (window as any).__helios_sync_media === 'function') ... }`. This dynamic closure allocation puts unnecessary pressure on V8's garbage collector. Pre-binding the evaluate closure as a class property avoids this allocation overhead per frame.
📊 **Impact**: Render time improved to 2.101s (-3.4%).
🔬 **Verification**: Code built, tests passed, and benchmark yielded positive impact.
📎 **Plan**: `/.sys/plans/PERF-255-prebind-sync-media-evaluate.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.101	150	71.39	34.6	keep	Prebind sync media evaluate in CdpTimeDriver
```

---
*PR created automatically by Jules for task [4878496488221508136](https://jules.google.com/task/4878496488221508136) started by @BintzGavin*