### PR TITLE
✨ RENDERER: Discard prebinding evaluate params in CdpTimeDriver (PERF-301)

### DIFF
--- a/.sys/plans/PERF-301-prebind-evaluate-params.md
+++ b/.sys/plans/PERF-301-prebind-evaluate-params.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-301
 slug: prebind-evaluate-params
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-04-18
 completed: ""
@@ -61,3 +61,11 @@ Run `npx tsx tests/verify-canvas-strategy.ts` to ensure Canvas rendering still w
 
 ## Correctness Check
 Run the DOM benchmark `npx tsx tests/fixtures/benchmark.ts` to verify performance gains and ensure the output video is generated correctly.
+
+## Results Summary
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	46.667	600	12.86	42.9	discard	Prebind evaluate params
+2	46.618	600	12.87	41.2	discard	Prebind evaluate params
+3	46.848	600	12.81	41.6	discard	Prebind evaluate params
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -138,3 +138,8 @@ Last updated by: PERF-277
 - Render time: 47.554s (Baseline: 61.877s)
 - Status: keep
 - **PERF-299**: Appended `--disable-software-rasterizer` and `--disable-gpu-compositing` to `GPU_DISABLED_ARGS` in `BrowserPool.ts`. The missing flags forced Chromium into SwiftShader. Adding them forces Chromium to use its native Skia CPU rasterization path, which bypasses the SwiftShader translation overhead entirely for DOM rendering. This resulted in a significant performance improvement (median: 47.554s vs baseline 61.877s). Kept.
+
+## PERF-301: Prebind evaluate parameters in CdpTimeDriver
+- Render time: 46.667s (Baseline: ~47.554s)
+- Status: inconclusive
+- **PERF-301**: Preallocated the `Runtime.evaluate` parameter object (`{ expression: ..., awaitPromise: true }`) for the single-frame stability checks in `CdpTimeDriver.ts` hot loop. The goal was to avoid dynamic object allocation overhead. The render time improved slightly by ~1.9% (median 46.667s vs baseline 47.554s). However, this improvement is within the environmental noise margin (< 5%), showing that V8 optimizes the inline anonymous object allocation very efficiently and explicit caching does not provide a definitive, clear-cut performance gain. Discarded as inconclusive to keep the code simpler.

--- a/packages/renderer/.sys/perf-results-PERF-301.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-301.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	46.667	600	12.86	42.9	discard	Prebind evaluate params
+2	46.618	600	12.87	41.2	discard	Prebind evaluate params
+3	46.848	600	12.81	41.6	discard	Prebind evaluate params


### PR DESCRIPTION
✨ RENDERER: Discard prebinding evaluate params in CdpTimeDriver (PERF-301)

💡 **What**: Preallocated the `Runtime.evaluate` parameter object (`{ expression: ..., awaitPromise: true }`) for single-frame stability checks in `CdpTimeDriver.ts`.
🎯 **Why**: To reduce GC pressure and avoid dynamic anonymous object allocation in the hot loop per frame.
📊 **Impact**: Render times improved slightly by ~1.9% (median 46.667s vs baseline ~47.554s). However, this improvement is within the noise margin (< 5%). V8 optimizes inline anonymous objects highly efficiently, so explicit caching provides no clear benefit and was discarded to keep code simple.
🔬 **Verification**: Code passed TS compilation, canvas smoke tests, and generated output successfully during benchmark validation before being reverted.
📎 **Plan**: `/.sys/plans/PERF-301-prebind-evaluate-params.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	46.667	600	12.86	42.9	discard	Prebind evaluate params
2	46.618	600	12.87	41.2	discard	Prebind evaluate params
3	46.848	600	12.81	41.6	discard	Prebind evaluate params
```

---
*PR created automatically by Jules for task [13375327328736525080](https://jules.google.com/task/13375327328736525080) started by @BintzGavin*