### PR TITLE
✨ RENDERER: Discard PERF-429 inline object allocation

### DIFF
--- a/.sys/plans/PERF-429-inline-object-allocation.md
+++ b/.sys/plans/PERF-429-inline-object-allocation.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-429
 slug: inline-object-allocation
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-05-03
-completed: ""
-result: ""
+completed: "2024-05-03"
+result: "discard"
 ---
 
 # PERF-429: Inline object literal allocation for `HeadlessExperimental.beginFrame` and `Runtime.evaluate`
@@ -68,3 +68,9 @@ None.
 
 ## Test Plan
 - Run `npx --prefix packages/renderer tsx packages/renderer/tests/verify-dom-strategy-capture.ts` to ensure frames capture correctly without hanging.
+
+## Results Summary
+- **Best render time**: 32.231s (vs baseline 32.146s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [Inline object literal allocation for CDP commands]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -220,3 +220,6 @@ Last updated by: PERF-399
 - **PERF-424**: Empty Image Dimensions
   - **What I tried**: Attempted to update the fallback 1x1 base64 encoded images (PNG, JPEG, WEBP) in `DomStrategy.ts` to 2x2 pixels to prevent FFmpeg crashes when encoding to `yuv420p`.
   - **WHY it didn't work**: Impossible/Obsolete (IMPOSSIBLE: DUPLICATION). The structural change was already implemented in a previous commit and is present in the codebase. Documented duplication and stopped work.
+
+## What Doesn't Work (and Why)
+- Inlining object literal allocations for CDP commands (`HeadlessExperimental.beginFrame`, `Runtime.evaluate`, `Emulation.setVirtualTimePolicy`) in `DomStrategy`, `SeekTimeDriver`, and `CdpTimeDriver` (PERF-429). Why: This was hypothesized to be faster (and was tested positively in an isolated earlier plan PERF-348), but the benchmark data shows absolutely no improvement (32.3s vs 32.3s). In V8, reusing a cached object's properties in a hot loop avoids the overhead of instantiating new objects and GCing them. The previous switch back to mutating class properties was likely already optimal or at parity due to hidden class optimizations.

--- a/packages/renderer/.sys/perf-results-PERF-429.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-429.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.376	150	4.63	38.6	keep	baseline
+2	32.278	150	4.65	38.0	keep	baseline
+3	32.146	150	4.67	38.5	keep	baseline
+4	32.314	150	4.64	37.6	discard	inline allocation
+5	32.231	150	4.65	38.1	discard	inline allocation
+6	32.398	150	4.63	37.7	discard	inline allocation


### PR DESCRIPTION
💡 **What**: Attempted to replace cached object property mutations with inline object literal allocations in `DomStrategy`, `SeekTimeDriver`, and `CdpTimeDriver` for CDP evaluate/beginFrame calls. 
🎯 **Why**: A previous experiment (PERF-348) showed promise with this approach, hypothetically reducing cached state.
📊 **Impact**: No improvement. Baseline was ~32.1s, the experiment was ~32.2s. V8 efficiently handles the property mutation of cached objects without garbage collection overhead compared to continuous inline object allocations.
🔬 **Verification**: Code built successfully. The test renderer showed parity/slight regression in memory/time so the changes were discarded and reverted.
📎 **Plan**: `/.sys/plans/PERF-429-inline-object-allocation.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.376	150	4.63	38.6	keep	baseline
2	32.278	150	4.65	38.0	keep	baseline
3	32.146	150	4.67	38.5	keep	baseline
4	32.314	150	4.64	37.6	discard	inline allocation
5	32.231	150	4.65	38.1	discard	inline allocation
6	32.398	150	4.63	37.7	discard	inline allocation
```

---
*PR created automatically by Jules for task [4143374211769636774](https://jules.google.com/task/4143374211769636774) started by @BintzGavin*