### PR TITLE
✨ RENDERER: Evaluate PERF-302 (Preallocate CdpTimeDriver params)

### DIFF
--- a/.sys/plans/PERF-302-preallocate-cdptimedriver-params.md
+++ b/.sys/plans/PERF-302-preallocate-cdptimedriver-params.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-302
 slug: preallocate-cdptimedriver-params
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2026-04-18"
+result: "discarded"
 ---
 
 # PERF-302: Preallocate Runtime.evaluate params in CdpTimeDriver.ts
@@ -61,3 +61,9 @@ Run the DOM smoke tests (`npx tsx tests/verify-dom-strategy-capture.ts`) and ver
 
 ## Prior Art
 - `SeekTimeDriver.ts` uses `this.evaluateParams` to avoid inline object allocation.
+
+## Results Summary
+- **Best render time**: 48.866s (vs baseline ~48.3s)
+- **Improvement**: 0% (discarded)
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-302]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 32.040s (baseline was 43.227s, -25.6%)
 Last updated by: PERF-277
 
 ## What Doesn't Work (and Why)
+- **PERF-302**: Attempted to preallocate the `Runtime.evaluate` parameter object in `CdpTimeDriver.ts` (`setTime` single-frame path) to avoid dynamic object allocation (`{ expression: ... }`). Yielded median time 48.866s (baseline was ~48.3s). Discarded because V8 efficiently optimizes inline object allocation here, and storing it statically did not provide any gain and slightly degraded performance.
 - **Bypass Playwright Overhead with Raw CDP Capture (PERF-002)**
   - What: Replaced Playwright's `page.screenshot()` with raw CDP `Page.captureScreenshot` in `DomStrategy.capture()`.
   - Why it didn't work: The render time actually regressed slightly (~47.7s vs ~47.6s). `page.screenshot` is only used as a fallback when `targetSelector` is enabled, and `HeadlessExperimental.beginFrame` is the primary capture mechanism. The overhead of Playwright's internal checks is minimal compared to the overall pipeline, and replacing it didn't yield improvements.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -364,3 +364,5 @@ PERF-286	32.361	90	2.78	22.9	keep	raw CDP evaluate multi-frame
 2	51.097	600	11.74	41.3	discard	PERF-294 inline formatResponse
 3	48.923	600	12.26	41.5	discard	PERF-294 inline formatResponse
 5	48.039	600	12.49	42.6	discard	PERF-298 Already Implemented via PERF-299
+
+6	48.866	600	12.28	43.3	discard	PERF-302 inline object allocation


### PR DESCRIPTION
✨ RENDERER: Evaluate PERF-302 (Preallocate CdpTimeDriver params)

💡 What: Evaluated preallocating the Runtime.evaluate parameter object in CdpTimeDriver.ts to avoid dynamic allocations per frame. The optimization was discarded due to negative performance impact. Code was reverted, and tracking files were updated.
🎯 Why: To reduce V8 garbage collection overhead inside the hot loop.
📊 Impact: Render time regressed from ~48.3s (baseline) to 48.866s. V8 optimizes inline object allocation more efficiently than reusing a long-lived object for CDP IPC.
🔬 Verification: 3 benchmark runs resulting in a median time of 48.866s. Test suite and canvas checks passed after reverting.
📎 Plan: /.sys/plans/PERF-302-preallocate-cdptimedriver-params.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
6	48.866	600	12.28	43.3	discard	PERF-302 inline object allocation

---
*PR created automatically by Jules for task [13584678355585188514](https://jules.google.com/task/13584678355585188514) started by @BintzGavin*