### PR TITLE
📋 RENDERER: Nullish Coalescing in DomStrategy

### DIFF
--- a/.sys/plans/PERF-434-nullish-coalescing.md
+++ b/.sys/plans/PERF-434-nullish-coalescing.md
@@ -1,0 +1,51 @@
+---
+id: PERF-434
+slug: nullish-coalescing
+status: unclaimed
+claimed_by: ""
+created: 2026-10-18
+completed: ""
+result: ""
+---
+
+# PERF-434: Eliminate Truthiness Check Allocations in DomStrategy Capture Loop
+
+## Context & Goal
+In the `DomStrategy.ts` capture hot loop, `handleBeginFrameSuccess` uses a truthiness fallback `result.screenshotData || this.lastFrameData!`. In V8, the logical OR `||` operator forces a `ToBoolean` type coercion on the left operand. For strings (like `screenshotData`), it has to verify if the string is non-empty, involving execution overhead on every frame.
+
+By replacing `||` with the nullish coalescing operator `??`, V8 only performs a direct check for `null` or `undefined`. Because `result.screenshotData` is guaranteed to be a string or undefined in the CDP protocol, this simple check avoids type coercion and minor execution overhead in the tight rendering loop.
+
+## File Inventory
+- `packages/renderer/src/strategies/DomStrategy.ts`
+
+## Implementation Spec
+
+### Architecture
+Modify the `handleBeginFrameSuccess` callback in `DomStrategy.ts` to use nullish coalescing.
+
+### Pseudo-Code
+```typescript
+// packages/renderer/src/strategies/DomStrategy.ts
+// Change:
+private handleBeginFrameSuccess = (result: any) => {
+  const frameData = result.screenshotData || this.lastFrameData!;
+  this.lastFrameData = frameData;
+  return frameData;
+};
+
+// To:
+private handleBeginFrameSuccess = (result: any) => {
+  const frameData = result.screenshotData ?? this.lastFrameData!;
+  this.lastFrameData = frameData;
+  return frameData;
+};
+```
+
+### Public API Changes
+None
+
+### Dependencies
+None
+
+## Test Plan
+- Run `cd packages/renderer && npx tsx tests/verify-dom-strategy-capture.ts`.


### PR DESCRIPTION
- 💡 **What**: Added an experiment plan (PERF-434) to replace the truthiness fallback (`||`) with the nullish coalescing operator (`??`) in the `handleBeginFrameSuccess` capture callback in `DomStrategy.ts`.
- 🎯 **Why**: To reduce `ToBoolean` coercion execution overhead in V8 during the hot frame capture loop, minimizing minor garbage collection pressure and latency per frame.
- 🔬 **Approach**: Replace the logical OR (`||`) with the nullish coalescing operator (`??`) for the `result.screenshotData` parameter.
- 📎 **Plan**: `/.sys/plans/PERF-434-nullish-coalescing.md`

---
*PR created automatically by Jules for task [15251432894264033855](https://jules.google.com/task/15251432894264033855) started by @BintzGavin*