### PR TITLE
✨ PLAYER: Document Media Session Properties

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -1,6 +1,6 @@
 # Context: PLAYER
 
-**Version**: 0.77.26
+**Version**: 0.77.27
 
 ## Section A: Component Structure
 
@@ -98,6 +98,10 @@
 - `exportCaptionMode`
 - `canvasSelector`
 - `controlsList`
+- `mediaTitle`: Maps to `media-title` attribute
+- `mediaArtist`: Maps to `media-artist` attribute
+- `mediaAlbum`: Maps to `media-album` attribute
+- `mediaArtwork`: Maps to `media-artwork` attribute
 - `sandbox`: Overrides the default iframe sandbox flags.
 - `disablepictureinpicture`: If present, hides the PiP button.
 
@@ -124,13 +128,6 @@
 - `requestPictureInPicture(): Promise<PictureInPictureWindow>`
 - `startAudioMetering(): void`
 - `stopAudioMetering(): void`
-## Section E: Media Session Properties
-
-The following standard media session metadata attributes are available as properties on the `HeliosPlayer` class, mapping to the respective DOM attributes:
-- `mediaTitle`: Maps to `media-title` attribute
-- `mediaArtist`: Maps to `media-artist` attribute
-- `mediaAlbum`: Maps to `media-album` attribute
-- `mediaArtwork`: Maps to `media-artwork` attribute
 
 ## Track Lists
 - `HeliosAudioTrackList`: Implements standard HTMLMediaElement event handler properties (`onaddtrack`, `onremovetrack`, `onchange`).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### PLAYER v0.77.27
+- ✅ Completed: Add Media Session properties to README
+
 ### STUDIO v0.121.9
 - ✅ Completed: STUDIO-Update-Keyboard-Shortcuts-Documentation - Updated KeyboardShortcutsModal to include J, K, L playback shortcuts.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,5 @@
-**Version**: 0.77.26
+**Version**: 0.77.27
+[v0.77.27] ✅ Completed: Add Media Session properties to README
 [v0.77.26] ✅ Completed: Implement WebVTT Support - Refactored WebVTT parser to use single-pass loops instead of chained map/filter arrays for better performance
 
 [v0.77.23] ✅ Completed: Document Undocumented Shortcuts

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -186,6 +186,10 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `exportCaptionMode` (string): Reflected export-caption-mode attribute.
 - `canvasSelector` (string): Reflected canvas-selector attribute.
 - `controlsList` (string): Reflected controlslist attribute.
+- `mediaTitle` (string): Reflected media-title attribute.
+- `mediaArtist` (string): Reflected media-artist attribute.
+- `mediaAlbum` (string): Reflected media-album attribute.
+- `mediaArtwork` (string): Reflected media-artwork attribute.
 
 
 ## Events


### PR DESCRIPTION
Fixes an issue where the `mediaTitle`, `mediaArtist`, `mediaAlbum`, and `mediaArtwork` standard HTMLMediaElement properties were implemented in `<helios-player>` but missing from the `README.md` properties section.

Documentation has been updated, and the completion version `0.77.27` is successfully bumped in all tracking files (Status, Progress, and LLM docs).

All Player tests passed.

---
*PR created automatically by Jules for task [5948320645519565203](https://jules.google.com/task/5948320645519565203) started by @BintzGavin*