### PR TITLE
✨ RENDERER: Discard prebind drain promise executor (PERF-385)

### DIFF
--- a/.sys/plans/PERF-385-prebind-drain-executor.md
+++ b/.sys/plans/PERF-385-prebind-drain-executor.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-385
 slug: prebind-drain-executor
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-18
-completed: ""
-result: ""
+completed: 2024-05-18
+result: "discard"
 ---
 
 # PERF-385: Prebind Drain Promise Executor in CaptureLoop
@@ -66,3 +66,13 @@ Run `cd packages/renderer && npx tsx tests/verify-dom-strategy-capture.ts`.
 ## Prior Art
 - `PERF-383`: Prebound the `screencastPromiseExecutor` in `DomStrategy.ts`.
 - `PERF-337`: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor`.
+
+## Results Summary
+| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
+|---|---|---|---|---|---|---|
+| 1 | 1.768 | 60 | 33.94 | 0.0 | keep | baseline |
+| 2 | 1.849 | 60 | 32.45 | 0.0 | keep | baseline |
+| 3 | 1.814 | 60 | 33.08 | 0.0 | keep | baseline |
+| 4 | 2.926 | 60 | 20.51 | 0.0 | discard | experiment (prebind drain executor) |
+| 5 | 1.894 | 60 | 31.68 | 0.0 | discard | experiment (prebind drain executor) |
+| 6 | 2.535 | 60 | 23.67 | 0.0 | discard | experiment (prebind drain executor) |

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -30,6 +30,8 @@ Last updated by: PERF-366
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-385**: Prebinding `drainPromiseExecutor` in `CaptureLoop.writeToStdin`.
+  - **Why it failed**: Render times increased significantly (~1.8s baseline vs ~2.5s median). Hoisting the Promise executor to the class level likely interfered with V8's fast-path optimizations for inline Promise resolution, or altered closure scope contexts in a way that added hidden overhead during high-frequency backpressure events.
 - **PERF-381**: Attempted to pipeline `HeadlessExperimental.beginFrame` with `Page.startScreencast` in `DomStrategy`. **WHY it didn't work**: The pipeline deadlocked. Chromium's compositor does not emit a `Page.screencastFrame` event when `beginFrame` ticks if there are no visual changes (no damage) on the screen. Because the capture loop strictly awaited a pushed screencast event, it hung indefinitely during static sequences. Discarded.
 - **PERF-332**: Prebind frameWaiterResolve executor in CaptureLoop.\
   - **WHY it didn't work**: Impossible/Obsolete. The structural change (prebinding `frameWaiterExecutor`) was already implemented and kept by a subsequent experiment (PERF-337). Documented duplication and stopped work.

--- a/packages/renderer/.sys/perf-results-PERF-385.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-385.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.768	60	33.94	0.0	keep	baseline
+2	1.849	60	32.45	0.0	keep	baseline
+3	1.814	60	33.08	0.0	keep	baseline
+4	2.926	60	20.51	0.0	discard	experiment (prebind drain executor)
+5	1.894	60	31.68	0.0	discard	experiment (prebind drain executor)
+6	2.535	60	23.67	0.0	discard	experiment (prebind drain executor)


### PR DESCRIPTION
✨ RENDERER: Discard prebind drain promise executor (PERF-385)

💡 **What**: Attempted to prebind the drain promise executor closure in CaptureLoop to reduce GC.
🎯 **Why**: To eliminate dynamic closure allocation overhead during FFmpeg backpressure in CaptureLoop.
📊 **Impact**: Render time severely regressed (1.8s -> 2.5s median). Discarding code changes.
🔍 **Verification**: Ran verify-dom-strategy-capture.ts tests and noted performance degradation.
📎 **Plan**: PERF-385

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.768	60	33.94	0.0	keep	baseline
2	1.849	60	32.45	0.0	keep	baseline
3	1.814	60	33.08	0.0	keep	baseline
4	2.926	60	20.51	0.0	discard	experiment (prebind drain executor)
5	1.894	60	31.68	0.0	discard	experiment (prebind drain executor)
6	2.535	60	23.67	0.0	discard	experiment (prebind drain executor)
```

---
*PR created automatically by Jules for task [12446812877509293623](https://jules.google.com/task/12446812877509293623) started by @BintzGavin*