### PR TITLE
✨ RENDERER: [Discarded] Restore TimeDriver Promise

### DIFF
--- a/.sys/plans/PERF-372-restore-timedriver-promise.md
+++ b/.sys/plans/PERF-372-restore-timedriver-promise.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-372
 slug: restore-timedriver-promise
-status: claimed
+status: complete
 claimed_by: "executor-session"
 created: 2024-05-01
 completed: ""
-result: ""
+result: "failed"
 ---
 
 # PERF-372: Restore TimeDriver Promise
@@ -35,3 +35,10 @@ PERF-368 changed `TimeDriver.setTime` to return `void` to eliminate Promise trac
 **File**: `packages/renderer/src/core/CaptureLoop.ts`
 **What to change**: Restore `await` logic for `timeDriver.setTime`.
 **Why**: Fixes the race condition.
+
+## Results Summary
+- **Best render time**: N/A
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [Restore TimeDriver Promise]
+- **Notes**: IMPOSSIBLE: DUPLICATION. The codebase already implements the TimeDriver interface returning `Promise<void>` and awaiting `timeDriver.setTime()` in `CaptureLoop.ts`.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -38,6 +38,9 @@ Last updated by: PERF-403
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-372**: Restore TimeDriver Promise
+  - **WHY it didn't work**: Impossible/Obsolete (IMPOSSIBLE: DUPLICATION). The structural change was already implemented in a previous commit and is present in the codebase. Documented duplication and stopped work.
+  - **Outcome**: discard
 - **PERF-410/412**: Optimize Promise allocations and race conditions in SeekTimeDriver
   - **WHY it didn't work**: Impossible/Obsolete (IMPOSSIBLE: DUPLICATION). The structural change was already implemented in a previous commit and present in the codebase. Documented duplication and stopped work.
 
@@ -222,5 +225,8 @@ Last updated by: PERF-399
   - **WHY it didn't work**: Impossible/Obsolete (IMPOSSIBLE: DUPLICATION). The structural change was already implemented in a previous commit and is present in the codebase. Documented duplication and stopped work.
 
 ## What Doesn't Work (and Why)
+- **PERF-372**: Restore TimeDriver Promise
+  - **WHY it didn't work**: Impossible/Obsolete (IMPOSSIBLE: DUPLICATION). The structural change was already implemented in a previous commit and is present in the codebase. Documented duplication and stopped work.
+  - **Outcome**: discard
 - Inlining object literal allocations for CDP commands (`HeadlessExperimental.beginFrame`, `Runtime.evaluate`, `Emulation.setVirtualTimePolicy`) in `DomStrategy`, `SeekTimeDriver`, and `CdpTimeDriver` (PERF-429). Why: This was hypothesized to be faster (and was tested positively in an isolated earlier plan PERF-348), but the benchmark data shows absolutely no improvement (32.3s vs 32.3s). In V8, reusing a cached object's properties in a hot loop avoids the overhead of instantiating new objects and GCing them. The previous switch back to mutating class properties was likely already optimal or at parity due to hidden class optimizations.
 - **PERF-430**: Optimized CDP evaluate stability and seek checks by forcing `returnByValue: false` in `SeekTimeDriver` and `CdpTimeDriver`. This reduces IPC payload and serialization overhead for void promises.

--- a/packages/renderer/.sys/perf-results-PERF-372.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-372.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	IMPOSSIBLE: DUPLICATION. TimeDriver promises are already restored in the codebase.


### PR DESCRIPTION
✨ RENDERER: [Discarded] Restore TimeDriver Promise

💡 What: Evaluated PERF-372 to restore TimeDriver Promise await tracking.
🎯 Why: The optimization was already fully implemented in the current codebase (`TimeDriver.ts` and `CaptureLoop.ts` already correctly await `setTime`).
📊 Impact: 0% (Duplicate/Obsolete).
📝 Updates: Updated `.sys/plans/PERF-372-restore-timedriver-promise.md`, `.sys/perf-results-PERF-372.tsv`, and `docs/status/RENDERER-EXPERIMENTS.md` as IMPOSSIBLE: DUPLICATION.
🔬 Verification: Verified using manual file reviews and successfully ran `verify-dom-strategy-capture.ts`.
📎 Plan: `/.sys/plans/PERF-372-restore-timedriver-promise.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	IMPOSSIBLE: DUPLICATION. TimeDriver promises are already restored in the codebase.
```

---
*PR created automatically by Jules for task [510212749571889710](https://jules.google.com/task/510212749571889710) started by @BintzGavin*