### PR TITLE
✨ RENDERER: Cache Media Synchronization Promises in SeekTimeDriver

### DIFF
--- a/.sys/plans/PERF-308-cache-media-promises.md
+++ b/.sys/plans/PERF-308-cache-media-promises.md
@@ -1,8 +1,11 @@
 ---
 id: PERF-308
 slug: cache-media-promises
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
+completed: 2024-05-24
+result: improved
+
 created: 2024-05-24
 completed: ""
 result: ""
@@ -100,3 +103,10 @@ Run `npx tsx tests/verify-dom-strategy-capture.ts` to verify DOM output is corre
 
 ## Prior Art
 PERF-226 originally suggested extracting `new Promise` but the current code creates a new instance inside the extracted function. This plan builds upon PERF-226 by preventing redundant instances.
+
+
+## Results Summary
+- **Best render time**: 46.939s (vs baseline 47.147s)
+- **Improvement**: 0.4%
+- **Kept experiments**: Cache Media Synchronization Promises in SeekTimeDriver
+- **Discarded experiments**: []

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -11,6 +11,10 @@ Last updated by: PERF-303
 - **PERF-296**: Replaced object mutation with inline object allocation in the hot loops of `SeekTimeDriver.ts` and `DomStrategy.ts`. The median render time worsened to ~48.743s compared to the baseline of ~47.232s. This indicates that creating new object literals inside the hot loop adds more overhead than the write barriers caused by mutating the long-lived properties. Discarded as slower.
 
 ## What Works
+## PERF-308: Cache Media Synchronization Promises in SeekTimeDriver
+- Render time: 46.939s (Baseline: 47.147s)
+- Status: keep
+- **PERF-308**: Cached the Promise in `createMediaPromise` on the `el` object (`el.__helios_sync_promise`) directly inside `SeekTimeDriver.ts`, eliminating redundant allocations across frames. Kept.
 - **PERF-298**: Verified the Skia CPU pathways in `BrowserPool.ts`. Re-tested and achieved ~48.0s median render time. The optimization is already implemented by PERF-299. Kept as baseline verification.
 - **PERF-295**: Removed `fallbackScreenshotOptions` cache from `DomStrategy.ts` and constructed fallback options inline. Render time: 47.232s (baseline ~47.460s). Avoids untyped property mutation and hidden class pollution. Kept.
 - **PERF-285**: Optimized SeekTimeDriver single-frame evaluation by replacing Playwright IPC closure with raw CDP string evaluation over Runtime.evaluate. Improved render time to ~32.1s.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -4,3 +4,5 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 3	49.280	600	12.18	42.0	keep	Removed formatResponse overhead
 4	48.141	600	12.46	43.2	keep	Removed formatResponse overhead
 5	47.147	600	12.73	41.6	keep	Removed formatResponse overhead
+
+6	46.939	600	12.78	43.3	keep	Cache Media Synchronization Promises in SeekTimeDriver

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -81,12 +81,15 @@ export class SeekTimeDriver implements TimeDriver {
         let cachedMediaElements = null;
 
         function createMediaPromise(el) {
-          return new Promise((resolve) => {
+          if (el.__helios_sync_promise) return el.__helios_sync_promise;
+
+          el.__helios_sync_promise = new Promise((resolve) => {
             let resolved = false;
             const finish = () => {
               if (resolved) return;
               resolved = true;
               cleanup();
+              el.__helios_sync_promise = null;
               resolve();
             };
             const cleanup = () => {
@@ -98,6 +101,8 @@ export class SeekTimeDriver implements TimeDriver {
             el.addEventListener('canplay', finish);
             el.addEventListener('error', finish);
           });
+
+          return el.__helios_sync_promise;
         }
 
         window.__helios_invalidate_cache = () => {


### PR DESCRIPTION
✨ RENDERER: Cache Media Synchronization Promises in SeekTimeDriver

💡 **What**: Modified `SeekTimeDriver.ts` to cache the Promise allocated inside `createMediaPromise` on the element (`el.__helios_sync_promise`), reusing it across frames and nullifying it on resolution. Appended results to `.sys/perf-results.tsv` and updated `RENDERER-EXPERIMENTS.md`.
🎯 **Why**: Eliminates redundant V8 Promise allocation and duplication of `seeked`/`canplay`/`error` DOM event listeners on every frame while waiting for the media element to stabilize.
📊 **Impact**: Render times improved very slightly over baseline (Median: 46.939s vs Baseline: 47.147s).
🔬 **Verification**: Code compiles (`npm run build`). Canvas smoke test (`npx tsx tests/verify-canvas-strategy.ts`) and DOM validation (`npx tsx tests/verify-dom-strategy-capture.ts`) pass successfully.
📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-308-cache-media-promises.md`)

```tsv
6	46.939	600	12.78	43.3	keep	Cache Media Synchronization Promises in SeekTimeDriver
```

---
*PR created automatically by Jules for task [2162315663958490377](https://jules.google.com/task/2162315663958490377) started by @BintzGavin*