### PR TITLE
✨ RENDERER: Inline seek promise race

### DIFF
--- a/.sys/plans/PERF-378-inline-seek-promise-race.md
+++ b/.sys/plans/PERF-378-inline-seek-promise-race.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-378
 slug: inline-seek-promise-race
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-01
-completed: ""
-result: ""
+completed: "2024-05-01"
+result: "discard"
 ---
 
 # PERF-378: Inline `__helios_seek` and Evaluate Promise.race Node-side
@@ -131,3 +131,9 @@ To:
 
 **Why**: Simplifies execution context and removes micro-allocations for timers on every frame. Node.js manages execution boundaries at the parent level, making the client-side timeout largely redundant and an unnecessary source of GC pressure.
 **Risk**: If a frame inherently hangs without resolution (e.g. fonts never load), it could stall the CDP response indefinitely without the client-side timeout wrapper. However, the BrowserPool enforces a timeout natively on page hangs if the orchestrator uses AbortSignals.
+
+## Results Summary
+- **Best render time**: 46.820s (vs baseline ~46.546s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-378]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -131,3 +131,4 @@ Last updated by: PERF-375
 
 ## What Works
 - Removed `await` from the single-frame and multi-frame `Runtime.evaluate` calls for media synchronization in `CdpTimeDriver.ts`. This pipelines the CDP commands natively, saving the IPC acknowledgment latency (~3.76% faster). (PERF-375)
+- **PERF-378**: Inlined the Promise.race logic in window.__helios_seek and removed timeout allocation to reduce micro-allocations in the hot loop of SeekTimeDriver. Performance was essentially identical to the baseline (~46.820s vs ~46.546s), showing V8 optimizes the `Promise.race` wrapper very efficiently. However, stability tests failed because the actual explicit stability checks depend on the client-side `setTimeout` properly acting as a fallback when an unresolved Promise prevents the script from returning. Discarded to maintain timeout stability.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -24,3 +24,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 2	46.605	600	12.87	0.0	keep	baseline
 3	45.939	600	13.06	0.0	keep	baseline
 2	46.003	600	13.04	0.0	discard	eliminate progress interval modulo
+1	46.820	600	12.82	39.5	inconclusive	inline seek promise race


### PR DESCRIPTION
Evaluated removing the Promise.race logic in window.__helios_seek and removing timeout allocation to reduce micro-allocations in the hot loop of SeekTimeDriver. The change was discarded because performance was identical to the baseline and it broke client-side stability timeouts.

---
*PR created automatically by Jules for task [10240323556738773264](https://jules.google.com/task/10240323556738773264) started by @BintzGavin*