### PR TITLE
✨ RENDERER: Discard PERF-282 inline promise allocation for small frame counts

### DIFF
--- a/.sys/plans/PERF-282-inline-promise-allocation.md
+++ b/.sys/plans/PERF-282-inline-promise-allocation.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-282
 slug: inline-promise-allocation
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2026-04-15
-completed: ""
-result: ""
+completed: "2026-04-15"
+result: "Discarded: No measurable performance improvement. Median time 32.321s vs baseline 32.164s. V8 optimizes the small iteration loop efficiently."
 ---
 
 # PERF-282: Inline Promise Allocation for Small Frame Counts in SeekTimeDriver

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -39,3 +39,4 @@ Last updated by: PERF-277
 ## PERF-283: Preallocate Evaluate Promises in SeekTimeDriver
 - Render time: 33.245s (Baseline: 42.955s)
 - Status: keep
+- **PERF-282**: Inlined promise allocation for `frames.length === 2` and `frames.length === 3` in `SeekTimeDriver.setTime()` to statically allocate `Promise.all` and avoid loop overhead. V8 handles dynamic indexing efficiently enough for very small arrays that the inline logic yielded no measurable performance improvement (median: 32.321s vs baseline 32.164s) and occasionally performed slightly worse due to branching overhead. Discarded as inconclusive.

--- a/packages/renderer/.sys/perf-results-PERF-282.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-282.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.678	90	2.75	36.6	discard	PERF-282 inline promise allocation for small frame counts
+2	32.321	90	2.78	36.6	discard	PERF-282 inline promise allocation for small frame counts
+3	32.004	90	2.81	36.9	discard	PERF-282 inline promise allocation for small frame counts

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -340,3 +340,6 @@ PERF-254	Pre-bind evaluate closures in SeekTimeDriver	render_time_s:      2.119
 277	32.040	90	2.81	36.7	keep	eliminate promise allocation in DomStrategy capture
 281	32.284	90	2.79	37.4	discard	preallocate state array
 341	33.245	90	2.71	36.9	keep	PERF-283: Preallocate Evaluate Promises in SeekTimeDriver
+1	32.678	90	2.75	36.6	discard	PERF-282 inline promise allocation for small frame counts
+2	32.321	90	2.78	36.6	discard	PERF-282 inline promise allocation for small frame counts
+3	32.004	90	2.81	36.9	discard	PERF-282 inline promise allocation for small frame counts


### PR DESCRIPTION
💡 What: Evaluated inline promise allocation for frames.length 2 and 3 in SeekTimeDriver. The code changes were reverted because the experiment was unsuccessful.
🎯 Why: To avoid for-loop mapping overhead inside the hot loop.
📊 Impact: No measurable performance improvement. Median time 32.321s vs baseline 32.164s. V8 optimizes the small iteration loop efficiently.
🔬 Verification: 4-gate verification process, tests, benchmark results recorded.
📎 Plan: PERF-282-inline-promise-allocation.md

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.678	90	2.75	36.6	discard	PERF-282 inline promise allocation for small frame counts
2	32.321	90	2.78	36.6	discard	PERF-282 inline promise allocation for small frame counts
3	32.004	90	2.81	36.9	discard	PERF-282 inline promise allocation for small frame counts
```

---
*PR created automatically by Jules for task [4514289558945306132](https://jules.google.com/task/4514289558945306132) started by @BintzGavin*