### PR TITLE
✨ RENDERER: [Discarded: preallocate noopCatch in SeekTimeDriver]

### DIFF
--- a/.sys/plans/PERF-316-remove-noopcatch-allocation.md
+++ b/.sys/plans/PERF-316-remove-noopcatch-allocation.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-316
 slug: remove-noopcatch-allocation
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2025-04-19
 completed: ""
-result: ""
+result: "discarded: preallocating noopCatch regressed render time"
 ---
 
 # PERF-316: Avoid Promise Allocation Overhead in SeekTimeDriver's Catch Handlers

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,8 @@ Current best: 47.554s (baseline was 61.877s, -23.1%)
 Last updated by: PERF-303
 
 ## What Doesn't Work (and Why)
+- **PERF-316**: Preallocated `noopCatch` function in `SeekTimeDriver.ts` hot loop.
+  - **WHY it didn't work**: The render time actually regressed slightly (~48.556s vs ~47.554s). Avoiding dynamic allocation of empty arrow functions inside the hot loop added minor overhead or disrupted V8 optimizations compared to leaving it inline. Discarded as slower.
 - Tried to optimize branch prediction in `DomStrategy.capture` by assigning the method dynamically in `prepare()` (polymorphic capture) using arrow functions to prevent branch evaluation overhead on every frame. (PERF-310)
   - **WHY it didn't work**: The variance was within the noise margin (<0.5%). Branch prediction for `if (this.targetElementHandle)` on every frame is fast enough that modifying it via polymorphic assignments provides no measurable benefit and only complicates the class structure.
 

--- a/packages/renderer/.sys/perf-results-PERF-316.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-316.tsv
@@ -1,0 +1,5 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	47.554	300	6.30	39.0	keep	baseline
+2	48.628	300	6.16	45.2	discard	preallocate noopcatch in seek
+3	48.526	300	6.18	43.2	discard	preallocate noopcatch in seek
+4	48.556	300	6.17	43.0	discard	preallocate noopcatch in seek


### PR DESCRIPTION
💡 **What**: Preallocated `noopCatch` function in `SeekTimeDriver.ts` hot loop.
🎯 **Why**: To avoid dynamic allocation of empty arrow functions inside the hot loop.
📊 **Impact**: The render time actually regressed slightly (~48.556s vs ~47.554s). Avoiding dynamic allocation of empty arrow functions inside the hot loop added minor overhead or disrupted V8 optimizations compared to leaving it inline. Discarded as slower.
🔬 **Verification**: 4-gate verification, benchmark results
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-316-remove-noopcatch-allocation.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	47.554	300	6.30	39.0	keep	baseline
2	48.628	300	6.16	45.2	discard	preallocate noopcatch in seek
3	48.526	300	6.18	43.2	discard	preallocate noopcatch in seek
4	48.556	300	6.17	43.0	discard	preallocate noopcatch in seek
```

---
*PR created automatically by Jules for task [932252917096402419](https://jules.google.com/task/932252917096402419) started by @BintzGavin*