### PR TITLE
✨ RENDERER: Discard PERF-256 (Prebind wait stable evaluate)

### DIFF
--- a/.sys/plans/PERF-256-prebind-wait-stable-evaluate.md
+++ b/.sys/plans/PERF-256-prebind-wait-stable-evaluate.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-256
 slug: prebind-wait-stable-evaluate
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-04-12
-completed: ""
-result: ""
+completed: "2026-04-12"
+result: "discard"
 ---
 
 # PERF-256: Prebind wait stable evaluate in CdpTimeDriver
@@ -48,3 +48,7 @@ Then update the fallback call in `setTime`:
 
 ## Correctness Check
 Run `tests/verify-cdp-driver.ts` to ensure the driver still passes basic execution flow and stability checks.
+
+## Results Summary
+- **Render time**: 11.948s (vs baseline 1.95s)
+- **Status**: discard

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -47,6 +47,10 @@ Last updated by: PERF-198
 
 - Moved closure logic outside CaptureLoop (~3.2% faster) [PERF-235]
 ## What Doesn't Work (and Why)
+- PERF-256: Prebind wait stable evaluate closure in CdpTimeDriver.ts
+  - Result: 11.948s (vs 1.95s baseline)
+  - Why it failed: Pre-binding the fallback closure surprisingly regressed performance drastically. This is likely because the hot-loop execution inside `page.evaluate()` behaves differently with class properties vs inline string/functions. Playwright's serialization of the bound property across the CDP boundary per-frame introduces significantly more overhead than compiling the inline string.
+
 - **PERF-251**: Pre-bind Closure in CaptureLoop Worker Dispatch
   - **Why it didn't work**: Like PERF-241, pre-allocating closures with captured state arrays (or context objects) did not improve performance. The overhead of looking up state from the closure array or the function call dispatch negated the savings of avoiding per-frame anonymous closure allocation. Render time remained around ~1.74s compared to ~1.71s baseline. V8 seems to optimize the inline arrow function allocation within the `.then()` very well.
 -

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -326,3 +326,4 @@ PERF-249	CaptureLoop	2.735	Sliding window pipeline optimization
 run	2.936	150	51.09	38.0	keep	Pre-allocate promises array and pre-bind closure in CdpTimeDriver hot loop
 253	2.392	150	62.71	0.0	keep	Prebind CaptureLoop stdin write callback closure
 PERF-254	Pre-bind evaluate closures in SeekTimeDriver	render_time_s:      2.119
+256	11.948	150	12.55	37.3	discard	PERF-256 prebind wait stable evaluate


### PR DESCRIPTION
💡 **What**: Tested pre-binding the `page.evaluate()` fallback closure for stability checks in `CdpTimeDriver.ts`.
🎯 **Why**: To attempt to reduce per-frame V8 garbage collection overhead caused by allocating anonymous closures inside the `setTime` hot loop.
📊 **Impact**: Severe performance regression. Render time spiked from ~1.95s to 11.948s. Pre-binding the function and letting Playwright serialize the property reference per frame was significantly slower than passing an inline arrow function. The source code changes were correctly reverted.
🔬 **Verification**: Code compilation, unit test suite (`verify-cdp-driver.ts`), and baseline rendering benchmark.
📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-256-prebind-wait-stable-evaluate.md`)

| run | render_time_s | frames | fps_effective | peak_mem_mb | status  | description                           |
|-----|---------------|--------|---------------|-------------|---------|---------------------------------------|
| 256 | 11.948        | 150    | 12.55         | 37.3        | discard | PERF-256 prebind wait stable evaluate |

---
*PR created automatically by Jules for task [2231342447288679452](https://jules.google.com/task/2231342447288679452) started by @BintzGavin*