### PR TITLE
✨ RENDERER: Eliminate Promise chain allocation in SeekTimeDriver

### DIFF
--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -282,7 +282,7 @@ export class SeekTimeDriver implements TimeDriver {
       return this.cdpSession!.send('Runtime.evaluate', {
         expression: 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')',
         awaitPromise: true
-      }).then(() => {});
+      }) as unknown as Promise<void>;
     }
 
     const expression = 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')';
@@ -295,6 +295,6 @@ export class SeekTimeDriver implements TimeDriver {
         awaitPromise: true
       }));
     }
-    return Promise.all(promises).then(() => {});
+    return Promise.all(promises) as unknown as Promise<void>;
   }
 }


### PR DESCRIPTION
Removed \`.then(() => {})\` from \`SeekTimeDriver.setTime()\` to avoid creating unneeded V8 heap allocations of new Promises and anonymous closures per frame. Tests passed successfully.

---
*PR created automatically by Jules for task [11166693829087529062](https://jules.google.com/task/11166693829087529062) started by @BintzGavin*