### PR TITLE
✨ RENDERER: Mark PERF-332 as obsolete duplicate

### DIFF
--- a/.sys/plans/PERF-332-prebind-frame-waiter-resolve.md
+++ b/.sys/plans/PERF-332-prebind-frame-waiter-resolve.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-332
 slug: prebind-frame-waiter-resolve
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-04-22
 completed: ""
-result: ""
+result: "impossible"
 ---
 
 # PERF-332: Prebind frameWaiterResolve executor in CaptureLoop
@@ -67,3 +67,9 @@ Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to ensure D
 ## Prior Art
 - PERF-324: Prebound frame promise executors for workers.
 - PERF-321: Prebound `workerBlockedExecutors`.
+
+## Results Summary
+- **Best render time**: 0.000s (vs baseline 0.000s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-332 (already implemented by PERF-337)]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -27,6 +27,8 @@ Last updated by: PERF-366
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-332**: Prebind frameWaiterResolve executor in CaptureLoop.\
+  - **WHY it didn't work**: Impossible/Obsolete. The structural change (prebinding `frameWaiterExecutor`) was already implemented and kept by a subsequent experiment (PERF-337). Documented duplication and stopped work.
 - **PERF-328: Inline CdpTimeDriver Evaluate Params**
   - **What I tried:** Inlined the parameter object for `Runtime.evaluate` in the single-frame setup for `CdpTimeDriver.ts` to reduce object allocation and GC pressure.
   - **Why it didn't work:** The median render time was ~47.811s, which is within the noise margin or slightly slower than recent baselines (~47.5s). V8 is efficient at inline dynamic object allocation, and manual caching added negligible or no benefit. Discarded to maintain code simplicity.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -18,3 +18,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 7	46.328	600	12.95	36.2	discard	eliminate polymorphic buffer checks (PERF-367)
 8	47.539	600	12.62	35.8	discard	eliminate polymorphic buffer checks (PERF-367)
 9	46.452	600	12.92	32.6	discard	eliminate polymorphic buffer checks (PERF-367)
+1	0.000	0	0.00	0.0	crash	PERF-332: Duplicate of PERF-337, impossible


### PR DESCRIPTION
✨ RENDERER: Mark PERF-332 as obsolete duplicate

💡 What: Discarded PERF-332 without running benchmarks. Marked as impossible.

🎯 Why: The experiment proposed prebinding frameWaiterResolve in CaptureLoop.ts, but this was already implemented by PERF-337. Structural duplicate.

📊 Impact: N/A - no code changes made.

🔬 Verification: N/A - verified no code changes required.

📎 Plan: Reference: .sys/plans/PERF-332-prebind-frame-waiter-resolve.md

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 0.000 | 0 | 0.00 | 0.0 | crash | PERF-332: Duplicate of PERF-337, impossible |

---
*PR created automatically by Jules for task [353861913538725365](https://jules.google.com/task/353861913538725365) started by @BintzGavin*