### PR TITLE
📋 RENDERER: Evaluate timeout optimization in CdpTimeDriver (PERF-257)

### DIFF
--- a/.sys/plans/PERF-257-evaluate-callFunctionOn.md
+++ b/.sys/plans/PERF-257-evaluate-callFunctionOn.md
@@ -1,10 +1,10 @@
 ---
 id: PERF-257
 slug: evaluate-callFunctionOn
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-24
-completed: ""
+completed: "2026-04-12"
 result: ""
 ---
 
@@ -116,3 +116,9 @@ Run the DOM render benchmark to ensure video generation completes successfully a
 
 ## Prior Art
 Previous optimizations (`PERF-241`, `PERF-242`, `PERF-252`) repeatedly proved that anonymous closures, promises, and dynamic object allocations inside the frame hot-loop (`CaptureLoop` and Time Drivers) cause V8 GC pressure overhead that slows down execution.
+
+## Results Summary
+- **Best render time**: 1.843s (vs baseline 1.843s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-257]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -47,6 +47,8 @@ Last updated by: PERF-198
 
 - Moved closure logic outside CaptureLoop (~3.2% faster) [PERF-235]
 ## What Doesn't Work (and Why)
+- PERF-257: Eliminate timeoutPromise allocation inside CdpTimeDriver.ts setTime
+  - **Why it didn't work**: Did not improve render time over the 1.843s baseline. It likely stalled or didn't provide a meaningful GC reduction compared to the baseline.
 - PERF-256: Prebind wait stable evaluate closure in CdpTimeDriver.ts
   - Result: 11.948s (vs 1.95s baseline)
   - Why it failed: Pre-binding the fallback closure surprisingly regressed performance drastically. This is likely because the hot-loop execution inside `page.evaluate()` behaves differently with class properties vs inline string/functions. Playwright's serialization of the bound property across the CDP boundary per-frame introduces significantly more overhead than compiling the inline string.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -327,3 +327,4 @@ run	2.936	150	51.09	38.0	keep	Pre-allocate promises array and pre-bind closure i
 253	2.392	150	62.71	0.0	keep	Prebind CaptureLoop stdin write callback closure
 PERF-254	Pre-bind evaluate closures in SeekTimeDriver	render_time_s:      2.119
 256	11.948	150	12.55	37.3	discard	PERF-256 prebind wait stable evaluate
+325	2.551	150	58.81	34.6	discard	PERF-257: Eliminate timeoutPromise allocation inside CdpTimeDriver.ts setTime


### PR DESCRIPTION
💡 **What**: Evaluated removing the `timeoutPromise` and `Promise.race()` allocation around the CDP call in `CdpTimeDriver.setTime()`. The experiment was discarded because it failed to improve the render time over the 1.843s baseline (recorded 2.551s).
🎯 **Why**: The `timeoutPromise` creates a new Promise and sets a `setTimeout` timer on the Node.js event loop on every frame. We hypothesized that removing it would reduce V8 garbage collection and event-loop overhead. However, removing it degraded performance or stalled execution compared to the baseline.
📊 **Impact**: N/A (Discarded). Render time increased from 1.843s to 2.551s.
🔬 **Verification**: 
- Benchmarked via `npx tsx scripts/benchmark-test.js`
- Baseline median: 1.843s
- Experiment median: 2.551s
- Reverted code changes safely
📎 **Plan**: `/.sys/plans/PERF-257-evaluate-callFunctionOn.md`

```
325	2.551	150	58.81	34.6	discard	PERF-257: Eliminate timeoutPromise allocation inside CdpTimeDriver.ts setTime
```

---
*PR created automatically by Jules for task [6375052215883310425](https://jules.google.com/task/6375052215883310425) started by @BintzGavin*