### PR TITLE
✨ RENDERER: Verify Chromium Skia CPU pathways in GPU-disabled environments (PERF-298)

### DIFF
--- a/.sys/plans/PERF-298-chromium-skia-cpu.md
+++ b/.sys/plans/PERF-298-chromium-skia-cpu.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-298
 slug: chromium-skia-cpu
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: "2024-04-17"
+result: "The proposed optimization was already implemented in PERF-299. Verified the baseline and logged the results."
 ---
 
 # PERF-298: Chromium Skia CPU Pathways for GPU-disabled Environments
@@ -63,3 +63,9 @@ Run the DOM benchmark `npx tsx tests/fixtures/benchmark.ts` to verify performanc
 
 ## Prior Art
 - PERF-006: Documented in `.jules/RENDERER.md` as successful but not fully present in code.
+
+## Results Summary
+- **Best render time**: 48.0s (vs baseline ~58.583s)
+- **Improvement**: N/A (already implemented)
+- **Kept experiments**: N/A
+- **Discarded experiments**: N/A

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -10,6 +10,7 @@ Last updated by: PERF-277
 - **PERF-296**: Replaced object mutation with inline object allocation in the hot loops of `SeekTimeDriver.ts` and `DomStrategy.ts`. The median render time worsened to ~48.743s compared to the baseline of ~47.232s. This indicates that creating new object literals inside the hot loop adds more overhead than the write barriers caused by mutating the long-lived properties. Discarded as slower.
 
 ## What Works
+- **PERF-298**: Verified the Skia CPU pathways in `BrowserPool.ts`. Re-tested and achieved ~48.0s median render time. The optimization is already implemented by PERF-299. Kept as baseline verification.
 - **PERF-295**: Removed `fallbackScreenshotOptions` cache from `DomStrategy.ts` and constructed fallback options inline. Render time: 47.232s (baseline ~47.460s). Avoids untyped property mutation and hidden class pollution. Kept.
 - **PERF-285**: Optimized SeekTimeDriver single-frame evaluation by replacing Playwright IPC closure with raw CDP string evaluation over Runtime.evaluate. Improved render time to ~32.1s.
 - **PERF-277**: Replaced `.then()` with `await` in `DomStrategy.capture()` to eliminate dynamic Promise allocation per frame.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -363,3 +363,4 @@ PERF-286	32.361	90	2.78	22.9	keep	raw CDP evaluate multi-frame
 1	51.193	600	11.72	43.3	discard	PERF-294 inline formatResponse
 2	51.097	600	11.74	41.3	discard	PERF-294 inline formatResponse
 3	48.923	600	12.26	41.5	discard	PERF-294 inline formatResponse
+5	48.039	600	12.49	42.6	discard	PERF-298 Already Implemented via PERF-299


### PR DESCRIPTION
💡 **What**: Picked up PERF-298 to enforce native Skia CPU pathways by appending `--disable-software-rasterizer` and `--disable-gpu-compositing` to `GPU_DISABLED_ARGS` in `BrowserPool.ts`. However, these flags were already added by PERF-299. The benchmark was run to verify the 48.0s median render time, and the tracking documents and TSV were updated to log this verification.
🎯 **Why**: To bypass SwiftShader translation overhead in CPU-only environments.
📊 **Impact**: N/A - already implemented. Median render time remains verified at ~48.0s compared to the ~58.5s initial baseline in the spec.
🔬 **Verification**: 4-gate verification completed. Compilation passed, 3x benchmark runs yielded 48.0s median, and Canvas smoke tests passed.
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-298-chromium-skia-cpu.md`

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
5	48.039	600	12.49	42.6	discard	PERF-298 Already Implemented via PERF-299

---
*PR created automatically by Jules for task [16340418034287365778](https://jules.google.com/task/16340418034287365778) started by @BintzGavin*