### PR TITLE
🚀 RENDERER: Increase pipeline depth in CaptureLoop

### DIFF
--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -95,7 +95,7 @@ export class CaptureLoop {
     let previousWritePromise: Promise<void> | undefined;
 
     const poolLen = this.pool.length;
-    let maxPipelineDepth = poolLen * 2;
+    let maxPipelineDepth = poolLen * 8;
     maxPipelineDepth = Math.pow(2, Math.ceil(Math.log2(maxPipelineDepth)));
     const ringMask = maxPipelineDepth - 1;
     const timeStep = 1000 / fps;


### PR DESCRIPTION
Increase CaptureLoop pipeline depth to smooth out async I/O spikes from FFmpeg and prevent blocking worker threads during DOM rendering, based on PERF-370.

---
*PR created automatically by Jules for task [16672954775349840815](https://jules.google.com/task/16672954775349840815) started by @BintzGavin*