### PR TITLE
✨ RENDERER: Discard preallocate Promise.race array in CdpTimeDriver (PERF-404)

### DIFF
--- a/.sys/plans/PERF-404-preallocate-promiserace-array.md
+++ b/.sys/plans/PERF-404-preallocate-promiserace-array.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-404
 slug: preallocate-promiserace-array
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-04-29
-completed: ""
-result: ""
+completed: "2026-04-29"
+result: "discard"
 ---
 
 # PERF-404: Preallocate Promise.race Array in CdpTimeDriver

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -36,6 +36,9 @@ Last updated by: PERF-403
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-404**: Attempted to preallocate the `Promise.race` array (`[evaluatePromise, timeoutPromise]`) in `CdpTimeDriver.ts`'s single-frame stability check loop.
+  - **WHY it didn't work**: The render time actually regressed slightly (~32.748s vs baseline ~31.854s). Managing the array state manually via an object property (and nulling it out to prevent leaks) adds more overhead or disrupts V8 optimization than the garbage collection pressure from a short-lived array literal. Discarded as slower.
+
 - **PERF-368**: Attempted to update TimeDriver to return void synchronously to eliminate Promise return overhead.
   - **WHY it didn't work**: Impossible. CaptureLoop explicitly awaits `timeDriver.setTime` to ensure CDP stability checks (in CdpTimeDriver) and Runtime.evaluate seeks (in SeekTimeDriver) finish before capturing the frame. Returning void causes frames to be captured out-of-sync before the browser finishes rendering. Discarded to maintain correctness.
 - **PERF-385**: Prebinding `drainPromiseExecutor` in `CaptureLoop.writeToStdin`.

--- a/packages/renderer/.sys/perf-results-PERF-404.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-404.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	34.295	90	2.62	38.6	discard	baseline preallocated race array
+2	32.794	90	2.74	38.7	discard	baseline preallocated race array
+3	32.748	90	2.75	37.7	discard	baseline preallocated race array


### PR DESCRIPTION
✨ RENDERER: Discard preallocate Promise.race array in CdpTimeDriver (PERF-404)

💡 What: Attempted to preallocate the `Promise.race` array (`[evaluatePromise, timeoutPromise]`) in `CdpTimeDriver.ts`'s single-frame stability check loop. Result: discard.
🎯 Why: To eliminate dynamic array allocation and reduce V8 GC pressure in the renderer hot loop.
📊 Impact: Render time regressed from a baseline of ~31.854s to ~32.748s. The overhead of managing the array state manually outweighed the garbage collection savings.
🔍 Verification: 3 benchmark runs executed via Node.js script. Evaluated median wall-clock time. Code changes reverted due to performance degradation. No logic checks required as code was restored.
📎 Plan: PERF-404

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	34.295	90	2.62	38.6	discard	baseline preallocated race array
2	32.794	90	2.74	38.7	discard	baseline preallocated race array
3	32.748	90	2.75	37.7	discard	baseline preallocated race array
```

---
*PR created automatically by Jules for task [13387327502065573350](https://jules.google.com/task/13387327502065573350) started by @BintzGavin*