### PR TITLE
✨ RENDERER: [Discarded] Inline Object Allocation for Hot Paths

### DIFF
--- a/.sys/perf-results-PERF-296.tsv
+++ b/.sys/perf-results-PERF-296.tsv
@@ -1,0 +1,1 @@
+1	48.743	600	12.31	42.0	discard	inline object allocation in hot paths

--- a/.sys/plans/PERF-296-inline-object-allocation.md
+++ b/.sys/plans/PERF-296-inline-object-allocation.md
@@ -1,12 +1,18 @@
 ---
 id: PERF-296
 slug: inline-object-allocation
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-18
-completed: ""
-result: ""
+completed: "2025-05-18"
+result: "Discarded: Inline object allocation in the hot loop degraded performance compared to mutating the long-lived property, likely due to V8 write barrier overhead being smaller than object instantiation overhead in this context."
 ---
+
+## Results Summary
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	48.743	600	12.31	42.0	discard	inline object allocation in hot paths
+```
 
 # PERF-296: Replace Old-Space Object Mutation with Inline Object Allocation in Hot Paths
 

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -2,6 +2,9 @@
 Current best: 32.040s (baseline was 43.227s, -25.6%)
 Last updated by: PERF-277
 
+## What Doesn't Work (and Why)
+- **PERF-296**: Replaced object mutation with inline object allocation in the hot loops of `SeekTimeDriver.ts` and `DomStrategy.ts`. The median render time worsened to ~48.743s compared to the baseline of ~47.232s. This indicates that creating new object literals inside the hot loop adds more overhead than the write barriers caused by mutating the long-lived properties. Discarded as slower.
+
 ## What Works
 - **PERF-295**: Removed `fallbackScreenshotOptions` cache from `DomStrategy.ts` and constructed fallback options inline. Render time: 47.232s (baseline ~47.460s). Avoids untyped property mutation and hidden class pollution. Kept.
 - **PERF-285**: Optimized SeekTimeDriver single-frame evaluation by replacing Playwright IPC closure with raw CDP string evaluation over Runtime.evaluate. Improved render time to ~32.1s.


### PR DESCRIPTION
**Results Summary:**
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	48.743	600	12.31	42.0	discard	inline object allocation in hot paths
```

---
*PR created automatically by Jules for task [13498696727973562798](https://jules.google.com/task/13498696727973562798) started by @BintzGavin*