### PR TITLE
✨ RENDERER: Document PERF-424 as Impossible Duplication

### DIFF
--- a/.sys/plans/PERF-424-empty-image-dimensions.md
+++ b/.sys/plans/PERF-424-empty-image-dimensions.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-424
 slug: empty-image-dimensions
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-05-03
-completed: ""
-result: ""
+completed: "2024-05-03"
+result: "failed"
 ---
 
 # PERF-424: 2x2 Empty Image Dimensions

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -217,3 +217,6 @@ Last updated by: PERF-399
 
 - **PERF-427**: Disabled GPU Compositing by Default in BrowserPool
   - Improved median render time to ~32.504s. Removed GPU/software rasterizer translation overhead from headless SwiftShader. Defaulting config.gpu !== true applies GPU_DISABLED_ARGS properly.
+- **PERF-424**: Empty Image Dimensions
+  - **What I tried**: Attempted to update the fallback 1x1 base64 encoded images (PNG, JPEG, WEBP) in `DomStrategy.ts` to 2x2 pixels to prevent FFmpeg crashes when encoding to `yuv420p`.
+  - **WHY it didn't work**: Impossible/Obsolete (IMPOSSIBLE: DUPLICATION). The structural change was already implemented in a previous commit and is present in the codebase. Documented duplication and stopped work.


### PR DESCRIPTION
This PR documents PERF-424 as an "IMPOSSIBLE: DUPLICATION" in the experiment journal and marks the plan file as complete/failed, as the proposed changes (using 2x2 fallback images) are already implemented in `DomStrategy.ts`.

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.0	0	0.0	0.0	discard	IMPOSSIBLE: DUPLICATION

---
*PR created automatically by Jules for task [14983175113283200272](https://jules.google.com/task/14983175113283200272) started by @BintzGavin*