### PR TITLE
📋 PLAYER: Document Missing Audio/Video Tracks

### DIFF
--- a/.sys/plans/2026-11-26-PLAYER-Document-Missing-Audio-Video-Tracks.md
+++ b/.sys/plans/2026-11-26-PLAYER-Document-Missing-Audio-Video-Tracks.md
@@ -1,0 +1,23 @@
+# Context & Goal
+- **Objective**: Document the `audioTracks` and `videoTracks` properties in the player's README.
+- **Trigger**: The implementation includes `get audioTracks()` and `get videoTracks()` in `packages/player/src/index.ts`, but they are missing from `packages/player/README.md`.
+- **Impact**: Completes API documentation parity with the actual implementation and HTMLMediaElement spec.
+
+# File Inventory
+- **Create**: None
+- **Modify**: `packages/player/README.md` (Add `audioTracks` and `videoTracks` to the Properties list)
+- **Read-Only**: `packages/player/src/index.ts`
+
+# Implementation Spec
+- **Architecture**: Documentation update to match codebase reality.
+- **Pseudo-Code**:
+  - Locate the `### Properties` section in `packages/player/README.md`
+  - Add `- \`audioTracks\` (AudioTrackList, read-only): The audio tracks associated with the media element.` right after `textTracks`
+  - Add `- \`videoTracks\` (VideoTrackList, read-only): The video tracks associated with the media element.` right after `audioTracks`
+- **Public API Changes**: None (Documentation only)
+- **Dependencies**: None
+
+# Test Plan
+- **Verification**: `cat packages/player/README.md | grep "audioTracks"` and `cat packages/player/README.md | grep "videoTracks"`
+- **Success Criteria**: The commands return the new property documentation lines.
+- **Edge Cases**: Ensure the formatting perfectly matches the existing markdown list.


### PR DESCRIPTION
Created a plan to document the missing `audioTracks` and `videoTracks` properties in the player's README. The properties are correctly implemented in `index.ts` but currently lack documentation, causing an API parity gap.

---
*PR created automatically by Jules for task [7371721293005139007](https://jules.google.com/task/7371721293005139007) started by @BintzGavin*