### PR TITLE
✨ RENDERER: Inline contextRing object properties into parallel arrays

### DIFF
--- a/.sys/perf-results-PERF-325.tsv
+++ b/.sys/perf-results-PERF-325.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	39.669	300	7.56	38.6	keep	inline-context-ring
+2	39.521	300	7.59	39.1	keep	inline-context-ring
+3	39.812	300	7.54	38.3	keep	inline-context-ring

--- a/.sys/plans/PERF-325-inline-context-ring.md
+++ b/.sys/plans/PERF-325-inline-context-ring.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-325
 slug: inline-context-ring
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-04-21
-completed: ""
-result: ""
+completed: "2024-04-21"
+result: " ## Results Summary | run | render_time_s | frames | fps_effective | peak_mem_mb | status | description | |-----|---------------|--------|---------------|-------------|--------|-------------| | 1 | 39.669 | 300 | 7.56 | 38.6 | keep | inline-context-ring | | 2 | 39.521 | 300 | 7.59 | 39.1 | keep | inline-context-ring | | 3 | 39.812 | 300 | 7.54 | 38.3 | keep | inline-context-ring |"
 ---
 
 # PERF-325: Inline Context Ring Arrays in CaptureLoop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -317,3 +317,8 @@ Last updated by: PERF-321
 - Render time: 39.997s (Baseline: 45.321s)
 - Status: keep
 - **PERF-323**: Changed TimeDriver and SeekTimeDriver interface to allow returning void to eliminate unobserved Promise allocations overhead. Kept.
+
+## PERF-325: Inline contextRing
+- Render time: 39.669s (Baseline: ~39.6s)
+- Status: keep
+- **PERF-325**: Inlined the `contextRing` object properties into parallel arrays (`resolveRing` and `rejectRing`) in `CaptureLoop.ts`. This structurally flattens the capture pipeline resolution arrays and removes object shape creation in the hot path. Render time remained effectively identical to baseline (median 39.669s vs 39.6s) but simplified the code layout. Kept.

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -104,19 +104,14 @@ export class CaptureLoop {
     const onProgress = this.jobOptions?.onProgress;
 
     const framePromises = new Array<Promise<Buffer | string>>(maxPipelineDepth);
-    const contextRing = new Array(maxPipelineDepth);
+    const resolveRing = new Array<((b: Buffer | string) => void) | null>(maxPipelineDepth).fill(null);
+    const rejectRing = new Array<((e: any) => void) | null>(maxPipelineDepth).fill(null);
     const framePromiseExecutors = new Array(maxPipelineDepth);
 
     for (let i = 0; i < maxPipelineDepth; i++) {
         framePromiseExecutors[i] = (res: (b: Buffer | string) => void, rej: (e: any) => void) => {
-            contextRing[i].resolve = res;
-            contextRing[i].reject = rej;
-        };
-        contextRing[i] = {
-            resolve: null as ((b: Buffer | string) => void) | null,
-            reject: null as ((e: any) => void) | null,
-            time: 0,
-            compositionTimeInSeconds: 0
+            resolveRing[i] = res;
+            rejectRing[i] = rej;
         };
     }
 
@@ -220,7 +215,6 @@ export class CaptureLoop {
             const compositionTimeInSeconds = (this.startFrame + i) * compTimeStep;
 
             const ringIndex = i & ringMask;
-            const ctx = contextRing[ringIndex];
 
             try {
                 const timePromise = timeDriver.setTime(page, compositionTimeInSeconds);
@@ -228,9 +222,9 @@ export class CaptureLoop {
                     timePromise.catch(noopCatch);
                 }
                 const buffer = await strategy.capture(page, time);
-                if (ctx.resolve) ctx.resolve(buffer);
+                if (resolveRing[ringIndex]) resolveRing[ringIndex]!(buffer);
             } catch (e) {
-                if (ctx.reject) ctx.reject(e);
+                if (rejectRing[ringIndex]) rejectRing[ringIndex]!(e);
             }
         }
     };


### PR DESCRIPTION
💡 **What**: Executed PERF-325 to inline `contextRing` into parallel arrays `resolveRing` and `rejectRing`.
🎯 **Why**: To remove object allocation and shape checking within the worker hot loop in `CaptureLoop.ts`.
📊 **Impact**: Render time remained functionally identical to baseline (median 39.669s vs 39.6s) but structural simplification removes unnecessary object property creation. Kept.
🔬 **Verification**: 4-gate verification completed. Build passed, `verify-canvas-strategy.ts` and `verify-dom-strategy-capture.ts` passed successfully.
📎 **Plan**: `/.sys/plans/PERF-325-inline-context-ring.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	39.669	300	7.56	38.6	keep	inline-context-ring
2	39.521	300	7.59	39.1	keep	inline-context-ring
3	39.812	300	7.54	38.3	keep	inline-context-ring
```

---
*PR created automatically by Jules for task [1394983936521465106](https://jules.google.com/task/1394983936521465106) started by @BintzGavin*