### PR TITLE
✨ RENDERER: Eliminate Progress Interval Modulo

### DIFF
--- a/.sys/plans/PERF-374-eliminate-progress-interval-modulo.md
+++ b/.sys/plans/PERF-374-eliminate-progress-interval-modulo.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-374
 slug: eliminate-progress-interval-modulo
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-01
 completed: ""
 result: ""
@@ -30,3 +30,9 @@ The modulo operator (`%`) in the hot loop of `CaptureLoop.ts` (`currentFrame % p
 
 ## Correctness Check
 Verify that progress logs are still emitted exactly 10 times during the render.
+
+## Results Summary
+- **Best render time**: 46.003s (vs baseline 46.546s)
+- **Improvement**: ~1.1% (inconclusive)
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-374]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -120,3 +120,7 @@ Last updated by: PERF-366
   - **WHY it didn't work**: Impossible/Obsolete. The structural change was already implemented by PERF-337 and is currently active in the codebase.
 - **PERF-327**: Attempted to inline `evaluateParams` allocation in `CdpTimeDriver.ts`.
   - **WHY it didn't work**: Impossible due to async mutation race conditions. Playwright's CDP serialization is asynchronous. Mutating a shared object across multiple `cdpSession.send` calls (such as in a `for` loop for multiple iframes) can result in sending overwritten state. Allocating new inline objects for each command is strictly required to ensure correct CDP messaging.
+
+- **PERF-374**: Eliminate Progress Interval Modulo in CaptureLoop
+  - **What I tried**: Replaced the modulo arithmetic (`currentFrame % progressInterval === 0`) with an explicit addition counter (`nextProgressFrame += progressInterval`) inside `CaptureLoop.ts`'s hot loop.
+  - **WHY it didn't work**: The median render time improved slightly from ~46.546s to ~46.003s, which represents a ~1.1% gain. However, this is well within the ~5% environmental noise margin. V8 handles the occasional integer modulo arithmetic efficiently enough that manual counter management does not provide a definitive, clear-cut performance gain. Discarded to maintain code simplicity.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -20,3 +20,7 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 9	46.452	600	12.92	32.6	discard	eliminate polymorphic buffer checks (PERF-367)
 1	0.000	0	0.00	0.0	crash	PERF-332: Duplicate of PERF-337, impossible
 1	0.000	0	0.00	0.0	crash	PERF-370: Duplicate of previous implementation, impossible
+1	46.546	600	12.89	0.0	keep	baseline
+2	46.605	600	12.87	0.0	keep	baseline
+3	45.939	600	13.06	0.0	keep	baseline
+2	46.003	600	13.04	0.0	discard	eliminate progress interval modulo


### PR DESCRIPTION
Executed performance experiment PERF-374. Replaced the modulo arithmetic in CaptureLoop.ts with an explicit counter. Benchmarked and achieved a ~1.1% gain, which is within the environmental noise margin. Concluded the optimization was not worth the complexity and cleanly reverted the code changes while committing the recorded data.

## Results Summary
- **Best render time**: 46.003s (vs baseline 46.546s)
- **Improvement**: ~1.1% (inconclusive)
- **Kept experiments**: []
- **Discarded experiments**: [PERF-374]

## Raw Results
```
1	46.546	600	12.89	0.0	keep	baseline
2	46.605	600	12.87	0.0	keep	baseline
3	45.939	600	13.06	0.0	keep	baseline
2	46.003	600	13.04	0.0	discard	eliminate progress interval modulo
```

---
*PR created automatically by Jules for task [2192525574967394301](https://jules.google.com/task/2192525574967394301) started by @BintzGavin*