### PR TITLE
📋 RENDERER: Skia CPU Pathways for GPU-disabled Environments

### DIFF
--- a/.sys/plans/PERF-298-chromium-skia-cpu.md
+++ b/.sys/plans/PERF-298-chromium-skia-cpu.md
@@ -1,0 +1,65 @@
+---
+id: PERF-298
+slug: chromium-skia-cpu
+status: unclaimed
+claimed_by: ""
+created: 2026-10-18
+completed: ""
+result: ""
+---
+
+# PERF-298: Chromium Skia CPU Pathways for GPU-disabled Environments
+
+## Focus Area
+`packages/renderer/src/core/BrowserPool.ts` - Chromium launch flags
+
+## Background Research
+The memory explicitly states: "All experiments run on a **CPU-only Jules microVM with no GPU**... Hardware encoding experiments (NVENC, VAAPI, VideoToolbox) will not work — focus on software encoding optimizations".
+Additionally, the `.jules/RENDERER.md` journal notes: "Removed GL flags and forced Chromium into native Skia CPU pathways via `--disable-gpu`, `--disable-software-rasterizer`, and `--disable-gpu-compositing`. Reduces translation overhead from SwiftShader (~2.75% faster). (PERF-006)".
+However, inspecting `BrowserPool.ts` reveals that `GPU_DISABLED_ARGS` currently only includes `--disable-gpu`. The critical flags `--disable-software-rasterizer` and `--disable-gpu-compositing` are missing. Without these, Chromium falls back to SwiftShader (a CPU-based Vulkan/GL implementation) instead of using the faster native Skia CPU rasterization paths directly.
+By fully disabling the software rasterizer and GPU compositing, we bypass SwiftShader overhead entirely for DOM rendering.
+
+## Benchmark Configuration
+- **Composition URL**: `tests/fixtures/benchmark.ts` (DOM benchmark)
+- **Render Settings**: 1920x1080, 60fps, 10s duration, libx264
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~58.583s
+- **Bottleneck analysis**: SwiftShader translation overhead during frame rasterization and composition.
+
+## Implementation Spec
+
+### Step 1: Add Skia CPU Flags
+**File**: `packages/renderer/src/core/BrowserPool.ts`
+**What to change**:
+Update `GPU_DISABLED_ARGS` to include the missing flags.
+```typescript
+<<<<<<< SEARCH
+const GPU_DISABLED_ARGS = [
+  '--disable-gpu',
+];
+=======
+const GPU_DISABLED_ARGS = [
+  '--disable-gpu',
+  '--disable-software-rasterizer',
+  '--disable-gpu-compositing',
+];
+>>>>>>> REPLACE
+```
+**Why**: Forces Chromium to use its native Skia CPU rasterization path instead of translating through SwiftShader, which is slower.
+**Risk**: Minimal, this aligns the code with the established PERF-006 findings.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run `npx tsx tests/verify-canvas-strategy.ts` to ensure Canvas rendering still works correctly (though Canvas strategy might be affected if it relies on SwiftShader for WebGL, the benchmark is primarily DOM focused, and Canvas fallback is standard).
+
+## Correctness Check
+Run the DOM benchmark `npx tsx tests/fixtures/benchmark.ts` to verify performance gains and ensure the output video is generated correctly without artifacts.
+
+## Prior Art
+- PERF-006: Documented in `.jules/RENDERER.md` as successful but not fully present in code.


### PR DESCRIPTION
Created plan PERF-298 to optimize Chromium launch arguments for CPU-only environments by enforcing Skia CPU pathways over SwiftShader.

---
*PR created automatically by Jules for task [7751477598124643298](https://jules.google.com/task/7751477598124643298) started by @BintzGavin*