### PR TITLE
✨ RENDERER: Eliminate dynamic promise allocation in getNextTask

### DIFF
--- a/.sys/plans/PERF-291-eliminate-getnexttask-promise.md
+++ b/.sys/plans/PERF-291-eliminate-getnexttask-promise.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-291
 slug: eliminate-getnexttask-promise
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-05-15
-completed: ""
-result: ""
+completed: "2024-05-16"
+result: "inconclusive"
 ---
 
 # PERF-291: Eliminate Dynamic Promise Allocation in CaptureLoop.ts getNextTask

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -90,3 +90,8 @@ Last updated by: PERF-277
 - Render time: 33.527s (Baseline: ~32.040s)
 - Status: inconclusive
 - **PERF-291**: Eliminated dynamic `Promise` allocation and `await` yielding inside the worker loops `getNextTask()` by allowing it to return a synchronous index integer when the buffer has capacity. While theoretically sound to avoid microtask yields and GC pressure per frame, testing showed no tangible improvement (33.527s due to noisy VM vs baseline ~32.040s) because V8 successfully optimizes small async functions and microtask hopping very well. Kept since the logic explicitly prevents unnecessary Promise wrapping without altering behavior.
+
+## PERF-291: Eliminate getNextTask Promise Allocation
+- Render time: 32.381s (Baseline: ~32.040s)
+- Status: inconclusive
+- **PERF-291**: Eliminated dynamic `Promise` allocation and `await` yielding inside the worker loops `getNextTask()` by allowing it to return a synchronous index integer when the buffer has capacity. While theoretically sound to avoid microtask yields and GC pressure per frame, testing showed no tangible improvement (32.381s vs baseline ~32.040s) because V8 successfully optimizes small async functions and microtask hopping very well. Kept since the logic explicitly prevents unnecessary Promise wrapping without altering behavior.

--- a/packages/renderer/.sys/perf-results-PERF-291.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-291.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.774	90	2.75	36.4	inconclusive	eliminate getNextTask promise allocation
+2	32.381	90	2.78	36.6	inconclusive	eliminate getNextTask promise allocation
+3	32.252	90	2.79	37.4	inconclusive	eliminate getNextTask promise allocation

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -172,35 +172,34 @@ export class CaptureLoop {
         }
     };
 
-    const getNextTask = async (): Promise<number> => {
-        return new Promise<number>((resolve) => {
-            if (aborted || nextFrameToSubmit >= this.totalFrames) {
-                resolve(-1);
-                return;
+    const getNextTask = (): number | Promise<number> => {
+        if (aborted || nextFrameToSubmit >= this.totalFrames) {
+            return -1;
+        }
+
+        if (nextFrameToSubmit - nextFrameToWrite < maxPipelineDepth) {
+            const i = nextFrameToSubmit++;
+            const ringIndex = i & ringMask;
+
+            const promise = new Promise<Buffer | string>((res, rej) => {
+                contextRing[ringIndex].resolve = res;
+                contextRing[ringIndex].reject = rej;
+            });
+            promise.catch(noopCatch); // Prevent unhandled rejections
+            framePromises[ringIndex] = promise;
+
+            if (frameWaiterResolve) {
+                const fRes = frameWaiterResolve;
+                frameWaiterResolve = null;
+                fRes();
             }
 
-            if (nextFrameToSubmit - nextFrameToWrite < maxPipelineDepth) {
-                const i = nextFrameToSubmit++;
-                const ringIndex = i & ringMask;
-
-                const promise = new Promise<Buffer | string>((res, rej) => {
-                    contextRing[ringIndex].resolve = res;
-                    contextRing[ringIndex].reject = rej;
-                });
-                promise.catch(noopCatch); // Prevent unhandled rejections
-                framePromises[ringIndex] = promise;
-
-                if (frameWaiterResolve) {
-                    const fRes = frameWaiterResolve;
-                    frameWaiterResolve = null;
-                    fRes();
-                }
-
-                resolve(i);
-            } else {
+            return i;
+        } else {
+            return new Promise<number>((resolve) => {
                 waitingWorkerResolves.push(resolve);
-            }
-        });
+            });
+        }
     };
 
     const runWorker = async (worker: WorkerInfo, workerIndex: number) => {
@@ -208,7 +207,8 @@ export class CaptureLoop {
         const formatResponse = strategy.formatResponse;
 
         while (!aborted) {
-            const i = await getNextTask();
+            const task = getNextTask();
+            const i = typeof task === 'number' ? task : await task;
             if (i === -1) break;
 
             const time = i * timeStep;


### PR DESCRIPTION
💡 **What**: Refactored `getNextTask` in `CaptureLoop.ts` to return `number | Promise<number>` to conditionally avoid dynamic `Promise` wrapper allocation and yield when the frame buffer has capacity.
🎯 **Why**: To reduce microtask queuing overhead and garbage collection pressure in the highly active worker pulling loop. 
📊 **Impact**: The results were inconclusive (~32.381s vs baseline ~32.040s), indicating V8 already optimizes this well, but it was kept because it correctly models synchronous buffer capacity without altering behavior.
🔬 **Verification**: Code compiles, DOM benchmarker generates correct video out (~42s but runs cleanly), unit tests run for CDP driver determinism. 
📎 **Plan**: `/.sys/plans/PERF-291-eliminate-getnexttask-promise.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.774	90	2.75	36.4	inconclusive	eliminate getNextTask promise allocation
2	32.381	90	2.78	36.6	inconclusive	eliminate getNextTask promise allocation
3	32.252	90	2.79	37.4	inconclusive	eliminate getNextTask promise allocation
```

---
*PR created automatically by Jules for task [2104730245542298702](https://jules.google.com/task/2104730245542298702) started by @BintzGavin*