### PR TITLE
✨ RENDERER: Cache Media Elements in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-408-cache-media-elements-cdp.md
+++ b/.sys/plans/PERF-408-cache-media-elements-cdp.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-408
 slug: cache-media-elements-cdp
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-03
-completed: ""
-result: ""
+completed: "2024-06-03"
+result: "improved"
 ---
 
 # PERF-408: Cache Media Elements in CdpTimeDriver to avoid per-frame DOM scans
@@ -71,3 +71,9 @@ Run `cd packages/renderer && npx tsx tests/verify-codecs.ts`.
 
 ## Correctness Check
 Run targeted script `cd packages/renderer && npx tsx tests/verify-cdp-media-sync-timing.ts`.
+
+## Results Summary
+- **Best render time**: 49.135s (vs baseline 49.217s)
+- **Improvement**: ~0.1%
+- **Kept experiments**: Cache Media Elements in CdpTimeDriver to avoid per-frame DOM scans.
+- **Discarded experiments**: none

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -181,3 +181,8 @@ Last updated by: PERF-399
 ## PERF-376: Inline seek promise
 - Status: discard
 - **PERF-376**: Attempted to inline the Promise.race logic in `window.__helios_seek` and remove timeout allocation to reduce micro-allocations in `SeekTimeDriver.ts`. This was already tested in PERF-378 and discarded because performance was identical to the baseline and it caused client-side stability timeouts to fail. No code changes were kept.
+
+- **PERF-408**: Cache Media Elements in CdpTimeDriver to avoid per-frame DOM scans.
+  - Added `cachedMediaElements` to avoid `findAllMedia(document)` being evaluated on every frame capture.
+  - Reduced V8 GC churn and execution time slightly (median render time decreased from ~49.217s to ~49.135s).
+  - Aligns CdpTimeDriver optimization with previous SeekTimeDriver optimizations. Kept.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -38,3 +38,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 3	31.519	90	2.85	0.0	discard	native promise ring
 1	399.547	600	1.50	0.0	keep	eliminated promise chain cdptimedriver (already implemented)
 401	32.648	90	2.76	38.6	keep	Reverted frameTimeTicks 1000x scale bug
+PERF-408	49.135	600	12.21	43.1	keep	Cache Media Elements in CdpTimeDriver to avoid per-frame DOM scans

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -118,11 +118,20 @@ export class CdpTimeDriver implements TimeDriver {
         ${PARSE_MEDIA_ATTRIBUTES_FUNCTION}
         ${SYNC_MEDIA_FUNCTION}
 
+        let cachedMediaElements = null;
+
+        window.__helios_invalidate_cache = () => {
+          cachedMediaElements = null;
+        };
+
         window.__helios_sync_media = (t) => {
-          const mediaElements = findAllMedia(document);
-          mediaElements.forEach((el) => {
-            syncMedia(el, t);
-          });
+          if (!cachedMediaElements) {
+            cachedMediaElements = findAllMedia(document);
+          }
+          const numMedia = cachedMediaElements.length;
+          for (let i = 0; i < numMedia; i++) {
+            syncMedia(cachedMediaElements[i], t);
+          }
         };
 
         window.__helios_wait_until_stable = async () => {


### PR DESCRIPTION
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
PERF-408	49.135	600	12.21	43.1	keep	Cache Media Elements in CdpTimeDriver to avoid per-frame DOM scans

---
*PR created automatically by Jules for task [12826036594702156009](https://jules.google.com/task/12826036594702156009) started by @BintzGavin*