### PR TITLE
✨ RENDERER: Discard PERF-415 (Duplication)

### DIFF
--- a/.sys/plans/PERF-415-inline-dom-strategy-object-allocation.md
+++ b/.sys/plans/PERF-415-inline-dom-strategy-object-allocation.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-415
 slug: inline-dom-strategy-object-allocation
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "EX"
 created: 2024-05-02
-completed: ""
-result: ""
+completed: "2026-05-03"
+result: "failed"
 ---
 
 # PERF-415: Preallocate CDP Screenshots Parameters and Object Literals in DomStrategy
@@ -116,3 +116,6 @@ None.
 
 ## Canvas Smoke Test
 Run `cd packages/renderer && npm run test` to verify no breakages.
+
+## Result
+IMPOSSIBLE: DUPLICATION. The structural change (preallocating `elementScreenshotParams`) was already implemented and kept by a previous experiment (PERF-414). Documented duplication and stopped work.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -38,6 +38,9 @@ Last updated by: PERF-403
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-415**: Preallocate CDP Screenshots Parameters and Object Literals in DomStrategy.
+  - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. The structural change (preallocating `elementScreenshotParams`) was already implemented and kept by a previous experiment (PERF-414). Documented duplication and stopped work.
+  - **Outcome**: discard
 - **PERF-407**: Prebind Promise Executor and Resolver Closures in SeekTimeDriver.
   - **WHY it didn't work**: The performance was essentially identical to the baseline (~45.3s vs ~45.5s), showing V8 optimizes the dynamic allocations inside window.__helios_seek very efficiently. Discarded to maintain code simplicity and as the variance is within the noise margin.
 - **PERF-404**: Attempted to preallocate the `Promise.race` array (`[evaluatePromise, timeoutPromise]`) in `CdpTimeDriver.ts`'s single-frame stability check loop.

--- a/packages/renderer/.sys/perf-results-PERF-415.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-415.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	IMPOSSIBLE: DUPLICATION


### PR DESCRIPTION
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	IMPOSSIBLE: DUPLICATION
```

This PR acknowledges PERF-415 as impossible due to duplication. The optimization of preallocating `elementScreenshotParams` in `DomStrategy.ts` was already completed in PERF-414. The plan status has been updated to failed, and a corresponding entry has been appended to `docs/status/RENDERER-EXPERIMENTS.md`.

---
*PR created automatically by Jules for task [6437792166075986811](https://jules.google.com/task/6437792166075986811) started by @BintzGavin*