### PR TITLE
✨ CLI: Document IMPOSSIBLE: DUPLICATION for Utils Regression Tests plan

### DIFF
--- a/.sys/plans/2027-06-03-CLI-Utils-Regression-Tests.md
+++ b/.sys/plans/2027-06-03-CLI-Utils-Regression-Tests.md
@@ -35,3 +35,7 @@
   - Test `ffmpeg` with missing input paths.
   - Test package manager installation failing (spawn exit code non-zero).
   - Test uninstallation when a component is not listed in `helios.config.json` or when file deletion fails.
+
+#### 5. Result
+- **Status**: IMPOSSIBLE: DUPLICATION
+- **Reason**: Discovered during implementation that the utility regression tests for `ffmpeg.ts`, `package-manager.ts`, and `uninstall.ts` are already fully implemented and pass successfully.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -1,3 +1,6 @@
+## CLI v0.46.20
+- ✅ Completed: Document duplicated CLI Utils Regression Tests plan - Logged the duplicated plan as impossible.
+
 ## CLI v0.46.3
 - ✅ Completed: Scaffold Hetzner Deployment Command - Verified existing implementation of helios deploy hetzner command fulfills the scaffolding requirements.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,9 @@
 # CLI Status
 
-**Version**: 0.46.19
+**Version**: 0.46.20
+
+[v0.46.20] ✅ Completed: Document duplicated CLI Utils Regression Tests plan - Logged the duplicated plan as impossible.
+
 [v0.46.19] ✅ Completed: CLI Utils Regression Tests - Implemented comprehensive unit tests for ffmpeg, package-manager, and uninstall utilities in packages/cli/src/utils/.
 
 ## Recent Completions


### PR DESCRIPTION
✨ CLI: Document IMPOSSIBLE: DUPLICATION for Utils Regression Tests plan

💡 What: Documented the `2027-06-03-CLI-Utils-Regression-Tests.md` plan as an impossible duplication and updated status and progress trackers.
🎯 Why: Avoid redundant work since the regression tests for utilities are already fully implemented in the codebase.
📊 Impact: Cleans up the plan backlog and accurately reflects progress.
🔬 Verification: Ran unit tests to verify the tests existed and worked. Read the modified documentation files.

---
*PR created automatically by Jules for task [17962566647053802474](https://jules.google.com/task/17962566647053802474) started by @BintzGavin*