### PR TITLE
✨ RENDERER: Prebind virtual time promise executor in CdpTimeDriver

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -172,3 +172,5 @@ Last updated by: PERF-249
 ## What Doesn't Work (and Why)
 - **PERF-262**: Prebound the CDP stability timeout promise executor.
   - **Why it didn't work**: Did not improve render time. V8 optimizes the inline promise and anonymous closure allocation better than the property lookup.
+- Prebind virtual time promise executor in CdpTimeDriver (PERF-260)
+  - **Why it didn't work**: Did not improve render time (median 32.507s vs baseline 32.156s). V8 seems to optimize the inline promise and anonymous closure allocation better than the property lookup, similar to the stability timeout experiment (PERF-262).

--- a/packages/renderer/.sys/perf-results-PERF-260.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-260.tsv
@@ -1,0 +1,5 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.156	90	2.80	36.6	keep	baseline
+2	33.611	90	2.68	36.6	discard	prebind-virtual-time-executor
+3	32.507	90	2.77	37.2	discard	prebind-virtual-time-executor
+4	32.482	90	2.77	37.1	discard	prebind-virtual-time-executor

--- a/packages/renderer/.sys/plans/PERF-260-prebind-virtual-time-executor.md
+++ b/packages/renderer/.sys/plans/PERF-260-prebind-virtual-time-executor.md
@@ -1,0 +1,23 @@
+---
+id: PERF-260
+slug: prebind-virtual-time-executor
+status: complete
+claimed_by: "executor-session"
+completed: 2024-05-28
+result: no-improvement
+---
+
+# RENDERER: Prebind virtual time promise executor in CdpTimeDriver (PERF-260)
+
+#### 1. Context & Goal
+- **Objective**: Prebind the virtual time promise executor to a class property in CdpTimeDriver to reduce dynamic closure allocation overhead.
+- **Goal**: Reduce GC overhead in the hot loop, potentially improving rendering speed.
+
+#### 2. File Inventory
+- **Modify**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+
+## Results Summary
+- **Best render time**: 32.482s (vs baseline 32.156s)
+- **Improvement**: ~-1.0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-260]


### PR DESCRIPTION
💡 **What**: Evaluated pre-binding the virtual time promise executor to a class property in CdpTimeDriver.ts, but reverted changes due to performance regression.
🎯 **Why**: To test if avoiding dynamic anonymous closure allocation per frame for Emulation.setVirtualTimePolicy would reduce GC overhead.
📊 **Impact**: No improvement (median 32.507s vs baseline 32.156s). V8 optimizations for inline promises are superior here.
🔬 **Verification**: Code changes reverted completely. Results recorded.
📎 **Plan**: /.sys/plans/PERF-260-prebind-virtual-time-executor.md

TSV Results:
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.156	90	2.80	36.6	keep	baseline
2	33.611	90	2.68	36.6	discard	prebind-virtual-time-executor
3	32.507	90	2.77	37.2	discard	prebind-virtual-time-executor
4	32.482	90	2.77	37.1	discard	prebind-virtual-time-executor

---
*PR created automatically by Jules for task [8265263019756337453](https://jules.google.com/task/8265263019756337453) started by @BintzGavin*