### PR TITLE
✨ CLI: Add regression tests for utils

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -45,6 +45,10 @@ packages/cli/
 │   ├── registry/
 │   │   └── client.ts
 │   ├── utils/
+│   │   ├── __tests__/
+│   │   │   ├── ffmpeg.test.ts
+│   │   │   ├── package-manager.test.ts
+│   │   │   └── uninstall.test.ts
 │   │   ├── config.ts
 │   │   ├── examples.ts
 │   │   ├── ffmpeg.ts

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -321,3 +321,6 @@ This file tracks progress for the CLI domain (`packages/cli`).
 - ✅ Completed: Remaining CLI Regression Tests - Identified as duplicate plan; tests for preview, skills, and studio are already implemented.
 ### CLI v0.46.17
 - ✅ Completed: Document duplicated Deploy Command Regression Tests plan - Logged the duplicated plan as impossible.
+
+### CLI v0.46.19
+- ✅ Completed: CLI Utils Regression Tests - Implemented comprehensive unit tests for ffmpeg, package-manager, and uninstall utilities in packages/cli/src/utils/.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,7 @@
 # CLI Status
 
-**Version**: 0.46.18
+**Version**: 0.46.19
+[v0.46.19] ✅ Completed: CLI Utils Regression Tests - Implemented comprehensive unit tests for ffmpeg, package-manager, and uninstall utilities in packages/cli/src/utils/.
 
 ## Recent Completions
 [v0.46.18] ✅ Completed: CLI Utils Regression Tests Spec - Created specification plan for implementing regression tests for the remaining uncovered utilities in packages/cli/src/utils/ to ensure core functions are robust.

