### PR TITLE
CLI: Duplicate Regression Tests Plan

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -143,3 +143,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## v0.46.12 - Duplicated Plan Handling
 **Learning:** When a plan specifies work that has already been completed (e.g., tests already exist and pass), the correct approach is to document the duplication as an impossibility in the plan file, and stop work. Do not overwrite existing tracking files.
 **Action:** Append to the journal with the finding, and do not increment versions or add new tracking entries. Always use `>>` when writing to journals.
+
+## v0.46.12 - Duplicated Regression Tests Plan
+**Learning:** The CLI status file listed regression tests for `job`, `render`, and `merge` commands as Next Steps, but these tests were already implemented.
+**Action:** Documented the duplication as an impossibility in the plan file and stopped work.

--- a/.sys/plans/2024-05-24-CLI-Regression-Tests-Duplicate.md
+++ b/.sys/plans/2024-05-24-CLI-Regression-Tests-Duplicate.md
@@ -1,0 +1,20 @@
+#### 1. Context & Goal
+- **Objective**: Implement regression tests for remaining CLI commands.
+- **Trigger**: `docs/status/CLI.md` Next Steps requested regression tests for `job.ts`, `render.ts`, and `merge.ts`.
+- **Impact**: IMPOSSIBLE: DUPLICATION. The tests already exist in `packages/cli/src/commands/__tests__/`.
+
+#### 2. File Inventory
+- **Create**: []
+- **Modify**: []
+- **Read-Only**: []
+
+#### 3. Implementation Spec
+- **Architecture**: Stop work. Work has already been completed.
+- **Pseudo-Code**: None
+- **Public API Changes**: None
+- **Dependencies**: None
+
+#### 4. Test Plan
+- **Verification**: None
+- **Success Criteria**: None
+- **Edge Cases**: None


### PR DESCRIPTION
Documented the impossibility of creating regression tests for job, render, and merge commands as they already exist, and updated the CLI journal.

---
*PR created automatically by Jules for task [7383836241012456414](https://jules.google.com/task/7383836241012456414) started by @BintzGavin*