### PR TITLE
✨ RENDERER: Evaluate PERF-304 process-per-tab architecture flag

### DIFF
--- a/.sys/plans/PERF-304-process-per-tab.md
+++ b/.sys/plans/PERF-304-process-per-tab.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-304
 slug: process-per-tab
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-24
 completed: ""
-result: ""
+result: "discarded"
 ---
 
 # PERF-304: Process Per Tab Architecture for Playwright Headless Chromium
@@ -52,3 +52,9 @@ Run the DOM render tests to ensure multi-page worker pools still capture frames 
 
 ## Prior Art
 - `PERF-213`: Attempted `--single-process` which failed.
+
+## Results Summary
+- **Best render time**: 48.161s (vs baseline ~47.554s)
+- **Improvement**: -1.65% (worse)
+- **Kept experiments**: []
+- **Discarded experiments**: [process-per-tab flag]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -154,3 +154,8 @@ Last updated by: PERF-303
 - Render time: 59.078s (Baseline: 2.004s)
 - Status: discard
 - **PERF-262**: Attempted to prebind the stability timeout promise executor in `CdpTimeDriver.ts` to avoid dynamic closure allocation. This degraded performance significantly compared to the baseline (59.078s vs 2.004s). This indicates that V8 optimizes the inline anonymous Promise and closure creation efficiently, and the prebinding approach may have introduced other state-handling overhead. Discarded.
+
+## PERF-304: Process Per Tab Architecture for Playwright Headless Chromium
+- Render time: 48.341s (Baseline: ~47.554s)
+- Status: discard
+- **PERF-304**: Added `--process-per-tab` to `BrowserPool.ts` Chromium flags to force multi-page instances on the same context to share renderer processes to save overhead. The median render time degraded slightly to 48.341s (vs baseline 47.554s), demonstrating that OS-level process consolidation via this flag in our specific headless usage pattern introduces contention or IPC bottlenecking rather than efficiency. Discarded.

--- a/packages/renderer/.sys/perf-results-PERF-304.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-304.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	50.027	600	11.99	43.1	discard	process-per-tab flag
+2	48.341	600	12.41	41.0	discard	process-per-tab flag
+3	48.161	600	12.46	43.1	discard	process-per-tab flag


### PR DESCRIPTION
💡 **What**: Tested adding `--process-per-tab` to Chromium flags in `BrowserPool.ts`. Result was discarded and code changes reverted.
🎯 **Why**: To see if consolidating renderer processes reduced OS-level context switching overhead and improved rendering performance.
📊 **Impact**: Median render time degraded to ~48.341s (from baseline ~47.554s). The flag caused IPC bottlenecking/contention instead of improving efficiency.
🔬 **Verification**: Compilation, DOM mode rendering `tests/fixtures/benchmark.ts` (3 runs), `output.mp4` ffmpeg evaluation, Canvas smoke test.
📎 **Plan**: `/.sys/plans/PERF-304-process-per-tab.md`

Results:
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	50.027	600	11.99	43.1	discard	process-per-tab flag
2	48.341	600	12.41	41.0	discard	process-per-tab flag
3	48.161	600	12.46	43.1	discard	process-per-tab flag
```

---
*PR created automatically by Jules for task [10502399821744536963](https://jules.google.com/task/10502399821744536963) started by @BintzGavin*