### PR TITLE
✨ CLI: Document duplicated Remaining Regression Tests plan

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -158,3 +158,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.46.14] - Duplicated Regression Tests Plan (Re-verification for job/render/merge)
 **Learning:** The CLI status file lists regression tests for `job`, `render`, and `merge` as Next Steps, but these tests are already fully implemented in `packages/cli/src/commands/__tests__/`. This is a recurring issue where the status file suggests work that is already done.
 **Action:** Created plan file documenting IMPOSSIBLE: DUPLICATION and stopping work to avoid inventing unnecessary refactors.
+
+## v0.46.15 - Remaining Regression Tests
+**Learning:** The plan for remaining CLI regression tests (preview, skills, studio) was an IMPOSSIBLE: DUPLICATION. Tests were already implemented in their respective `__tests__` files and passing.
+**Action:** Always verify test file existence before assuming a plan needs execution.

--- a/.sys/plans/2027-06-01-CLI-Regression-Tests-Remaining.md
+++ b/.sys/plans/2027-06-01-CLI-Regression-Tests-Remaining.md
@@ -1,5 +1,7 @@
 ---
-result: impossible
+status: complete
+---
+result: failed
 ---
 #### 1. Context & Goal
 - **Objective**: Implement comprehensive regression tests for the remaining untested CLI commands (`helios preview`, `helios skills`, `helios studio`).
@@ -38,3 +40,6 @@ result: impossible
   - Missing directories for `preview`.
   - Missing skills directory for `skills install`.
   - Failed server start for `preview` and `studio`.
+
+IMPOSSIBLE: DUPLICATION
+These tests (preview, skills, studio) have already been fully implemented in the codebase.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -314,3 +314,6 @@ This file tracks progress for the CLI domain (`packages/cli`).
 
 ### CLI v0.46.13
 - ✅ Completed: Document duplicated Remove Regression Tests plan - Logged the duplicated plan as impossible.
+
+### CLI v0.46.15
+- ✅ Completed: Document duplicated Remaining Regression Tests plan - Logged the duplicated plan as impossible.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,8 +1,9 @@
 # CLI Status
 
-**Version**: 0.46.14
+**Version**: 0.46.15
 
 ## Recent Completions
+[v0.46.15] ✅ Completed: Document duplicated Remaining Regression Tests plan - Logged the duplicated plan as impossible.
 [v0.46.14] ✅ Completed: Document duplicated Regression Tests plan - Logged the duplicated plan for job, render, and merge commands as impossible.
 [v0.46.13] ✅ Completed: Document duplicated Remove Regression Tests plan - Logged the duplicated plan as impossible.
 [v0.46.12] ✅ Completed: Regression Tests Remaining Commands - Verified comprehensive unit tests for `helios preview`, `helios skills`, and `helios studio`.


### PR DESCRIPTION
💡 What:
Updated the plan `2027-06-01-CLI-Regression-Tests-Remaining.md` to reflect that the requested tests (for `preview`, `skills`, and `studio`) were already fully implemented and passing. Added journal insights and progress logs reflecting the duplicated impossibility.

🎯 Why:
The status file triggered a task to implement regression tests for the remaining CLI commands, but these tests were already added in a previous feature implementation (around `v0.46.12`). Continuing to try to implement them would be a duplicated effort, so it was documented as an impossibility and aborted.

📊 Impact:
Saves development time, maintains an accurate tracking history, and prevents creating unnecessary or redundant PRs for already implemented tasks.

🔬 Verification:
Ran `npm run test -w packages/cli` ensuring that `preview.test.ts`, `skills.test.ts`, and `studio.test.ts` pass via vitest. Verified that tracking files were appropriately updated indicating the `IMPOSSIBLE: DUPLICATION`.

📎 Plan:
.sys/plans/2027-06-01-CLI-Regression-Tests-Remaining.md

---
*PR created automatically by Jules for task [12879493463700752035](https://jules.google.com/task/12879493463700752035) started by @BintzGavin*