### PR TITLE
📋 RENDERER: Eliminate Playwright Page Object Serialization Overhead in CaptureLoop Hot Path

### DIFF
--- a/.sys/plans/PERF-288-inline-worker-call-arguments.md
+++ b/.sys/plans/PERF-288-inline-worker-call-arguments.md
@@ -1,0 +1,99 @@
+---
+id: PERF-288
+slug: inline-worker-call-arguments
+status: unclaimed
+claimed_by: ""
+created: 2026-04-16
+completed: ""
+result: ""
+---
+
+# PERF-288: Eliminate Playwright Page Object Serialization Overhead in CaptureLoop Hot Path
+
+## Focus Area
+`packages/renderer/src/core/CaptureLoop.ts` - `runWorker` and `run` execution loop.
+
+## Background Research
+Currently in `CaptureLoop.ts`, the multi-worker ACTOR MODEL passes a complex `WorkerInfo` object, which contains the Playwright `Page` object and the configured `Strategy` to each worker iteration via `worker.timeDriver.setTime(worker.page, ...)` and `worker.strategy.capture(worker.page, ...)`.
+
+Passing Playwright `Page` objects deeply into tight loop functions comes with overhead, especially given how Playwright internally routes those objects across IPC boundaries and proxies property accesses. Since each worker operates on its own dedicated context, we can cache the essential references needed for frame capture directly inside the `CaptureLoop` ring buffer loop closure without repeatedly destructuring or passing the `Page` object around where unnecessary.
+
+Additionally, in PERF-278 and PERF-281, we established that V8 handles Promise resolution fast, but there is still IPC latency inside the hot loop.
+
+## Baseline
+- **Current estimated render time**: ~42.6s (baseline)
+- **Bottleneck analysis**: The overhead from repeatedly passing complex `Page` objects to driver and strategy calls in `runWorker`.
+
+## Implementation Spec
+
+### Step 1: Inline Worker Call Arguments
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In `CaptureLoop.ts`, locate the `runWorker` function:
+
+```typescript
+<<<<<<< SEARCH
+    const runWorker = async (worker: WorkerInfo, workerIndex: number) => {
+        while (!aborted) {
+            const i = await getNextTask();
+            if (i === -1) break;
+
+            const time = i * timeStep;
+            const compositionTimeInSeconds = (this.startFrame + i) * compTimeStep;
+
+            const ringIndex = i & ringMask;
+            const ctx = contextRing[ringIndex];
+
+            try {
+                worker.timeDriver.setTime(worker.page, compositionTimeInSeconds).then(undefined, noopCatch);
+                const rawResponse = await worker.strategy.capture(worker.page, time);
+                const buffer = worker.strategy.formatResponse ? worker.strategy.formatResponse(rawResponse) : rawResponse;
+                if (ctx.resolve) ctx.resolve(buffer);
+            } catch (e) {
+                if (ctx.reject) ctx.reject(e);
+            }
+        }
+    };
+=======
+    const runWorker = async (worker: WorkerInfo, workerIndex: number) => {
+        const { timeDriver, strategy, page } = worker;
+        const formatResponse = strategy.formatResponse;
+
+        while (!aborted) {
+            const i = await getNextTask();
+            if (i === -1) break;
+
+            const time = i * timeStep;
+            const compositionTimeInSeconds = (this.startFrame + i) * compTimeStep;
+
+            const ringIndex = i & ringMask;
+            const ctx = contextRing[ringIndex];
+
+            try {
+                timeDriver.setTime(page, compositionTimeInSeconds).then(undefined, noopCatch);
+                const rawResponse = await strategy.capture(page, time);
+                const buffer = formatResponse ? formatResponse.call(strategy, rawResponse) : rawResponse;
+                if (ctx.resolve) ctx.resolve(buffer);
+            } catch (e) {
+                if (ctx.reject) ctx.reject(e);
+            }
+        }
+    };
+>>>>>>> REPLACE
+```
+
+**Why**: By destructuring `timeDriver`, `strategy`, and `page` outside the hot `while(!aborted)` loop and caching the `formatResponse` method reference, we avoid repeated property lookups on the `WorkerInfo` object every single frame, potentially reducing V8's internal lookup overhead and keeping the hot loop leaner.
+
+**Risk**: Negligible risk, simple refactor.
+
+### Step 2: Verification
+Use `run_in_bash_session` to execute the benchmark `cd packages/renderer && npx tsx scripts/benchmark-test.js` to verify any performance gains. If successful, append the results to the journal.
+
+## Variation
+If no improvement, discard the changes.
+
+## Canvas Smoke Test
+Run benchmark-test.js on canvas mode.
+
+## Correctness Check
+Output video should still be 90 frames and render smoothly.


### PR DESCRIPTION
📋 RENDERER: Eliminate Playwright Page Object Serialization Overhead in CaptureLoop Hot Path

💡 What: Creating a new experiment plan to destructure Playwright objects out of the capture hot loop.
🎯 Why: To reduce V8 lookup overhead and keep the hot loop leaner during CaptureLoop multi-worker rendering.
🔬 Approach: Destructure `page`, `strategy`, and `timeDriver` from `WorkerInfo` outside the `runWorker` while loop.
📎 Plan: `/.sys/plans/PERF-288-inline-worker-call-arguments.md`

---
*PR created automatically by Jules for task [13818327232822642077](https://jules.google.com/task/13818327232822642077) started by @BintzGavin*