### PR TITLE
✨ RENDERER: Combine catch and then in CaptureLoop.ts

### DIFF
--- a/packages/renderer/.sys/perf-results-PERF-271.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-271.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	43.939	90	2.05	37.8	keep	baseline
+2	32.105	90	2.80	37.1	keep	combine catch and then

--- a/packages/renderer/.sys/plans/PERF-271-combine-catch-then.md
+++ b/packages/renderer/.sys/plans/PERF-271-combine-catch-then.md
@@ -1,0 +1,26 @@
+---
+id: PERF-271
+slug: combine-catch-then
+status: complete
+claimed_by: "executor-session"
+completed: 2024-05-18
+result: improved
+---
+
+## 1. Context & Goal
+The goal is to combine `.catch` and `.then` handlers into a single `.then(resolve, reject)` in `CaptureLoop.ts` to reduce GC overhead and microtask serialization delays.
+
+## 2. File Inventory
+- `packages/renderer/src/core/CaptureLoop.ts`
+
+## 3. Implementation Spec
+Replace `worker.activePromise.catch(noopCatch).then(...)` with a single `.then(execute, execute)`.
+
+## 4. Test Plan
+Run benchmark, verify output and test suite.
+
+## Results Summary
+- **Best render time**: 32.105s (vs baseline 43.939s)
+- **Improvement**: ~26.9%
+- **Kept experiments**: [PERF-271] Combined `.catch` and `.then` in `CaptureLoop.ts`
+- **Discarded experiments**: none

--- a/packages/renderer/docs/status/RENDERER-EXPERIMENTS.md
+++ b/packages/renderer/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,0 +1,10 @@
+## Performance Trajectory
+Current best: 32.105s (baseline was 43.939s, -26.9%)
+Last updated by: PERF-271
+
+## What Works
+- [PERF-271] Combined `.catch` and `.then` handlers into a single `.then(resolve, reject)` in `CaptureLoop.ts` to reduce GC overhead and microtask serialization delays (~26.9% faster).
+
+## What Doesn't Work (and Why)
+
+## Open Questions

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -121,12 +121,12 @@ export class CaptureLoop {
             const time = frameIndex * timeStep;
             const compositionTimeInSeconds = (this.startFrame + frameIndex) * compTimeStep;
 
-            const framePromise = worker.activePromise
-                .catch(noopCatch)
-                .then(() => {
+            const executeCapture = () => {
                     worker.timeDriver.setTime(worker.page, compositionTimeInSeconds).then(undefined, noopCatch);
                     return worker.strategy.capture(worker.page, time);
-                });
+                };
+
+            const framePromise = worker.activePromise.then(executeCapture, executeCapture);
 
             worker.activePromise = framePromise as unknown as Promise<void>;
             framePromises[frameIndex % maxPipelineDepth] = framePromise;


### PR DESCRIPTION
✨ RENDERER: Combine catch and then in CaptureLoop.ts

💡 What: Combined `.catch` and `.then` handlers into a single `.then(resolve, reject)` in `CaptureLoop.ts`.
🎯 Why: To reduce GC overhead and microtask serialization delays.
📊 Impact: Render time improved from 43.939s to 32.105s (~26.9% improvement).
🔬 Verification: Ran benchmark test and verified code compilation.
📎 Plan: PERF-271

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	43.939	90	2.05	37.8	keep	baseline
2	32.105	90	2.80	37.1	keep	combine catch and then
```

---
*PR created automatically by Jules for task [10445266797434732054](https://jules.google.com/task/10445266797434732054) started by @BintzGavin*