### PR TITLE
✨ RENDERER: Evaluate PERF-262 Pre-bind stability timeout promise executor

### DIFF
--- a/.sys/plans/PERF-262-prebind-stability-timeout.md
+++ b/.sys/plans/PERF-262-prebind-stability-timeout.md
@@ -89,3 +89,11 @@ Run `cd packages/renderer && npx tsx scripts/benchmark-test.js` to ensure the be
 
 ## Correctness Check
 Run the DOM rendering tests to verify frames are generated correctly and the pipeline completes.
+
+## Results Summary
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+4	32.167	90	2.80	36.6	discard	prebind-stability-timeout
+5	32.127	90	2.80	36.6	discard	prebind-stability-timeout
+6	32.152	90	2.80	36.8	discard	prebind-stability-timeout
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -85,3 +85,8 @@ Last updated by: PERF-277
 - Render time: 32.707s (Baseline: 32.040s)
 - Status: discard
 - **PERF-278**: Attempted to implement a worker-centric async loop in `CaptureLoop.ts` to bypass pipeline allocations for a single worker pool by avoiding `contextRing` and `framePromises` entirely. Found that the actor model with backpressure had already been partially implemented, but benchmarking revealed that running it without the actor model or trying to bypass it (if poolLen === 1) degraded performance (32.707s vs baseline 32.040s). The existing pipelined actor model is faster even with a single worker. Discarded.
+
+## PERF-262: Pre-bind stability timeout promise executor in CdpTimeDriver.ts
+- Render time: 32.152s (Baseline: 32.040s)
+- Status: discard
+- **PERF-262**: Prebound the CDP stability timeout promise executor. V8 optimizes the inline promise and anonymous closure allocation better than the property lookup. The method is no longer re-entrant or safe to call concurrently. Discarded.

--- a/packages/renderer/.sys/perf-results-PERF-262.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-262.tsv
@@ -2,3 +2,6 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	2.004	150	74.85	48.0	keep	baseline
 2	2.692	150	55.71	34.4	discard	prebind stability timeout executor
 3	2.843	150	52.76	34.8	discard	prebind-stability-timeout
+4	32.167	90	2.80	36.6	discard	prebind-stability-timeout
+5	32.127	90	2.80	36.6	discard	prebind-stability-timeout
+6	32.152	90	2.80	36.8	discard	prebind-stability-timeout


### PR DESCRIPTION
💡 **What**: The experiment evaluated replacing the inline timeout promise allocation with a pre-bound executor and properties in `CdpTimeDriver.ts`. Outcome: Discarded.
🎯 **Why**: To reduce GC pressure by eliminating dynamic closures per frame.
📊 **Impact**: Render time regressed from 32.040s to 32.152s. Making it an instance property also degraded concurrency safety.
🔬 **Verification**: Code was reverted. Test suite passed.
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-262-prebind-stability-timeout.md`

## Results Summary
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
4	32.167	90	2.80	36.6	discard	prebind-stability-timeout
5	32.127	90	2.80	36.6	discard	prebind-stability-timeout
6	32.152	90	2.80	36.8	discard	prebind-stability-timeout
```

---
*PR created automatically by Jules for task [15440883643852634393](https://jules.google.com/task/15440883643852634393) started by @BintzGavin*