### PR TITLE
📋 RENDERER: DomStrategy formatResponse CDP optimization

### DIFF
--- a/.sys/plans/PERF-293-reorder-format-response-checks.md
+++ b/.sys/plans/PERF-293-reorder-format-response-checks.md
@@ -1,0 +1,83 @@
+---
+id: PERF-293
+slug: reorder-format-response-checks
+status: unclaimed
+claimed_by: ""
+created: 2024-05-18
+completed: ""
+result: ""
+---
+# PERF-293: Reorder DomStrategy formatResponse checks for CDP hot path
+
+## Focus Area
+The hot loop in DOM rendering mode (DOM-to-Video path). Specifically, the `formatResponse` method in `packages/renderer/src/strategies/DomStrategy.ts` which is executed for every single frame captured during the render loop.
+
+## Background Research
+During the frame capture loop in `CaptureLoop.ts`, `DomStrategy.formatResponse` is called to extract the image buffer or base64 string from the raw capture response. Currently, the code first checks `if (Buffer.isBuffer(res))` before checking `else if (res && res.screenshotData)`.
+
+Since the DOM strategy uses CDP `HeadlessExperimental.beginFrame` almost exclusively (unless forced into fallback), the response is typically a plain JSON object containing `screenshotData` (a base64 string), not a Node.js `Buffer` object (which is only returned by fallback screenshot or canvas strategies).
+
+Calling `Buffer.isBuffer(res)` on a plain object on every frame involves a function call overhead. By reordering the condition to check for `res && res.screenshotData` first, we replace a function call with a fast V8 hidden-class property access for the vast majority of frames.
+
+## Benchmark Configuration
+- **Composition URL**: http://localhost:3000/benchmark
+- **Render Settings**: 1920x1080, 60fps, 10s, libx264
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~32.1s
+- **Bottleneck analysis**: Micro-optimizing the frame capture loop logic avoids unnecessary function calls in the V8 hot path.
+
+## Implementation Spec
+
+### Step 1: Reorder formatResponse conditions
+**File**: `packages/renderer/src/strategies/DomStrategy.ts`
+**What to change**:
+Locate the `formatResponse` property assignment in the class.
+Change it from:
+```typescript
+  public formatResponse = (res: any): Buffer | string => {
+    if (Buffer.isBuffer(res)) {
+      this.lastFrameData = res;
+      return res;
+    } else if (res && res.screenshotData) {
+      this.lastFrameData = res.screenshotData;
+      return res.screenshotData;
+    } else if (this.lastFrameData) {
+      return this.lastFrameData;
+    } else {
+      this.lastFrameData = this.emptyImageBase64;
+      return this.emptyImageBase64;
+    }
+  };
+```
+To:
+```typescript
+  public formatResponse = (res: any): Buffer | string => {
+    if (res && res.screenshotData) {
+      this.lastFrameData = res.screenshotData;
+      return res.screenshotData;
+    } else if (Buffer.isBuffer(res)) {
+      this.lastFrameData = res;
+      return res;
+    } else if (this.lastFrameData) {
+      return this.lastFrameData;
+    } else {
+      this.lastFrameData = this.emptyImageBase64;
+      return this.emptyImageBase64;
+    }
+  };
+```
+**Why**: Avoids the `Buffer.isBuffer` function call on the common CDP path, replacing it with a faster object property access `res.screenshotData`.
+**Risk**: Negligible. The logical behavior remains completely unchanged.
+
+## Variations
+No variations necessary.
+
+## Canvas Smoke Test
+Run `npm run build:examples` or the equivalent canvas smoke tests to ensure Canvas fallback isn't affected.
+
+## Correctness Check
+Verify that the output video retains all frames correctly and deterministically.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -98,3 +98,6 @@ Last updated by: PERF-277
 - **PERF-291**: Eliminated dynamic `Promise` allocation and `await` yielding inside the worker loops `getNextTask()` by allowing it to return a synchronous index integer when the buffer has capacity. While theoretically sound to avoid microtask yields and GC pressure per frame, testing showed no tangible improvement (32.381s vs baseline ~32.040s) because V8 successfully optimizes small async functions and microtask hopping very well. Kept since the logic explicitly prevents unnecessary Promise wrapping without altering behavior.
 
 - **PERF-292**: Tried eliminating `formatResponse.call` in `CaptureLoop.ts` by replacing it with direct invocation `formatResponse(rawResponse)`. V8 effectively optimizes the `.call()` dynamic dispatch overhead inside tight loops so there was no performance improvement. Render time was slightly worse (~32.204s compared to ~32.112s baseline).
+
+## Open Questions
+- **PERF-293**: Can we avoid the `Buffer.isBuffer()` function call overhead in `DomStrategy.formatResponse()` by prioritizing the `res.screenshotData` check for CDP?


### PR DESCRIPTION
📋 RENDERER: DomStrategy formatResponse CDP optimization

💡 What: Reorder `formatResponse` to prioritize CDP property checking in `packages/renderer/src/strategies/DomStrategy.ts`.
🎯 Why: `Buffer.isBuffer()` adds function call overhead on every frame. Since CDP `HeadlessExperimental.beginFrame` is the primary path in DOM mode, `res.screenshotData` is the common case. Replacing the function call with a hidden-class property lookup first avoids the overhead.
🔬 Approach: Prioritize `res.screenshotData` check over `Buffer.isBuffer`.
📎 Plan: `/.sys/plans/PERF-293-reorder-format-response-checks.md`

---
*PR created automatically by Jules for task [1342636856988540113](https://jules.google.com/task/1342636856988540113) started by @BintzGavin*