### PR TITLE
✨ RENDERER: Added optimizeForSpeed: true in beginFrame

### DIFF
--- a/.sys/perf-results-PERF-311.tsv
+++ b/.sys/perf-results-PERF-311.tsv
@@ -1,0 +1,8 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.299	90	2.79	37.8	keep	baseline
+2	32.089	90	2.80	37.4	keep	baseline
+3	32.136	90	2.80	37.4	keep	baseline
+4	32.101	90	2.80	37.6	keep	baseline
+5	32.120	90	2.80	37.6	inconclusive	optimizeForSpeed: true in beginFrame
+6	32.103	90	2.80	37.5	inconclusive	optimizeForSpeed: true in beginFrame
+7	32.131	90	2.80	36.7	inconclusive	optimizeForSpeed: true in beginFrame

--- a/.sys/plans/PERF-311-optimize-for-speed.md
+++ b/.sys/plans/PERF-311-optimize-for-speed.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-311
 slug: optimize-for-speed
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-25
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -187,3 +187,8 @@ Last updated by: PERF-303
 - Render time: 47.078s (Baseline: 47.304s)
 - Status: inconclusive
 - **PERF-309**: Attempted to preallocate the `Runtime.evaluate` parameter object inside `SeekTimeDriver.ts` hot loop for multiple contexts (iframes). This replaced per-frame dynamic object allocations with property assignments on statically cached objects (`cachedEvaluateParams`). The performance change was inconclusive as the render times fluctuated closely around the baseline (median ~47.0s vs ~47.3s), suggesting that V8 garbage collection and allocation overhead for these simple literal objects is already very well optimized and doesn't bottleneck the multi-frame virtual time seeking. The experiment was discarded to avoid unnecessary caching state complexity.
+
+## PERF-311: optimizeForSpeed in beginFrame for DOM Capture
+- Render time: ~32.118s (Baseline: ~32.108s)
+- Status: inconclusive
+- **PERF-311**: Added `optimizeForSpeed: true` to the screenshot parameters passed to `HeadlessExperimental.beginFrame` during DOM capture in `DomStrategy.ts`. While Chromium documentation suggests this flag prioritizes encoding speed, benchmark results inside the headless VM environment showed no measurable performance difference (median 32.118s vs baseline 32.108s). The Chromium screenshot encoding pathway is likely not the bottleneck, or the flag's effect is negligible for our specific headless setup and frame dimensions. Left the code change as it doesn't degrade performance and may yield benefits on other hardware or larger resolutions.

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -145,7 +145,7 @@ export class DomStrategy implements RenderStrategy {
       screenshotOptions.omitBackground = hasAlpha;
     }
 
-    const cdpScreenshotParams: any = { format };
+    const cdpScreenshotParams: any = { format, optimizeForSpeed: true };
     if ((format === 'jpeg' || format === 'webp') && quality !== undefined) {
       cdpScreenshotParams.quality = quality;
     }


### PR DESCRIPTION
💡 **What**: Added `optimizeForSpeed: true` to the screenshot parameters passed to `HeadlessExperimental.beginFrame` during DOM capture.
🎯 **Why**: To test if Chromium's rendering and screenshot encoding speed could be improved by prioritizing it.
📊 **Impact**: The render time remained inconclusive (median 32.118s vs baseline 32.108s). Kept the change since it doesn't degrade performance and may yield benefits on other setups.
🔬 **Verification**: Code compiles, canvas and dom capture strategies verify successfully, benchmark run completed successfully.
📎 **Plan**: Reference the plan file (/.sys/plans/PERF-311-optimize-for-speed.md)

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.299	90	2.79	37.8	keep	baseline
2	32.089	90	2.80	37.4	keep	baseline
3	32.136	90	2.80	37.4	keep	baseline
4	32.101	90	2.80	37.6	keep	baseline
5	32.120	90	2.80	37.6	inconclusive	optimizeForSpeed: true in beginFrame
6	32.103	90	2.80	37.5	inconclusive	optimizeForSpeed: true in beginFrame
7	32.131	90	2.80	36.7	inconclusive	optimizeForSpeed: true in beginFrame

---
*PR created automatically by Jules for task [1441988637765120073](https://jules.google.com/task/1441988637765120073) started by @BintzGavin*