### PR TITLE
✨ RENDERER: Evaluate PERF-344: Eliminate Promise.race Array Allocation in SeekTimeDriver

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -117,3 +117,6 @@ The Renderer constructs FFmpeg commands dynamically using `FFmpegBuilder`.
 
 - Preallocated `multiFrameEvaluateParams` in `SeekTimeDriver.ts` (PERF-334) to avoid inline GC overhead.
 - PERF-343: Eliminated `Promise.race` and array allocation in `CdpTimeDriver.setTime` stability check by pre-binding executors, improving render time by ~12% (49.437s).
+
+### Recent Work
+- **PERF-344**: Evaluated manual Promise resolution to eliminate Promise.race array and wrapper allocation in `SeekTimeDriver.ts`. Discarded as performance gains were negligible (within the noise margin) compared to the logic complexity it introduced.

--- a/.sys/perf-results-PERF-344.tsv
+++ b/.sys/perf-results-PERF-344.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	47.183	600	12.72	41.4	discard	eliminate promiserace array allocation in SeekTimeDriver (within noise margin, negligible improvement)

--- a/.sys/plans/PERF-344-eliminate-promiserace-in-seektimedriver.md
+++ b/.sys/plans/PERF-344-eliminate-promiserace-in-seektimedriver.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-344
 slug: eliminate-promiserace-in-seektimedriver
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2025-02-23
 completed: ""
@@ -72,3 +72,7 @@ Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts`
 
 ## Prior Art
 - PERF-343 (Eliminate Promise.race Array Allocation in CdpTimeDriver)
+## Results Summary
+| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
+|---|---|---|---|---|---|---|
+| 1 | 47.183 | 600 | 12.72 | 41.4 | discard | eliminate promiserace array allocation in SeekTimeDriver (within noise margin, negligible improvement) |

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -544,3 +544,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### Completed
 - `packages/renderer`: **PERF-334** Preallocated `multiFrameEvaluateParams` in `SeekTimeDriver.ts` to reduce GC churn and improve headless CPU performance.
+
+### 2026-04-23
+- **Renderer**: Evaluated PERF-344 (Eliminate Promise.race Array Allocation in SeekTimeDriver). The performance gains were negligible (within the noise margin) compared to the logic complexity it introduced, so the optimization was discarded.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -8,6 +8,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- PERF-344: Eliminate Promise.race Array Allocation in SeekTimeDriver. Attempted to eliminate Promise.race array and closure allocations inside the `window.__helios_seek` script. The performance gains were negligible (~47.18s vs ~47.00s baseline, within noise margin). V8 optimizes these short-lived closures and arrays efficiently in the renderer process, so manual Promise resolution isn't worth the logic complexity.
+
 
 ## PERF-339: Prebind CaptureLoop Waiter Executors
 - Render time: 47.362s (Baseline: ~47.5s)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14024,7 +14024,7 @@
     },
     "packages/renderer": {
       "name": "@helios-project/renderer",
-      "version": "1.78.2",
+      "version": "1.78.3",
       "license": "ELv2",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/renderer",
-  "version": "1.78.2",
+  "version": "1.78.3",
   "description": "Renderer for Helios video engine.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",


### PR DESCRIPTION
💡 **What**: The experiment evaluated eliminating `Promise.race` array and wrapper allocations in `SeekTimeDriver.ts`. Discarded as the gains were negligible.
🎯 **Why**: To target V8 GC overhead in the `window.__helios_seek` browser execution context.
📊 **Impact**: The performance gains were negligible (~47.18s vs ~47.0s baseline), within the noise margin.
🔬 **Verification**: Code compilation and test suite ran. Benchmark data recorded. Discarded the changes as it isn't worth the complexity.
📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-344-eliminate-promiserace-in-seektimedriver.md`)

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 47.183 | 600 | 12.72 | 41.4 | discard | eliminate promiserace array allocation in SeekTimeDriver (within noise margin, negligible improvement) |

---
*PR created automatically by Jules for task [2796777964037254835](https://jules.google.com/task/2796777964037254835) started by @BintzGavin*