### PR TITLE
✨ RENDERER: Discard PERF-407: Prebind SeekTimeDriver closures (negligible variance)

### DIFF
--- a/.sys/plans/PERF-407-prebind-seek-closures.md
+++ b/.sys/plans/PERF-407-prebind-seek-closures.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-407
 slug: prebind-seek-closures
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-01
 completed: ""
@@ -129,3 +129,9 @@ Run `npx tsx tests/verify-canvas-strategy.ts` to ensure core rendering functions
 
 ## Correctness Check
 Run `npx tsx tests/verify-seek-driver-stability.ts` to ensure the timeout still fires correctly with the prebound variables and execution contexts don't leak.
+
+## Results Summary
+- **Best render time**: 45.379s (vs baseline 45.545s)
+- **Improvement**: ~0.3%
+- **Kept experiments**:
+- **Discarded experiments**: Prebind Promise Executor and Resolver Closures in SeekTimeDriver

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -38,6 +38,8 @@ Last updated by: PERF-403
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-407**: Prebind Promise Executor and Resolver Closures in SeekTimeDriver.
+  - **WHY it didn't work**: The performance was essentially identical to the baseline (~45.3s vs ~45.5s), showing V8 optimizes the dynamic allocations inside window.__helios_seek very efficiently. Discarded to maintain code simplicity and as the variance is within the noise margin.
 - **PERF-404**: Attempted to preallocate the `Promise.race` array (`[evaluatePromise, timeoutPromise]`) in `CdpTimeDriver.ts`'s single-frame stability check loop.
   - **WHY it didn't work**: The render time actually regressed slightly (~32.748s vs baseline ~31.854s). Managing the array state manually via an object property (and nulling it out to prevent leaks) adds more overhead or disrupts V8 optimization than the garbage collection pressure from a short-lived array literal. Discarded as slower.
 

--- a/packages/renderer/.sys/perf-results-PERF-407.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-407.tsv
@@ -1,0 +1,8 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	59.931	600	10.01	42.2	baseline	pre-experiment run 1
+2	45.545	600	13.17	44.3	baseline	pre-experiment run 2
+3	45.936	600	13.06	44.0	baseline	pre-experiment run 3
+4	47.291	600	12.68	44.5	baseline	post-experiment run 1
+5	45.726	600	13.12	44.5	baseline	post-experiment run 2
+6	45.379	600	13.22	44.5	baseline	post-experiment run 3
+7	0.000	0	0.00	0.0	discard	prebind-seek-closures


### PR DESCRIPTION
Discarded the PERF-407 experiment which attempted to prebind Promise executor and resolver closures inside the `SeekTimeDriver` injected script (`window.__helios_seek`). The performance variance was well within the margin of noise (effectively ~45.3s vs ~45.5s), indicating that V8 optimizes these dynamic allocations efficiently enough that hoisting them provides no measurable benefit. Reverting maintains code simplicity. Render time was ~45.379s, compared to a baseline of ~45.545s (~0.3% improvement, statistically insignificant).

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	59.931	600	10.01	42.2	baseline	pre-experiment run 1
2	45.545	600	13.17	44.3	baseline	pre-experiment run 2
3	45.936	600	13.06	44.0	baseline	pre-experiment run 3
4	47.291	600	12.68	44.5	baseline	post-experiment run 1
5	45.726	600	13.12	44.5	baseline	post-experiment run 2
6	45.379	600	13.22	44.5	baseline	post-experiment run 3
7	0.000	0	0.00	0.0	discard	prebind-seek-closures
```

---
*PR created automatically by Jules for task [1471360634292364822](https://jules.google.com/task/1471360634292364822) started by @BintzGavin*