### PR TITLE
📋 PLAYER: Fix Arrow Key Shortcuts

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -25,3 +25,6 @@
 ## v0.77.15 - Strict Execution of Plans
 **Learning:** Even if a feature like srcObject persistence has been previously completed according to the status file, I must strictly identify the *next uncompleted plan* for my domain and implement it, or create a new plan for an unaddressed vision gap. In this case,  parity was already completed in , so creating another plan for it was incorrect.
 **Action:** Always check  for completed versions to avoid creating duplicate plans. If the latest plan is completed, look for new gaps in the vision.
+## [v0.77.20] - Frame-based Keydown Alignments
+**Learning:** The implementation of keyboard shortcuts like `ArrowLeft` and `ArrowRight` was originally seeking by seconds, but the `README.md` explicitly promised frame-based seeking.
+**Action:** When planning, double-check that the fine-grained implementation details match the high-level documentation in `README.md`.

--- a/.sys/plans/2026-04-14-PLAYER-Fix-Arrow-Key-Shortcuts.md
+++ b/.sys/plans/2026-04-14-PLAYER-Fix-Arrow-Key-Shortcuts.md
@@ -1,0 +1,25 @@
+#### 1. Context & Goal
+- **Objective**: Fix the arrow key keyboard shortcuts to match the documented vision.
+- **Trigger**: The `README.md` documents `ArrowLeft` / `ArrowRight` as seeking 1 frame and `Shift` + `ArrowLeft` / `ArrowRight` as seeking 10 frames. The current implementation in `index.ts` seeks by 5 seconds and 10 seconds.
+- **Impact**: Brings implementation into parity with the promised keyboard shortcut behaviors, preventing user confusion.
+
+#### 2. File Inventory
+- **Create**: []
+- **Modify**:
+  - `packages/player/src/index.ts`: Update `handleKeydown` to use `seekRelative` instead of `seekRelativeSeconds` for `ArrowLeft` and `ArrowRight`.
+  - `packages/player/src/index.test.ts`: Update the keyboard shortcut unit tests to assert frame-based seeking instead of second-based seeking.
+- **Read-Only**: [`packages/player/README.md`]
+
+#### 3. Implementation Spec
+- **Architecture**: Keyboard events in the `HeliosPlayer` component delegate seeking logic to internal `seekRelative` helpers.
+- **Pseudo-Code**:
+  - In `index.ts`, change `case "ArrowRight": this.seekRelativeSeconds(e.shiftKey ? 10 : 5);` to `this.seekRelative(e.shiftKey ? 10 : 1);`.
+  - Change `case "ArrowLeft": this.seekRelativeSeconds(e.shiftKey ? -10 : -5);` to `this.seekRelative(e.shiftKey ? -10 : -1);`.
+  - In `index.test.ts`, update the tests `dispatchKey('ArrowRight')` and `dispatchKey('ArrowLeft')` to assert `expect(mockController.seek).toHaveBeenCalledWith(currentFrame +/- (shiftKey ? 10 : 1))`.
+- **Public API Changes**: None.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `cd packages/player && npx vitest run src/index.test.ts`
+- **Success Criteria**: All unit tests for keyboard shortcuts pass and the tests reflect the frame-based increments.
+- **Edge Cases**: Ensure the boundaries (seeking past end or before start) still behave correctly and clamp at 0 or total frames.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -208,3 +208,4 @@
 [v0.77.15] ✅ Verified: Bridge coverage for postMessage expanded and properties verified. Completed plans: 2026-12-25, 2026-12-26, 2027-01-16, 2027-01-08.
 [v0.77.16] ✅ Completed: Document API Parity Gap - Deleted lingering plan file as the README already contained the required documentation updates.
 [v0.77.19] ✅ Completed: Improve index.ts test coverage - Added export-options.test.ts covering untested getters and setters.
+[v0.77.20] ✅ Completed: Discovered discrepancy in arrow key shortcut behavior between README documentation (seeks by frames) and actual implementation (seeks by seconds). Created plan to fix this vision gap.


### PR DESCRIPTION
Added spec file to fix the vision gap where arrow keys were seeking by seconds instead of frames, aligning the implementation with the documented behavior in README.md. Updated docs/status and .jules journal.

---
*PR created automatically by Jules for task [8856541804191705753](https://jules.google.com/task/8856541804191705753) started by @BintzGavin*