### PR TITLE
✨ RENDERER: [Failed] Inline beginFrame params in DomStrategy

### DIFF
--- a/.sys/plans/PERF-440-inline-begin-frame-params.md
+++ b/.sys/plans/PERF-440-inline-begin-frame-params.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-440
 slug: inline-begin-frame-params
-status: claimed
+status: complete
 claimed_by: "jules"
 created: 2024-05-28
 completed: "2026-05-06"
@@ -57,3 +57,9 @@ Ensure Canvas mode works (since it uses `CdpTimeDriver`).
 
 ## Correctness Check
 Run the DOM render benchmark script multiple times to verify median render time improvement and ensure generated `output.mp4` contains 600 correct frames.
+
+## Results Summary
+- **Best render time**: 32.662s (vs baseline 32.662s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [Inline beginFrame parameter allocation]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -41,9 +41,9 @@ Last updated by: PERF-432
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
-- **PERF-440**: Inline beginFrame parameter allocation in DomStrategy.
-  - **What I tried**: Attempted to inline the object allocation `{ screenshot, interval, frameTimeTicks }` in the `capture` method instead of mutating a preallocated object.
-  - **WHY it didn't work**: The performance improvement was negligible (median ~32.621s vs baseline ~32.776s). While inlining avoids mutating object properties in the hot loop, V8 is already highly optimized for hidden class mutations. The overhead of instantiating new objects for GC slightly outweighs or equals the cost of write-barriers for mutated properties. Reverted to maintain parity and reduce GC churn.
+- **PERF-440**: Inline beginFrame parameter allocation in DomStrategy
+  - **What I tried**: Attempted to inline the `HeadlessExperimental.beginFrame` parameters instead of mutating `this.beginFrameParams`.
+  - **WHY it didn't work**: The performance improvement was non-existent (median ~32.68s vs baseline ~32.66s). V8 is already incredibly efficient at mutating pre-allocated object properties in a hot loop (likely due to Hidden Classes), so allocating a fresh object literally provided zero benefit and just slightly increased GC activity.
   - **Outcome**: discard
 - **PERF-438**: Eliminate try/catch in CdpTimeDriver stability check
   - **What I tried**: Attempted to replace the `try/catch/finally` around `await Promise.race` inside `runSetTime` with native promise chaining (`.then()`, `.catch()`, `.finally()`).

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -44,3 +44,5 @@ PERF-408	49.135	600	12.21	43.1	keep	Cache Media Elements in CdpTimeDriver to avo
 2	32.475	90	2.77	37.8	discard	PERF-434 nullish coalescing
 2	32.429	90	2.78	38.0	discard	PERF-436 nullish coalescing
 3	32.530	90	2.77	37.7	discard	PERF-438 eliminate try/catch in CdpTimeDriver stability check
+1	32.662	90	2.76	38.7	keep	PERF-440 baseline (median of 32.662, 32.649, 33.560)
+2	32.680	90	2.75	37.8	discard	PERF-440 inline beginFrame allocation


### PR DESCRIPTION
The PERF-440 experiment attempted to inline the `HeadlessExperimental.beginFrame` parameter allocation to replace mutating `this.beginFrameParams`. The change did not yield any performance improvement (median 32.680s vs 32.662s baseline) and was discarded to avoid unnecessary GC overhead and complexity.

```
1	32.662	90	2.76	38.7	keep	PERF-440 baseline (median of 32.662, 32.649, 33.560)
2	32.680	90	2.75	37.8	discard	PERF-440 inline beginFrame allocation
```

---
*PR created automatically by Jules for task [18075465985354033840](https://jules.google.com/task/18075465985354033840) started by @BintzGavin*