### PR TITLE
✨ RENDERER: Pass syncMedia fallback evaluate as string

### DIFF
--- a/.sys/plans/PERF-274-syncmedia-string.md
+++ b/.sys/plans/PERF-274-syncmedia-string.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-274
 slug: syncmedia-string
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2026-04-14
 completed: ""
@@ -44,3 +44,7 @@ Do the same inside the `framePromises` loop.
 
 ## Correctness Check
 Run the canvas mode benchmark or any media example to ensure rendering still works and media sync functions correctly.
+## Results Summary
+- **Best render time**: 2.549s
+- **Kept experiments**: inline syncmedia string evaluation
+- **Discarded experiments**: none

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 32.264s (baseline was 43.227s, -25.3%)
 Last updated by: PERF-270
 
 ## What Works
+- **PERF-274**: Replaced syncMedia closure evaluation with string evaluation in CdpTimeDriver.ts. Faster and avoids IPC overhead.
 - Prebinding virtualTimePromiseExecutor in CdpTimeDriver.ts (PERF-267) improved performance. Median time: 32.264 (baseline: 43.227).
 - PERF-268: Returned Base64 String directly from CanvasStrategy WebCodecs capture. Render time: 32.326s (baseline 32.596s)
 - Pre-bound the `syncMedia` catch handlers to `this.handleSyncMediaError` inside `CdpTimeDriver.ts` hot loop (PERF-265).
@@ -16,6 +17,7 @@ Last updated by: PERF-270
 - Can we eliminate dynamic Promise `.then` closure allocation in the `CaptureLoop.ts` by pre-binding?
 
 ## What Works
+- **PERF-274**: Replaced syncMedia closure evaluation with string evaluation in CdpTimeDriver.ts. Faster and avoids IPC overhead.
 - Pre-bind fallback callback in DomStrategy.capture() (PERF-269) - Eliminates GC pressure overhead in fallback screenshot loop
 
 ## What Doesn't Work (and Why)

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -331,3 +331,4 @@ PERF-254	Pre-bind evaluate closures in SeekTimeDriver	render_time_s:      2.119
 326	2.657	150	0	0	keep	PERF-258 String evaluate fallback
 270	32.140	90	2.80	36.6	discard	Prebind CaptureLoop then closures
 1	33.045	90	2.72	37.2	discard	PERF-272 Eliminate Fallback Closure Allocation
+1	2.549	90	35.31	48.4	keep	inline syncmedia evaluation

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -33,12 +33,6 @@ export class CdpTimeDriver implements TimeDriver {
     this.client!.send('Emulation.setVirtualTimePolicy', this.setVirtualTimePolicyParams).catch(this.handleVirtualTimeBudgetError);
   };
 
-  private syncMediaClosure = (t: number) => {
-    if (typeof (window as any).__helios_sync_media === 'function') {
-      (window as any).__helios_sync_media(t);
-    }
-  };
-
   private handleSyncMediaError = (e: any) => {
     console.warn('[CdpTimeDriver] Failed to sync media:', e);
   };
@@ -161,7 +155,7 @@ export class CdpTimeDriver implements TimeDriver {
       await this.client!.send('Runtime.callFunctionOn', this.syncMediaParams).catch(this.handleSyncMediaError);
     } else {
       if (frames.length === 1) {
-        await frames[0].evaluate(this.syncMediaClosure, timeInSeconds).catch(this.handleSyncMediaError);
+        await frames[0].evaluate("if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");").catch(this.handleSyncMediaError);
       } else {
         if (this.cachedPromises.length !== frames.length) {
           this.cachedPromises = new Array(frames.length);
@@ -169,7 +163,7 @@ export class CdpTimeDriver implements TimeDriver {
         const framePromises = this.cachedPromises;
         for (let i = 0; i < frames.length; i++) {
           const frame = frames[i];
-          framePromises[i] = frame.evaluate(this.syncMediaClosure, timeInSeconds).catch(this.handleSyncMediaError);
+          framePromises[i] = frame.evaluate("if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");").catch(this.handleSyncMediaError);
         }
         await Promise.all(framePromises);
       }


### PR DESCRIPTION
💡 **What**: Replaced `syncMediaClosure` with inline string evaluation in `CdpTimeDriver.ts`.
🎯 **Why**: To bypass IPC serialization overhead for the closure allocation across the Node boundary on every frame.
📊 **Impact**: Render time improved. Benchmark metrics appended to perf-results.tsv and the plan file.
🔬 **Verification**: Canvas smoke test passed, `verify-cdp-driver.ts` passed.
📎 **Plan**: `.sys/plans/PERF-274-syncmedia-string.md`

TSV Data:
1\t2.549\t90\t35.31\t48.4\tkeep\tinline syncmedia evaluation

---
*PR created automatically by Jules for task [13159791634802817847](https://jules.google.com/task/13159791634802817847) started by @BintzGavin*