### PR TITLE
📋 RENDERER: Replace Multi-Frame Playwright Closure IPC with Raw CDP Evaluate

### DIFF
--- a/.sys/plans/PERF-286-raw-cdp-multi-frame.md
+++ b/.sys/plans/PERF-286-raw-cdp-multi-frame.md
@@ -1,0 +1,61 @@
+---
+id: PERF-286
+slug: raw-cdp-multi-frame
+status: unclaimed
+claimed_by: ""
+created: 2026-04-15
+completed: ""
+result: ""
+---
+
+# PERF-286: Replace Multi-Frame Playwright Closure IPC with Raw CDP Evaluate in SeekTimeDriver
+
+## Focus Area
+`packages/renderer/src/drivers/SeekTimeDriver.ts` - `setTime()` method.
+
+## Background Research
+In PERF-285, we saw a performance improvement when bypassing Playwright's `frame.evaluate()` closure serialization for single-frame executions in `SeekTimeDriver.ts`, directly utilizing raw CDP (`Runtime.evaluate`). In Playwright, `frame.evaluate` adds layers of overhead by constructing an argument array, serializing it, communicating it over IPC via `Runtime.callFunctionOn` across the Node-Browser boundary, executing it in V8, and deserializing the result.
+
+The `test-multi-frame-evaluate.js` benchmark confirms this theory extends to multi-frame scenarios. Executing `Runtime.evaluate` directly via raw CDP IPC is ~15% faster (7.5s) than using Playwright's `frame.evaluate()` closure execution (8.9s) or Playwright's string evaluation (8.2s).
+
+## Benchmark Configuration
+- **Composition URL**: `file:///app/output/example-build/examples/dom-benchmark/composition.html`
+- **Render Settings**: 1280x720, 30fps, libx264
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~32.083s
+- **Bottleneck analysis**: Playwright `frame.evaluate()` overhead for multi-frame DOM captures.
+
+## Implementation Spec
+
+### Step 1: Pre-fetch Execution Context IDs in `prepare()`
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+In `prepare()`, after establishing the CDP session (`this.cdpSession = ...`), listen to `Runtime.executionContextCreated` to store the Context IDs for all loaded frames.
+Enable the runtime domain (`await this.cdpSession.send('Runtime.enable')`) so we receive these events. Wait until the contexts array length matches the number of frames loaded in `this.cachedFrames = page.frames()`.
+
+**Why**: To perform raw CDP `Runtime.evaluate` on specific iframes, we need their exact V8 execution context IDs.
+**Risk**: If contexts are destroyed and recreated dynamically during rendering, the cached IDs would become stale. In our benchmark, the DOM structure is static during rendering.
+
+### Step 2: Use Raw CDP `Runtime.evaluate` for Multi-Frame Iteration
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+In `setTime()`, instead of using `frames[i].evaluate(this.evaluateClosure, this.evaluateArgs)`, iterate over the gathered execution context IDs and dispatch raw `Runtime.evaluate` commands via CDP using `Promise.all`.
+
+**Why**: Bypasses the Playwright `evaluate` closure array serialization and deserialization IPC overhead for every frame, replacing it with a leaner, direct CDP payload.
+**Risk**: Misses any implicit Playwright context validity checks, but rendering environments are controlled and static.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Ensure Canvas logic is unbroken by running basic canvas scripts.
+
+## Correctness Check
+Run the benchmark script `npx tsx scripts/benchmark-test.js` to ensure the multi-frame seek synchronization operates exactly as before without visual regressions.
+
+## Prior Art
+- PERF-285 optimized single-frame execution using `Runtime.evaluate`.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -57,3 +57,6 @@ Last updated by: PERF-277
 - Render time: 32.241s (Baseline: 32.170s)
 - Status: discard
 - **PERF-280**: Eliminated per-frame dynamic `Promise` object allocation in `CaptureLoop.ts` by replacing `framePromises` with a reusable `frameWaiterResolve` and a `ready` state boolean in `contextRing`. The microtask creation per frame was eliminated, but the result showed no measurable performance improvement compared to the baseline (~32.2s vs baseline ~32.1s). This indicates that V8 handles the per-frame Promise creation and garbage collection efficiently enough in this context, making the allocation overhead negligible. Discarded as inconclusive.
+
+## Open Questions
+- **PERF-286**: Can we improve multi-frame synchronization in SeekTimeDriver by prefetching Context IDs and iterating with raw CDP Runtime.evaluate over all frames?


### PR DESCRIPTION
💡 What: Plan to optimize `SeekTimeDriver.ts` multi-frame execution overhead.
🎯 Why: Playwright's `frame.evaluate()` closure execution introduces significant IPC serialization and string parsing overhead per frame, which slows down rendering in multi-iframe compositions.
🔬 Approach: Pre-fetch execution context IDs for all iframes using CDP `Runtime.executionContextCreated` during preparation, then iterate with `Promise.all` using raw CDP `Runtime.evaluate` directly across all frame contexts.
📎 Plan: `/.sys/plans/PERF-286-raw-cdp-multi-frame.md`

---
*PR created automatically by Jules for task [18434252105360082195](https://jules.google.com/task/18434252105360082195) started by @BintzGavin*