### PR TITLE
✨ RENDERER: Discard PERF-278 worker-centric async loop pipeline bypass

### DIFF
--- a/.sys/plans/PERF-278-worker-centric-async-loop.md
+++ b/.sys/plans/PERF-278-worker-centric-async-loop.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-278
 slug: worker-centric-async-loop
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-04-14
-completed: ""
-result: ""
+completed: "2026-04-16"
+result: "failed"
 ---
 
 # PERF-278: Eliminate worker.activePromise Promise Chain Allocation
@@ -56,3 +56,9 @@ Verify Canvas strategy remains unaffected and correctly renders.
 
 ## Correctness Check
 Run the DOM benchmark and inspect the output video to verify visual correctness and frame ordering.
+
+## Results Summary
+- **Best render time**: 32.707s (vs baseline 32.040s)
+- **Improvement**: -2.1% (Regressed)
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-278 (Already partially implemented by previous experiment; attempting single worker bypass logic caused regression)]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -80,3 +80,8 @@ Last updated by: PERF-277
 - Render time: 32.271s (Baseline: 32.040s)
 - Status: inconclusive
 - **PERF-290**: Replaced Playwright IPC closure evaluation (`Runtime.callFunctionOn`) with raw CDP string evaluation (`Runtime.evaluate`) for stability checks and single-frame media synchronization in `CdpTimeDriver.ts`. Cleaned up unused execution initializers. Time remained practically identical/within noise margins, indicating that while raw strings save object-mapping overhead on IPC, single-frame evaluate allocations are not the primary bottleneck here. Kept for cleaner code and consistency with SeekTimeDriver.
+
+## PERF-278: Worker-centric async loop actor model check
+- Render time: 32.707s (Baseline: 32.040s)
+- Status: discard
+- **PERF-278**: Attempted to implement a worker-centric async loop in `CaptureLoop.ts` to bypass pipeline allocations for a single worker pool by avoiding `contextRing` and `framePromises` entirely. Found that the actor model with backpressure had already been partially implemented, but benchmarking revealed that running it without the actor model or trying to bypass it (if poolLen === 1) degraded performance (32.707s vs baseline 32.040s). The existing pipelined actor model is faster even with a single worker. Discarded.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -354,3 +354,4 @@ PERF-254	Pre-bind evaluate closures in SeekTimeDriver	render_time_s:      2.119
 PERF-286	32.361	90	2.78	22.9	keep	raw CDP evaluate multi-frame
 5	32.560	90	2.76	36.6	keep	Inline worker call arguments (PERF-288)
 6	32.308	90	2.79	36.7	keep	Use Runtime.evaluate for multi-frame (PERF-289)
+1	32.707	90	2.75	36.6	discard	PERF-278 worker-centric async loop actor model check


### PR DESCRIPTION
# PERF-278: Discard Worker-Centric Async Loop Bypass

💡 **What**: The PERF-278 experiment attempted to bypass the pipelined actor model (`contextRing` and `framePromises`) when the worker pool length is 1. The code changes were discarded because the experiment regressed performance. The PR documents this failure.
🎯 **Why**: Benchmarking showed that the pipelined actor model with backpressure is actually faster than awaiting captures sequentially without the pipeline, even for a single worker (32.707s vs baseline 32.040s).
📊 **Impact**: Render times regressed by ~2.1%. Discarded the code changes to preserve the 32.040s baseline.
🔬 **Verification**: Ran `scripts/benchmark-test.js`. Checked Git diff to ensure all source code remains untouched.
📎 **Plan**: `/.sys/plans/PERF-278-worker-centric-async-loop.md`

## Results Summary
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.707	90	2.75	36.6	discard	PERF-278 worker-centric async loop actor model check
```

---
*PR created automatically by Jules for task [12997284354490481735](https://jules.google.com/task/12997284354490481735) started by @BintzGavin*