### PR TITLE
📋 PLAYER: Fix API Parity Media Session Properties in README

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -31,3 +31,7 @@
 ## [v0.77.25] - Addressing Environment Issues in Tests
 **Learning:** `packages/player/src/export-options.test.ts` was failing because the `vitest` environment defaults to Node, making `document` unavailable. The `HeliosPlayer` Web Component uses `document` at the module level.
 **Action:** Created plan to ensure the `@vitest-environment jsdom` pragma is added to files testing DOM components.
+
+## [v0.77.25] - Missing README properties
+**Learning:** Properties implemented in `index.ts` (e.g., `mediaTitle`) are sometimes missing from the `README.md` properties list due to disconnected implementation and documentation steps.
+**Action:** When adding new properties, explicitly include updating the README in the implementation spec, or periodically cross-reference `index.ts` exported properties with the README.

--- a/.sys/plans/2027-02-15-PLAYER-Fix-API-Parity-Media-Session.md
+++ b/.sys/plans/2027-02-15-PLAYER-Fix-API-Parity-Media-Session.md
@@ -1,0 +1,24 @@
+#### 1. Context & Goal
+- **Objective**: Add `mediaTitle`, `mediaArtist`, `mediaAlbum`, and `mediaArtwork` properties to the README to match the implementation in `HeliosPlayer`.
+- **Trigger**: Discovered that properties for OS Media Session attributes (`media-title`, `media-artist`, `media-album`, `media-artwork`) are implemented in `index.ts` but missing from the README's Properties section.
+- **Impact**: Ensures accurate documentation for the HTMLMediaElement API parity.
+
+#### 2. File Inventory
+- **Create**: none
+- **Modify**: `packages/player/README.md`
+- **Read-Only**: `packages/player/src/index.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Append the missing properties to the "Properties" list in `packages/player/README.md`.
+- **Pseudo-Code**:
+  - Add `- \`mediaTitle\` (string): Reflected media-title attribute.`
+  - Add `- \`mediaArtist\` (string): Reflected media-artist attribute.`
+  - Add `- \`mediaAlbum\` (string): Reflected media-album attribute.`
+  - Add `- \`mediaArtwork\` (string): Reflected media-artwork attribute.`
+- **Public API Changes**: Documentation only.
+- **Dependencies**: None
+
+#### 4. Test Plan
+- **Verification**: `cat packages/player/README.md | grep "mediaTitle"`
+- **Success Criteria**: The README includes the four Media Session properties.
+- **Edge Cases**: None


### PR DESCRIPTION
Created a specification plan to address the vision gap where the Media Session properties (`mediaTitle`, `mediaArtist`, `mediaAlbum`, `mediaArtwork`) were missing from the `README.md` properties list despite being implemented in `packages/player/src/index.ts`. Also updated the PLAYER journal with learning about disconnected implementation and documentation steps.

---
*PR created automatically by Jules for task [9824373167601698391](https://jules.google.com/task/9824373167601698391) started by @BintzGavin*