### PR TITLE
✨ RENDERER: Discard PERF-361 avoid-promise-race-in-seek

### DIFF
--- a/.sys/plans/PERF-361-avoid-promise-race-in-seek.md
+++ b/.sys/plans/PERF-361-avoid-promise-race-in-seek.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-361
 slug: avoid-promise-race-in-seek
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-05
-completed: ""
-result: ""
+completed: "2026-04-26"
+result: "discarded - slower (48.761s vs 46.298s baseline)"
 ---
 
 # PERF-361: Avoid Promise.race allocation in SeekTimeDriver injected script
@@ -151,3 +151,10 @@ Run `npm run test -- tests/verify-canvas-strategy.ts` to ensure Canvas mode is u
 
 ## Correctness Check
 Run `npm run test -- tests/verify-dom-strategy-capture.ts` to ensure DOM output continues to correctly encode PNGs and fallback to cached frames without crashing.
+
+
+## Results Summary
+- **Best render time**: 48.761s (vs baseline 46.298s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-361]

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -11,3 +11,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 3	46.537	600	12.89	35.0	keep	inline allocation
 4	47.262	600	12.70	36.3	keep	inline allocation
 5	46.298	600	12.96	32.7	keep	inline allocation
+6	48.761	600	12.30	40.9	discard	avoid Promise.race allocation in SeekTimeDriver (PERF-361)

--- a/packages/renderer/docs/status/RENDERER-EXPERIMENTS.md
+++ b/packages/renderer/docs/status/RENDERER-EXPERIMENTS.md
@@ -6,5 +6,6 @@ Last updated by: PERF-271
 - [PERF-271] Combined `.catch` and `.then` handlers into a single `.then(resolve, reject)` in `CaptureLoop.ts` to reduce GC overhead and microtask serialization delays (~26.9% faster).
 
 ## What Doesn't Work (and Why)
+- [PERF-361] Attempted to avoid `Promise.race` allocation in `SeekTimeDriver` injected script. DISCARDED because it was slower (48.761s vs 46.298s baseline). V8 handles the Promise.race array wrapper very efficiently, and the manual state machine added overhead.
 
 ## Open Questions


### PR DESCRIPTION
Attempted to replace Promise.race with a manual promise wrapper in SeekTimeDriver to reduce GC overhead.

Results showed a regression (median render time of ~48.761s vs baseline of ~46.298s). V8 handles the native `Promise.race` wrapper more efficiently than the manual state machine, so the changes were discarded. The results have been logged and the plan marked complete.

## Results Summary
- **Best render time**: 48.761s (vs baseline 46.298s)
- **Improvement**: 0%
- **Kept experiments**: []
- **Discarded experiments**: [PERF-361]

---
*PR created automatically by Jules for task [9382151391845150631](https://jules.google.com/task/9382151391845150631) started by @BintzGavin*