### PR TITLE
📋 RENDERER: Disable Renderer Backgrounding

### DIFF
--- a/.sys/perf-results.tsv
+++ b/.sys/perf-results.tsv
@@ -1,1 +1,2 @@
 2	33.527	90	2.68	36.5	keep	PERF-291: Eliminate Dynamic Promise Allocation in CaptureLoop.ts getNextTask
+3	49.152	90	2.68	36.5	discard	PERF-307: Disable Renderer Backgrounding

--- a/.sys/plans/PERF-307-disable-renderer-backgrounding.md
+++ b/.sys/plans/PERF-307-disable-renderer-backgrounding.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-307
 slug: disable-renderer-backgrounding
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: 2024-05-24
+result: "failed"
 ---
 
 # PERF-307: Disable Renderer Backgrounding in Multi-Worker Actor Model

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -169,3 +169,8 @@ Last updated by: PERF-303
 - Render time: 48.608s (Baseline: 48.156s)
 - Status: discard
 - **PERF-004**: Attempted to use `webp` format as intermediate image capturing format by extending types and `CanvasStrategy.ts` implementation. The tests and implementation successfully passed types and supported `webp` without failure but the rendering median performance slightly degraded (48.608s vs 48.156s). In a non-hardware accelerated environment for Chromium screenshot encoding, JPEG encoding overhead and Node.js intermediate base64 mapping seems sufficiently optimized by existing pathways. Discarded the changes in code.
+
+## PERF-307: Disable Renderer Backgrounding in Multi-Worker Actor Model
+- Render time: 49.152s (Baseline: 48.102s)
+- Status: discard
+- **PERF-307**: Re-tested adding `--disable-renderer-backgrounding` and `--disable-backgrounding-occluded-windows` to `BrowserPool.ts` Chromium flags under the new multi-worker actor model. Expected performance gain by preventing Chromium from deprioritizing background renderer processes, but it actually degraded performance (median 49.152s vs baseline 48.102s). This suggests OS scheduling heuristics or IPC congestion worsens when explicitly forcing Chromium to not background non-visible renderers in a highly saturated environment. Discarded.


### PR DESCRIPTION
💡 What: Tested adding `--disable-renderer-backgrounding` and `--disable-backgrounding-occluded-windows` to BrowserPool.ts under the new multi-worker architecture.
🎯 Why: Expected performance gain by preventing Chromium from deprioritizing background renderer processes to improve OS scheduling and CPU utilization.
🔬 Approach: Explicitly provided the Chromium flags and verified changes via benchmark tests.
📎 Plan: /.sys/plans/PERF-307-disable-renderer-backgrounding.md

The result showed performance degradation within the noise margin (median 49.152s compared to the baseline median 48.102s). The attempt was discarded. Tracker logs and documents were updated.

---
*PR created automatically by Jules for task [1003671363095544415](https://jules.google.com/task/1003671363095544415) started by @BintzGavin*