### PR TITLE
PLAYER: API Parity Spec

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -35,3 +35,6 @@
 ## [v0.77.25] - Missing README properties
 **Learning:** Properties implemented in `index.ts` (e.g., `mediaTitle`) are sometimes missing from the `README.md` properties list due to disconnected implementation and documentation steps.
 **Action:** When adding new properties, explicitly include updating the README in the implementation spec, or periodically cross-reference `index.ts` exported properties with the README.
+## v0.76.20 - Template Compliance
+**Learning:** Missing one of the required bullet points in the implementation spec template can cause validation failure.
+**Action:** When planning, make sure to include all required sections from the template (Context & Goal, File Inventory, Implementation Spec, Test Plan) and their respective sub-bullets.

--- a/.sys/plans/2026-12-30-PLAYER-Fix-API-Parity-videoTracks.md
+++ b/.sys/plans/2026-12-30-PLAYER-Fix-API-Parity-videoTracks.md
@@ -1,0 +1,31 @@
+#### 1. Context & Goal
+- **Objective**: Implement `disableRemotePlayback` property parity and document `videoTracks` and `disableRemotePlayback` in the README.
+- **Trigger**: The HTMLMediaElement interface defines `disableRemotePlayback` and `videoTracks`. The `videoTracks` property is implemented but missing from the README, and `disableRemotePlayback` is completely missing.
+- **Impact**: Completes HTMLMediaElement API parity and ensures README matches the actual API surface.
+
+#### 2. File Inventory
+- **Create**: (None)
+- **Modify**:
+  - `packages/player/src/index.ts`: Implement `disableRemotePlayback` getter and setter to persist the state. Add `disableremoteplayback` to `observedAttributes`.
+  - `packages/player/README.md`: Document `videoTracks` and `disableRemotePlayback` properties.
+- **Read-Only**: `docs/status/PLAYER.md`
+
+#### 3. Implementation Spec
+- **Architecture**: Standard Web Components attribute reflection and property getters/setters for HTMLMediaElement parity.
+- **Pseudo-Code**:
+  - In `packages/player/src/index.ts`:
+    - Add `disableremoteplayback` to `observedAttributes`.
+    - Implement `get disableRemotePlayback(): boolean` to reflect `this.hasAttribute("disableremoteplayback")`.
+    - Implement `set disableRemotePlayback(val: boolean)` to toggle the attribute.
+  - In `packages/player/README.md`:
+    - Under the Properties section, add `videoTracks` (VideoTrackList, read-only) matching `audioTracks` style.
+    - Under the Properties section, add `disableRemotePlayback` (boolean) description.
+    - Under the Attributes section, add `disableremoteplayback` description.
+- **Public API Changes**:
+  - Adds `disableRemotePlayback` getter/setter to `<helios-player>`.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: Run `npm test -w packages/player` to ensure no regressions. Check the typescript compilation with `npm run build -w packages/player`.
+- **Success Criteria**: The `disableRemotePlayback` property functions correctly, and the README reflects the actual API properties.
+- **Edge Cases**: Ensure `disableRemotePlayback` reflection works correctly as a boolean attribute.


### PR DESCRIPTION
Created an implementation spec to implement `disableRemotePlayback` parity and update documentation for `videoTracks` and `disableRemotePlayback`.

---
*PR created automatically by Jules for task [17848901015111321331](https://jules.google.com/task/17848901015111321331) started by @BintzGavin*