### PR TITLE
📋 RENDERER: Document PERF-411 as duplicate

### DIFF
--- a/.sys/plans/PERF-411-optimize-cdp-evaluate-stability.md
+++ b/.sys/plans/PERF-411-optimize-cdp-evaluate-stability.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-411
 slug: optimize-cdp-evaluate-stability
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2026-05-02
 completed: ""
-result: ""
+result: failed
 ---
 
 # PERF-411: Optimize CDP Stability Checks in CdpTimeDriver
@@ -131,3 +131,7 @@ Run `cd packages/renderer && npm run test` to verify no breakages.
 
 ## Prior Art
 - PERF-404: Attempted to preallocate the Promise.race array and failed due to object mutation overhead. This alternative wrapper Promise sidesteps that.
+
+## Results Summary
+IMPOSSIBLE: DUPLICATION
+The experiment PERF-411 has already been attempted and is documented in the RENDERER-EXPERIMENTS.md journal as failed.


### PR DESCRIPTION
Documented PERF-411 as a duplicate in both the plan file and journal, properly closing out the experimental plan without any unnecessary code modifications.

---
*PR created automatically by Jules for task [11734752457701632780](https://jules.google.com/task/11734752457701632780) started by @BintzGavin*