### PR TITLE
✨ RENDERER: Eliminate Fallback Closure Allocation in SeekTimeDriver

### DIFF
--- a/.sys/plans/PERF-272-eliminate-fallback-closure.md
+++ b/.sys/plans/PERF-272-eliminate-fallback-closure.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-272
 slug: eliminate-fallback-closure
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-04-13
-completed: ""
-result: ""
+completed: "2026-04-13"
+result: "discarded"
 ---
 
 # PERF-272: Eliminate Fallback Closure Allocation in SeekTimeDriver
@@ -89,3 +89,7 @@ If we use static strings, we no longer need the `evaluateClosure` and `evaluateA
 
 ## Correctness Check
 Run the DOM benchmark and inspect the resulting `test-output.mp4` to verify visual correctness.
+
+## Results Summary
+- **Best render time**: Regressed
+- **Discarded experiments**: PERF-272

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -17,3 +17,6 @@ Last updated by: PERF-270
 
 ## What Works
 - Pre-bind fallback callback in DomStrategy.capture() (PERF-269) - Eliminates GC pressure overhead in fallback screenshot loop
+
+## What Doesn't Work (and Why)
+- Eliminated fallback closure allocation in SeekTimeDriver (PERF-272). Render time regressed to 33.045.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -330,3 +330,4 @@ PERF-254	Pre-bind evaluate closures in SeekTimeDriver	render_time_s:      2.119
 325	2.551	150	58.81	34.6	discard	PERF-257: Eliminate timeoutPromise allocation inside CdpTimeDriver.ts setTime
 326	2.657	150	0	0	keep	PERF-258 String evaluate fallback
 270	32.140	90	2.80	36.6	discard	Prebind CaptureLoop then closures
+1	33.045	90	2.72	37.2	discard	PERF-272 Eliminate Fallback Closure Allocation


### PR DESCRIPTION
What: Replaced Playwright evaluate Closure with Static String in SeekTimeDriver. 
Why: Bottleneck in Playwright evaluate overhead 
Impact: Regressed time (33.045s vs 32.029s) 
Verification: test benchmark. 
Plan: .sys/plans/PERF-272-eliminate-fallback-closure.md
Code changes were reverted.

Results:
render_time_s:      33.045
total_frames:       90
fps_effective:      2.72
peak_mem_mb:        36.8

---
*PR created automatically by Jules for task [7056937795540406910](https://jules.google.com/task/7056937795540406910) started by @BintzGavin*