### PR TITLE
✨ RENDERER: [Discarded] Replace Runtime.evaluate with Runtime.callFunctionOn

### DIFF
--- a/.sys/plans/PERF-442-cdp-call-function-on.md
+++ b/.sys/plans/PERF-442-cdp-call-function-on.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-442
 slug: cdp-call-function-on
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2025-05-24
 completed: ""
@@ -106,3 +106,14 @@ Run the standard tests to verify the canvas path isn't broken.
 
 ## Correctness Check
 Run the `scripts/benchmark-test.js` script to ensure seeking still functions correctly.
+
+## Results Summary
+| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
+|---|---|---|---|---|---|---|
+| 1 | 32.596 | 90 | 2.76 | 37.8 | discard | cdp call function on instead of evaluate |
+| 2 | 32.515 | 90 | 2.77 | 37.8 | discard | cdp call function on instead of evaluate |
+| 3 | 32.339 | 90 | 2.78 | 38.4 | discard | cdp call function on instead of evaluate |
+| 4 | 32.312 | 90 | 2.79 | 38.7 | discard | cdp call function on instead of evaluate |
+| 5 | 32.666 | 90 | 2.76 | 37.6 | discard | cdp call function on instead of evaluate |
+
+**Outcome**: DISCARDED. Median render time was 32.515s, which is slower than the baseline ~32.45s. V8 is already incredibly efficient at parsing simple JS strings, and the added overhead of `Runtime.enable` to track execution context IDs negates any small parsing optimization.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -41,6 +41,11 @@ Last updated by: PERF-432
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-442**: Replace Runtime.evaluate with Runtime.callFunctionOn
+  - **What I tried**: Used `Runtime.callFunctionOn` instead of `Runtime.evaluate` to avoid V8 parsing overhead for dynamic JS strings in `SeekTimeDriver.ts`.
+  - **WHY it didn't work**: The performance improvement was negligible (median ~32.51s vs baseline ~32.45s). V8 is already incredibly efficient at parsing simple JS strings, and the added overhead of `Runtime.enable` to track execution context IDs negates any small parsing optimization.
+  - **Outcome**: discard
+
 - **PERF-440**: Inline beginFrame parameter allocation in DomStrategy
   - **What I tried**: Attempted to inline the `HeadlessExperimental.beginFrame` parameters instead of mutating `this.beginFrameParams`.
   - **WHY it didn't work**: The performance improvement was non-existent (median ~32.68s vs baseline ~32.66s). V8 is already incredibly efficient at mutating pre-allocated object properties in a hot loop (likely due to Hidden Classes), so allocating a fresh object literally provided zero benefit and just slightly increased GC activity.

--- a/packages/renderer/.sys/perf-results-PERF-442.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-442.tsv
@@ -1,0 +1,6 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	32.596	90	2.76	37.8	discard	cdp call function on instead of evaluate
+2	32.515	90	2.77	37.8	discard	cdp call function on instead of evaluate
+3	32.339	90	2.78	38.4	discard	cdp call function on instead of evaluate
+4	32.312	90	2.79	38.7	discard	cdp call function on instead of evaluate
+5	32.666	90	2.76	37.6	discard	cdp call function on instead of evaluate


### PR DESCRIPTION
Attempted to replace `Runtime.evaluate` with `Runtime.callFunctionOn` in `SeekTimeDriver.ts` to avoid V8 parsing overhead for dynamically constructed JS strings. The performance improvement was negligible (median ~32.515s vs baseline ~32.45s, ~-0.2%). V8 handles parsing short JS strings very efficiently, and tracking `executionContextId` via `Runtime.enable` adds its own slight overhead. The experiment was discarded and code changes reverted.

### Results Summary
| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 32.596 | 90 | 2.76 | 37.8 | discard | cdp call function on instead of evaluate |
| 2 | 32.515 | 90 | 2.77 | 37.8 | discard | cdp call function on instead of evaluate |
| 3 | 32.339 | 90 | 2.78 | 38.4 | discard | cdp call function on instead of evaluate |
| 4 | 32.312 | 90 | 2.79 | 38.7 | discard | cdp call function on instead of evaluate |
| 5 | 32.666 | 90 | 2.76 | 37.6 | discard | cdp call function on instead of evaluate |

---
*PR created automatically by Jules for task [96747251181116957](https://jules.google.com/task/96747251181116957) started by @BintzGavin*