### PR TITLE
Execute PERF-328: Inline CdpTimeDriver Evaluate Params

### DIFF
--- a/.sys/plans/PERF-328-inline-cdptime-driver-evaluate.md
+++ b/.sys/plans/PERF-328-inline-cdptime-driver-evaluate.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-328
 slug: inline-cdptime-driver-evaluate
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor"
 created: 2024-05-28
-completed: ""
-result: ""
+completed: "2024-05-28"
+result: "discard"
 ---
 
 # PERF-328: Inline CdpTimeDriver Evaluate Params
@@ -58,3 +58,10 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to ensure the DOM strategy logic runs and correctly falls back to the mocked `lastFrameData` buffer.
+
+## Results Summary
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	61.065	600	9.83	33.2	discard	Inlined CdpTimeDriver evaluate params
+2	49.584	600	12.10	42.4	discard	Inlined CdpTimeDriver evaluate params
+3	47.811	600	12.55	37.2	discard	Inlined CdpTimeDriver evaluate params
+4	47.439	600	12.65	43.7	discard	Inlined CdpTimeDriver evaluate params

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -24,6 +24,9 @@ Last updated by: PERF-366
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-328: Inline CdpTimeDriver Evaluate Params**
+  - **What I tried:** Inlined the parameter object for `Runtime.evaluate` in the single-frame setup for `CdpTimeDriver.ts` to reduce object allocation and GC pressure.
+  - **Why it didn't work:** The median render time was ~47.811s, which is within the noise margin or slightly slower than recent baselines (~47.5s). V8 is efficient at inline dynamic object allocation, and manual caching added negligible or no benefit. Discarded to maintain code simplicity.
 - **PERF-367: Eliminate Polymorphic Buffer Checks in CaptureLoop**
   - **What I tried:** Enforced strict `string` (base64) return types from `DomStrategy.capture()` to eliminate the dynamic `typeof buffer === 'string'` check in the `CaptureLoop.ts` `writeToStdin` method, attempting to optimize V8 branch prediction.
   - **Why it didn't work:** The median render time was identical (~46.452s vs baseline ~46.443s). V8's JIT optimization easily handles the binary branch for `typeof buffer === 'string'` with negligible overhead, so explicitly converting Playwright fallback screenshots to base64 offers no overall pipeline advantage. Discarded to maintain code simplicity.

--- a/packages/renderer/.sys/perf-results-PERF-328.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-328.tsv
@@ -1,0 +1,4 @@
+1	61.065	600	9.83	33.2	discard	Inlined CdpTimeDriver evaluate params
+2	49.584	600	12.10	42.4	discard	Inlined CdpTimeDriver evaluate params
+3	47.811	600	12.55	37.2	discard	Inlined CdpTimeDriver evaluate params
+4	47.439	600	12.65	43.7	discard	Inlined CdpTimeDriver evaluate params


### PR DESCRIPTION
Executed PERF-328 to try and reduce object allocations in the CdpTimeDriver `setTime` method. The median benchmark performance was ~47.811s, indicating no significant improvement or a slight regression compared to the baseline of ~47.5s. As a result, the code changes were discarded, but the documentation and plan status files have been updated with the results.

---
*PR created automatically by Jules for task [7473412317385327648](https://jules.google.com/task/7473412317385327648) started by @BintzGavin*