### PR TITLE
✨ RENDERER: Document impossible PERF-327 experiments

### DIFF
--- a/.sys/plans/PERF-327-inline-cdptime-driver-evaluate.md
+++ b/.sys/plans/PERF-327-inline-cdptime-driver-evaluate.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-327
 slug: inline-cdptime-driver-evaluate
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-28
-completed: ""
-result: ""
+completed: "2026-04-27"
+result: "impossible - async mutation race condition"
 ---
 
 # PERF-327: Inline CdpTimeDriver Evaluate Params
@@ -58,3 +58,6 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to ensure the DOM strategy logic runs and correctly falls back to the mocked `lastFrameData` buffer.
+
+## Results Summary
+Impossible. Playwright's CDP serialization is asynchronous. Mutating a shared object across multiple `cdpSession.send` calls (such as in a `for` loop for multiple iframes) can result in sending overwritten state from a subsequent tick. Therefore, allocating inline objects is strictly required to prevent async mutation race conditions.

--- a/.sys/plans/PERF-327-prebind-frame-waiter.md
+++ b/.sys/plans/PERF-327-prebind-frame-waiter.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-327
 slug: prebind-frame-waiter
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-04-21
-completed: ""
-result: ""
+completed: "2026-04-27"
+result: "impossible - already implemented"
 ---
 
 # PERF-327: Prebind Frame Waiter Promise Executor in CaptureLoop
@@ -77,3 +77,6 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts` to ensure Canvas
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to verify DOM output is correct.
+
+## Results Summary
+Impossible. The structural change (prebinding `frameWaiterExecutor`) was already implemented and kept by a subsequent experiment (PERF-337). Documented duplication and stopped work.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -116,3 +116,7 @@ Last updated by: PERF-366
 - **PERF-333**: Eliminated `multiFrameEvaluateParams` array caching in `SeekTimeDriver` and `CdpTimeDriver`. Moving to strictly inline object literal allocation for multi-frame CDP `Runtime.evaluate` calls prevents race conditions caused by asynchronous serialization of mutated shared objects over Playwright CDP connections without impacting performance.
 - **PERF-370**: Attempted to increase the `CaptureLoop.ts` pipeline depth from `poolLen * 2` to `poolLen * 8`.
   - **WHY it didn't work**: Impossible/Obsolete. The structural change was already implemented in a previous commit and present in the codebase. Documented duplication and stopped work.
+- **PERF-327**: Attempted to prebind `frameWaiterExecutor` in `CaptureLoop.ts`.
+  - **WHY it didn't work**: Impossible/Obsolete. The structural change was already implemented by PERF-337 and is currently active in the codebase.
+- **PERF-327**: Attempted to inline `evaluateParams` allocation in `CdpTimeDriver.ts`.
+  - **WHY it didn't work**: Impossible due to async mutation race conditions. Playwright's CDP serialization is asynchronous. Mutating a shared object across multiple `cdpSession.send` calls (such as in a `for` loop for multiple iframes) can result in sending overwritten state. Allocating new inline objects for each command is strictly required to ensure correct CDP messaging.


### PR DESCRIPTION
This PR marks the PERF-327 experiments as completed but discarded because they were deemed structurally impossible or obsolete based on the codebase constraints.

1. **PERF-327 `prebind-frame-waiter`:** This optimization (prebinding `frameWaiterExecutor`) was already implemented natively via PERF-337 in `CaptureLoop.ts`.
2. **PERF-327 `inline-cdptime-driver-evaluate`:** Playwright's CDP serialization is asynchronous. Thus, mutating a shared object across multiple `cdpSession.send` calls inside a tight loop causes race conditions where later iterations overwrite the state of earlier messages before they are fully serialized. Inline object allocations are strictly required.

The journal and plan files have been updated to reflect these limitations.

---
*PR created automatically by Jules for task [16745592432575069893](https://jules.google.com/task/16745592432575069893) started by @BintzGavin*