### PR TITLE
✨ RENDERER: Document PERF-335 as impossible

### DIFF
--- a/.sys/plans/PERF-335-prebind-frame-waiter-resolve.md
+++ b/.sys/plans/PERF-335-prebind-frame-waiter-resolve.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-335
 slug: prebind-frame-waiter-resolve
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor"
 created: 2024-04-22
 completed: ""
-result: ""
+result: "impossible"
 ---
 
 # PERF-335: Prebind frameWaiterResolve executor in CaptureLoop
@@ -67,3 +67,7 @@ Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to ensure D
 ## Prior Art
 - PERF-324: Prebound frame promise executors for workers.
 - PERF-321: Prebound `workerBlockedExecutors`.
+
+## Results Summary
+- **Result**: impossible
+- **Details**: The structural change proposed in this plan (prebinding `frameWaiterExecutor`) was already implemented and kept by a subsequent experiment (PERF-337). The task is redundant and obsolete.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -107,3 +107,5 @@ Last updated by: PERF-366
   - Plan: PERF-002
 - **PERF-296**: Replaced object mutation with inline object allocation in the hot loops of `SeekTimeDriver.ts` and `DomStrategy.ts`. The median render time worsened to ~48.743s compared to the baseline of ~47.232s. This indicates that creating new object literals inside the hot loop adds more overhead than the write barriers caused by mutating the long-lived properties. Discarded as slower.
 
+- **PERF-335**: Prebind frameWaiterResolve executor in CaptureLoop.
+  - **WHY it didn't work**: Impossible/Obsolete. The structural change (prebinding `frameWaiterExecutor`) was already implemented and kept by a subsequent experiment (PERF-337). Documented duplication and stopped work.


### PR DESCRIPTION
Marked PERF-335 as impossible because the optimization was already applied in PERF-337. Avoid redundant work and keep the protocol intact.

---
*PR created automatically by Jules for task [2813424675505177234](https://jules.google.com/task/2813424675505177234) started by @BintzGavin*