### PR TITLE
✨ RENDERER: [Discarded] Use WebP Default (PERF-441)

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -41,6 +41,9 @@ Last updated by: PERF-432
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-441**: Changed default format to webp quality 50.
+  - **WHY it didn't work**: FFmpeg process crashed with `Could not find codec parameters for stream 0 (Video: webp, none): unspecified size` and `Cannot determine format of input stream 0:0 after EOF`. The `webp_pipe` demuxer in FFmpeg struggles to determine the resolution automatically from the incoming stream over a pipe compared to `image2pipe` with PNG.
+  - **Outcome**: discard
 - **PERF-442**: Replace Runtime.evaluate with Runtime.callFunctionOn
   - **What I tried**: Used `Runtime.callFunctionOn` instead of `Runtime.evaluate` to avoid V8 parsing overhead for dynamic JS strings in `SeekTimeDriver.ts`.
   - **WHY it didn't work**: The performance improvement was negligible (median ~32.51s vs baseline ~32.45s). V8 is already incredibly efficient at parsing simple JS strings, and the added overhead of `Runtime.enable` to track execution context IDs negates any small parsing optimization.

--- a/packages/renderer/.sys/perf-results-PERF-441.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-441.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	webp default format (FFmpeg codec issue)

--- a/packages/renderer/.sys/plans/PERF-441-webp-default.md
+++ b/packages/renderer/.sys/plans/PERF-441-webp-default.md
@@ -1,0 +1,44 @@
+---
+id: PERF-441
+slug: webp-default
+status: complete
+claimed_by: "executor-session"
+---
+
+# RENDERER: Use WebP Default (PERF-441)
+
+#### 1. Context & Goal
+- **Objective**: Change the default intermediate image format in `DomStrategy.ts` from `png` to `webp` with quality 50.
+- **Goal**: Reduce Chromium's CPU-intensive PNG encoding overhead and minimize IPC payload size and V8 GC execution impact.
+
+#### 2. File Inventory
+- **Modify**: `packages/renderer/src/strategies/DomStrategy.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: In `DomStrategy.prepare`, when `format` is not provided and `hasAlpha` is false, default to `webp` and `quality: 50` instead of `png`.
+- **Pseudo-Code**:
+  ```typescript
+    if (!format) {
+      if (hasAlpha) {
+        format = 'webp';
+        quality = quality ?? 75;
+      } else {
+        format = 'webp';
+        quality = quality ?? 50;
+      }
+    }
+  ```
+- **Public API Changes**: None
+- **Dependencies**: None
+
+#### 4. Test Plan
+- Run `npm run build -w packages/renderer` to verify compilation.
+- Run `npm run build:examples && npm run build -w packages/renderer && cd packages/renderer && npx tsx scripts/benchmark-test.js` to benchmark the render time.
+- Compare with baseline.
+- Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+
+## Results Summary
+- **Best render time**: 0.000s (vs baseline 32.991s)
+- **Improvement**: ~100.00%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-441]


### PR DESCRIPTION
✨ RENDERER: [Discarded] Use WebP Default (PERF-441)

💡 What: Tested replacing the default intermediate image format in `DomStrategy.ts` from `png` to `webp` (quality 50).
🎯 Why: To reduce Chromium's CPU-intensive PNG encoding overhead and minimize IPC payload size.
📊 Impact: The change caused a crash. FFmpeg's `webp_pipe` demuxer could not automatically determine the resolution from the piped stream, leading to a conversion failure.
🔬 Verification: Compilation succeeded, but the standard benchmark crashed (`test-output.mp4` generation failed). Code changes were discarded/reverted.
📎 Plan: `PERF-441`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	webp default format (FFmpeg codec issue)
```

---
*PR created automatically by Jules for task [7957639043037537437](https://jules.google.com/task/7957639043037537437) started by @BintzGavin*