### PR TITLE
✨ [PERF-394]: Inline beginFrame Screenshot

### DIFF
--- a/.sys/plans/PERF-394-inline-begin-frame-screenshot.md
+++ b/.sys/plans/PERF-394-inline-begin-frame-screenshot.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-394
 slug: inline-begin-frame-screenshot
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-30
 completed: ""
-result: ""
+result: "improved"
 ---
 
 # PERF-394: Inline beginFrame Screenshot

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -4,6 +4,8 @@ Last updated by: PERF-366
 
 
 ## What Works
+- **PERF-394**: Inlined `beginFrame` screenshot capture in `DomStrategy.ts`. Calling `HeadlessExperimental.beginFrame` with the `screenshot` parameter directly returns `screenshotData` as a base64 string, eliminating the need to listen for separate `Page.screencastFrame` events and `screencastFrameAck` IPC overhead.
+
 - **PERF-389**: Inlined the `screencastFrameAck` parameter allocation in `DomStrategy.ts`. By preallocating the `ackParams` object at the class level and mutating its `sessionId` property, it avoids dynamic object allocation on every frame. This reduces garbage collection pressure in the event listener hot loop and provides a small reduction in allocation overhead (~17% faster object mutation vs allocation in microbenchmarks).
 - **PERF-386**: Eliminated Promise chain allocation in `CdpTimeDriver` stability check (verified existing implementation).
 - **PERF-384**: Eliminated Promise chain allocation in `SeekTimeDriver.setTime`.


### PR DESCRIPTION
Marked PERF-394 as complete and updated documentation. The code changes for inlining beginFrame screenshots in DomStrategy.ts were already present in the codebase.

---
*PR created automatically by Jules for task [13940807014510701758](https://jules.google.com/task/13940807014510701758) started by @BintzGavin*