### PR TITLE
✨ RENDERER: Prebind CaptureLoop then closures

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,6 +1,6 @@
 ## Performance Trajectory
 Current best: 32.264s (baseline was 43.227s, -25.3%)
-Last updated by: PERF-267
+Last updated by: PERF-270
 
 ## What Works
 - Prebinding virtualTimePromiseExecutor in CdpTimeDriver.ts (PERF-267) improved performance. Median time: 32.264 (baseline: 43.227).
@@ -8,6 +8,7 @@ Last updated by: PERF-267
 - Pre-bound the `syncMedia` catch handlers to `this.handleSyncMediaError` inside `CdpTimeDriver.ts` hot loop (PERF-265).
 
 ## What Doesn't Work (and Why)
+- **PERF-270**: Prebind CaptureLoop then closures. Avoided creating anonymous closures in the hot pipeline loop by using a pre-allocated state array, but V8 already optimizes this well enough so there was zero performance improvement.
 - **PERF-262**: Prebound the CDP stability timeout promise executor. V8 optimizes the inline promise and anonymous closure allocation better than the property lookup.
 - Prebind virtual time promise executor in CdpTimeDriver (PERF-260). Did not improve render time.
 

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -329,3 +329,4 @@ PERF-254	Pre-bind evaluate closures in SeekTimeDriver	render_time_s:      2.119
 256	11.948	150	12.55	37.3	discard	PERF-256 prebind wait stable evaluate
 325	2.551	150	58.81	34.6	discard	PERF-257: Eliminate timeoutPromise allocation inside CdpTimeDriver.ts setTime
 326	2.657	150	0	0	keep	PERF-258 String evaluate fallback
+270	32.140	90	2.80	36.6	discard	Prebind CaptureLoop then closures

--- a/packages/renderer/.sys/plans/PERF-270-prebind-capture-loop.md
+++ b/packages/renderer/.sys/plans/PERF-270-prebind-capture-loop.md
@@ -1,0 +1,22 @@
+---
+id: PERF-270
+slug: prebind-capture-loop-then
+status: completed
+claimed_by: "executor-session"
+---
+
+# RENDERER: Prebind CaptureLoop then closures (PERF-270)
+
+#### 1. Context & Goal
+- **Objective**: Pre-allocate closures for the promise chain in `CaptureLoop.ts` to avoid creating anonymous `.then` closures inside the hot loop.
+- **Trigger**: Identified as an open question in `docs/status/RENDERER-EXPERIMENTS.md`.
+- **Impact**: Reduces GC overhead.
+
+#### 2. File Inventory
+- **Modify**: `packages/renderer/src/core/CaptureLoop.ts`
+
+## Results Summary
+- **Best render time**: 32.14s (vs baseline ~32.13s)
+- **Improvement**: ~0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-270]


### PR DESCRIPTION
💡 **What**: Pre-allocate `PipelineState` objects and bind their `processFrame` methods, avoiding dynamic anonymous closures in the `CaptureLoop.ts` `run()` pipeline.
🎯 **Why**: Identified as a potential source of GC overhead in `CaptureLoop.ts` inside `docs/status/RENDERER-EXPERIMENTS.md`.
📊 **Impact**: Evaluated and marked as discarded based on benchmark output vs baseline (32.14s vs 32.13s)
🔬 **Verification**: Ran tests and validated via output `ffprobe`.
📎 **Plan**: `/.sys/plans/PERF-270-prebind-capture-loop.md`

run render_time_s frames fps_effective peak_mem_mb status description
270 32.140 90 2.80 36.6 discard Prebind CaptureLoop then closures

---
*PR created automatically by Jules for task [2207081085501960291](https://jules.google.com/task/2207081085501960291) started by @BintzGavin*