### PR TITLE
✨ RENDERER: Prebind SeekTimeDriver closures experiment (discarded)

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -197,3 +197,7 @@ Last updated by: PERF-399
 - **Refactor Media Discovery Logic (2026-03-12-RENDERER-Refactor-Media-Discovery)**
   - **What I tried**: Attempted to consolidate duplicate "find all media" and "find all scopes" logic into a single source of truth (`dom-scripts.ts`).
   - **WHY it didn't work**: Impossible/Obsolete (IMPOSSIBLE: DUPLICATION). The structural change was already implemented in a previous commit and present in the codebase. Documented duplication and stopped work.
+
+- **PERF-422**: Prebind SeekTimeDriver Closures (window.__helios_seek)
+  - **WHY it didn't work**: The performance improvement was negligible (baseline ~33.4s vs ~33.3s). This indicates that V8 is already optimizing closure allocations inside `window.__helios_seek` and `createMediaPromise` well enough that moving them out of the hot loop via prebinding/module scope does not yield a meaningful performance benefit. The small gain is within the ~5% margin of error and the manual state management introduces unnecessary code complexity.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-422.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-422.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	33.432	300	8.97	40.9	keep	baseline
+2	33.328	300	9.00	40.4	keep	prebind seek closures
+3	33.253	300	9.02	40.2	keep	prebind seek closures (module scoped)

--- a/packages/renderer/.sys/plans/PERF-422-prebind-seek-closures.md
+++ b/packages/renderer/.sys/plans/PERF-422-prebind-seek-closures.md
@@ -1,0 +1,52 @@
+---
+id: PERF-422
+slug: prebind-seek-closures
+status: complete
+claimed_by: "executor-session"
+---
+
+# RENDERER: Prebind SeekTimeDriver Closures (PERF-422)
+
+#### 1. Context & Goal
+- **Objective**: Prebind closures (`stabilityExecutor`, `finish`, `fail`) in the `SeekTimeDriver.ts` injected script (`window.__helios_seek`) and cache media promise handlers directly on DOM elements.
+- **Goal**: Eliminate per-frame dynamic allocations and reduce V8 garbage collection overhead in the `SeekTimeDriver` hot path.
+
+#### 2. File Inventory
+- **Modify**: `packages/renderer/src/drivers/SeekTimeDriver.ts`
+
+#### 3. Implementation Spec
+- **Architecture**:
+  - Introduce a module-scoped `seekState` object in the injected script to track variables across the pre-bound stability promise executor.
+  - Pre-bind `stabilityFinish`, `stabilityFail`, and `stabilityExecutor` functions to avoid creating new closures dynamically inside `window.__helios_seek`.
+  - Cache `el.__helios_media_finish` and `el.__helios_media_executor` handlers directly on the media element inside `createMediaPromise` to prevent dynamic allocation of these closures for every seek.
+- **Pseudo-Code**:
+  ```javascript
+  // In window.__helios_seek
+  const seekState = { t: 0, timeoutMs: 0, ... };
+  const stabilityFinish = () => { /* use seekState */ };
+  const stabilityFail = (err) => { /* use seekState */ };
+  const stabilityExecutor = (resolve, reject) => { /* use seekState */ };
+
+  // In createMediaPromise
+  if (!el.__helios_media_finish) {
+     el.__helios_media_finish = () => { ... };
+  }
+  if (!el.__helios_media_executor) {
+     el.__helios_media_executor = (resolve) => { ... };
+  }
+  ```
+- **Public API Changes**: None
+- **Dependencies**: None
+
+#### 4. Test Plan
+- Run `npm run build` to verify compilation.
+- Run `npm test` to verify `SeekTimeDriver` and all other tests pass, ensuring no scoping or functional issues.
+- Benchmark and compare DOM render time using `node benchmark.ts` (or standard benchmark tool).
+- Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+
+## Results Summary
+- **Best render time**: 33.253s (vs baseline 33.432s)
+- **Improvement**: ~0.5%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-422]


### PR DESCRIPTION
Tested pre-binding closures in `window.__helios_seek` and caching media promise handlers in `SeekTimeDriver.ts`.

The median render time improved from ~33.432s to ~33.253s (~0.5%). This is within the margin of error, indicating V8 already optimizes these allocations efficiently. The changes were discarded to avoid unnecessary code complexity.

**Results Summary:**
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	33.432	300	8.97	40.9	keep	baseline
2	33.328	300	9.00	40.4	keep	prebind seek closures
3	33.253	300	9.02	40.2	keep	prebind seek closures (module scoped)
```

---
*PR created automatically by Jules for task [11561071787222046504](https://jules.google.com/task/11561071787222046504) started by @BintzGavin*