### PR TITLE
✨ RENDERER: Document duplicated PERF-402 plan as IMPOSSIBLE

### DIFF
--- a/.sys/plans/PERF-402-preallocate-multi-frame-sync-media-params.md
+++ b/.sys/plans/PERF-402-preallocate-multi-frame-sync-media-params.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-402
 slug: preallocate-multi-frame-sync-media-params
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-06-03
 completed: ""
-result: ""
+result: "failed"
 ---
 
 # PERF-402: Preallocate multi-frame sync media params array in CdpTimeDriver
@@ -88,3 +88,7 @@ None.
 
 ## Correctness Check
 Run targeted script `cd packages/renderer && npx tsx tests/verify-cdp-driver.ts`.
+
+## Results Summary
+- IMPOSSIBLE: DUPLICATION
+- The preallocation of `multiFrameSyncMediaParams` is already present in `packages/renderer/src/drivers/CdpTimeDriver.ts`.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -186,3 +186,5 @@ Last updated by: PERF-399
   - Added `cachedMediaElements` to avoid `findAllMedia(document)` being evaluated on every frame capture.
   - Reduced V8 GC churn and execution time slightly (median render time decreased from ~49.217s to ~49.135s).
   - Aligns CdpTimeDriver optimization with previous SeekTimeDriver optimizations. Kept.
+- **PERF-402**: Preallocate multi-frame sync media params array in CdpTimeDriver.
+  - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. The structural change (prebinding `multiFrameSyncMediaParams`) was already implemented and kept by a previous experiment. Documented duplication and stopped work.


### PR DESCRIPTION
💡 What: Documented PERF-402 as IMPOSSIBLE: DUPLICATION.
🎯 Why: The structural change to preallocate multiFrameSyncMediaParams in CdpTimeDriver is already present.
📊 Impact: Prevents overwriting or duplicating work.
🔍 Verification: Checked packages/renderer/src/drivers/CdpTimeDriver.ts.
📎 Plan: PERF-402

---
*PR created automatically by Jules for task [2214008874297396557](https://jules.google.com/task/2214008874297396557) started by @BintzGavin*