### PR TITLE
✨ RENDERER: Discard PERF-380 startScreencast experiment

### DIFF
--- a/.sys/plans/PERF-380-raw-cdp-screencast.md
+++ b/.sys/plans/PERF-380-raw-cdp-screencast.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-380
 slug: raw-cdp-screencast
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor"
 created: 2024-05-01
-completed: ""
-result: ""
+completed: "2026-04-28"
+result: "discard"
 ---
 
 # PERF-380: Replace HeadlessExperimental.beginFrame with Page.startScreencast
@@ -70,3 +70,9 @@ Run `npx tsx tests/verify-canvas-strategy.ts` (if exists) or confirm Canvas mode
 
 ## Correctness Check
 Run `npm run benchmark:dom` (if available) or `node` script to verify frame sequence.
+
+## Results Summary
+- **Best render time**: 0.000s (vs baseline ~46.546s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [Step 1: Replace HeadlessExperimental.beginFrame with Page.startScreencast]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -132,3 +132,8 @@ Last updated by: PERF-375
 ## What Works
 - Removed `await` from the single-frame and multi-frame `Runtime.evaluate` calls for media synchronization in `CdpTimeDriver.ts`. This pipelines the CDP commands natively, saving the IPC acknowledgment latency (~3.76% faster). (PERF-375)
 - **PERF-378**: Inlined the Promise.race logic in window.__helios_seek and removed timeout allocation to reduce micro-allocations in the hot loop of SeekTimeDriver. Performance was essentially identical to the baseline (~46.820s vs ~46.546s), showing V8 optimizes the `Promise.race` wrapper very efficiently. However, stability tests failed because the actual explicit stability checks depend on the client-side `setTimeout` properly acting as a fallback when an unresolved Promise prevents the script from returning. Discarded to maintain timeout stability.
+
+## PERF-380: Raw CDP Screencast
+- **What I tried**: Replaced HeadlessExperimental.beginFrame with Page.startScreencast in DomStrategy to invert pull-to-push screenshoting and avoid IPC roundtrip wait.
+- **WHY it didn't work**: When the Chromium browser is launched with `--enable-begin-frame-control` and `--run-all-compositor-stages-before-draw` (which is strictly required by Helios for deterministic offline rendering and precise time synchronization), `Page.startScreencast` fails to emit any `Page.screencastFrame` events, deadlocking the capture pipeline. The underlying Chromium architecture disables or suppresses automatic screencast frame emission when external compositor control is active, as it expects explicit ticks (`HeadlessExperimental.beginFrame`). Attempting to use `Page.startScreencast` alongside explicit compositor control is fundamentally incompatible.
+- **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -25,3 +25,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 3	45.939	600	13.06	0.0	keep	baseline
 2	46.003	600	13.04	0.0	discard	eliminate progress interval modulo
 1	46.820	600	12.82	39.5	inconclusive	inline seek promise race
+27	0.000	0	0.00	0.0	crash	PERF-380: raw-cdp-screencast is incompatible with begin-frame-control


### PR DESCRIPTION
Attempted to use Page.startScreencast to stream base64 frames natively from Chromium to replace HeadlessExperimental.beginFrame.
To avoid the sequential IPC roundtrip overhead of HeadlessExperimental.beginFrame.
Checked if the median render time improved. Outcome: discard (deadlocked).
Discovered Page.startScreencast fails to emit events when running with --enable-begin-frame-control.

---
*PR created automatically by Jules for task [16252768502443150650](https://jules.google.com/task/16252768502443150650) started by @BintzGavin*