### PR TITLE
📋 CLI: Document IMPOSSIBLE DUPLICATION

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -147,3 +147,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## v0.46.12 - Duplicated Regression Tests Plan
 **Learning:** The CLI status file listed regression tests for `job`, `render`, and `merge` commands as Next Steps, but these tests were already implemented.
 **Action:** Documented the duplication as an impossibility in the plan file and stopped work.
+
+## [0.46.13] - Duplicated Regression Tests Plan (Re-verification)
+**Learning:** The CLI status file still lists regression tests for `job`, `render`, and `merge` as Next Steps, but these tests are already fully implemented. This is a known issue from previous planner executions.
+**Action:** Created plan file documenting IMPOSSIBLE: DUPLICATION and stopping work to avoid inventing unnecessary refactors.

--- a/.sys/plans/2025-05-01-CLI-Regression-Tests-Impossibility.md
+++ b/.sys/plans/2025-05-01-CLI-Regression-Tests-Impossibility.md
@@ -1,0 +1,20 @@
+#### 1. Context & Goal
+- **Objective**: IMPOSSIBLE: DUPLICATION
+- **Trigger**: `docs/status/CLI.md` lists "Implement regression tests for remaining commands (e.g. job.ts, render.ts, merge.ts)" as the Next Step.
+- **Impact**: No action can be taken because `packages/cli/src/commands/__tests__/job.test.ts`, `render.test.ts`, and `merge.test.ts` already exist and contain comprehensive tests.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**: None
+- **Read-Only**: `packages/cli/src/commands/__tests__/job.test.ts`, `packages/cli/src/commands/__tests__/render.test.ts`, `packages/cli/src/commands/__tests__/merge.test.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: N/A - The tests are already implemented.
+- **Pseudo-Code**: N/A
+- **Public API Changes**: None
+- **Dependencies**: None
+
+#### 4. Test Plan
+- **Verification**: Run `npm test` in `packages/cli` to verify tests pass.
+- **Success Criteria**: Tests exist and pass successfully.
+- **Edge Cases**: N/A


### PR DESCRIPTION
The CLI planner was tasked to "Implement regression tests for remaining commands (e.g. job.ts, render.ts, merge.ts)" according to the `docs/status/CLI.md` next steps. However, exploration revealed these tests already exist in `packages/cli/src/commands/__tests__/`. In accordance with the project's duplicated plan handling guidelines, I have created a spec file to document this impossibility and updated the journal with a critical learning to prevent future duplication loops.

---
*PR created automatically by Jules for task [3408705797382320217](https://jules.google.com/task/3408705797382320217) started by @BintzGavin*