### PR TITLE
✨ RENDERER: Prebind Worker Blocked Promise Executors in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-321-prebind-worker-blocked-executor.md
+++ b/.sys/plans/PERF-321-prebind-worker-blocked-executor.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-321
 slug: prebind-worker-blocked-executor
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-27
-completed: ""
-result: ""
+completed: "2024-05-27"
+result: "keep"
 ---
 
 # PERF-321: Prebind Worker Blocked Promise Executors in CaptureLoop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,6 +1,7 @@
 ## Performance Trajectory
-Current best: 47.554s (baseline was 61.877s, -23.1%)
-Last updated by: PERF-303
+Current best: 45.321s (baseline was 47.554s, -4.7%)
+Last updated by: PERF-321
+
 
 ## What Doesn't Work (and Why)
 
@@ -27,6 +28,7 @@ Last updated by: PERF-303
 - **PERF-296**: Replaced object mutation with inline object allocation in the hot loops of `SeekTimeDriver.ts` and `DomStrategy.ts`. The median render time worsened to ~48.743s compared to the baseline of ~47.232s. This indicates that creating new object literals inside the hot loop adds more overhead than the write barriers caused by mutating the long-lived properties. Discarded as slower.
 
 ## What Works
+- **PERF-321**: Prebound the promise resolve executors for `workerBlockedResolves` in `CaptureLoop.ts` outside the hot loop. This avoids dynamic closure memory allocation during backpressure events when workers wait. Render times improved compared to the baseline (45.321s vs 47.554s). Kept.
 ## PERF-308: Cache Media Synchronization Promises in SeekTimeDriver
 - Render time: 46.939s (Baseline: 47.147s)
 - Status: keep

--- a/packages/renderer/.sys/perf-results-PERF-321.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-321.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	45.321	300	6.62	450.0	keep	Prebind Worker Blocked Promise Executors in CaptureLoop

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -181,6 +181,13 @@ export class CaptureLoop {
     };
 
 
+    const workerBlockedExecutors = new Array(poolLen);
+    for (let w = 0; w < poolLen; w++) {
+        workerBlockedExecutors[w] = (resolve: (i: number) => void) => {
+            workerBlockedResolves[w] = resolve;
+        };
+    }
+
     const runWorker = async (worker: WorkerInfo, workerIndex: number) => {
         const { timeDriver, strategy, page } = worker;
 
@@ -205,9 +212,7 @@ export class CaptureLoop {
                     fRes();
                 }
             } else {
-                i = await new Promise<number>(resolve => {
-                    workerBlockedResolves[workerIndex] = resolve;
-                });
+                i = await new Promise<number>(workerBlockedExecutors[workerIndex]);
             }
 
             if (i === -1) break;


### PR DESCRIPTION
✨ RENDERER: Prebind Worker Blocked Promise Executors in CaptureLoop

💡 What: Pre-allocated the `workerBlockedExecutors` array outside the hot loop in `CaptureLoop.ts` to statically bind the promise `resolve` functions.
🎯 Why: To eliminate dynamic closure allocation (`resolve => { ... }`) during worker backpressure events, reducing garbage collection pressure inside the main actor loop.
📊 Impact: Render times improved compared to the baseline (45.321s vs 47.554s, -4.7%).
🔬 Verification: Passed TypeScript compilation, DOM capture verification, and Canvas strategy smoke tests. Benchmark executed and documented.
📎 Plan: `.sys/plans/PERF-321-prebind-worker-blocked-executor.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	45.321	300	6.62	450.0	keep	Prebind Worker Blocked Promise Executors in CaptureLoop
```

---
*PR created automatically by Jules for task [11558578409739458733](https://jules.google.com/task/11558578409739458733) started by @BintzGavin*