### PR TITLE
✨ RENDERER: Discarded PERF-439 countdown loop experiment

### DIFF
--- a/.sys/plans/PERF-439-seek-countdown.md
+++ b/.sys/plans/PERF-439-seek-countdown.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-439
 slug: seek-countdown
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2025-05-23
-completed: ""
-result: ""
+completed: "2026-05-06"
+result: "failed"
 ---
 
 # PERF-439: Eliminate `Promise.all` via Counter Loop in `SeekTimeDriver.ts`
@@ -79,3 +79,9 @@ return new Promise((resolve, reject) => {
 ## Prior Art
 - PERF-312: Attempted to remove `Promise.all` but broke the pipeline by returning synchronously.
 - PERF-406: Preallocated the promises array but kept `Promise.all`.
+
+## Results Summary
+- **Best render time**: 32.651s
+- **Improvement**: -0.58% (worse)
+- **Kept experiments**: []
+- **Discarded experiments**: [Replace Promise.all with countdown in SeekTimeDriver]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -273,3 +273,8 @@ Last updated by: PERF-432
 
 - **PERF-436 (Chromium Disable Features)**: Disabled unnecessary background Chromium features (\`PaintHolding\`, \`Translate\`, \`OptimizationHints\`, \`OptimizationGuideModelDownloading\`, \`CalculateNativeWinOcclusion\`) in \`BrowserPool.ts\` \`DEFAULT_BROWSER_ARGS\`.
   - Improved median render time to ~33.513s (baseline ~42.161s on unoptimized run, significant reduction in CPU contention). Kept.
+
+- **PERF-439**: Replace Promise.all with countdown in SeekTimeDriver
+  - **What I tried**: Attempted to eliminate the `Promise.all(cachedPromises)` allocation overhead in `window.__helios_seek` by manually counting down resolved promises.
+  - **WHY it didn't work**: The performance difference was negligible or worse (median ~32.651s vs baseline ~32.462s). Tracking asynchronous state with manual countdown logic and inline closures actually slightly adds to the overhead compared to letting V8's highly optimized `Promise.all` implementation handle the small array of native promises. Discarded to maintain code simplicity and performance.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-439.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-439.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.651	90	2.76	37.7	discard	Replace Promise.all with countdown


### PR DESCRIPTION
✨ RENDERER: Discarded PERF-439 countdown loop experiment

💡 **What**: Attempted to eliminate `Promise.all(cachedPromises)` allocation overhead in `window.__helios_seek` by manually counting down resolved promises.
🎯 **Why**: To reduce V8 garbage collection churn during the frame capture loop in SeekTimeDriver.
📊 **Impact**: Render time degraded slightly compared to the baseline (~32.651s vs ~32.462s). Tracking asynchronous state with manual countdown logic and inline closures actually slightly adds to the overhead compared to letting V8's highly optimized `Promise.all` implementation handle the small array of native promises.
🔬 **Verification**: 4-gate verification process completed. Benchmarked using dom-benchmark script. Tests and compilation passed locally prior to revert. Code changes were cleanly reverted.
📎 **Plan**: /.sys/plans/PERF-439-seek-countdown.md

**Results Summary:**
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	32.651	90	2.76	37.7	discard	Replace Promise.all with countdown
```

---
*PR created automatically by Jules for task [9114034072668492450](https://jules.google.com/task/9114034072668492450) started by @BintzGavin*