### PR TITLE
✨ RENDERER: Discard PERF-342

### DIFF
--- a/.sys/llmdocs/context-renderer.md
+++ b/.sys/llmdocs/context-renderer.md
@@ -120,3 +120,5 @@ The Renderer constructs FFmpeg commands dynamically using `FFmpegBuilder`.
 
 ### Recent Work
 - **PERF-344**: Evaluated manual Promise resolution to eliminate Promise.race array and wrapper allocation in `SeekTimeDriver.ts`. Discarded as performance gains were negligible (within the noise margin) compared to the logic complexity it introduced.
+
+- (PERF-342): Executed performance experiment: Prebind CaptureLoop Waiter Executors (Discarded).

--- a/.sys/plans/PERF-342-prebind-captureloop-waiters.md
+++ b/.sys/plans/PERF-342-prebind-captureloop-waiters.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-342
 slug: prebind-captureloop-waiters
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2024-05-24"
+result: "discarded"
 ---
 
 # PERF-342: Prebind CaptureLoop Waiter Executors
@@ -65,3 +65,9 @@ Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts`
 ## Prior Art
 - PERF-321 (Prebind worker blocked executor)
 - PERF-338 (Prebind stability timeout executor)
+
+## Results Summary
+- **Best render time**: 48.811s (vs baseline 46.939s)
+- **Improvement**: Regressed
+- **Kept experiments**: []
+- **Discarded experiments**: [Prebind captureloop waiter executors]

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -549,3 +549,5 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### 2026-04-23
 - **Renderer**: Evaluated PERF-344 (Eliminate Promise.race Array Allocation in SeekTimeDriver). The performance gains were negligible (within the noise margin) compared to the logic complexity it introduced, so the optimization was discarded.
+
+- (PERF-342): Executed performance experiment: Prebind CaptureLoop Waiter Executors (Discarded due to slight regression).

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -13,6 +13,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-342 (Prebind CaptureLoop Waiter Executors)**: Discarded. Prebinding `writerWaiterExecutor` and `frameWaiterExecutor` outside the run closure to avoid dynamic Promise allocation actually slightly regressed performance (48.811s vs 46.939s baseline), likely within noise margin, but indicates V8 optimizes these short-lived closures in tight loops well enough that the manual state management overhead is not worth it.
+
 - **Eliminating `async`/`await` in `DomStrategy.capture()`**: Refactored `capture` to return a `Promise` directly instead of using `async`/`await` to avoid generator overhead in the hot loop. The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP. Discarded to maintain code simplicity. (PERF-345)
 
 - PERF-344: Eliminate Promise.race Array Allocation in SeekTimeDriver. Attempted to eliminate Promise.race array and closure allocations inside the `window.__helios_seek` script. The performance gains were negligible (~47.18s vs ~47.00s baseline, within noise margin). V8 optimizes these short-lived closures and arrays efficiently in the renderer process, so manual Promise resolution isn't worth the logic complexity.
@@ -102,6 +104,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-342 (Prebind CaptureLoop Waiter Executors)**: Discarded. Prebinding `writerWaiterExecutor` and `frameWaiterExecutor` outside the run closure to avoid dynamic Promise allocation actually slightly regressed performance (48.811s vs 46.939s baseline), likely within noise margin, but indicates V8 optimizes these short-lived closures in tight loops well enough that the manual state management overhead is not worth it.
+
 - **Eliminating `async`/`await` in `DomStrategy.capture()`**: Refactored `capture` to return a `Promise` directly instead of using `async`/`await` to avoid generator overhead in the hot loop. The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP. Discarded to maintain code simplicity. (PERF-345)
 
 
@@ -145,6 +149,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-342 (Prebind CaptureLoop Waiter Executors)**: Discarded. Prebinding `writerWaiterExecutor` and `frameWaiterExecutor` outside the run closure to avoid dynamic Promise allocation actually slightly regressed performance (48.811s vs 46.939s baseline), likely within noise margin, but indicates V8 optimizes these short-lived closures in tight loops well enough that the manual state management overhead is not worth it.
+
 - **Eliminating `async`/`await` in `DomStrategy.capture()`**: Refactored `capture` to return a `Promise` directly instead of using `async`/`await` to avoid generator overhead in the hot loop. The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP. Discarded to maintain code simplicity. (PERF-345)
 
 
@@ -168,6 +174,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-342 (Prebind CaptureLoop Waiter Executors)**: Discarded. Prebinding `writerWaiterExecutor` and `frameWaiterExecutor` outside the run closure to avoid dynamic Promise allocation actually slightly regressed performance (48.811s vs 46.939s baseline), likely within noise margin, but indicates V8 optimizes these short-lived closures in tight loops well enough that the manual state management overhead is not worth it.
+
 - **Eliminating `async`/`await` in `DomStrategy.capture()`**: Refactored `capture` to return a `Promise` directly instead of using `async`/`await` to avoid generator overhead in the hot loop. The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP. Discarded to maintain code simplicity. (PERF-345)
 
 
@@ -232,6 +240,8 @@ Last updated by: PERF-321
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-342 (Prebind CaptureLoop Waiter Executors)**: Discarded. Prebinding `writerWaiterExecutor` and `frameWaiterExecutor` outside the run closure to avoid dynamic Promise allocation actually slightly regressed performance (48.811s vs 46.939s baseline), likely within noise margin, but indicates V8 optimizes these short-lived closures in tight loops well enough that the manual state management overhead is not worth it.
+
 - **Eliminating `async`/`await` in `DomStrategy.capture()`**: Refactored `capture` to return a `Promise` directly instead of using `async`/`await` to avoid generator overhead in the hot loop. The results were within the noise margin (baseline median: 47.013s, experiment median: 46.805s). V8 seems to optimize async/await overhead extremely well when the Promises are resolved quickly or natively by CDP. Discarded to maintain code simplicity. (PERF-345)
 
 

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -4,5 +4,5 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 3	49.280	600	12.18	42.0	keep	Removed formatResponse overhead
 4	48.141	600	12.46	43.2	keep	Removed formatResponse overhead
 5	47.147	600	12.73	41.6	keep	Removed formatResponse overhead
-
 6	46.939	600	12.78	43.3	keep	Cache Media Synchronization Promises in SeekTimeDriver
+7	48.811	600	12.29	36.2	discard	PERF-342: prebind captureloop waiters


### PR DESCRIPTION
💡 **What**: Executed PERF-342 to prebind `writerWaiterExecutor` and `frameWaiterExecutor` closures in `CaptureLoop.ts`. The changes were discarded as they regressed performance.
🎯 **Why**: To test if prebinding these closures could avoid dynamic Promise allocation and reduce GC overhead.
📊 **Impact**: Regression from 46.939s baseline to 48.811s. Code changes were reverted.
🔬 **Verification**: Compilation, DOM testing, and repeated DOM benchmark executions were verified.
📎 **Plan**: Reference `/.sys/plans/PERF-342-prebind-captureloop-waiters.md`.

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
7	48.811	600	12.29	36.2	discard	PERF-342: prebind captureloop waiters

---
*PR created automatically by Jules for task [17338995593882623311](https://jules.google.com/task/17338995593882623311) started by @BintzGavin*