### PR TITLE
✨ CLI: Document Remaining Regression Tests Duplication

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -162,3 +162,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## v0.46.15 - Remaining Regression Tests
 **Learning:** The plan for remaining CLI regression tests (preview, skills, studio) was an IMPOSSIBLE: DUPLICATION. Tests were already implemented in their respective `__tests__` files and passing.
 **Action:** Always verify test file existence before assuming a plan needs execution.
+
+## v0.46.16 - Regression Tests Duplication (Re-verification)
+**Learning:** The plan "2027-06-01-CLI-Regression-Tests-Remaining" requests adding tests for `preview`, `skills`, and `studio` commands, but these are already implemented in `packages/cli/src/commands/__tests__/` and pass successfully when run via Vitest.
+**Action:** Always verify if tests requested in the plan exist in the repository before generating or rewriting identical tests, and mark the plan as an impossibility if so.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -119,6 +119,7 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] **CLI**: Implement render command.
 - [x] **CLI**: Implement example init (`helios init --example`).
 - [x] **CLI**: Make example registry configurable (remove hardcoded URL).
+- [x] **CLI**: Implement regression tests for remaining commands.
 - [x] **Examples**: Create examples demonstrating distributed rendering workflows.
 - [x] **Examples**: Create examples demonstrating component usage.
 

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -317,3 +317,5 @@ This file tracks progress for the CLI domain (`packages/cli`).
 
 ### CLI v0.46.15
 - ✅ Completed: Document duplicated Remaining Regression Tests plan - Logged the duplicated plan as impossible.
+### CLI v0.46.16
+- ✅ Completed: Remaining CLI Regression Tests - Identified as duplicate plan; tests for preview, skills, and studio are already implemented.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,8 +1,9 @@
 # CLI Status
 
-**Version**: 0.46.15
+**Version**: 0.46.16
 
 ## Recent Completions
+[v0.46.16] ✅ Completed: Remaining CLI Regression Tests - Identified as duplicate plan; tests for preview, skills, and studio are already implemented.
 [v0.46.15] ✅ Completed: Document duplicated Remaining Regression Tests plan - Logged the duplicated plan as impossible.
 [v0.46.14] ✅ Completed: Document duplicated Regression Tests plan - Logged the duplicated plan for job, render, and merge commands as impossible.
 [v0.46.13] ✅ Completed: Document duplicated Remove Regression Tests plan - Logged the duplicated plan as impossible.


### PR DESCRIPTION
Closes the plan `2027-06-01-CLI-Regression-Tests-Remaining.md` as duplicated work since the regression tests for `preview`, `skills`, and `studio` commands were already implemented. Updated relevant documentation tracking.

---
*PR created automatically by Jules for task [12146712909183640630](https://jules.google.com/task/12146712909183640630) started by @BintzGavin*