### PR TITLE
✨ STUDIO: Toggle Loop Shortcut

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -1,0 +1,47 @@
+# Studio Context
+
+## Section A: Architecture
+Helios Studio is a React-based web application served locally by Vite. It provides a visual development environment for creating, previewing, and configuring video compositions. The frontend communicates with the backend via API endpoints (e.g., asset discovery, rendering tasks) and directly manipulates the embedded `<helios-player>` to control playback and state. The Studio integrates tightly with the Core schema system, enabling dynamic UI generation for properties.
+
+## Section B: File Tree
+```
+packages/studio/
+├── bin/
+├── src/
+│   ├── components/       # Reusable UI components (Timeline, PropsEditor, Stage, RendersPanel, AssetsPanel)
+│   ├── context/          # React Context providers (StudioContext)
+│   ├── hooks/            # Custom React hooks
+│   ├── server/           # Backend API routes and Vite dev server
+│   ├── types/            # TypeScript interface definitions
+│   ├── App.tsx           # Main application root
+│   ├── index.css         # Global styles
+│   └── main.tsx          # Entry point
+```
+
+## Section C: CLI Interface
+The Studio is invoked via `npx helios studio` (or `npm run dev` in development). The CLI starts the Vite development server and opens the Studio UI in the default browser. It accepts options to configure the server port or specify a custom project root path for composition discovery.
+
+## Section D: UI Components
+- **Stage**: Renders the `<helios-player>` and handles resolution, panning, zooming, and snapshot captures. Includes Safe Area Guides.
+- **Timeline**: Visualizes the composition duration, current playhead, draggable In/Out point markers, audio waveforms, and snap-to guides. Supports dragging and dropping assets.
+- **Props Editor**: Dynamically generated input fields based on the active composition's schema, allowing real-time modification of props. Includes specialized editors (JSON, Color, Enum, Asset Inputs).
+- **Assets Panel**: Displays and manages project assets (images, videos, audio, fonts, 3D models). Supports rich preview, drag & drop uploading, and directory organization.
+- **Renders Panel**: Manages remote and local rendering jobs, showing progress and providing export options.
+- **Captions Panel**: Edits and synchronizes subtitle data with the video timeline.
+
+**Key Shortcuts**:
+- `Space`: Play/Pause
+- `Home`: Restart/Rewind
+- `Shift+L`: Toggle Loop
+- `L`: Play Forward / Speed Up
+- `J`: Play Reverse / Speed Up Reverse
+- `K`: Pause
+- `Cmd+K`: Switch Composition
+- `?`: Show Shortcuts Modal
+- `I`/`O`: Set In/Out Point
+- `Shift + ←/→`: Navigate 10 frames
+
+## Section E: Integration
+- **Core (`packages/core`)**: Consumes the `Helios` class and schema definitions to discover properties and handle data synchronization.
+- **Player (`packages/player`)**: Directly integrates the `<helios-player>` web component to power the Stage playback and preview logic.
+- **Renderer (`packages/renderer`)**: Orchestrates and manages background rendering tasks requested via the Studio's backend API.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,4 +1,5 @@
-## STUDIO v0.121.3
+### STUDIO v0.121.5
+- ✅ Completed: Toggle Loop Shortcut - Restored loop toggle functionality using Shift+L keyboard shortcut.
 
 ### STUDIO v0.121.4
 - ✅ Completed: STUDIO-Timeline-Drag-Drop - Added visual styling when dragging an asset over the Timeline component for visual feedback.

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,9 +1,10 @@
-**Version**: 0.121.4
+**Version**: 0.121.5
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
 # Studio Domain Status
 
+- [v0.121.5] ✅ Completed: Toggle Loop Shortcut - Restored loop toggle functionality using Shift+L keyboard shortcut.
 **Status**: 🟢 Active
 
 **Focus**: UI Implementation & CLI

--- a/packages/studio/src/components/GlobalShortcuts.tsx
+++ b/packages/studio/src/components/GlobalShortcuts.tsx
@@ -11,7 +11,8 @@ export const GlobalShortcuts: React.FC = () => {
     inPoint,
     setInPoint,
     outPoint,
-    setOutPoint
+    setOutPoint,
+    toggleLoop
   } = useStudio();
 
   const { currentFrame, duration, fps } = playerState;
@@ -91,8 +92,13 @@ export const GlobalShortcuts: React.FC = () => {
     controller.pause();
   }, { ignoreInput: true });
 
-  // L: Play Forward / Speed Up
-  useKeyboardShortcut('l', () => {
+  // L: Play Forward / Speed Up, Shift+L: Toggle Loop
+  useKeyboardShortcut('l', (e) => {
+    if (e.shiftKey) {
+      toggleLoop();
+      return;
+    }
+
     if (!controller) return;
     const currentRate = playerState.playbackRate || 1;
     if (!playerState.isPlaying || currentRate < 0.25) {

--- a/packages/studio/src/components/KeyboardShortcutsModal.tsx
+++ b/packages/studio/src/components/KeyboardShortcutsModal.tsx
@@ -18,7 +18,7 @@ const SHORTCUTS: ShortcutSection[] = [
     shortcuts: [
       { description: 'Play / Pause', keys: ['Space'] },
       { description: 'Restart / Rewind', keys: ['Home'] },
-      { description: 'Toggle Loop', keys: ['L'] },
+      { description: 'Toggle Loop', keys: ['Shift', 'L'] },
     ]
   },
   {


### PR DESCRIPTION
💡 **What**: Added `Shift+L` shortcut to toggle playback loop and updated the shortcuts modal to display the correct key combination.
🎯 **Why**: The 'L' shortcut was recently mapped to "Play Forward / Speed Up", removing the quick way to toggle looping and causing discrepancy with existing documentation. Restoring this to `Shift+L` resolves this vision gap without interfering with standard J/K/L editing conventions.
📊 **Impact**: Developers regain quick toggle looping support directly via keyboard in the Studio interface.
🔬 **Verification**: Run `npm run test -w @helios-project/studio` and `npm run lint -w @helios-project/studio` successfully. Verified manually via Vitest testing tools.

---
*PR created automatically by Jules for task [17079230640218539987](https://jules.google.com/task/17079230640218539987) started by @BintzGavin*