### PR TITLE
✨ RENDERER: Evaluate PERF-411 - Prebind stability promise in CdpTimeDriver

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -188,3 +188,5 @@ Last updated by: PERF-399
   - Aligns CdpTimeDriver optimization with previous SeekTimeDriver optimizations. Kept.
 - **PERF-402**: Preallocate multi-frame sync media params array in CdpTimeDriver.
   - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. The structural change (prebinding `multiFrameSyncMediaParams`) was already implemented and kept by a previous experiment. Documented duplication and stopped work.
+- **PERF-411**: Prebind stability promise in CdpTimeDriver to eliminate Promise.race and Array allocations.
+  - **WHY it didn't work**: The performance difference was negligible or worse (median ~33.517s vs baseline ~33.35s). V8 optimizations likely handle Promise.race efficiently enough that eliminating it doesn't yield a net benefit when considering the overhead of manual promise state tracking.

--- a/packages/renderer/.sys/perf-results-PERF-411.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-411.tsv
@@ -1,0 +1,1 @@
+1	33.517	300	8.95	40.0	discard	PERF-411 prebind stability promise

--- a/packages/renderer/.sys/plans/PERF-411.md
+++ b/packages/renderer/.sys/plans/PERF-411.md
@@ -1,0 +1,11 @@
+---
+id: PERF-411
+slug: prebind-stability-promise
+status: complete
+---
+
+## Results Summary
+- **Best render time**: 33.517s (vs baseline ~33.35s)
+- **Improvement**: ~0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-411]


### PR DESCRIPTION
Evaluated prebinding the stability promise in CdpTimeDriver to eliminate `Promise.race` and Array allocations during stability checks. The experiment was discarded because it didn't improve performance.

No performance improvement (median ~33.517s vs baseline ~33.35s). V8 optimizations likely handle Promise.race efficiently enough that eliminating it doesn't yield a net benefit when considering the overhead of manual promise state tracking.

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	33.52	300	8.95	40.0	discard	PERF-411 prebind stability promise
```

---
*PR created automatically by Jules for task [214780803485110741](https://jules.google.com/task/214780803485110741) started by @BintzGavin*