### PR TITLE
✨ RENDERER: Discard preallocate multi-frame eval params (PERF-287)

### DIFF
--- a/.sys/plans/PERF-287-preallocate-multi-evaluate-params.md
+++ b/.sys/plans/PERF-287-preallocate-multi-evaluate-params.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-287
 slug: preallocate-multi-evaluate-params
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-04-15
-completed: ""
-result: ""
+completed: "2026-04-15"
+result: "Discarded - Optimization degraded performance"
 ---
 
 # PERF-287: Preallocate CDP Parameters for Multi-Frame seek in SeekTimeDriver
@@ -66,3 +66,11 @@ Run `npx tsx scripts/benchmark-test.js` to ensure rendering output matches the s
 ## Prior Art
 - PERF-286 introduced the `Runtime.evaluate` multi-frame logic, uncovering this micro-allocation opportunity.
 - Various prior PERFs (e.g., PERF-087, PERF-147) successfully optimized CDP parameter allocations.
+
+## Results Summary
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.851	90	2.74	36.4	discard	preallocate multi-frame eval params
+2	32.749	90	2.75	36.6	discard	preallocate multi-frame eval params
+3	32.246	90	2.79	36.7	discard	preallocate multi-frame eval params
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -65,3 +65,9 @@ Last updated by: PERF-277
 - Replaced Playwright closure IPC with raw CDP `Runtime.evaluate` for multi-frame in `SeekTimeDriver`
 - Improved render time for multi-frame compositions
 - PERF-286
+
+## What Doesn't Work (and Why)
+- **Preallocating CDP evaluate parameter object for multi-frame seek execution (PERF-287)**
+  - What: In `SeekTimeDriver.ts`, preallocated a statically-sized array of `multiEvaluateParams` objects to reuse during the `setTime` multi-frame execution loop instead of allocating new objects dynamically on every tick.
+  - Why it didn't work: Yielded a median run time of ~32.749s, compared to the baseline median of ~32.186s. The optimization actually degraded performance by adding memory lookup and branching overhead, demonstrating that V8 easily optimizes the inline dynamic object allocation inside this tight loop, rendering the explicit preallocation slower.
+  - Plan: PERF-287

--- a/packages/renderer/.sys/perf-results-PERF-287.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-287.tsv
@@ -1,0 +1,3 @@
+1	32.851	90	2.74	36.4	discard	preallocate multi-frame eval params
+2	32.749	90	2.75	36.6	discard	preallocate multi-frame eval params
+3	32.246	90	2.79	36.7	discard	preallocate multi-frame eval params


### PR DESCRIPTION
✨ RENDERER: Discard preallocate multi-frame eval params (PERF-287)

💡 What: Evaluated preallocating `multiEvaluateParams` in `SeekTimeDriver` for multi-frame execution. Discarded the optimization as it degraded performance. Code modifications were reverted; only administrative files (journal, TSV, plan) are updated.
🎯 Why: Attempted to reduce GC overhead by replacing dynamic object allocation with reused pre-allocated objects during the `setTime` hot loop.
📊 Impact: Degraded performance. Baseline median ~32.186s; experimental median ~32.749s. V8 optimizes inline dynamic allocation efficiently, and explicit preallocation adds overhead.
🔬 Verification: Ran the benchmark script `scripts/benchmark-test.js` successfully 3 times.
📎 Plan: `/.sys/plans/PERF-287-preallocate-multi-evaluate-params.md`

## Results Summary
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.851	90	2.74	36.4	discard	preallocate multi-frame eval params
2	32.749	90	2.75	36.6	discard	preallocate multi-frame eval params
3	32.246	90	2.79	36.7	discard	preallocate multi-frame eval params
```

---
*PR created automatically by Jules for task [15060465341759617258](https://jules.google.com/task/15060465341759617258) started by @BintzGavin*