### PR TITLE
✨ RENDERER: Replace EventEmitter.once with static .on in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-405-cdp-driver-event-listener.md
+++ b/.sys/plans/PERF-405-cdp-driver-event-listener.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-405
 slug: cdp-driver-event-listener
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2025-05-01
 completed: ""
@@ -48,3 +48,9 @@ Inside `async prepare(page: Page): Promise<void>`, after `this.client` is initia
 
 ## Correctness Check
 Run `npx tsx tests/verify-cdp-driver.ts` to verify that virtual time still advances correctly without timing out.
+
+## Results Summary
+- **Best render time**: 34.041s
+- **Improvement**: N/A (structural fix)
+- **Kept experiments**: [PERF-405]
+- **Discarded experiments**: []

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,9 +1,11 @@
 ## Performance Trajectory
-Current best: 44.500s (baseline was 49.197s, -9.5%)
+Current best: 34.041s (baseline was 49.197s, -9.5%)
 Last updated by: PERF-403
 
 
 ## What Works
+
+- **PERF-405**: Eliminated `EventEmitter.once` churn in `CdpTimeDriver.ts`. Moving to a static `.on` listener removes closure and array mutation in the virtual time hot loop, reducing V8 GC pressure. Render time: 34.041s.
 
 - **PERF-403**: Preallocated the `multiFrameEvaluateParams` array in `SeekTimeDriver.ts` multi-frame hot path. By allocating parameter objects for each execution context once and mutating the `expression` property, it reduces V8 dynamic object allocation and garbage collection pressure in the `setTime()` loop without encountering the race conditions of a single shared object literal. Render time improved to 44.500s.
 - **PERF-394**: Inlined `beginFrame` screenshot capture in `DomStrategy.ts`. Calling `HeadlessExperimental.beginFrame` with the `screenshot` parameter directly returns `screenshotData` as a base64 string, eliminating the need to listen for separate `Page.screencastFrame` events and `screencastFrameAck` IPC overhead.

--- a/packages/renderer/.sys/perf-results-PERF-405.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-405.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	34.041	150	4.41	37.6	keep	static event listener

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -36,7 +36,7 @@ export class CdpTimeDriver implements TimeDriver {
   private virtualTimePromiseExecutor = (resolve: () => void, reject: (err: Error) => void) => {
     this.cdpResolve = resolve;
     this.cdpReject = reject;
-    this.client!.once('Emulation.virtualTimeBudgetExpired', this.handleVirtualTimeBudgetExpired);
+
     this.client!.send('Emulation.setVirtualTimePolicy', this.setVirtualTimePolicyParams).catch(this.handleVirtualTimeBudgetError);
   };
 
@@ -90,6 +90,9 @@ export class CdpTimeDriver implements TimeDriver {
 
     // Clean up potential previous listeners if reusing driver or session
     this.client!.removeListener('Runtime.executionContextCreated', this.handleExecutionContextCreated);
+
+    this.client!.removeListener('Emulation.virtualTimeBudgetExpired', this.handleVirtualTimeBudgetExpired);
+    this.client!.on('Emulation.virtualTimeBudgetExpired', this.handleVirtualTimeBudgetExpired);
 
     this.executionContextIds = [];
     this.client!.on('Runtime.executionContextCreated', this.handleExecutionContextCreated);


### PR DESCRIPTION
Replaced dynamic `this.client!.once` with a static `.on` listener in `CdpTimeDriver.prepare()`.
Eliminated closure and array mutation churn from `EventEmitter.once` to reduce V8 GC pressure in the virtual time hot loop.
Reduced GC churn, maintaining stable rendering speed.
Verified via `tsx verify-cdp-driver.ts` and manual benchmark run.
Plan: PERF-405

---
*PR created automatically by Jules for task [6688193059165033977](https://jules.google.com/task/6688193059165033977) started by @BintzGavin*