### PR TITLE
📋 PLAYER: Fix export-options test configuration

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -28,3 +28,6 @@
 ## [v0.77.20] - Frame-based Keydown Alignments
 **Learning:** The implementation of keyboard shortcuts like `ArrowLeft` and `ArrowRight` was originally seeking by seconds, but the `README.md` explicitly promised frame-based seeking.
 **Action:** When planning, double-check that the fine-grained implementation details match the high-level documentation in `README.md`.
+## [v0.77.25] - Addressing Environment Issues in Tests
+**Learning:** `packages/player/src/export-options.test.ts` was failing because the `vitest` environment defaults to Node, making `document` unavailable. The `HeliosPlayer` Web Component uses `document` at the module level.
+**Action:** Created plan to ensure the `@vitest-environment jsdom` pragma is added to files testing DOM components.

--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -135,3 +135,6 @@ The following standard media session metadata attributes are available as proper
 ## Track Lists
 - `HeliosAudioTrackList`: Implements standard HTMLMediaElement event handler properties (`onaddtrack`, `onremovetrack`, `onchange`).
 - `HeliosVideoTrackList`: Implements standard HTMLMediaElement event handler properties (`onaddtrack`, `onremovetrack`, `onchange`).
+
+### v0.77.25 Update
+- Created plan to resolve `document is not defined` error in tests by adding vitest environment pragma.

--- a/.sys/plans/2026-12-29-PLAYER-Fix-Export-Options-Test.md
+++ b/.sys/plans/2026-12-29-PLAYER-Fix-Export-Options-Test.md
@@ -1,0 +1,21 @@
+#### 1. Context & Goal
+- **Objective**: Fix the `export-options.test.ts` failure caused by the `document is not defined` error when evaluating the module containing `<helios-player>`.
+- **Trigger**: Test suite for `packages/player` fails because `document` is used at the top-level of `index.ts` before JSDOM is initialized in the test environment.
+- **Impact**: Enables the test suite to run and allows us to verify new changes in the player components.
+
+#### 2. File Inventory
+- **Create**: none
+- **Modify**: `packages/player/src/export-options.test.ts`
+- **Read-Only**: `packages/player/src/index.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: The `vitest` environment defaults to Node.js, meaning `document` is not available by default. We need to add the `@vitest-environment jsdom` pragma to the top of `export-options.test.ts` to instruct Vitest to set up JSDOM before executing the file.
+- **Pseudo-Code**:
+  - Add `// @vitest-environment jsdom` to the first line of `packages/player/src/export-options.test.ts`.
+- **Public API Changes**: none
+- **Dependencies**: none
+
+#### 4. Test Plan
+- **Verification**: Run `npx vitest run packages/player/src/export-options.test.ts` to verify the test passes.
+- **Success Criteria**: The test executes successfully without throwing `ReferenceError: document is not defined`.
+- **Edge Cases**: none

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -524,3 +524,7 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### STUDIO v0.121.6
 - ✅ Completed: STUDIO-Timeline-Drag-Drop - Verified timeline drag and drop for assets is already implemented.
+
+## [v0.77.25] PLAYER
+**Objective**: Fix the export options test failure.
+**Action**: Created plan to add `// @vitest-environment jsdom` to `export-options.test.ts`.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -217,3 +217,4 @@
 [v0.77.20] ✅ Completed: Discovered discrepancy in arrow key shortcut behavior between README documentation (seeks by frames) and actual implementation (seeks by seconds). Created plan to fix this vision gap.
 [v0.77.21] ✅ Completed: Discovered undocumented keyboard shortcuts (J, L, comma, period) in actual implementation that are missing from the README. Created plan to fix this vision gap.
 [v0.77.24] ✅ Completed: Add Undocumented Shortcuts UI - Added undocumented keyboard shortcuts (J, L, comma, period) to the player's Shortcuts UI menu.
+[v0.77.25] ✅ Completed: Discovered broken test due to missing vitest environment pragma. Created plan .sys/plans/2026-12-29-PLAYER-Fix-Export-Options-Test.md to fix test configuration.


### PR DESCRIPTION
Created plan to fix the `export-options.test.ts` failure caused by the `document is not defined` error.

---
*PR created automatically by Jules for task [11544141840486260819](https://jules.google.com/task/11544141840486260819) started by @BintzGavin*