### PR TITLE
✨ RENDERER: Discard PERF-294 Inline formatResponse in CaptureLoop.ts

### DIFF
--- a/.sys/plans/PERF-294-inline-dom-strategy-format-response.md
+++ b/.sys/plans/PERF-294-inline-dom-strategy-format-response.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-294
 slug: inline-dom-strategy-format-response
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-04-17
-completed: ""
-result: ""
+completed: 2026-04-17
+result: "no-improvement"
 ---
 
 # PERF-294: Inline `formatResponse` in `CaptureLoop.ts` to Eliminate Function Dispatch Overhead
@@ -70,3 +70,9 @@ Run `npm run build:examples` and then run `npx tsx tests/verify-canvas-strategy.
 
 ## Correctness Check
 Run the DOM benchmark (`npx tsx tests/fixtures/benchmark.ts`) to verify performance gains and ensure the output video is generated correctly.
+
+## Results Summary
+- **Best render time**: 51.097s (vs baseline 48.225s)
+- **Improvement**: -5.9%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-294: Inline `formatResponse` in `CaptureLoop.ts`]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -106,3 +106,8 @@ Last updated by: PERF-277
 - Render time: 48.225s (Baseline: 49.244s)
 - Status: keep
 - **PERF-293**: Reordered `DomStrategy.formatResponse()` to check `if (res && res.screenshotData)` before checking `Buffer.isBuffer(res)`. This prioritizes the CDP hot path, avoiding the `Buffer.isBuffer()` function call overhead on every frame, which replaces a function call with a fast V8 hidden-class property access. It improved render times slightly compared to baseline (~48.2s vs baseline ~49.2s). Kept.
+
+## PERF-294: Inline formatResponse in CaptureLoop.ts
+- Render time: 51.097s (Baseline: 48.225s)
+- Status: discard
+- **PERF-294**: Inlined `formatResponse` CDP extraction directly inside the hot loop (`runWorker`) in `CaptureLoop.ts` to avoid the `.call` method invocation overhead. V8 handles the function dispatch effectively, and the added branching `typeof rawResponse.screenshotData === 'string'` in the hot loop actually slightly degraded performance (~51.097s vs baseline ~48.225s). Discarded because the dynamic function dispatch is faster than checking type/property dynamically.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -360,3 +360,6 @@ PERF-286	32.361	90	2.78	22.9	keep	raw CDP evaluate multi-frame
 3	47.778	600	12.56	42.6	keep	PERF-293 reorder formatResponse checks
 4	48.157	600	12.46	41.5	keep	PERF-293 reorder formatResponse checks
 5	48.293	600	12.42	42.7	keep	PERF-293 reorder formatResponse checks
+1	51.193	600	11.72	43.3	discard	PERF-294 inline formatResponse
+2	51.097	600	11.74	41.3	discard	PERF-294 inline formatResponse
+3	48.923	600	12.26	41.5	discard	PERF-294 inline formatResponse


### PR DESCRIPTION
✨ RENDERER: Discard PERF-294 Inline formatResponse in CaptureLoop.ts

💡 **What**: Attempted to inline `formatResponse` CDP extraction directly inside the hot loop (`runWorker`) in `CaptureLoop.ts`. Reverted the code modifications as performance was not improved.
🎯 **Why**: To test if bypassing the dynamic function `.call` overhead inside `CaptureLoop` improves render time by extracting the string directly from the CDP response in the tight loop.
📊 **Impact**: Degraded rendering performance from a median of 48.225s to 51.097s (-5.9%). Discarded.
🔬 **Verification**: Code passed all compilation gates, Canvas mode worked properly, and the benchmark harness was run 3 times to measure median render speed.
📎 **Plan**: `/.sys/plans/PERF-294-inline-dom-strategy-format-response.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | 51.193 | 600 | 11.72 | 43.3 | discard | PERF-294 inline formatResponse |
| 2 | 51.097 | 600 | 11.74 | 41.3 | discard | PERF-294 inline formatResponse |
| 3 | 48.923 | 600 | 12.26 | 41.5 | discard | PERF-294 inline formatResponse |


---
*PR created automatically by Jules for task [4887481997419796322](https://jules.google.com/task/4887481997419796322) started by @BintzGavin*