### PR TITLE
✨ RENDERER: Document PERF-410 and PERF-412 as impossible duplications

### DIFF
--- a/.sys/plans/PERF-410-optimize-seek-browser-promises.md
+++ b/.sys/plans/PERF-410-optimize-seek-browser-promises.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-410
 slug: optimize-seek-browser-promises
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2026-05-02
 completed: ""
-result: ""
+result: "failed"
 ---
 
 # PERF-410: Optimize Promise Allocations in SeekTimeDriver Browser Script
@@ -102,3 +102,6 @@ Run `cd packages/renderer && npm run test` or an equivalent check to verify no b
 ## Prior Art
 - PERF-406: Preallocated the `cachedPromises` array to avoid dynamic array allocation inside this same block.
 - PERF-409: Attempted replacing Node.js-side `Promise.race` for stability checks in `CdpTimeDriver.ts`. This applies the same optimization strategy to the browser-side script in `SeekTimeDriver.ts`.
+
+## Duplication Note
+IMPOSSIBLE: DUPLICATION. The optimization to eliminate the Promise.race wrapper and optimize the stability timeout logic in the injected script was already implemented and kept by a previous experiment.

--- a/.sys/plans/PERF-412-optimize-seek-stability-race.md
+++ b/.sys/plans/PERF-412-optimize-seek-stability-race.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-412
 slug: optimize-seek-stability-race
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2026-05-02
 completed: ""
-result: ""
+result: "failed"
 ---
 
 # PERF-412: Optimize Promise.race Allocation in SeekTimeDriver
@@ -81,3 +81,6 @@ Run `cd packages/renderer && npm run test` to verify no breakages.
 
 ## Prior Art
 - PERF-411: Attempted the exact same optimization in CdpTimeDriver.ts.
+
+## Duplication Note
+IMPOSSIBLE: DUPLICATION. The optimization to eliminate the Promise.race wrapper and optimize the stability timeout logic in the injected script was already implemented and kept by a previous experiment.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -38,6 +38,9 @@ Last updated by: PERF-403
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-410/412**: Optimize Promise allocations and race conditions in SeekTimeDriver
+  - **WHY it didn't work**: Impossible/Obsolete (IMPOSSIBLE: DUPLICATION). The structural change was already implemented in a previous commit and present in the codebase. Documented duplication and stopped work.
+
 - **PERF-415**: Preallocate CDP Screenshots Parameters and Object Literals in DomStrategy.
   - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. The structural change (preallocating `elementScreenshotParams`) was already implemented and kept by a previous experiment (PERF-414). Documented duplication and stopped work.
   - **Outcome**: discard


### PR DESCRIPTION
This submission updates the plan tracking files for PERF-410 and PERF-412, marking them as `complete` and `failed` due to duplication. The proposed optimizations to remove `Promise.race` array and wrapper allocations in the `SeekTimeDriver.ts` injected script (`window.__helios_seek`) have already been implemented in the codebase by previous iterations.

Changes include:
- Status updates and explanatory headers in the respective `.sys/plans` Markdown files.
- Addition of a duplication entry to the `docs/status/RENDERER-EXPERIMENTS.md` journal.
- Verification tests ensuring the environment remains functional.

---
*PR created automatically by Jules for task [13900945052782015891](https://jules.google.com/task/13900945052782015891) started by @BintzGavin*