### PR TITLE
✨ RENDERER: Optimize FFmpeg Pipe thread_queue_size

### DIFF
--- a/.sys/plans/PERF-435-optimize-ffmpeg-thread-queue.md
+++ b/.sys/plans/PERF-435-optimize-ffmpeg-thread-queue.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-435
 slug: optimize-ffmpeg-thread-queue
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-04
-completed: ""
-result: ""
+completed: "2024-05-04"
+result: "no-improvement"
 ---
 
 # PERF-435: Optimize FFmpeg Pipe thread_queue_size
@@ -44,3 +44,9 @@ None.
 ## Test Plan
 - Run the DOM Correctness check: `cd packages/renderer && npx tsx tests/verify-dom-strategy-capture.ts`.
 - Run the performance benchmark to record metrics: `npm run build -w packages/core && npm run build -w packages/renderer && npm run build:examples && cd packages/renderer && npx tsx scripts/benchmark-test.js`.
+
+## Results Summary
+- **Best render time**: 32.533s (vs baseline 32.682s)
+- **Improvement**: ~0.4%
+- **Kept experiments**: None
+- **Discarded experiments**: thread_queue_size 4096 (discarded due to negligible performance improvement, confirming default queue is sufficient)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -254,3 +254,8 @@ Last updated by: PERF-432
   - **What I tried**: Replaced `result.screenshotData || this.lastFrameData!` with `result.screenshotData ?? this.lastFrameData!` in `DomStrategy.ts` to avoid V8's `ToBoolean` string coercion overhead.
   - **WHY it didn't work**: The performance improvement was non-existent (baseline ~32.45s vs ~32.47s). V8 is already highly optimized for logical OR truthiness checks on strings inside hot loops (likely through Hidden Classes and inline caches), making the manual micro-optimization of using nullish coalescing irrelevant.
   - **Outcome**: discard
+
+- **PERF-435**: Optimize FFmpeg Pipe thread_queue_size
+  - **What I tried**: Attempted to increase the `-thread_queue_size` for FFmpeg's stdin from `512` to `4096` in `DomStrategy.ts`.
+  - **WHY it didn't work**: The performance improvement was negligible (median ~32.54s vs baseline ~32.68s). This suggests that the default queue size of `512` is already sufficient to buffer the frames and OS-level backpressure is not the primary bottleneck in the capture loop, or the encoder is keeping up closely enough that a larger buffer doesn't significantly unblock Node.js.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-435.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-435.tsv
@@ -1,0 +1,5 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	43.070	90	2.09	38.7	keep	baseline
+2	32.682	90	2.75	38.5	keep	baseline retry
+3	32.554	90	2.76	38.6	keep	thread_queue_size 4096 (1)
+4	32.533	90	2.77	37.7	keep	thread_queue_size 4096 (2)


### PR DESCRIPTION
💡 **What**: Executed and discarded PERF-435 to increase FFmpeg `-thread_queue_size` from 512 to 4096.
🎯 **Why**: To attempt to reduce OS-level backpressure when piping frames into FFmpeg by buffering more frames.
📊 **Impact**: Negligible (32.533s vs baseline 32.682s, ~0.4% improvement).
🔬 **Verification**: Ran `scripts/benchmark-test.js` under `mode: 'dom'`. Validated that the default `512` queue size is sufficient.
📎 **Plan**: Reference `.sys/plans/PERF-435-optimize-ffmpeg-thread-queue.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	43.070	90	2.09	38.7	keep	baseline
2	32.682	90	2.75	38.5	keep	baseline retry
3	32.554	90	2.76	38.6	keep	thread_queue_size 4096 (1)
4	32.533	90	2.77	37.7	keep	thread_queue_size 4096 (2)
```

---
*PR created automatically by Jules for task [17199532328337881245](https://jules.google.com/task/17199532328337881245) started by @BintzGavin*