### PR TITLE
✨ RENDERER: Record PERF-434 nullish coalescing experiment outcome

### DIFF
--- a/.sys/plans/PERF-434-nullish-coalescing.md
+++ b/.sys/plans/PERF-434-nullish-coalescing.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-434
 slug: nullish-coalescing
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: "2026-05-04"
+result: "no-improvement"
 ---
 
 # PERF-434: Eliminate Truthiness Check Allocations in DomStrategy Capture Loop
@@ -49,3 +49,9 @@ None
 
 ## Test Plan
 - Run `cd packages/renderer && npx tsx tests/verify-dom-strategy-capture.ts`.
+
+## Results Summary
+- **Best render time**: 32.475s (vs baseline 32.452s)
+- **Improvement**: ~0.0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-434]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -249,3 +249,8 @@ Last updated by: PERF-432
 - **PERF-389**: Inline screencastFrameAck parameter allocation
   - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. The codebase no longer uses `Page.screencastFrame` or `Page.screencastFrameAck`. A previous experiment (PERF-394) inlined the `beginFrame` screenshot capture, eliminating the need to listen for separate `Page.screencastFrame` events and `screencastFrameAck` IPC overhead. Documented duplication and stopped work.
   - **Outcome**: discard
+
+- **PERF-434**: Nullish Coalescing in DomStrategy
+  - **What I tried**: Replaced `result.screenshotData || this.lastFrameData!` with `result.screenshotData ?? this.lastFrameData!` in `DomStrategy.ts` to avoid V8's `ToBoolean` string coercion overhead.
+  - **WHY it didn't work**: The performance improvement was non-existent (baseline ~32.45s vs ~32.47s). V8 is already highly optimized for logical OR truthiness checks on strings inside hot loops (likely through Hidden Classes and inline caches), making the manual micro-optimization of using nullish coalescing irrelevant.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-434.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-434.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.452	90	2.77	38.1	keep	baseline
+2	32.475	90	2.77	37.8	discard	nullish coalescing ??

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -40,3 +40,5 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 401	32.648	90	2.76	38.6	keep	Reverted frameTimeTicks 1000x scale bug
 PERF-408	49.135	600	12.21	43.1	keep	Cache Media Elements in CdpTimeDriver to avoid per-frame DOM scans
 5	48.792	600	12.30	30.2	keep	eliminated async wrapper in CdpTimeDriver
+1	32.452	90	2.77	38.1	keep	PERF-434 baseline
+2	32.475	90	2.77	37.8	discard	PERF-434 nullish coalescing


### PR DESCRIPTION
💡 **What**: Executed PERF-434 to replace `||` with `??` in DomStrategy capture loop.
🎯 **Why**: To test if avoiding V8 `ToBoolean` string coercion on `screenshotData` would improve performance.
📊 **Impact**: No improvement (32.452s -> 32.475s). Code reverted. Documentation updated.
🔬 **Verification**: Ran `benchmark-test.js` script. Final output tested via `verify-dom-strategy-capture.ts`.
📎 **Plan**: `/.sys/plans/PERF-434-nullish-coalescing.md`

## Results Summary
| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 32.452 | 90 | 2.77 | 38.1 | keep | baseline |
| 2 | 32.475 | 90 | 2.77 | 37.8 | discard | nullish coalescing ?? |

---
*PR created automatically by Jules for task [1964360674121670274](https://jules.google.com/task/1964360674121670274) started by @BintzGavin*