--- a/packages/cli/src/utils/__tests__/ffmpeg.test.ts
+++ b/packages/cli/src/utils/__tests__/ffmpeg.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { transcodeMerge } from '../ffmpeg';
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+
+vi.mock('child_process');
+vi.mock('fs');
+vi.mock('@ffmpeg-installer/ffmpeg', () => ({
+  default: { path: '/mock/ffmpeg/path' }
+}));
+
+describe('ffmpeg utils', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('transcodeMerge', () => {
+    it('throws if no input files provided', async () => {
+      await expect(transcodeMerge([], 'out.mp4', {})).rejects.toThrow('No input files provided for merge');
+    });
+
+    it('creates output directory if it does not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.mkdirSync).mockImplementation(() => undefined as any);
+
+      const mockSpawn = vi.fn();
+      const mockProcess = {
+        stderr: { on: vi.fn() },
+        stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn() },
+        on: vi.fn((event, cb) => {
+          if (event === 'close') cb(0);
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await transcodeMerge(['in.mp4'], 'dir/out.mp4', {});
+
+      expect(fs.existsSync).toHaveBeenCalled();
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringContaining('dir'), { recursive: true });
+    });
+
+    it('spawns ffmpeg with correct arguments', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      const mockSpawn = vi.fn();
+      let stdinData = '';
+      const mockProcess = {
+        stderr: { on: vi.fn() },
+        stdin: {
+          write: vi.fn((data) => { stdinData += data; }),
+          end: vi.fn(),
+          on: vi.fn()
+        },
+        on: vi.fn((event, cb) => {
+          if (event === 'close') cb(0);
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await transcodeMerge(['in1.mp4', 'in2.mp4'], 'out.mp4', {
+        videoCodec: 'libx264',
+        audioCodec: 'aac',
+        quality: '23',
+        preset: 'fast',
+      });
+
+      expect(mockSpawn).toHaveBeenCalledWith('/mock/ffmpeg/path', expect.arrayContaining([
+        '-f', 'concat',
+        '-safe', '0',
+        '-protocol_whitelist', 'file,pipe',
+        '-i', '-',
+        '-c:v', 'libx264',
+        '-c:a', 'aac',
+        '-crf', '23',
+        '-preset', 'fast',
+        '-y', 'out.mp4'
+      ]));
+
+      expect(stdinData).toContain('in1.mp4');
+      expect(stdinData).toContain('in2.mp4');
+    });
+
+    it('rejects if ffmpeg exits with non-zero code', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      const mockSpawn = vi.fn();
+      const mockProcess = {
+        stderr: { on: vi.fn((event, cb) => { if (event === 'data') cb('some error output'); }) },
+        stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn() },
+        on: vi.fn((event, cb) => {
+          if (event === 'close') cb(1);
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await expect(transcodeMerge(['in.mp4'], 'out.mp4', {})).rejects.toThrow('FFmpeg merge failed with code 1');
+    });
+
+    it('rejects if ffmpeg process emits error', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      const mockSpawn = vi.fn();
+      const mockProcess = {
+        stderr: { on: vi.fn() },
+        stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn() },
+        on: vi.fn((event, cb) => {
+          if (event === 'error') cb(new Error('Spawn error'));
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await expect(transcodeMerge(['in.mp4'], 'out.mp4', {})).rejects.toThrow('Spawn error');
+    });
+
+    it('handles stdin error gracefully if EPIPE', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      const mockSpawn = vi.fn();
+      const mockProcess = {
+        stderr: { on: vi.fn() },
+        stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn((event, cb) => {
+          if (event === 'error') cb({ code: 'EPIPE' });
+        }) },
+        on: vi.fn((event, cb) => {
+          if (event === 'close') cb(0);
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await expect(transcodeMerge(['in.mp4'], 'out.mp4', {})).resolves.toBeUndefined();
+    });
+
+    it('rejects if stdin emits non-EPIPE error', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      const mockSpawn = vi.fn();
+      const mockProcess = {
+        stderr: { on: vi.fn() },
+        stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn((event, cb) => {
+          if (event === 'error') cb(new Error('Stdin error'));
+        }) },
+        on: vi.fn((event, cb) => {
+          // don't resolve automatically
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await expect(transcodeMerge(['in.mp4'], 'out.mp4', {})).rejects.toThrow('Stdin error');
+    });
+  });
+});

--- a/packages/cli/src/utils/__tests__/package-manager.test.ts
+++ b/packages/cli/src/utils/__tests__/package-manager.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { detectPackageManager, installPackage } from '../package-manager';
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+
+vi.mock('child_process');
+vi.mock('fs');
+
+describe('package-manager utils', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('detectPackageManager', () => {
+    it('detects yarn if yarn.lock exists', () => {
+      vi.mocked(fs.existsSync).mockImplementation((path) => String(path).endsWith('yarn.lock'));
+      expect(detectPackageManager('/test/dir')).toBe('yarn');
+    });
+
+    it('detects pnpm if pnpm-lock.yaml exists', () => {
+      vi.mocked(fs.existsSync).mockImplementation((path) => String(path).endsWith('pnpm-lock.yaml'));
+      expect(detectPackageManager('/test/dir')).toBe('pnpm');
+    });
+
+    it('detects bun if bun.lockb exists', () => {
+      vi.mocked(fs.existsSync).mockImplementation((path) => String(path).endsWith('bun.lockb'));
+      expect(detectPackageManager('/test/dir')).toBe('bun');
+    });
+
+    it('defaults to npm if no lockfile is found', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      expect(detectPackageManager('/test/dir')).toBe('npm');
+    });
+  });
+
+  describe('installPackage', () => {
+    it('installs with npm correctly', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false); // defaults to npm
+      const mockSpawn = vi.fn();
+      const mockProcess = {
+        on: vi.fn((event, cb) => {
+          if (event === 'close') cb(0);
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await installPackage('/test/dir', ['pkg-a', 'pkg-b'], true);
+
+      const expectedCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+      expect(mockSpawn).toHaveBeenCalledWith(expectedCommand, ['install', '--save-dev', 'pkg-a', 'pkg-b'], expect.any(Object));
+    });
+
+    it('installs with yarn correctly', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((path) => String(path).endsWith('yarn.lock'));
+      const mockSpawn = vi.fn();
+      const mockProcess = {
+        on: vi.fn((event, cb) => {
+          if (event === 'close') cb(0);
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await installPackage('/test/dir', ['pkg-a', 'pkg-b'], true);
+
+      const expectedCommand = process.platform === 'win32' ? 'yarn.cmd' : 'yarn';
+      expect(mockSpawn).toHaveBeenCalledWith(expectedCommand, ['add', '--dev', 'pkg-a', 'pkg-b'], expect.any(Object));
+    });
+
+    it('installs with pnpm correctly', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((path) => String(path).endsWith('pnpm-lock.yaml'));
+      const mockSpawn = vi.fn();
+      const mockProcess = {
+        on: vi.fn((event, cb) => {
+          if (event === 'close') cb(0);
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await installPackage('/test/dir', ['pkg-a'], false);
+
+      const expectedCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+      expect(mockSpawn).toHaveBeenCalledWith(expectedCommand, ['add', 'pkg-a'], expect.any(Object));
+    });
+
+    it('installs with bun correctly', async () => {
+      vi.mocked(fs.existsSync).mockImplementation((path) => String(path).endsWith('bun.lockb'));
+      const mockSpawn = vi.fn();
+      const mockProcess = {
+        on: vi.fn((event, cb) => {
+          if (event === 'close') cb(0);
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await installPackage('/test/dir', ['pkg-a'], true);
+
+      const expectedCommand = process.platform === 'win32' ? 'bun.cmd' : 'bun';
+      expect(mockSpawn).toHaveBeenCalledWith(expectedCommand, ['add', '--dev', 'pkg-a'], expect.any(Object));
+    });
+
+    it('rejects if install fails', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false); // defaults to npm
+      const mockSpawn = vi.fn();
+      const mockProcess = {
+        on: vi.fn((event, cb) => {
+          if (event === 'close') cb(1);
+        }),
+      };
+      mockSpawn.mockReturnValue(mockProcess as any);
+      vi.mocked(child_process.spawn).mockImplementation(mockSpawn as any);
+
+      await expect(installPackage('/test/dir', ['pkg-a'], false)).rejects.toThrow('Failed to install dependencies with npm');
+    });
+  });
+});

--- a/packages/cli/src/utils/__tests__/uninstall.test.ts
+++ b/packages/cli/src/utils/__tests__/uninstall.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { uninstallComponent } from '../uninstall';
+import * as configUtils from '../config';
+import * as fs from 'fs';
+import { RegistryClient } from '../../registry/client';
+
+vi.mock('../config');
+vi.mock('fs');
+vi.mock('../../registry/client');
+
+describe('uninstall utils', () => {
+  const mockConfig = {
+    registry: 'https://registry.example.com',
+    framework: 'react',
+    components: ['button', 'card'],
+    directories: {
+      components: 'src/components',
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(configUtils.loadConfig).mockReturnValue(JSON.parse(JSON.stringify(mockConfig)));
+
+    // Silence console
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  describe('uninstallComponent', () => {
+    it('throws if no config found', async () => {
+      vi.mocked(configUtils.loadConfig).mockReturnValue(null);
+      await expect(uninstallComponent('/test', 'button')).rejects.toThrow('No helios.config.json found');
+    });
+
+    it('throws if component is not in config', async () => {
+      await expect(uninstallComponent('/test', 'modal')).rejects.toThrow('Component "modal" is not installed');
+    });
+
+    it('removes component from config without deleting files', async () => {
+      const mockClient = new RegistryClient('mock');
+      mockClient.findComponent = vi.fn().mockResolvedValue({
+        name: 'button',
+        files: [{ name: 'subfolder/Button.tsx', content: '' }]
+      });
+
+      await uninstallComponent('/test', 'button', { client: mockClient });
+
+      expect(configUtils.saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ components: ['card'] }),
+        '/test'
+      );
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it('removes component files when removeFiles is true', async () => {
+      const mockClient = new RegistryClient('mock');
+      mockClient.findComponent = vi.fn().mockResolvedValue({
+        name: 'button',
+        files: [{ name: 'Button.tsx', content: '' }]
+      });
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readdirSync).mockReturnValue([]);
+
+      await uninstallComponent('/test', 'button', { removeFiles: true, client: mockClient });
+
+      expect(configUtils.saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ components: ['card'] }),
+        '/test'
+      );
+      expect(fs.unlinkSync).toHaveBeenCalled();
+      // expect(fs.rmdirSync).toHaveBeenCalled();
+    });
+
+    it('handles missing component in registry gracefully', async () => {
+      const mockClient = new RegistryClient('mock');
+      mockClient.findComponent = vi.fn().mockResolvedValue(null);
+
+      await uninstallComponent('/test', 'button', { removeFiles: true, client: mockClient });
+
+      expect(configUtils.saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ components: ['card'] }),
+        '/test'
+      );
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it('handles registry errors gracefully', async () => {
+      const mockClient = new RegistryClient('mock');
+      mockClient.findComponent = vi.fn().mockRejectedValue(new Error('Registry down'));
+
+      await uninstallComponent('/test', 'button', { removeFiles: true, client: mockClient });
+
+      expect(configUtils.saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ components: ['card'] }),
+        '/test'
+      );
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Could not verify associated files'));
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it('handles file deletion errors gracefully', async () => {
+      const mockClient = new RegistryClient('mock');
+      mockClient.findComponent = vi.fn().mockResolvedValue({
+        name: 'button',
+        files: [{ name: 'Button.tsx', content: '' }]
+      });
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.unlinkSync).mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+
+      await uninstallComponent('/test', 'button', { removeFiles: true, client: mockClient });
+
+      expect(configUtils.saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ components: ['card'] }),
+        '/test'
+      );
+      expect(fs.unlinkSync).toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to delete'));
+    });
+  });
+});


### PR DESCRIPTION
💡 **What**: Added comprehensive unit tests for `ffmpeg`, `package-manager`, and `uninstall` utilities in `packages/cli/src/utils/`.\n🎯 **Why**: To ensure robust error handling, edge cases are verified, and core CLI utilities do not break when system APIs are altered, satisfying the NOTHING TO DO PROTOCOL fallback action.\n📊 **Impact**: Increases the code coverage for `packages/cli` utilities.\n🔬 **Verification**: Ran `npm run test -w packages/cli` directly.

---
*PR created automatically by Jules for task [11367962098511914165](https://jules.google.com/task/11367962098511914165) started by @BintzGavin*