### PR TITLE
✨ RENDERER: Preallocate CDP Screenshots Parameters and Object Literals in DomStrategy

### DIFF
--- a/.sys/plans/PERF-414-inline-dom-strategy-object-allocation.md
+++ b/.sys/plans/PERF-414-inline-dom-strategy-object-allocation.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-414
 slug: inline-dom-strategy-object-allocation
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-02
 completed: ""
-result: ""
+result: "improved"
 ---
 
 # PERF-414: Preallocate CDP Screenshots Parameters and Object Literals in DomStrategy

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -190,3 +190,6 @@ Last updated by: PERF-399
   - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. The structural change (prebinding `multiFrameSyncMediaParams`) was already implemented and kept by a previous experiment. Documented duplication and stopped work.
 - **PERF-411**: Prebind stability promise in CdpTimeDriver to eliminate Promise.race and Array allocations.
   - **WHY it didn't work**: The performance difference was negligible or worse (median ~33.517s vs baseline ~33.35s). V8 optimizations likely handle Promise.race efficiently enough that eliminating it doesn't yield a net benefit when considering the overhead of manual promise state tracking.
+- **PERF-414**: Preallocate CDP Screenshots Parameters and Object Literals in DomStrategy.
+  - Implemented logic to preallocate `screenshot` parameters object (`elementScreenshotParams`) when capturing from an element handle, removing per-frame string comparisons and dynamic object allocations inside the hot loop.
+  - Result: Minor reduction in V8 GC pause times for DOM-based multi-frame rendering. Kept.

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -16,6 +16,7 @@ export class DomStrategy implements RenderStrategy {
   private cleanupAudio: () => Promise<void> | void = () => {};
   private cdpSession: CDPSession | null = null;
   private lastFrameData: Buffer | string | null = null;
+  private elementScreenshotParams: any = null;
 
   private cdpScreenshotParams: any = null;
   private targetElementHandle: any = null;
@@ -123,6 +124,12 @@ export class DomStrategy implements RenderStrategy {
     this.cdpScreenshotParams = cdpScreenshotParams;
     this.beginFrameParams.screenshot = cdpScreenshotParams;
 
+    this.elementScreenshotParams = {
+      type: cdpScreenshotParams.format,
+      quality: cdpScreenshotParams.quality,
+      omitBackground: cdpScreenshotParams.format !== 'jpeg'
+    };
+
     // Set format-appropriate empty buffer
     if (format === 'jpeg') {
         // 1x1 JPEG pixel
@@ -157,12 +164,7 @@ export class DomStrategy implements RenderStrategy {
 
   async capture(page: Page, frameTime: number): Promise<Buffer | string> {
     if (this.targetElementHandle) {
-      const isOpaque = this.cdpScreenshotParams.format === 'jpeg';
-      const res = await this.targetElementHandle.screenshot({
-        type: this.cdpScreenshotParams.format,
-        quality: this.cdpScreenshotParams.quality,
-        omitBackground: !isOpaque
-      });
+      const res = await this.targetElementHandle.screenshot(this.elementScreenshotParams);
       if (res) {
         this.lastFrameData = res;
         return res;


### PR DESCRIPTION
Preallocate the screenshot parameters object in DomStrategy.ts when targeting a specific element. To remove per-frame string comparisons and dynamic object allocation, relieving GC pressure in the capture hot loop.

---
*PR created automatically by Jules for task [15171677431173754655](https://jules.google.com/task/15171677431173754655) started by @BintzGavin*