### PR TITLE
✨ PLAYER: Fix Arrow Key Shortcuts

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,7 @@
+### PLAYER v0.77.22
+- ✅ Completed: Fix Arrow Key Shortcuts
+
+
 ### STUDIO v0.121.5
 - ✅ Completed: Toggle Loop Shortcut - Restored loop toggle functionality using Shift+L keyboard shortcut.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,7 @@
-**Version**: 0.77.21
+**Version**: 0.77.22
+[v0.77.22] ✅ Completed: Fix Arrow Key Shortcuts
+
+
 
 [v0.77.21] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner to create the next implementation spec.
 

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -177,23 +177,23 @@ describe('HeliosPlayer', () => {
     // Reset mocks
     mockController.seek.mockClear();
 
-    // ArrowRight: Seek +5s (Default) -> 150 frames
+    // ArrowRight: Seek +1 frame (Default) -> 1 frame
     mockController.getState.mockReturnValue({ currentFrame: 0, duration: 10, fps: 30, isPlaying: false });
     dispatchKey('ArrowRight');
-    expect(mockController.seek).toHaveBeenCalledWith(150);
+    expect(mockController.seek).toHaveBeenCalledWith(1);
 
-    // ArrowRight + Shift: Seek +10s -> 300 frames
+    // ArrowRight + Shift: Seek +10 frames -> 10 frames
     dispatchKey('ArrowRight', { shiftKey: true });
-    expect(mockController.seek).toHaveBeenCalledWith(300);
+    expect(mockController.seek).toHaveBeenCalledWith(10);
 
-    // ArrowLeft: Seek -5s (Default) -> 150 frames
+    // ArrowLeft: Seek -1 frame (Default) -> 199 frames
     mockController.getState.mockReturnValue({ currentFrame: 200, duration: 10, fps: 30, isPlaying: false });
     dispatchKey('ArrowLeft');
-    expect(mockController.seek).toHaveBeenCalledWith(50); // 200 - 150
+    expect(mockController.seek).toHaveBeenCalledWith(199); // 200 - 1
 
-    // ArrowLeft + Shift: Seek -10s -> 300 frames
+    // ArrowLeft + Shift: Seek -10 frames -> 190 frames
     dispatchKey('ArrowLeft', { shiftKey: true });
-    expect(mockController.seek).toHaveBeenCalledWith(0); // 200 - 300 -> 0
+    expect(mockController.seek).toHaveBeenCalledWith(190); // 200 - 10
 
     // .: Seek +1
     mockController.getState.mockReturnValue({ currentFrame: 10, duration: 10, fps: 30, isPlaying: false });

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -3026,14 +3026,14 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
         this.toggleShortcutsOverlay();
         break;
       case "ArrowRight":
-        this.seekRelativeSeconds(e.shiftKey ? 10 : 5);
+        this.seekRelative(e.shiftKey ? 10 : 1);
         break;
       case "l":
       case "L":
         this.seekRelativeSeconds(10);
         break;
       case "ArrowLeft":
-        this.seekRelativeSeconds(e.shiftKey ? -10 : -5);
+        this.seekRelative(e.shiftKey ? -10 : -1);
         break;
       case "j":
       case "J":


### PR DESCRIPTION
✨ PLAYER: Fix Arrow Key Shortcuts

💡 What: Updated ArrowLeft/ArrowRight to seek by frames instead of seconds.
🎯 Why: To align keyboard shortcuts with the documented vision (1 frame default, 10 frames with shift).
📊 Impact: Arrow keys now perform precise frame-based seeking matching expectations.
🔬 Verification: Unit tests in `packages/player/src/index.test.ts` pass indicating correct frame calculations.
Reference: .sys/plans/2026-04-14-PLAYER-Fix-Arrow-Key-Shortcuts.md

---
*PR created automatically by Jules for task [17673599457893655500](https://jules.google.com/task/17673599457893655500) started by @BintzGavin*