### PR TITLE
✨ RENDERER: Optimize SeekTimeDriver CDP callParams assignment (#3151)

### DIFF
--- a/.sys/plans/PERF-273-inline-seektimedriver.md
+++ b/.sys/plans/PERF-273-inline-seektimedriver.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-273
 slug: inline-seektimedriver-callParams
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-04-13
-completed: ""
-result: ""
+completed: "2026-04-13"
+result: "kept"
 ---
 
 # PERF-273: Optimize SeekTimeDriver CDP callParams assignment
@@ -79,3 +79,10 @@ Run a standard canvas benchmark to ensure no breakage.
 
 ## Correctness Check
 Run the DOM benchmark tests and ensure the video renders.
+
+## Results Summary
+- **Best render time**: 32.267s (vs baseline 32.264s)
+- **Improvement**: 0% (Cleaned up IPC payload serialization, performance difference is negligible).
+- **Kept experiments**:
+  - Inlined `this.timeout` into the `functionDeclaration` and omitted it from the `arguments` array inside the `SeekTimeDriver` CDP hot loop `Runtime.callFunctionOn` payload to marginally improve JSON stringification overhead in playwright.
+- **Discarded experiments**: [none]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -20,3 +20,5 @@ Last updated by: PERF-270
 
 ## What Doesn't Work (and Why)
 - Eliminated fallback closure allocation in SeekTimeDriver (PERF-272). Render time regressed to 33.045.
+
+- **PERF-273**: Inline SeekTimeDriver CDP callParams. The `timeout` value is now dynamically injected into the `functionDeclaration` instead of dynamically passing it through arguments list over IPC on every frame. Reduced object tree size for IPC payload. Time: 32.286s (baseline 32.264s). Marginal difference, but logically optimized payload size over CDP IPC, kept.

--- a/packages/renderer/.sys/perf-results-PERF-273.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-273.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.286	90	2.79	36.5	keep	inline timeout in SeekTimeDriver callParams
+2	32.267	90	2.79	36.7	keep	inline timeout in SeekTimeDriver callParams
+3	32.357	90	2.78	36.6	keep	inline timeout in SeekTimeDriver callParams

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -13,9 +13,8 @@ export class SeekTimeDriver implements TimeDriver {
   private evaluateArgs: [number, number] = [0, 0];
   private evaluateClosure = ([t, timeoutMs]: any) => { (window as any).__helios_seek(t, timeoutMs); };
   private callParams: any = {
-    functionDeclaration: 'function(t, timeout) { return this.__helios_seek(t, timeout); }',
     objectId: '',
-    arguments: [ { value: 0 }, { value: 0 } ],
+    arguments: [ { value: 0 } ],
     awaitPromise: true,
     returnByValue: false
   };
@@ -262,6 +261,7 @@ export class SeekTimeDriver implements TimeDriver {
     this.cachedFrames = page.frames();
     this.cachedMainFrame = page.mainFrame();
 
+    this.callParams.functionDeclaration = `function(t) { return this.__helios_seek(t, ${this.timeout}); }`;
     const windowRes = await this.cdpSession!.send('Runtime.evaluate', { expression: 'window' });
     if (windowRes.result && windowRes.result.objectId) {
       this.callParams.objectId = windowRes.result.objectId;
@@ -273,7 +273,6 @@ export class SeekTimeDriver implements TimeDriver {
 
     if (frames.length === 1 && this.callParams.objectId) {
       this.callParams.arguments[0].value = timeInSeconds;
-      this.callParams.arguments[1].value = this.timeout;
       return this.cdpSession!.send('Runtime.callFunctionOn', this.callParams) as Promise<any>;
     }
 


### PR DESCRIPTION
✨ RENDERER: Optimize SeekTimeDriver CDP callParams assignment (#3151)

💡 **What**: Inlined `this.timeout` into the `SeekTimeDriver.ts` CDP callParams `functionDeclaration` and removed it from the dynamically passed arguments array in the `Runtime.callFunctionOn` loop.
🎯 **Why**: Reduces the depth and size of the object graph serialized to a JSON payload over the CDP IPC boundary on every frame during DOM mode rendering.
📊 **Impact**: Render times remained essentially unchanged (baseline 32.264s -> median 32.286s) but IPC overhead conceptually decreases slightly.
🔬 **Verification**: Passed `npm run build`, `tests/verify-seek-driver-offsets.ts`, benchmark loops, and canvas smoke test.
📎 **Plan**: `/.sys/plans/PERF-273-inline-seektimedriver.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.286	90	2.79	36.5	keep	inline timeout in SeekTimeDriver callParams
2	32.267	90	2.79	36.7	keep	inline timeout in SeekTimeDriver callParams
3	32.357	90	2.78	36.6	keep	inline timeout in SeekTimeDriver callParams
```

---
*PR created automatically by Jules for task [577863818037273746](https://jules.google.com/task/577863818037273746) started by @BintzGavin*