### PR TITLE
✨ RENDERER: Discard PERF-002 (Bypass Playwright Overhead with Raw CDP Capture)

### DIFF
--- a/.sys/plans/PERF-002-raw-cdp-capture.md
+++ b/.sys/plans/PERF-002-raw-cdp-capture.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-002
 slug: raw-cdp-capture
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-03-19
-completed: ""
-result: ""
+completed: "2024-05-18"
+result: "discard"
 ---
 
 # PERF-002: Bypass Playwright Overhead with Raw CDP Capture
@@ -90,3 +90,13 @@ Run a standard Canvas smoke test. The changes in `DomStrategy` should not affect
 ## Prior Art
 - Playwright page.screenshot overhead: Standard knowledge in performance-sensitive scraping contexts is to drop down to raw CDP for screenshots.
 - CDP Documentation for `Page.captureScreenshot`: https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot
+
+
+## Results Summary
+
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	47.689	600	12.58	41.3	keep	baseline
+2	47.773	600	12.56	41.3	discard	CDP captureScreenshot instead of page.screenshot
+3	47.651	600	12.59	42.6	discard	CDP captureScreenshot instead of page.screenshot
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,10 @@ Current best: 32.040s (baseline was 43.227s, -25.6%)
 Last updated by: PERF-277
 
 ## What Doesn't Work (and Why)
+- **Bypass Playwright Overhead with Raw CDP Capture (PERF-002)**
+  - What: Replaced Playwright's `page.screenshot()` with raw CDP `Page.captureScreenshot` in `DomStrategy.capture()`.
+  - Why it didn't work: The render time actually regressed slightly (~47.7s vs ~47.6s). `page.screenshot` is only used as a fallback when `targetSelector` is enabled, and `HeadlessExperimental.beginFrame` is the primary capture mechanism. The overhead of Playwright's internal checks is minimal compared to the overall pipeline, and replacing it didn't yield improvements.
+  - Plan: PERF-002
 - **PERF-296**: Replaced object mutation with inline object allocation in the hot loops of `SeekTimeDriver.ts` and `DomStrategy.ts`. The median render time worsened to ~48.743s compared to the baseline of ~47.232s. This indicates that creating new object literals inside the hot loop adds more overhead than the write barriers caused by mutating the long-lived properties. Discarded as slower.
 
 ## What Works

--- a/packages/renderer/.sys/perf-results-PERF-002.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-002.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	47.689	600	12.58	41.3	keep	baseline
+2	47.773	600	12.56	41.3	discard	CDP captureScreenshot instead of page.screenshot
+3	47.651	600	12.59	42.6	discard	CDP captureScreenshot instead of page.screenshot


### PR DESCRIPTION
💡 **What**: Replaced `page.screenshot` with `Page.captureScreenshot` via CDP in `DomStrategy.capture()`.
🎯 **Why**: To bypass actionability and layout thrashing checks added by Playwright's `screenshot` API in the fallback path.
📊 **Impact**: Render time regressed slightly to ~47.7s from a baseline of ~47.6s. The experiment was discarded.
🔬 **Verification**: Code restored to baseline. Benchmark results recorded and logged in TSV.
📎 **Plan**: PERF-002

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	47.689	600	12.58	41.3	keep	baseline
2	47.773	600	12.56	41.3	discard	CDP captureScreenshot instead of page.screenshot
3	47.651	600	12.59	42.6	discard	CDP captureScreenshot instead of page.screenshot
```

---
*PR created automatically by Jules for task [17283085886377867353](https://jules.google.com/task/17283085886377867353) started by @BintzGavin*