### PR TITLE
✨ RENDERER: Force Chromium Skia CPU pathways in GPU-disabled environments

### DIFF
--- a/.sys/perf-results-PERF-299.tsv
+++ b/.sys/perf-results-PERF-299.tsv
@@ -1,0 +1,5 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	61.877	600	9.70	42.1	keep	baseline
+2	48.815	600	12.29	42.9	keep	appended --disable-software-rasterizer and --disable-gpu-compositing
+3	47.252	600	12.70	41.4	keep	appended --disable-software-rasterizer and --disable-gpu-compositing
+4	47.554	600	12.62	41.3	keep	appended --disable-software-rasterizer and --disable-gpu-compositing

--- a/.sys/plans/PERF-299-chromium-skia-cpu.md
+++ b/.sys/plans/PERF-299-chromium-skia-cpu.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-299
 slug: chromium-skia-cpu
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: "2024-04-17"
+result: "Appended `--disable-software-rasterizer` and `--disable-gpu-compositing` to `GPU_DISABLED_ARGS`. Render time improved from 61.877s to a median of 47.554s. The test proves SwiftShader translation was indeed a major bottleneck in CPU-only environments. Kept."
 ---
 
 # PERF-299: Chromium Skia CPU Pathways for GPU-disabled Environments

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -127,3 +127,8 @@ Last updated by: PERF-277
 
 ## Open Questions
 - **PERF-299**: Will explicitly appending `--disable-software-rasterizer` and `--disable-gpu-compositing` to `GPU_DISABLED_ARGS` fully disable SwiftShader and improve render performance by forcing native Skia CPU rasterization?
+
+## PERF-299: Chromium Skia CPU Pathways for GPU-disabled Environments
+- Render time: 47.554s (Baseline: 61.877s)
+- Status: keep
+- **PERF-299**: Appended `--disable-software-rasterizer` and `--disable-gpu-compositing` to `GPU_DISABLED_ARGS` in `BrowserPool.ts`. The missing flags forced Chromium into SwiftShader. Adding them forces Chromium to use its native Skia CPU rasterization path, which bypasses the SwiftShader translation overhead entirely for DOM rendering. This resulted in a significant performance improvement (median: 47.554s vs baseline 61.877s). Kept.

--- a/packages/renderer/src/core/BrowserPool.ts
+++ b/packages/renderer/src/core/BrowserPool.ts
@@ -35,6 +35,8 @@ const DEFAULT_BROWSER_ARGS = [
 
 const GPU_DISABLED_ARGS = [
   '--disable-gpu',
+  '--disable-software-rasterizer',
+  '--disable-gpu-compositing',
 ];
 
 export interface WorkerInfo {


### PR DESCRIPTION
💡 **What**: Added missing CPU rendering flags (`--disable-software-rasterizer`, `--disable-gpu-compositing`) to `GPU_DISABLED_ARGS` in `BrowserPool.ts`.
🎯 **Why**: In CPU-only environments (like Jules microVM), `--disable-gpu` alone forces Chromium to use SwiftShader (a CPU GL implementation), which adds translation overhead compared to using native Skia CPU rendering directly.
📊 **Impact**: Render time improved from 61.877s to a median of 47.554s.
🔬 **Verification**: Ran `build`, `run-all.ts` suite tests, Canvas smoke tests (`verify-canvas-strategy.ts`), and verified outputs via `ffprobe`.
📎 **Plan**: `/.sys/plans/PERF-299-chromium-skia-cpu.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	61.877	600	9.70	42.1	keep	baseline
2	48.815	600	12.29	42.9	keep	appended --disable-software-rasterizer and --disable-gpu-compositing
3	47.252	600	12.70	41.4	keep	appended --disable-software-rasterizer and --disable-gpu-compositing
4	47.554	600	12.62	41.3	keep	appended --disable-software-rasterizer and --disable-gpu-compositing
```

---
*PR created automatically by Jules for task [15733019192744570824](https://jules.google.com/task/15733019192744570824) started by @BintzGavin*