### PR TITLE
📋 RENDERER: Preallocate Evaluate Promises in SeekTimeDriver

### DIFF
--- a/.sys/plans/PERF-283-cache-cachedframes.md
+++ b/.sys/plans/PERF-283-cache-cachedframes.md
@@ -1,0 +1,58 @@
+---
+id: PERF-283
+slug: cache-cachedframes-seek
+status: unclaimed
+claimed_by: ""
+created: 2026-04-15
+completed: ""
+result: ""
+---
+
+# PERF-283: Preallocate Evaluate Promises in SeekTimeDriver
+
+## Focus Area
+`packages/renderer/src/drivers/SeekTimeDriver.ts` hot loop, specifically `setTime()`.
+
+## Background Research
+Currently in `SeekTimeDriver.ts`, if `frames.length !== 1`, it dynamically checks `this.cachedPromises.length !== frames.length` and potentially allocates an array `this.cachedPromises = new Array(frames.length)`. We know from earlier experiments that V8 struggles when arrays are re-allocated or checked dynamically over frames versus fixed arrays. In Playwright, `page.frames()` length is virtually constant after load for typical animations.
+
+## Benchmark Configuration
+- **Composition URL**: `file:///app/output/example-build/examples/dom-benchmark/composition.html`
+- **Render Settings**: 1280x720, 30fps, libx264
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: 32.089s
+- **Bottleneck analysis**: Overhead of evaluating `this.cachedPromises.length !== frames.length` and potentially reallocating arrays within `setTime()` hot loop in `SeekTimeDriver.ts`.
+
+## Implementation Spec
+
+### Step 1: Pre-initialize `this.cachedPromises`
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+Inside `prepare()`, after `this.cachedFrames = page.frames();`, pre-allocate `this.cachedPromises = new Array(this.cachedFrames.length)` exactly once instead of doing it defensively per-frame in `setTime()`.
+
+**Why**: By asserting that frame counts are static during the seek/render hot path, we eliminate branching and dynamic array reallocations on every frame `setTime()` iteration.
+**Risk**: If frames are dynamically added/removed during rendering, it might cause out-of-bounds errors or missed frame evaluations, but typically in our benchmark, frame counts are static.
+
+### Step 2: Remove `frames.length` conditionals in `setTime` loop
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+In `setTime`, remove the dynamic `if (this.cachedPromises.length !== frames.length)` resizing logic block. Use the pre-allocated `this.cachedPromises` directly.
+
+**Why**: Same as above, V8 prefers monomorphic hot paths without resizing or checking array dimensions conditionally inside hot loops.
+**Risk**: Same as above.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Verify canvas functionality remains intact.
+
+## Correctness Check
+Run the DOM benchmark and ensure frame count remains accurate and visual correctness is retained.
+
+## Prior Art
+Prior experiments exploring closure allocations and array sizing in V8 hot loops.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -32,3 +32,6 @@ Last updated by: PERF-277
 ## What Doesn't Work (and Why)
 - **PERF-271**: Optimized pipeline promise chain in CaptureLoop.ts and CdpTimeDriver.ts by avoiding extra Promise allocations. Eliminated intermediate `.then` and `.catch` wrappers. The changes yielded no measurable improvement (32.076s vs baseline 32.091s), indicating that V8 effectively optimizes simple try/catch and single argument `.then` vs chain allocations, meaning the allocation overhead was negligible compared to the underlying Playwright/IPC calls. Discarded as inconclusive.
 - **PERF-281**: Replaced per-frame Promise allocation in `CaptureLoop.ts` with a preallocated array of `buffer`, `error`, and `done` state. Expected to reduce GC overhead. The microtask creation per frame was eliminated, but the result showed no measurable performance improvement compared to the baseline (~32.2s vs baseline ~32.1s), indicating V8 handles the per-frame Promise creation and garbage collection efficiently enough that the allocation overhead was negligible in this context. Discarded.
+
+## Open Questions
+- **PERF-283**: Will preallocating `this.cachedPromises` and eliminating the dynamic check `if (this.cachedPromises.length !== frames.length)` in `SeekTimeDriver.ts` hot loop improve render times?


### PR DESCRIPTION
📋 RENDERER: Preallocate Evaluate Promises in SeekTimeDriver

💡 What: Creating PERF-283 to preallocate `this.cachedPromises` and remove dynamic length checks inside the `SeekTimeDriver.ts` hot loop.
🎯 Why: In Playwright, `page.frames()` length is typically constant for typical animations. Removing the dynamic allocation/checks should reduce branching overhead and memory reallocation in the hot path.
🔬 Approach: Preallocate exactly once during the `prepare()` method using the cached frames.
📎 Plan: `/.sys/plans/PERF-283-cache-cachedframes.md`

---
*PR created automatically by Jules for task [5321779677383915676](https://jules.google.com/task/5321779677383915676) started by @BintzGavin*