### PR TITLE
✨ RENDERER: [PERF-421] Prebind Promise Executors in CaptureLoop writeToStdin

### DIFF
--- a/.sys/plans/PERF-421-prebind-capture-loop-executors.md
+++ b/.sys/plans/PERF-421-prebind-capture-loop-executors.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-421
 slug: prebind-capture-loop-executors
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-02
 completed: ""
-result: ""
+result: "improved"
 ---
 
 # PERF-421: Prebind Promise Executors in CaptureLoop writeToStdin

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -9,6 +9,7 @@ const noopCatch = () => {};
 export class CaptureLoop {
   private drainResolve: (() => void) | null = null;
   private drainReject: ((err: Error) => void) | null = null;
+  private drainPromiseExecutor = (resolve: () => void, reject: (err: Error) => void) => { this.drainResolve = resolve; this.drainReject = reject; };
 
   private handleWriteError = (err?: Error | null) => {
     if (err) {
@@ -79,10 +80,7 @@ export class CaptureLoop {
     }
 
     if (!canWriteMore) {
-        return new Promise<void>((resolve, reject) => {
-            this.drainResolve = resolve;
-            this.drainReject = reject;
-        });
+        return new Promise<void>(this.drainPromiseExecutor);
     }
   }
 


### PR DESCRIPTION
Implemented PERF-421. By pre-binding the drainPromiseExecutor to the `CaptureLoop` instance, we eliminate the need to create a new anonymous arrow function each time `writeToStdin` hits a backpressure condition where it needs to wait for the stream to drain. This aligns with other optimizations across the application that avoid dynamic allocation inside hot rendering loops.

Tests were successfully run. 
- `npm run build` completed successfully without any compilation errors
- `tsx packages/renderer/tests/verify-dom-strategy-capture.ts` passed.

---
*PR created automatically by Jules for task [4227779959132146736](https://jules.google.com/task/4227779959132146736) started by @BintzGavin*