### PR TITLE
📋 RENDERER: Preallocate executeCapture closure in CaptureLoop (PERF-275)

### DIFF
--- a/.sys/plans/PERF-275-preallocate-execute-capture-closure.md
+++ b/.sys/plans/PERF-275-preallocate-execute-capture-closure.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-275
 slug: preallocate-execute-capture-closure
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-30
-completed: ""
-result: ""
+completed: "2026-04-14"
+result: "32.143s"
 ---
 
 # PERF-275: Preallocate Execute Capture Closure in Ring Buffer

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,6 +1,6 @@
 ## Performance Trajectory
-Current best: 32.264s (baseline was 43.227s, -25.3%)
-Last updated by: PERF-270
+Current best: 32.143s (baseline was 43.227s, -25.6%)
+Last updated by: PERF-275
 
 ## What Works
 - **PERF-274**: Replaced syncMedia closure evaluation with string evaluation in CdpTimeDriver.ts. Faster and avoids IPC overhead.
@@ -24,3 +24,4 @@ Last updated by: PERF-270
 - Eliminated fallback closure allocation in SeekTimeDriver (PERF-272). Render time regressed to 33.045.
 
 - **PERF-273**: Inline SeekTimeDriver CDP callParams. The `timeout` value is now dynamically injected into the `functionDeclaration` instead of dynamically passing it through arguments list over IPC on every frame. Reduced object tree size for IPC payload. Time: 32.286s (baseline 32.264s). Marginal difference, but logically optimized payload size over CDP IPC, kept.
+- **PERF-275**: Preallocated executeCapture closures dynamically using a ring buffer of context objects. Render time: 32.143

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -332,3 +332,6 @@ PERF-254	Pre-bind evaluate closures in SeekTimeDriver	render_time_s:      2.119
 270	32.140	90	2.80	36.6	discard	Prebind CaptureLoop then closures
 1	33.045	90	2.72	37.2	discard	PERF-272 Eliminate Fallback Closure Allocation
 1	2.549	90	35.31	48.4	keep	inline syncmedia evaluation
+1	32.048	90	2.81	36.5	keep	PERF-275
+2	32.830	90	2.74	36.4	keep	PERF-275
+3	32.143	90	2.80	36.5	keep	PERF-275

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -105,6 +105,17 @@ export class CaptureLoop {
     const onProgress = this.jobOptions?.onProgress;
 
     const framePromises = new Array<Promise<Buffer | string>>(maxPipelineDepth);
+    const contextRing = new Array(maxPipelineDepth);
+    const executeCaptures = new Array<() => Promise<Buffer | string>>(maxPipelineDepth);
+
+    for (let i = 0; i < maxPipelineDepth; i++) {
+        const ctx = { time: 0, compositionTimeInSeconds: 0, worker: null as any };
+        contextRing[i] = ctx;
+        executeCaptures[i] = () => {
+            ctx.worker.timeDriver.setTime(ctx.worker.page, ctx.compositionTimeInSeconds).then(undefined, noopCatch);
+            return ctx.worker.strategy.capture(ctx.worker.page, ctx.time);
+        };
+    }
 
     while (nextFrameToWrite < this.totalFrames) {
         if (this.capturedErrors.length > 0) {
@@ -121,15 +132,17 @@ export class CaptureLoop {
             const time = frameIndex * timeStep;
             const compositionTimeInSeconds = (this.startFrame + frameIndex) * compTimeStep;
 
-            const executeCapture = () => {
-                    worker.timeDriver.setTime(worker.page, compositionTimeInSeconds).then(undefined, noopCatch);
-                    return worker.strategy.capture(worker.page, time);
-                };
+            const ringIndex = frameIndex % maxPipelineDepth;
+            const ctx = contextRing[ringIndex];
+            ctx.time = time;
+            ctx.compositionTimeInSeconds = compositionTimeInSeconds;
+            ctx.worker = worker;
 
+            const executeCapture = executeCaptures[ringIndex];
             const framePromise = worker.activePromise.then(executeCapture, executeCapture);
 
             worker.activePromise = framePromise as unknown as Promise<void>;
-            framePromises[frameIndex % maxPipelineDepth] = framePromise;
+            framePromises[ringIndex] = framePromise;
             nextFrameToSubmit++;
         }
 

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,11 +1,10 @@
-💡 **What**: Changed BrowserPool to create a single shared BrowserContext and spawn pages within it instead of creating a new BrowserContext per worker.
-🎯 **Why**: Creating isolated contexts per worker increases memory pressure and context switching overhead in the CPU-bound microVM.
-📊 **Impact**: Render time improved from 49.440s to 47.634s (~3.6% faster).
-🔬 **Verification**: Passed compilation, DOM tests, and performance benchmark runs.
-📎 **Plan**: PERF-260
+💡 What: Preallocate executeCapture anonymous functions dynamically using a ring buffer of context objects.
+🎯 Why: Microtask overhead and dynamic closure allocations during the hot loop in CaptureLoop.
+📊 Impact: Render time was evaluated against the 32.264s baseline, improving to a median of 32.143s.
+🔬 Verification: 4-gate verification + benchmark test.
+📎 Plan: /.sys/plans/PERF-275-preallocate-execute-capture-closure.md
 
-```tsv
 run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
-baseline	49.440	600	12.13	42.0	keep	baseline
-run1	48.655	600	12.33	42.0	keep	Shared BrowserContext
-```
+1	32.048	90	2.81	36.5	keep	PERF-275
+2	32.830	90	2.74	36.4	keep	PERF-275
+3	32.143	90	2.80	36.5	keep	PERF-275


### PR DESCRIPTION
💡 What: Preallocate executeCapture anonymous functions dynamically using a ring buffer of context objects.
🎯 Why: Microtask overhead and dynamic closure allocations during the hot loop in CaptureLoop.
📊 Impact: Render time was evaluated against the 32.264s baseline, improving to a median of 32.143s.
🔬 Verification: 4-gate verification + benchmark test.
📎 Plan: /.sys/plans/PERF-275-preallocate-execute-capture-closure.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.048	90	2.81	36.5	keep	PERF-275
2	32.830	90	2.74	36.4	keep	PERF-275
3	32.143	90	2.80	36.5	keep	PERF-275

---
*PR created automatically by Jules for task [4438229227001211664](https://jules.google.com/task/4438229227001211664) started by @BintzGavin*