### PR TITLE
✨ RENDERER: Restore TimeDriver Promise

### DIFF
--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -217,7 +217,7 @@ export class CaptureLoop {
             const ringIndex = i & ringMask;
 
             try {
-                timeDriver.setTime(page, compositionTimeInSeconds);
+                await timeDriver.setTime(page, compositionTimeInSeconds);
                 const buffer = await strategy.capture(page, time);
                 frameBufferRing[ringIndex] = buffer;
                 frameReadyRing[ringIndex] = 1;

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -161,8 +161,8 @@ export class CdpTimeDriver implements TimeDriver {
     this.currentTime = 0;
   }
 
-  setTime(page: Page, timeInSeconds: number): void {
-    this.runSetTime(page, timeInSeconds).catch(noopCatch);
+  setTime(page: Page, timeInSeconds: number): Promise<void> | void {
+    return this.runSetTime(page, timeInSeconds);
   }
 
   private async runSetTime(page: Page, timeInSeconds: number): Promise<void> {

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -275,25 +275,26 @@ export class SeekTimeDriver implements TimeDriver {
     this.cachedMainFrame = page.mainFrame();
       }
 
-  setTime(page: Page, timeInSeconds: number): void {
+  setTime(page: Page, timeInSeconds: number): Promise<void> | void {
     const frames = this.cachedFrames;
 
     if (frames.length === 1) {
-      this.cdpSession!.send('Runtime.evaluate', {
+      return this.cdpSession!.send('Runtime.evaluate', {
         expression: 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')',
         awaitPromise: true
-      }).catch(noopCatch);
-      return;
+      }).then(() => {});
     }
 
     const expression = 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')';
 
+    const promises = [];
     for (let i = 0; i < this.executionContextIds.length; i++) {
-      this.cdpSession!.send('Runtime.evaluate', {
+      promises.push(this.cdpSession!.send('Runtime.evaluate', {
         expression,
         contextId: this.executionContextIds[i],
         awaitPromise: true
-      }).catch(noopCatch);
+      }));
     }
+    return Promise.all(promises).then(() => {});
   }
 }

--- a/packages/renderer/src/drivers/TimeDriver.ts
+++ b/packages/renderer/src/drivers/TimeDriver.ts
@@ -18,5 +18,5 @@ export interface TimeDriver {
    * @param page The Playwright page instance.
    * @param timeInSeconds The time to seek to in seconds.
    */
-  setTime(page: Page, timeInSeconds: number): void;
+  setTime(page: Page, timeInSeconds: number): Promise<void> | void;
 }


### PR DESCRIPTION
✨ RENDERER: Restore TimeDriver Promise

💡 What: Changed TimeDriver setTime to return Promise<void> and awaited it in CaptureLoop.ts

🎯 Why: To fix race conditions caused by dropping the Promise when running Runtime.evaluate with awaitPromise: true.

📊 Impact: Restores deterministic frame synchronization.

🔬 Verification: Ran targeted tests (e.g. verify-seek-driver-determinism.ts, verify-cdp-determinism.ts, verify-dom-strategy-capture.ts).

Reference: .sys/plans/PERF-373-restore-timedriver-promise.md. Key decision: Restored awaited Promises for TimeDriver.

---
*PR created automatically by Jules for task [3442580762778531412](https://jules.google.com/task/3442580762778531412) started by @BintzGavin*