### PR TITLE
✨ RENDERER: Discard PERF-358

### DIFF
--- a/.sys/plans/PERF-358-cdp-callfunctionon-seek-cache.md
+++ b/.sys/plans/PERF-358-cdp-callfunctionon-seek-cache.md
@@ -1,10 +1,10 @@
 ---
 id: PERF-358
 slug: cdp-callfunctionon-seek-cache
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-10-18
-completed: ""
+completed: "2026-10-18"
 result: ""
 ---
 
@@ -140,3 +140,8 @@ Run the DOM render benchmark script multiple times to verify median render time 
 ## Prior Art
 - `PERF-257` used `callFunctionOn` for stability checks but was discarded because it didn't improve over `page.evaluate` with a timeout node-side. However, this is for the hot loop `setTime` execution, which happens 60 times a second per worker.
 - `PERF-350` and `PERF-351` showed that inline object allocations for evaluate parameters were slower than mutating cached objects. The executor should mutate the cached `multiFrameEvaluateParams` array to avoid GC churn.
+
+## Results
+- **Baseline**: 47.727s median
+- **Experiment**: 47.843s median
+- **Outcome**: Discarded. V8 dynamic string parsing/compilation overhead for such a short string is completely offset by the JSON serialization overhead for `arguments: [{value: x}]` via CDP. Code was reverted.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -19,6 +19,11 @@ Last updated by: PERF-355
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+
+- **PERF-358: Replace `Runtime.evaluate` with `Runtime.callFunctionOn` in SeekTimeDriver**
+  - **What I tried:** Replacing dynamic string generation (`window.__helios_seek(${time})`) sent via `Runtime.evaluate` with a cached function declaration and mutated `arguments` array via `Runtime.callFunctionOn` on every single frame.
+  - **Why it didn't work:** V8 string concatenation for `window.__helios_seek(t)` combined with its dynamic compilation cache performs equivalently to allocating and parsing the inline `arguments: [{value: x}]` payload over CDP on every frame. Median baseline was ~47.727s, while median experiment was ~47.843s. The JSON serialization overhead of `arguments` arrays via CDP offsets the cost of compiling the 1-liner dynamic evaluation. Discarded to maintain code simplicity.
+
 - **PERF-292**: Attempted to remove redundant `Function.prototype.call` overhead on `formatResponse` in `CaptureLoop.ts`.
   - **WHY it didn't work**: The `formatResponse` logic itself was completely eliminated in a previous superseding experiment (PERF-303), moving the formatting extraction directly into the strategy's capture resolution. Replacing the call logic is now structurally obsolete, so the experiment was discarded without further modification.
 - **PERF-351**: Attempted to inline `multiFrameEvaluateParams` array and replace `Promise.race` allocation with a custom `Promise` inside `SeekTimeDriver.ts` and the injected `__helios_seek` script.

--- a/packages/renderer/.sys/perf-results-PERF-358.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-358.tsv
@@ -1,0 +1,8 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	47.708	600	12.58	37.2	discard	baseline
+2	47.868	600	12.53	33.2	discard	baseline
+3	47.727	600	12.57	43.8	discard	baseline
+4	47.937	600	12.52	35.1	discard	exp_mutate
+5	47.737	600	12.57	32.7	discard	exp2_preallocate
+6	49.677	600	12.08	36.6	discard	exp2_preallocate
+7	47.843	600	12.54	34.5	discard	exp2_preallocate


### PR DESCRIPTION
💡 **What**: Replaced `Runtime.evaluate` with `Runtime.callFunctionOn` in `SeekTimeDriver.ts`'s `setTime` loop. Experiment was discarded.
🎯 **Why**: Attempted to bypass V8 string parsing and compilation overhead that occurs when evaluating dynamic strings (`window.__helios_seek(...)`) on every rendering frame.
📊 **Impact**: The render time degraded slightly (Baseline Median: ~47.727s vs Experiment Median: ~47.843s). V8's compilation caching for small dynamic strings combined with the fast string concatenation performs equivalently or better than allocating and parsing the inline `arguments` array object required for `callFunctionOn` over CDP.
🔬 **Verification**: Code changes were completely reverted (`git restore`). Build passed (`npm run build`). Targeted test (`verify-dom-strategy-capture.ts`) passed successfully.
📎 **Plan**: `/.sys/plans/PERF-358-cdp-callfunctionon-seek-cache.md`

### Results Summary
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	47.708	600	12.58	37.2	discard	baseline
2	47.868	600	12.53	33.2	discard	baseline
3	47.727	600	12.57	43.8	discard	baseline
4	47.937	600	12.52	35.1	discard	exp_mutate
5	47.737	600	12.57	32.7	discard	exp2_preallocate
6	49.677	600	12.08	36.6	discard	exp2_preallocate
7	47.843	600	12.54	34.5	discard	exp2_preallocate
```

---
*PR created automatically by Jules for task [15703012345897934391](https://jules.google.com/task/15703012345897934391) started by @BintzGavin*