### PR TITLE
✨ RENDERER: Cache inline evaluate params in CdpTimeDriver and SeekTimeDriver

### DIFF
--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -16,6 +16,7 @@ export class CdpTimeDriver implements TimeDriver {
   private cdpResolve: (() => void) | null = null;
   private cdpReject: ((err: Error) => void) | null = null;
   private evaluateStabilityParams: any = { expression: "if (typeof window.__helios_wait_until_stable === 'function') window.__helios_wait_until_stable();", awaitPromise: true };
+  private singleFrameSyncMediaParams: any = { expression: "", awaitPromise: false };
 
   private stabilityTimeoutId: NodeJS.Timeout | null = null;
   private stabilityTimeoutReject: ((err: Error) => void) | null = null;
@@ -183,10 +184,8 @@ export class CdpTimeDriver implements TimeDriver {
     // Execute in all frames (including main frame) to support iframes
     const frames = this.cachedFrames;
     if (frames.length === 1) {
-      this.client!.send('Runtime.evaluate', {
-        expression: "if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");",
-        awaitPromise: false
-      }).catch(this.handleSyncMediaError);
+      this.singleFrameSyncMediaParams.expression = "if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");";
+      this.client!.send('Runtime.evaluate', this.singleFrameSyncMediaParams).catch(this.handleSyncMediaError);
     } else {
         if (this.executionContextIds.length > 0) {
           const expression = "if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");";

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -14,8 +14,8 @@ export class SeekTimeDriver implements TimeDriver {
   private cachedMainFrame: import('playwright').Frame | null = null;
     private executionContextIds: number[] = [];
   private multiFramePromises: Promise<any>[] = [];
+  private singleFrameEvaluateParams: any = { expression: '', awaitPromise: true };
   private evaluateArgs: [number, number] = [0, 0];
-  private multiFramePromises: Promise<any>[] = [];
   private evaluateClosure = ([t, timeoutMs]: any) => { (window as any).__helios_seek(t, timeoutMs); };
 
   constructor(private timeout: number = 30000) {
@@ -281,10 +281,8 @@ export class SeekTimeDriver implements TimeDriver {
     const frames = this.cachedFrames;
 
     if (frames.length === 1) {
-      return this.cdpSession!.send('Runtime.evaluate', {
-        expression: 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')',
-        awaitPromise: true
-      }) as unknown as Promise<void>;
+      this.singleFrameEvaluateParams.expression = 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')';
+      return this.cdpSession!.send('Runtime.evaluate', this.singleFrameEvaluateParams) as unknown as Promise<void>;
     }
 
     const expression = 'window.__helios_seek(' + timeInSeconds + ', ' + this.timeout + ')';


### PR DESCRIPTION
Implemented PERF-393 by preallocating evaluateParams object literals in CdpTimeDriver and SeekTimeDriver to reduce GC overhead.

---
*PR created automatically by Jules for task [5768770313092434984](https://jules.google.com/task/5768770313092434984) started by @BintzGavin*