### PR TITLE
✨ RENDERER: Disable V8 Idle Tasks in Headless Chromium

### DIFF
--- a/.sys/plans/PERF-305-disable-v8-idle-tasks.md
+++ b/.sys/plans/PERF-305-disable-v8-idle-tasks.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-305
 slug: disable-v8-idle-tasks
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2024-05-24"
+result: "inconclusive"
 ---
 
 # PERF-305: Disable V8 Idle Tasks in Headless Chromium

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -159,3 +159,8 @@ Last updated by: PERF-303
 - Render time: 48.341s (Baseline: ~47.554s)
 - Status: discard
 - **PERF-304**: Added `--process-per-tab` to `BrowserPool.ts` Chromium flags to force multi-page instances on the same context to share renderer processes to save overhead. The median render time degraded slightly to 48.341s (vs baseline 47.554s), demonstrating that OS-level process consolidation via this flag in our specific headless usage pattern introduces contention or IPC bottlenecking rather than efficiency. Discarded.
+
+## PERF-305: Disable V8 Idle Tasks in Headless Chromium
+- Render time: 48.702s (Baseline: 48.341s)
+- Status: inconclusive
+- **PERF-305**: Added `--disable-v8-idle-tasks` to `BrowserPool.ts` Chromium flags. The median render time degraded slightly to 48.702s (vs baseline 48.341s). Adding the flag `--disable-v8-idle-tasks` instructs V8 to not perform background garbage collection during idle time. However, this did not improve the performance and it degraded slightly. This experiment was deemed inconclusive and the changes were discarded.

--- a/packages/renderer/.sys/perf-results-PERF-305.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-305.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	56.672	600	10.59	26.7	inconclusive	disable-v8-idle-tasks
+2	46.968	600	12.77	29.6	inconclusive	disable-v8-idle-tasks
+3	48.702	600	12.32	28.1	inconclusive	disable-v8-idle-tasks


### PR DESCRIPTION
💡 **What**: Added `--disable-v8-idle-tasks` to `BrowserPool.ts` Chromium flags to test performance impact. The result was inconclusive and the change was discarded.

🎯 **Why**: To prevent V8 from attempting background garbage collection and other idle tasks that could interfere with the tight frame rendering loop.

📊 **Impact**: Render times degraded slightly (median 48.702s vs baseline 48.341s).

🔬 **Verification**: Tested against baseline rendering. Results recorded in .sys/perf-results-PERF-305.tsv

📎 **Plan**: PERF-305-disable-v8-idle-tasks

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	56.672	600	10.59	26.7	inconclusive	disable-v8-idle-tasks
2	46.968	600	12.77	29.6	inconclusive	disable-v8-idle-tasks
3	48.702	600	12.32	28.1	inconclusive	disable-v8-idle-tasks
```

---
*PR created automatically by Jules for task [8888956055630294503](https://jules.google.com/task/8888956055630294503) started by @BintzGavin*