### PR TITLE
✨ RENDERER: Optimize CdpTimeDriver hot loop evaluation (Discarded)

### DIFF
--- a/.sys/plans/PERF-284-cdp-evaluate-closure.md
+++ b/.sys/plans/PERF-284-cdp-evaluate-closure.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-284
 slug: cdp-evaluate-closure
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-04-15
-completed: ""
-result: ""
+completed: "2026-04-15"
+result: "discarded"
 ---
 
 # PERF-284: Optimize CdpTimeDriver hot loop evaluation
@@ -88,3 +88,11 @@ Run the DOM benchmark (`npx tsx scripts/benchmark-test.js`) and ensure frame cou
 
 ## Prior Art
 PERF-272 showed that keeping pre-bound closures and passing arguments is faster than sending raw dynamic strings over Playwright's `evaluate`.
+
+## Results Summary
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	33.333	90	2.70	37.3	discard	Pre-bound evaluate closure for CdpTimeDriver multi-frame branch
+2	32.655	90	2.76	37.3	discard	Pre-bound evaluate closure for CdpTimeDriver multi-frame branch
+3	32.492	90	2.77	36.7	discard	Pre-bound evaluate closure for CdpTimeDriver multi-frame branch
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -40,3 +40,8 @@ Last updated by: PERF-277
 - Render time: 33.245s (Baseline: 42.955s)
 - Status: keep
 - **PERF-282**: Inlined promise allocation for `frames.length === 2` and `frames.length === 3` in `SeekTimeDriver.setTime()` to statically allocate `Promise.all` and avoid loop overhead. V8 handles dynamic indexing efficiently enough for very small arrays that the inline logic yielded no measurable performance improvement (median: 32.321s vs baseline 32.164s) and occasionally performed slightly worse due to branching overhead. Discarded as inconclusive.
+
+## PERF-284: Optimize CdpTimeDriver hot loop evaluation
+- Render time: 32.655s (Baseline: 32.207s)
+- Status: discard
+- **PERF-284**: Extracted dynamic inline string evaluation into a pre-bound closure property (`syncMediaClosure`) passed via `frame.evaluate` in `CdpTimeDriver.setTime()`. The goal was to reduce V8 string parsing and compilation overhead over Playwright's CDP IPC when operating on multiple frames. The rendering times regressed slightly (~32.655s vs baseline 32.207s). This indicates that the V8 and IPC overhead of serializing the argument array (`this.evaluateArgs`) combined with invoking the closure dynamically outweighs the cost of the inline string evaluation in this multi-frame hot path. Discarded as slower.

--- a/packages/renderer/.sys/perf-results-PERF-284.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-284.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	33.333	90	2.70	37.3	discard	Pre-bound evaluate closure for CdpTimeDriver multi-frame branch
+2	32.655	90	2.76	37.3	discard	Pre-bound evaluate closure for CdpTimeDriver multi-frame branch
+3	32.492	90	2.77	36.7	discard	Pre-bound evaluate closure for CdpTimeDriver multi-frame branch


### PR DESCRIPTION
✨ RENDERER: Optimize CdpTimeDriver hot loop evaluation (Discarded)

💡 **What**: Extracted dynamic inline string evaluation into a pre-bound closure property (`syncMediaClosure`) passed via `frame.evaluate` in `CdpTimeDriver.setTime()`. The goal was to reduce V8 string parsing and compilation overhead over Playwright's CDP IPC when operating on multiple frames.
🎯 **Why**: To reduce V8 compilation and IPC payload parsing costs in the CdpTimeDriver multi-frame path.
📊 **Impact**: Render time regressed from baseline 32.207s to ~32.655s (-1.3%). The code changes were discarded.
🔬 **Verification**: Ran the DOM benchmark tool. The results showed a performance regression. Code was reverted. Test suite and TS compilation skipped post-revert since code is unchanged.
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-284-cdp-evaluate-closure.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	33.333	90	2.70	37.3	discard	Pre-bound evaluate closure for CdpTimeDriver multi-frame branch
2	32.655	90	2.76	37.3	discard	Pre-bound evaluate closure for CdpTimeDriver multi-frame branch
3	32.492	90	2.77	36.7	discard	Pre-bound evaluate closure for CdpTimeDriver multi-frame branch
```

---
*PR created automatically by Jules for task [2977059558171980299](https://jules.google.com/task/2977059558171980299) started by @BintzGavin*