### PR TITLE
📋 RENDERER: Return Base64 String directly from CanvasStrategy capture

### DIFF
--- a/.sys/plans/PERF-268-base64-string-capture.md
+++ b/.sys/plans/PERF-268-base64-string-capture.md
@@ -1,0 +1,48 @@
+---
+id: PERF-268
+slug: base64-string-capture
+status: unclaimed
+claimed_by: ""
+created: 2026-04-13
+completed: ""
+result: ""
+---
+
+# PERF-268: Return Base64 String directly from CanvasStrategy WebCodecs capture
+
+## 1. Context & Goal
+During DOM capture when using WebCodecs, `CanvasStrategy` currently receives a base64 string from the browser context but allocates a new Node.js Buffer via `Buffer.from(chunkData, 'base64')` for every frame in the `captureWebCodecs` method. The `CaptureLoop` and `FFmpegManager` already support passing raw base64 strings directly to the `stdin.write(buffer, 'base64')` stream. By returning the raw string instead of a Buffer, we eliminate a heavy dynamic Buffer allocation per frame, reducing memory pressure and execution time.
+
+## 2. File Inventory
+- `packages/renderer/src/strategies/CanvasStrategy.ts`
+
+## 3. Implementation Spec
+- **Architecture**: Modify `capture`, `captureWebCodecs`, and `finish` methods in `CanvasStrategy.ts` to return `Promise<Buffer | string>`. Instead of `Buffer.from(chunkData, 'base64')`, return `chunkData` directly.
+- **Pseudo-Code**:
+```typescript
+  // In packages/renderer/src/strategies/CanvasStrategy.ts
+  async capture(page: Page, frameTime: number): Promise<Buffer | string> {
+      // ...
+  }
+
+  private async captureWebCodecs(page: Page, frameTime: number): Promise<Buffer | string> {
+    // ...
+    if (chunkData && chunkData.length > 0) {
+        return chunkData; // Return string directly instead of Buffer.from(chunkData, 'base64')
+    }
+    return Buffer.alloc(0);
+  }
+
+  async finish(page: Page): Promise<Buffer | string | void> {
+    // ...
+      if (chunkData && chunkData.length > 0) {
+        return chunkData; // Return string directly instead of Buffer.from(chunkData, 'base64')
+      }
+    // ...
+  }
+```
+- **Public API Changes**: `CanvasStrategy.capture` and `CanvasStrategy.finish` return type broadened to `Promise<Buffer | string | void>`, which is already supported by the `RenderStrategy` interface.
+- **Dependencies**: None
+
+## 4. Test Plan
+Run `benchmark-test.js` to ensure the frames are still correctly piped to FFmpeg.


### PR DESCRIPTION
💡 **What**: Return the raw base64 string from `CanvasStrategy.captureWebCodecs` instead of allocating a new Buffer.
🎯 **Why**: Eliminates a heavy `Buffer.from` allocation per frame since the underlying `CaptureLoop` stream can natively write base64 strings.
🔬 **Approach**: Return `chunkData` directly in `CanvasStrategy.ts`.
📎 **Plan**: `/.sys/plans/PERF-268-base64-string-capture.md`

---
*PR created automatically by Jules for task [1410054658485663066](https://jules.google.com/task/1410054658485663066) started by @BintzGavin*