### PR TITLE
Discard PERF-357: Eliminate setTimeout in seek

### DIFF
--- a/.sys/plans/PERF-357-eliminate-settimeout-in-seek.md
+++ b/.sys/plans/PERF-357-eliminate-settimeout-in-seek.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-357
 slug: eliminate-settimeout-in-seek
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: "2026-04-25"
+result: "failed"
 ---
 
 # PERF-357: Eliminate setTimeout allocation in injected seek script

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -20,6 +20,11 @@ Last updated by: PERF-355
 
 ## What Doesn't Work (and Why)
 
+- **PERF-357: Eliminate setTimeout in injected seek script**
+  - **What I tried:** Attempted to remove `setTimeout` and custom `Promise.race` inside `SeekTimeDriver` injected `window.__helios_seek` function, and rely completely on Playwright's CDP `Runtime.evaluate` timeout (`awaitPromise: true`, `timeout: this.timeout`).
+  - **Why it didn't work:** Experiment median (~48.6s, excluding an extreme outlier) regressed slightly against baseline (~47.8s median in my tests), and `Runtime.evaluate` timeout caused CDP stability issues with some runs resulting in higher variance. The overhead of setting `setTimeout` inside Chrome's V8 is actually very optimized, while mutating CDP parameters adds slight overhead. Discarded as inconclusive/slower.
+
+
 - **PERF-358: Replace `Runtime.evaluate` with `Runtime.callFunctionOn` in SeekTimeDriver**
   - **What I tried:** Replacing dynamic string generation (`window.__helios_seek(${time})`) sent via `Runtime.evaluate` with a cached function declaration and mutated `arguments` array via `Runtime.callFunctionOn` on every single frame.
   - **Why it didn't work:** V8 string concatenation for `window.__helios_seek(t)` combined with its dynamic compilation cache performs equivalently to allocating and parsing the inline `arguments: [{value: x}]` payload over CDP on every frame. Median baseline was ~47.727s, while median experiment was ~47.843s. The JSON serialization overhead of `arguments` arrays via CDP offsets the cost of compiling the 1-liner dynamic evaluation. Discarded to maintain code simplicity.

--- a/docs/status/RENDERER.md
+++ b/docs/status/RENDERER.md
@@ -1,4 +1,4 @@
-**Version**: 1.80.0
+**Version**: 1.80.1
 
 **Posture**: MAINTENANCE WITH V2 EXPANSION
 


### PR DESCRIPTION
- Evaluated `PERF-357` to eliminate `setTimeout` allocations in `SeekTimeDriver.ts`.
- Benchmarked the change and determined it introduced a slight performance regression and increased variance compared to the baseline.
- Discarded the code changes to maintain current optimal performance.
- Documented the failure in `docs/status/RENDERER-EXPERIMENTS.md` to prevent future redundant attempts.
- Updated the plan `.sys/plans/PERF-357-eliminate-settimeout-in-seek.md` to marked as failed.
- Bumped `RENDERER.md` version patch string.

---
*PR created automatically by Jules for task [1448452036447963414](https://jules.google.com/task/1448452036447963414) started by @BintzGavin*