### PR TITLE
✨ RENDERER: Evaluate PERF-280 CaptureLoop.ts worker promise elimination

### DIFF
--- a/.sys/plans/PERF-280-worker-promise-elimination.md
+++ b/.sys/plans/PERF-280-worker-promise-elimination.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-280
 slug: worker-promise-elimination
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2026-04-14
-completed: ""
-result: ""
+completed: "2026-04-15"
+result: "Discarded: No measurable performance improvement. Median time 32.241s vs baseline 32.170s. V8 optimizes the small promise loop effectively."
 ---
 
 # PERF-280: Replace `CaptureLoop.ts` Frame Promise Allocation with Preallocated Signal Array

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -50,3 +50,8 @@ Last updated by: PERF-277
 - Render time: 32.211s (Baseline: 32.540s)
 - Status: discard
 - **PERF-259**: Extracted anonymous promise executor function into a prebound class property `handleDrainPromiseExecutor` when handling FFmpeg write backpressure `drain` event inside `CaptureLoop`. The change yielded a slightly faster render time, however the improvement was smaller than the noise variance and the overall results were inconclusive compared to baseline since backpressure didn't cause enough garbage collection issues to be a primary bottleneck. Discarded as inconclusive.
+
+## PERF-280: Replace CaptureLoop.ts Frame Promise Allocation with Preallocated Signal Array
+- Render time: 32.241s (Baseline: 32.170s)
+- Status: discard
+- **PERF-280**: Eliminated per-frame dynamic `Promise` object allocation in `CaptureLoop.ts` by replacing `framePromises` with a reusable `frameWaiterResolve` and a `ready` state boolean in `contextRing`. The microtask creation per frame was eliminated, but the result showed no measurable performance improvement compared to the baseline (~32.2s vs baseline ~32.1s). This indicates that V8 handles the per-frame Promise creation and garbage collection efficiently enough in this context, making the allocation overhead negligible. Discarded as inconclusive.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -347,3 +347,6 @@ PERF-254	Pre-bind evaluate closures in SeekTimeDriver	render_time_s:      2.119
 2	32.940	90	2.73	36.6	discard	prebind-drain-promise-executor
 3	32.264	90	2.79	36.7	discard	prebind-drain-promise-executor
 4	32.211	90	2.79	37.4	discard	prebind-drain-promise-executor
+1	33.504	90	2.69	36.9	discard	PERF-280 preallocate worker promises
+2	32.241	90	2.79	37.5	discard	PERF-280 preallocate worker promises
+3	32.089	90	2.80	36.6	discard	PERF-280 preallocate worker promises


### PR DESCRIPTION
💡 **What**: Evaluated replacing the per-frame Promise allocation in `CaptureLoop.ts` with a preallocated state array and a shared `frameWaiterResolve` promise. The results showed no measurable improvement (32.241s vs baseline 32.170s) so the code changes were reverted.
🎯 **Why**: To test if microtask generation and Promise garbage collection were bottlenecks in the `CaptureLoop.ts` frame processing pipeline.
📊 **Impact**: No impact, changes discarded. V8 appears to optimize the small promise allocation loop effectively.
🔬 **Verification**:
- Benchmarks executed 3 times via `npx tsx scripts/benchmark-test.js`
- Results appended to `packages/renderer/.sys/perf-results.tsv`
- `docs/status/RENDERER-EXPERIMENTS.md` updated with findings
- `.sys/plans/PERF-280-worker-promise-elimination.md` updated to `complete`
📎 **Plan**: `/.sys/plans/PERF-280-worker-promise-elimination.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 33.504 | 90 | 2.69 | 36.9 | discard | PERF-280 preallocate worker promises |
| 2 | 32.241 | 90 | 2.79 | 37.5 | discard | PERF-280 preallocate worker promises |
| 3 | 32.089 | 90 | 2.80 | 36.6 | discard | PERF-280 preallocate worker promises |

---
*PR created automatically by Jules for task [10289638036355230949](https://jules.google.com/task/10289638036355230949) started by @BintzGavin*