### PR TITLE
✨ RENDERER: webp intermediate format (PERF-004)

### DIFF
--- a/.sys/plans/PERF-004-webp-intermediate-format.md
+++ b/.sys/plans/PERF-004-webp-intermediate-format.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-004
 slug: webp-intermediate-format
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: "2026-04-19"
+result: "discarded"
 ---
 
 # PERF-004: Intermediate Format Optimization (WEBP)
@@ -60,3 +60,9 @@ Run a standard Canvas smoke test. The changes should not negatively impact the C
 
 ## Prior Art
 - Image format performance comparisons in Chromium often show WebP encoding is faster than PNG, especially for screenshots.
+## Results Summary
+- **Best render time**: 48.608s (vs baseline 48.156s)
+- **Improvement**: 0% (degraded)
+- **Kept experiments**: [none]
+- **Discarded experiments**:
+  - PERF-004: Added webp support to CanvasStrategy and made it the default for alpha channels. Degraded render time slightly.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -164,3 +164,8 @@ Last updated by: PERF-303
 - Render time: 48.702s (Baseline: 48.341s)
 - Status: inconclusive
 - **PERF-305**: Added `--disable-v8-idle-tasks` to `BrowserPool.ts` Chromium flags. The median render time degraded slightly to 48.702s (vs baseline 48.341s). Adding the flag `--disable-v8-idle-tasks` instructs V8 to not perform background garbage collection during idle time. However, this did not improve the performance and it degraded slightly. This experiment was deemed inconclusive and the changes were discarded.
+
+## PERF-004: Intermediate Format Optimization (WEBP)
+- Render time: 48.608s (Baseline: 48.156s)
+- Status: discard
+- **PERF-004**: Attempted to use `webp` format as intermediate image capturing format by extending types and `CanvasStrategy.ts` implementation. The tests and implementation successfully passed types and supported `webp` without failure but the rendering median performance slightly degraded (48.608s vs 48.156s). In a non-hardware accelerated environment for Chromium screenshot encoding, JPEG encoding overhead and Node.js intermediate base64 mapping seems sufficiently optimized by existing pathways. Discarded the changes in code.

--- a/packages/renderer/.sys/perf-results-PERF-004.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-004.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	49.584	600	12.10	41.5	keep	baseline
+2	47.954	600	12.51	43.5	keep	baseline
+3	48.156	600	12.46	43.6	keep	baseline
+4	48.608	600	12.34	43.2	discard	webp intermediate format
+5	48.284	600	12.43	42.1	discard	webp intermediate format
+6	48.925	600	12.26	42.0	discard	webp intermediate format


### PR DESCRIPTION
Attempted to implement webp as the default intermediate image format for captures requiring alpha channels. Added webp to RendererOptions types and extended CanvasStrategy to support it. 

The implementation was successful and verified via tests, but the benchmark results demonstrated a degradation in median performance in the headless environment (48.608s vs 48.156s baseline). As such, the code changes were discarded to keep the performance optimal.

### Results Summary
| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 49.584 | 600 | 12.10 | 41.5 | keep | baseline |
| 2 | 47.954 | 600 | 12.51 | 43.5 | keep | baseline |
| 3 | 48.156 | 600 | 12.46 | 43.6 | keep | baseline |
| 4 | 48.608 | 600 | 12.34 | 43.2 | discard | webp intermediate format |
| 5 | 48.284 | 600 | 12.43 | 42.1 | discard | webp intermediate format |
| 6 | 48.925 | 600 | 12.26 | 42.0 | discard | webp intermediate format |

---
*PR created automatically by Jules for task [9902790102997790385](https://jules.google.com/task/9902790102997790385) started by @BintzGavin*