### PR TITLE
✨ [RENDERER]: PERF-386 Eliminate Promise Chain in CdpTimeDriver

### DIFF
--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -219,12 +219,15 @@ export class CdpTimeDriver implements TimeDriver {
 
     // We still need a timeout mechanism because CDP evaluate with awaitPromise doesn't have an inherent timeout,
     // and virtual time is paused, so internal setTimeout won't work.
-    const evaluatePromise = this.client!.send('Runtime.evaluate', this.evaluateStabilityParams).then(this.handleStabilityCheckResponse);
+    const evaluatePromise = this.client!.send('Runtime.evaluate', this.evaluateStabilityParams);
 
     const timeoutPromise = new Promise<void>(this.stabilityTimeoutExecutor);
 
     try {
-        await Promise.race([evaluatePromise, timeoutPromise]);
+        const res = await Promise.race([evaluatePromise, timeoutPromise]);
+        if (res) {
+            this.handleStabilityCheckResponse(res);
+        }
     } catch (e: any) {
         if (e.message === 'Stability check timed out') {
             console.warn(`[CdpTimeDriver] Stability check timed out after ${this.timeout}ms. Terminating execution.`);


### PR DESCRIPTION
Eliminated `.then()` chaining inside `CdpTimeDriver.ts` stability check. By racing the raw evaluate promise directly against the timeout promise and handling the response synchronously, we avoid dynamic allocation of anonymous closures on the event loop for every frame in the hot loop. This adheres to previous optimization patterns (e.g. PERF-384) to reduce V8 garbage collection churn during the capture process. Verified with canvas capture test.

---
*PR created automatically by Jules for task [6092946005235057558](https://jules.google.com/task/6092946005235057558) started by @BintzGavin*