### PR TITLE
✨ RENDERER: Discard PERF-389 as impossible duplication

### DIFF
--- a/.sys/plans/PERF-389-inline-screencast-ack-params.md
+++ b/.sys/plans/PERF-389-inline-screencast-ack-params.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-389
 slug: inline-screencast-ack-params
-status: claimed
+status: complete
 claimed_by: "executor-perf-389"
 created: 2024-05-28
 completed: "2024-05-28"
-result: "keep"
+result: "failed"
 ---
 
 # PERF-389: Inline screencastFrameAck parameter allocation in DomStrategy
@@ -63,3 +63,7 @@ N/A
 
 ## Correctness Check
 Run targeted script `cd packages/renderer && npx tsx tests/verify-dom-strategy-capture.ts`.
+
+## Results Summary
+**IMPOSSIBLE: DUPLICATION**
+The codebase no longer uses `Page.screencastFrame` or `Page.screencastFrameAck`. A previous experiment (PERF-394) inlined the `beginFrame` screenshot capture, eliminating the need to listen for separate `Page.screencastFrame` events and `screencastFrameAck` IPC overhead. Therefore, this plan is obsolete and cannot be implemented.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -245,3 +245,7 @@ Last updated by: PERF-432
   - **Outcome**: discard
 - Inlining object literal allocations for CDP commands (`HeadlessExperimental.beginFrame`, `Runtime.evaluate`, `Emulation.setVirtualTimePolicy`) in `DomStrategy`, `SeekTimeDriver`, and `CdpTimeDriver` (PERF-429). Why: This was hypothesized to be faster (and was tested positively in an isolated earlier plan PERF-348), but the benchmark data shows absolutely no improvement (32.3s vs 32.3s). In V8, reusing a cached object's properties in a hot loop avoids the overhead of instantiating new objects and GCing them. The previous switch back to mutating class properties was likely already optimal or at parity due to hidden class optimizations.
 - **PERF-430**: Optimized CDP evaluate stability and seek checks by forcing `returnByValue: false` in `SeekTimeDriver` and `CdpTimeDriver`. This reduces IPC payload and serialization overhead for void promises.
+
+- **PERF-389**: Inline screencastFrameAck parameter allocation
+  - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. The codebase no longer uses `Page.screencastFrame` or `Page.screencastFrameAck`. A previous experiment (PERF-394) inlined the `beginFrame` screenshot capture, eliminating the need to listen for separate `Page.screencastFrame` events and `screencastFrameAck` IPC overhead. Documented duplication and stopped work.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-389.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-389.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	IMPOSSIBLE: DUPLICATION


### PR DESCRIPTION
💡 **What**: Documented PERF-389 as an IMPOSSIBLE: DUPLICATION and discarded it.
🎯 **Why**: The target code (`Page.screencastFrame` and `Page.screencastFrameAck`) is no longer used in `DomStrategy.ts` because a previous experiment (PERF-394) inlined the `beginFrame` screenshot capture.
📊 **Impact**: N/A (Discarded)
🔬 **Verification**: Verified via `grep` and test script `verify-dom-strategy-capture.ts`.
📎 **Plan**: `/.sys/plans/PERF-389-inline-screencast-ack-params.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	IMPOSSIBLE: DUPLICATION
```

---
*PR created automatically by Jules for task [12996782332454141009](https://jules.google.com/task/12996782332454141009) started by @BintzGavin*