### PR TITLE
✨ RENDERER: Record results for PERF-345 eliminate async capture

### DIFF
--- a/.sys/plans/PERF-345-eliminate-capture-await.md
+++ b/.sys/plans/PERF-345-eliminate-capture-await.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-345
 slug: eliminate-capture-await
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-18
-completed: ""
-result: ""
+completed: "2024-05-18"
+result: "no-improvement"
 ---
 
 # PERF-345: Eliminate `async`/`await` overhead in `DomStrategy.capture()`
@@ -100,3 +100,9 @@ Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts`
 ## Prior Art
 - PERF-277 initially used `await` over `.then()` but didn't combine it with pre-bound closures.
 - Pre-binding executor handlers (e.g., PERF-324, PERF-343) consistently improves GC pressure and render times.
+
+## Results Summary
+- **Best render time**: 46.805s (vs baseline 47.013s)
+- **Improvement**: ~0.4% (inconclusive, within noise margin)
+- **Kept experiments**: none
+- **Discarded experiments**: Eliminate `async`/`await` generator overhead in single-frame `capture()`.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -8,6 +8,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **Eliminating `async`/`await` in `DomStrategy.capture()`**: Refactored `capture` to return a `Promise` directly instead of using `async`/`await` to avoid generator overhead in the hot loop. The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP. Discarded to maintain code simplicity. (PERF-345)
+
 - PERF-344: Eliminate Promise.race Array Allocation in SeekTimeDriver. Attempted to eliminate Promise.race array and closure allocations inside the `window.__helios_seek` script. The performance gains were negligible (~47.18s vs ~47.00s baseline, within noise margin). V8 optimizes these short-lived closures and arrays efficiently in the renderer process, so manual Promise resolution isn't worth the logic complexity.
 
 
@@ -95,6 +97,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **Eliminating `async`/`await` in `DomStrategy.capture()`**: Refactored `capture` to return a `Promise` directly instead of using `async`/`await` to avoid generator overhead in the hot loop. The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP. Discarded to maintain code simplicity. (PERF-345)
+
 
 ## PERF-312: Avoid Promise.all() Allocation Overhead in SeekTimeDriver
 - Render time: 32.193s (Baseline: ~32.112s)
@@ -136,6 +140,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **Eliminating `async`/`await` in `DomStrategy.capture()`**: Refactored `capture` to return a `Promise` directly instead of using `async`/`await` to avoid generator overhead in the hot loop. The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP. Discarded to maintain code simplicity. (PERF-345)
+
 
 ## PERF-312: Avoid Promise.all() Allocation Overhead in SeekTimeDriver
 - Render time: 32.193s (Baseline: ~32.112s)
@@ -157,6 +163,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **Eliminating `async`/`await` in `DomStrategy.capture()`**: Refactored `capture` to return a `Promise` directly instead of using `async`/`await` to avoid generator overhead in the hot loop. The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP. Discarded to maintain code simplicity. (PERF-345)
+
 
 ## PERF-312: Avoid Promise.all() Allocation Overhead in SeekTimeDriver
 - Render time: 32.193s (Baseline: ~32.112s)
@@ -219,6 +227,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **Eliminating `async`/`await` in `DomStrategy.capture()`**: Refactored `capture` to return a `Promise` directly instead of using `async`/`await` to avoid generator overhead in the hot loop. The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP. Discarded to maintain code simplicity. (PERF-345)
+
 
 ## PERF-312: Avoid Promise.all() Allocation Overhead in SeekTimeDriver
 - Render time: 32.193s (Baseline: ~32.112s)

--- a/packages/renderer/.sys/perf-results-PERF-345.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-345.tsv
@@ -1,0 +1,5 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	47.013	600	12.76	42.8	keep	baseline (median of multiple runs: 58.379, 46.813, 48.648, 46.650, 47.013)
+2	46.805	600	12.82	41.6	discard	experiment run 1
+3	47.245	600	12.70	42.7	discard	experiment run 2
+4	46.433	600	12.92	41.6	discard	experiment run 3 (median: 46.805, inconclusive, noise margin)


### PR DESCRIPTION
💡 **What**: Refactored `DomStrategy.capture()` to return the raw `Promise` from CDP directly with a prebound `.then()` handler, instead of using the `async`/`await` generator pattern, to avoid dynamic closure allocation in the hot loop. The experiment was discarded.
🎯 **Why**: Attempted to micro-optimize V8 GC churn and generator overhead in the single-frame capture loop.
📊 **Impact**: The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). Since V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP, the code was reverted to maintain simplicity.
🔬 **Verification**: Code restored to baseline. Tests pass (`tests/verify-dom-strategy-capture.ts` and `tests/verify-canvas-strategy.ts`). 
📎 **Plan**: `/.sys/plans/PERF-345-eliminate-capture-await.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	47.013	600	12.76	42.8	keep	baseline (median of multiple runs: 58.379, 46.813, 48.648, 46.650, 47.013)
2	46.805	600	12.82	41.6	discard	experiment run 1
3	47.245	600	12.70	42.7	discard	experiment run 2
4	46.433	600	12.92	41.6	discard	experiment run 3 (median: 46.805, inconclusive, noise margin)
```

---
*PR created automatically by Jules for task [15025681280602389230](https://jules.google.com/task/15025681280602389230) started by @BintzGavin*