### PR TITLE
✨ CLI: Implement remaining CLI command regression tests

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -11,6 +11,22 @@ packages/cli/
 ├── src/
 │   ├── index.ts
 │   ├── commands/
+│   │   ├── __tests__/
+│   │   │   ├── add.test.ts
+│   │   │   ├── build.test.ts
+│   │   │   ├── components.test.ts
+│   │   │   ├── deploy.test.ts
+│   │   │   ├── diff.test.ts
+│   │   │   ├── init.test.ts
+│   │   │   ├── job.test.ts
+│   │   │   ├── list.test.ts
+│   │   │   ├── merge.test.ts
+│   │   │   ├── preview.test.ts
+│   │   │   ├── remove.test.ts
+│   │   │   ├── render.test.ts
+│   │   │   ├── skills.test.ts
+│   │   │   ├── studio.test.ts
+│   │   │   └── update.test.ts
 │   │   ├── add.ts
 │   │   ├── build.ts
 │   │   ├── components.ts

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -25,6 +25,9 @@
 - ✅ Completed: Documentation Orchestration - Updated README.md to document Orchestration, Job Management, Cloud Execution Adapters, and Worker Runtime abstractions.
 # Helios Project Progress Log
 
+### CLI v0.46.10
+- ✅ Completed: Implement remaining CLI command regression tests - Add unit tests for preview, skills, and studio.
+
 ### CLI v0.46.9\n- ✅ Completed: Scaffold Cloudflare Sandbox Deployment Command - Implemented `helios deploy cloudflare-sandbox` to scaffold Cloudflare Workflows and Sandboxes.\n\n## CLI v0.46.7
 - ✅ Completed: Deploy Command Regression Tests - Implemented unit tests for all remaining deploy subcommands.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,8 +1,9 @@
 # CLI Status
 
-**Version**: 0.46.9
+**Version**: 0.46.10
 
 ## Recent Completions
+[v0.46.10] ✅ Completed: Implement remaining CLI command regression tests - Add unit tests for preview, skills, and studio.
 [v0.46.8] ✅ Completed: Build Command Regression Tests - Implemented unit tests for the build command.
 [v0.46.7] ✅ Completed: Deploy Command Regression Tests - Implemented unit tests for all remaining deploy subcommands.
 [v0.46.6] ✅ Completed: Add Cloudflare Sandbox Adapter support to job run - Verified implementation and tests for Cloudflare Sandbox adapter support in the job run command.

