### PR TITLE
✨ RENDERER: Discard PERF-339 (prebind waiter executors)

### DIFF
--- a/.sys/plans/PERF-339-prebind-captureloop-waiter-executors.md
+++ b/.sys/plans/PERF-339-prebind-captureloop-waiter-executors.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-339
 slug: prebind-captureloop-waiter-executors
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-24
 completed: ""
-result: ""
+result: "discard"
 ---
 
 # PERF-339: Prebind CaptureLoop Waiter Executors

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -8,6 +8,11 @@ Last updated by: PERF-321
 
 ## What Doesn't Work (and Why)
 
+## PERF-339: Prebind CaptureLoop Waiter Executors
+- Render time: 47.362s (Baseline: ~47.5s)
+- Status: discard
+- **PERF-339**: Attempted to prebind the `writerWaiterExecutor` and `frameWaiterExecutor` closures in `CaptureLoop.ts` to reduce dynamic allocation overhead during backpressure synchronization, mitigating V8 GC churn. However, performance remained basically the same (47.362s vs 47.5s), well within the margin of noise, indicating that the V8 optimization is already good enough for these short lived promises. Discarded to maintain code simplicity.
+
 ## PERF-336: Promise-Free Frame Ring Executor
 - Render time: 47.419s (Baseline: 46.581s)
 - Status: inconclusive

--- a/packages/renderer/.sys/perf-results-PERF-339.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-339.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	46.937	600	12.78	41.3	discard	prebind waiter executors
+2	47.362	600	12.67	44.9	discard	prebind waiter executors
+3	47.504	600	12.63	41.4	discard	prebind waiter executors


### PR DESCRIPTION
Discarded PERF-339 to maintain code simplicity as the performance difference was negligible.

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	46.937	600	12.78	41.3	discard	prebind waiter executors
2	47.362	600	12.67	44.9	discard	prebind waiter executors
3	47.504	600	12.63	41.4	discard	prebind waiter executors
```

---
*PR created automatically by Jules for task [12233358799296169096](https://jules.google.com/task/12233358799296169096) started by @BintzGavin*