### PR TITLE
✨ RENDERER: Eliminate Polymorphic Buffer Checks (Discarded)

### DIFF
--- a/.sys/plans/PERF-367-eliminate-polymorphic-buffer-checks.md
+++ b/.sys/plans/PERF-367-eliminate-polymorphic-buffer-checks.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-367
 slug: eliminate-polymorphic-buffer-checks
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-04-26
-completed: ""
-result: ""
+completed: 2024-04-26
+result: discard
 ---
 
 # PERF-367: Eliminate Polymorphic Buffer Checks in CaptureLoop
@@ -99,3 +99,9 @@ Run the DOM render benchmark script multiple times to verify median render time 
 
 ## Prior Art
 - PERF-360 attempted to decode strings to buffers inside `DomStrategy` and failed. This experiment forces everything to strictly remain as strings in DOM mode, relying on FFmpeg `stdin.write`'s native fast C++ base64 decoder.
+
+## Results Summary
+- **Best render time**: 46.328s (vs baseline 46.443s, median: 46.452s vs 46.443s)
+- **Improvement**: ~0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-367]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -24,6 +24,9 @@ Last updated by: PERF-366
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-367: Eliminate Polymorphic Buffer Checks in CaptureLoop**
+  - **What I tried:** Enforced strict `string` (base64) return types from `DomStrategy.capture()` to eliminate the dynamic `typeof buffer === 'string'` check in the `CaptureLoop.ts` `writeToStdin` method, attempting to optimize V8 branch prediction.
+  - **Why it didn't work:** The median render time was identical (~46.452s vs baseline ~46.443s). V8's JIT optimization easily handles the binary branch for `typeof buffer === 'string'` with negligible overhead, so explicitly converting Playwright fallback screenshots to base64 offers no overall pipeline advantage. Discarded to maintain code simplicity.
 - **PERF-338**: Attempted to prebind the `stabilityTimeoutExecutor` and `stabilityTimeoutCallback` closures in `CdpTimeDriver.ts`.
   - **WHY it didn't work**: The variables and methods are already pre-bound as class properties from a prior optimization. The plan is structurally obsolete and impossible to run, so it was discarded without further modification.
 - **PERF-365: Avoid Promise.race allocation in CdpTimeDriver stability check**

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -12,3 +12,9 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 4	47.262	600	12.70	36.3	keep	inline allocation
 5	46.298	600	12.96	32.7	keep	inline allocation
 6	48.761	600	12.30	40.9	discard	avoid Promise.race allocation in SeekTimeDriver (PERF-361)
+1	48.271	600	12.43	38.5	keep	baseline
+2	46.297	600	12.96	39.9	keep	baseline
+3	46.443	600	12.92	39.4	keep	baseline
+7	46.328	600	12.95	36.2	discard	eliminate polymorphic buffer checks (PERF-367)
+8	47.539	600	12.62	35.8	discard	eliminate polymorphic buffer checks (PERF-367)
+9	46.452	600	12.92	32.6	discard	eliminate polymorphic buffer checks (PERF-367)


### PR DESCRIPTION
Experiment run for PERF-367. Attempted to eliminate polymorphic buffer returns from `DomStrategy` capture path to optimize `writeToStdin` branch prediction in `CaptureLoop`. The performance was within the noise margin (0% improvement), so changes were discarded and the outcome journaled.

Results Summary:
```tsv
7	46.328	600	12.95	36.2	discard	eliminate polymorphic buffer checks (PERF-367)
8	47.539	600	12.62	35.8	discard	eliminate polymorphic buffer checks (PERF-367)
9	46.452	600	12.92	32.6	discard	eliminate polymorphic buffer checks (PERF-367)
```

---
*PR created automatically by Jules for task [15349173768774103108](https://jules.google.com/task/15349173768774103108) started by @BintzGavin*