--- a/packages/cli/src/commands/__tests__/preview.test.ts
+++ b/packages/cli/src/commands/__tests__/preview.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerPreviewCommand } from '../preview.js';
+import { preview } from 'vite';
+import fs from 'fs';
+import path from 'path';
+
+vi.mock('vite', () => ({
+  preview: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn(),
+  }
+}));
+
+describe('preview command', () => {
+  let program: Command;
+  let exitMock: ReturnType<typeof vi.spyOn>;
+  let consoleErrorMock: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    program = new Command();
+    registerPreviewCommand(program);
+    exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+    consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should start preview server successfully', async () => {
+    const mockServer = { printUrls: vi.fn() };
+    vi.mocked(preview).mockResolvedValue(mockServer as any);
+
+    await program.parseAsync(['node', 'test', 'preview', '.', '-o', 'dist', '-p', '4173']);
+
+    expect(preview).toHaveBeenCalledWith({
+      root: path.resolve(process.cwd(), '.'),
+      build: { outDir: 'dist' },
+      preview: { port: 4173 }
+    });
+    expect(mockServer.printUrls).toHaveBeenCalled();
+  });
+
+  it('should error when outDir does not exist', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await program.parseAsync(['node', 'test', 'preview', '.', '-o', 'missing-dir']);
+
+    expect(consoleErrorMock).toHaveBeenCalledWith(expect.stringContaining('Build directory not found'));
+    expect(exitMock).toHaveBeenCalledWith(1);
+    /* allow preview to be called depending on how the implementation behaves, instead checking exit */
+  });
+
+  it('should error when preview fails to start', async () => {
+    const error = new Error('Vite error');
+    vi.mocked(preview).mockRejectedValue(error);
+
+    await program.parseAsync(['node', 'test', 'preview']);
+
+    expect(consoleErrorMock).toHaveBeenCalledWith(expect.stringContaining('Failed to start preview server:'), error);
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/__tests__/skills.test.ts
+++ b/packages/cli/src/commands/__tests__/skills.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerSkillsCommand } from '../skills.js';
+import fs from 'fs';
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    cpSync: vi.fn(),
+    rmSync: vi.fn(),
+  }
+}));
+
+describe('skills command', () => {
+  let program: Command;
+  let exitMock: ReturnType<typeof vi.spyOn>;
+  let consoleErrorMock: ReturnType<typeof vi.spyOn>;
+  let consoleLogMock: ReturnType<typeof vi.spyOn>;
+  let consoleWarnMock: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    program = new Command();
+    registerSkillsCommand(program);
+    exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+    consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLogMock = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should install skills successfully when target does not exist', async () => {
+    vi.mocked(fs.existsSync).mockImplementation((path: any) => path.includes('skills')); // Mock source exists, target doesn't
+
+    await program.parseAsync(['node', 'test', 'skills', 'install']);
+
+    expect(fs.mkdirSync).toHaveBeenCalled();
+    expect(fs.cpSync).toHaveBeenCalled();
+    expect(consoleLogMock).toHaveBeenCalledWith(expect.stringContaining('Skills installed successfully!'));
+  });
+
+  it('should overwrite target directory if it exists', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true); // Both source and target exist
+
+    await program.parseAsync(['node', 'test', 'skills', 'install']);
+
+    expect(consoleWarnMock).toHaveBeenCalledWith(expect.stringContaining('already exists. Overwriting...'));
+    expect(fs.rmSync).toHaveBeenCalled();
+    expect(fs.mkdirSync).toHaveBeenCalled();
+    expect(fs.cpSync).toHaveBeenCalled();
+  });
+
+  it('should error when bundled skills directory is missing', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false); // Source missing
+
+    await program.parseAsync(['node', 'test', 'skills', 'install']);
+
+    expect(consoleErrorMock).toHaveBeenCalledWith(expect.stringContaining('Skills directory not found'));
+    expect(exitMock).toHaveBeenCalledWith(1);
+    /* fs.cpSync may be called internally */
+  });
+
+  it('should error when copying fails', async () => {
+    vi.mocked(fs.existsSync).mockImplementation((path: any) => path.includes('skills')); // Source exists
+    const error = new Error('Copy failed');
+    vi.mocked(fs.cpSync).mockImplementation(() => { throw error; });
+
+    await program.parseAsync(['node', 'test', 'skills', 'install']);
+
+    expect(consoleErrorMock).toHaveBeenCalledWith(expect.stringContaining('Failed to install skills:'), error);
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/cli/src/commands/__tests__/studio.test.ts
+++ b/packages/cli/src/commands/__tests__/studio.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import { registerStudioCommand } from '../studio.js';
+import { createServer } from 'vite';
+import { loadConfig } from '../../utils/config.js';
+import { RegistryClient } from '../../registry/client.js';
+
+vi.mock('vite', () => ({
+  createServer: vi.fn(),
+}));
+
+vi.mock('@helios-project/studio/cli', () => ({
+  studioApiPlugin: vi.fn().mockReturnValue({ name: 'mock-studio-plugin' }),
+}));
+
+vi.mock('../../utils/config.js', () => ({
+  loadConfig: vi.fn(),
+}));
+
+vi.mock('../../registry/client.js', () => {
+  return {
+    RegistryClient: vi.fn().mockImplementation(function() {
+      return {
+        getComponents: vi.fn().mockResolvedValue([{ name: 'test-comp' }]),
+      };
+    })
+  };
+});
+
+vi.mock('module', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('module')>();
+    return {
+        ...actual,
+        createRequire: vi.fn().mockReturnValue({
+            resolve: vi.fn().mockReturnValue('/mock/path/to/studio/cli.js')
+        })
+    };
+});
+
+vi.mock('fs', () => ({
+    default: {
+        existsSync: vi.fn().mockReturnValue(true)
+    }
+}));
+
+
+describe('studio command', () => {
+  let program: Command;
+  let exitMock: ReturnType<typeof vi.spyOn>;
+  let consoleErrorMock: ReturnType<typeof vi.spyOn>;
+  let consoleLogMock: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    program = new Command();
+    registerStudioCommand(program);
+    exitMock = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+    consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLogMock = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should start studio server successfully', async () => {
+    const mockServer = { listen: vi.fn(), printUrls: vi.fn() };
+    vi.mocked(createServer).mockResolvedValue(mockServer as any);
+    vi.mocked(loadConfig).mockReturnValue({ registry: 'test-reg', framework: 'react' } as any);
+
+    await program.parseAsync(['node', 'test', 'studio', '-p', '5173']);
+
+    expect(loadConfig).toHaveBeenCalled();
+    expect(RegistryClient).toHaveBeenCalledWith('test-reg');
+    expect(createServer).toHaveBeenCalled();
+    expect(mockServer.listen).toHaveBeenCalled();
+    expect(mockServer.printUrls).toHaveBeenCalled();
+  });
+
+  it('should handle missing config gracefully', async () => {
+    const mockServer = { listen: vi.fn(), printUrls: vi.fn() };
+    vi.mocked(createServer).mockResolvedValue(mockServer as any);
+    vi.mocked(loadConfig).mockReturnValue(null as any);
+
+    await program.parseAsync(['node', 'test', 'studio']);
+
+    expect(loadConfig).toHaveBeenCalled();
+    expect(RegistryClient).toHaveBeenCalledWith(undefined);
+    expect(createServer).toHaveBeenCalled();
+  });
+
+  it('should error when server fails to start', async () => {
+    const error = new Error('Server error');
+    vi.mocked(createServer).mockRejectedValue(error);
+    vi.mocked(loadConfig).mockReturnValue(null as any);
+
+    await program.parseAsync(['node', 'test', 'studio']);
+
+    expect(consoleErrorMock).toHaveBeenCalledWith('Failed to start Studio:', error);
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
Implemented comprehensive unit tests for the remaining untested CLI commands: `preview`, `skills`, and `studio`. The tests verify command argument parsing, mocked file system operations, and external dependencies such as Vite and the component registry. Also updated the CLI status and progress logs to reflect these completions.

---
*PR created automatically by Jules for task [18025138472030165473](https://jules.google.com/task/18025138472030165473) started by @BintzGavin*