### PR TITLE
📋 RENDERER: Prebind Worker Blocked Promise Executors in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-321-avoid-cdp-promise-allocation.md
+++ b/.sys/plans/PERF-321-avoid-cdp-promise-allocation.md
@@ -1,0 +1,100 @@
+---
+id: PERF-321
+slug: avoid-cdp-promise-allocation
+status: unclaimed
+claimed_by: ""
+created: 2024-05-27
+completed: ""
+result: ""
+---
+
+# PERF-321: Avoid CDP Promise Array Allocation in SeekTimeDriver
+
+## Focus Area
+DOM Rendering Pipeline - Frame Capture Loop Hot Path in `SeekTimeDriver.ts`
+
+## Background Research
+In `SeekTimeDriver.setTime()`, when there are multiple execution contexts (e.g., iframes), we allocate an array of Promises and return `Promise.all(promises)`. The caller in `CaptureLoop.ts` does not await this promise (`timeDriver.setTime(page, compositionTimeInSeconds).then(undefined, noopCatch);`).
+
+Because the promise is unobserved except for error catching, allocating `Promise.all()` wrapper and assigning array elements inside the hot loop adds unnecessary GC overhead. This was explored in PERF-312 and PERF-318, but the implementation spec of PERF-318 includes inline anonymous object allocation inside the CDP send loop: `{ expression: expression, contextId: this.executionContextIds[i], awaitPromise: true }`.
+
+To maximize GC reduction, we can combine avoiding `Promise.all()` with preallocating the evaluation parameters object. The `evaluateParams` for multiple contexts can just reuse a single parameter object or be simplified, but since it's an asynchronous send, a preallocated array of parameter objects during `prepare()` is best. Actually, since CDP serialization reads the object synchronously before sending, we can mutate a single shared object during the loop and send it, avoiding even an array of parameter objects! Wait, mutating a single object inside a loop of async sends is safe as long as the CDP client serializes synchronously. Playwright does serialize synchronously. We can reuse `this.evaluateParams`.
+
+## Benchmark Configuration
+- **Composition URL**: `http://localhost:3000/composition.html`
+- **Render Settings**: Baseline identical settings across all runs, dom mode
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~51.645s
+- **Bottleneck analysis**: Cost of executing array allocation and `Promise.all` in the hot loop when the promise is unused by the `CaptureLoop.ts` caller.
+
+## Implementation Spec
+
+### Step 1: Attach catch handlers inline and avoid Promise.all()
+**File**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+**What to change**:
+In the `setTime` method:
+
+```typescript
+<<<<<<< SEARCH
+  setTime(page: Page, timeInSeconds: number): Promise<void> {
+    const frames = this.cachedFrames;
+
+    if (frames.length === 1) {
+      this.evaluateParams.expression = 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')';
+      return this.cdpSession!.send('Runtime.evaluate', this.evaluateParams) as Promise<any>;
+    }
+
+    const promises = this.cachedPromises;
+    const expression = 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')';
+
+    for (let i = 0; i < this.executionContextIds.length; i++) {
+      promises[i] = this.cdpSession!.send('Runtime.evaluate', {
+        expression: expression,
+        contextId: this.executionContextIds[i],
+        awaitPromise: true
+      });
+    }
+
+    return Promise.all(promises) as unknown as Promise<void>;
+  }
+=======
+  setTime(page: Page, timeInSeconds: number): Promise<void> {
+    const frames = this.cachedFrames;
+
+    if (frames.length === 1) {
+      this.evaluateParams.expression = 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')';
+      this.evaluateParams.contextId = undefined; // Ensure contextId is removed for main frame
+      return this.cdpSession!.send('Runtime.evaluate', this.evaluateParams) as Promise<any>;
+    }
+
+    const expression = 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')';
+    this.evaluateParams.expression = expression;
+
+    for (let i = 0; i < this.executionContextIds.length; i++) {
+      this.evaluateParams.contextId = this.executionContextIds[i];
+      this.cdpSession!.send('Runtime.evaluate', this.evaluateParams).catch(() => {});
+    }
+
+    return Promise.resolve();
+  }
+>>>>>>> REPLACE
+```
+
+**Why**: By attaching a no-op catch handler immediately and avoiding `Promise.all()`, we stop allocating dynamic wrapper promises. Reusing `this.evaluateParams` stops inline object allocation completely.
+**Risk**: Playwright `cdpSession.send` might keep a reference to `evaluateParams`. Playwright serializes `evaluateParams` immediately to JSON for the CDP WebSocket, so mutating it synchronously inside the loop is safe. We also need to clear `contextId` on the single-frame path to ensure it doesn't try to use an old `contextId` if it was somehow set before.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+None needed. SeekTimeDriver is for DOM mode.
+
+## Correctness Check
+Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to ensure it still runs correctly.
+
+## Prior Art
+- PERF-312, PERF-318 (Avoid seek promises allocation but had minor regressions or were left unexecuted, and didn't remove parameter object allocations).

--- a/.sys/plans/PERF-321-prebind-worker-blocked-executor.md
+++ b/.sys/plans/PERF-321-prebind-worker-blocked-executor.md
@@ -1,0 +1,82 @@
+---
+id: PERF-321
+slug: prebind-worker-blocked-executor
+status: unclaimed
+claimed_by: ""
+created: 2024-05-27
+completed: ""
+result: ""
+---
+
+# PERF-321: Prebind Worker Blocked Promise Executors in CaptureLoop
+
+## Focus Area
+DOM Rendering Pipeline - Frame Capture Loop Hot Path in `CaptureLoop.ts`
+
+## Background Research
+In `packages/renderer/src/core/CaptureLoop.ts`, the actor model pipeline utilizes an array of resolvers `workerBlockedResolves` to block workers when the pipeline is full or waiting for a frame.
+
+Currently, when a worker gets blocked due to backpressure, it performs a dynamic Promise and closure allocation inside the hot loop:
+
+```typescript
+                i = await new Promise<number>(resolve => {
+                    workerBlockedResolves[workerIndex] = resolve;
+                });
+```
+
+Because `runWorker` is a hot loop processing thousands of frames, and pipeline backpressure frequently blocks and unblocks workers depending on FFmpeg's read speed or CDP strategy variations, this dynamic promise executor closure allocation creates continuous garbage collection pressure. V8 must allocate the closure, and once resolved, garbage collect it.
+
+We can optimize this by preallocating the executor closures for each worker once outside the loop.
+
+## Benchmark Configuration
+- **Composition URL**: `http://localhost:3000/composition.html`
+- **Render Settings**: Baseline identical settings across all runs, dom mode
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: 45.854s
+- **Bottleneck analysis**: The cost of executing dynamic closure allocation in the hot loop when a worker gets blocked due to backpressure.
+
+## Implementation Spec
+
+### Step 1: Prebind promise resolve executors
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In `CaptureLoop.ts`, replace the inline closure allocation for the blocked worker promise.
+Before `const runWorker = async (worker: WorkerInfo, workerIndex: number) => {`, add:
+
+```typescript
+    const workerBlockedExecutors = new Array(poolLen);
+    for (let w = 0; w < poolLen; w++) {
+        workerBlockedExecutors[w] = (resolve: (i: number) => void) => {
+            workerBlockedResolves[w] = resolve;
+        };
+    }
+```
+
+Then in the loop, change:
+<<<<<<< SEARCH
+            } else {
+                i = await new Promise<number>(resolve => {
+                    workerBlockedResolves[workerIndex] = resolve;
+                });
+            }
+=======
+            } else {
+                i = await new Promise<number>(workerBlockedExecutors[workerIndex]);
+            }
+>>>>>>> REPLACE
+
+**Why**: By pre-allocating the promise executor function, we prevent dynamic closure memory allocation every time a worker blocks. V8's GC does not need to collect the closure each block cycle.
+**Risk**: Minimal. The logic is functionally identical.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+None.
+
+## Correctness Check
+Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to ensure the DOM strategy logic runs. Note that `CaptureLoop.ts` logic can only be fully tested using `npm test -w packages/renderer`, but since it times out, verify using targeted DOM capture tests.


### PR DESCRIPTION
📋 RENDERER: Prebind Worker Blocked Promise Executors in CaptureLoop

💡 **What**: Pre-bind promise executor functions for blocked workers in `CaptureLoop.ts`.
🎯 **Why**: Eliminates dynamic closure and promise allocations in the core actor model loop, reducing V8 GC overhead under heavy backpressure.
🔬 **Approach**: Create an array of statically allocated executor closures and reuse them.
📎 **Plan**: `/.sys/plans/PERF-321-prebind-worker-blocked-executor.md`

---
*PR created automatically by Jules for task [10064981381732959132](https://jules.google.com/task/10064981381732959132) started by @BintzGavin*