### PR TITLE
✨ RENDERER: Evaluate inline multiframe params (PERF-359)

### DIFF
--- a/.sys/plans/PERF-359-inline-multiframe-params.md
+++ b/.sys/plans/PERF-359-inline-multiframe-params.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-359
 slug: inline-multiframe-params
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-04-25
-completed: ""
-result: ""
+completed: "2024-04-26"
+result: "discarded"
 ---
 
 # PERF-359: Inline multi-frame `Runtime.evaluate` array params
@@ -103,3 +103,15 @@ Run the DOM render benchmark script multiple times to verify median render time 
 
 ## Canvas Smoke Test
 Ensure Canvas mode works (since it uses `CdpTimeDriver`).
+
+## Results Summary
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	48.668	600	12.33	36.5	discard	baseline_iframe
+2	48.658	600	12.33	40.5	discard	baseline_iframe
+3	49.480	600	12.13	41.5	discard	baseline_iframe
+4	48.604	600	12.34	41.9	discard	inline_params
+5	48.630	600	12.34	36.4	discard	inline_params
+6	48.993	600	12.25	35.5	discard	inline_params
+```
+Outcome: Discarded. The median time for inline params (48.630s) was essentially identical to the baseline (48.668s). V8 handles the write barrier for updating the cached `multiFrameEvaluateParams` array just as efficiently as inline object allocations for this specific multi-frame hot path.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -20,6 +20,9 @@ Last updated by: PERF-355
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-359**: Replaced `multiFrameEvaluateParams` array with inline object allocation in `SeekTimeDriver.ts` and `CdpTimeDriver.ts` for the multi-frame hot loops.
+  - **WHY it didn't work**: The performance gain was negligible for multi-frame rendering with iframes (median ~48.630s vs baseline ~48.668s, well within the noise margin). Since most compositions don't use multi-frames, and V8's GC handles this small array efficiently enough, the change didn't yield a measurable render time improvement and it's simpler to keep the existing cached array. Discarded to maintain current code state.
+
 
 - **PERF-357: Eliminate setTimeout in injected seek script**
   - **What I tried:** Attempted to remove `setTimeout` and custom `Promise.race` inside `SeekTimeDriver` injected `window.__helios_seek` function, and rely completely on Playwright's CDP `Runtime.evaluate` timeout (`awaitPromise: true`, `timeout: this.timeout`).

--- a/packages/renderer/.sys/perf-results-PERF-359.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-359.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	48.668	600	12.33	36.5	discard	baseline_iframe
+2	48.658	600	12.33	40.5	discard	baseline_iframe
+3	49.480	600	12.13	41.5	discard	baseline_iframe
+4	48.604	600	12.34	41.9	discard	inline_params
+5	48.630	600	12.34	36.4	discard	inline_params
+6	48.993	600	12.25	35.5	discard	inline_params


### PR DESCRIPTION
💡 **What**: Evaluated replacing `multiFrameEvaluateParams` arrays with inline literal allocations in `SeekTimeDriver` and `CdpTimeDriver`. Discarded due to negligible gain.
🎯 **Why**: To bypass V8 old-space write barrier overhead during multi-frame execution.
📊 **Impact**: Median baseline 48.668s vs experiment 48.630s (inconclusive / noise margin).
🔬 **Verification**: Ran DOM render benchmark with iframe composition 6 times.
📎 **Plan**: Reference the plan file (/.sys/plans/PERF-359-inline-multiframe-params.md)

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	48.668	600	12.33	36.5	discard	baseline_iframe
2	48.658	600	12.33	40.5	discard	baseline_iframe
3	49.480	600	12.13	41.5	discard	baseline_iframe
4	48.604	600	12.34	41.9	discard	inline_params
5	48.630	600	12.34	36.4	discard	inline_params
6	48.993	600	12.25	35.5	discard	inline_params
```

---
*PR created automatically by Jules for task [10774439446650237291](https://jules.google.com/task/10774439446650237291) started by @BintzGavin*