### PR TITLE
📋 RENDERER: Use WebP with Low Quality for All Intermediate Formats

### DIFF
--- a/.sys/plans/PERF-443-webp-quality-50.md
+++ b/.sys/plans/PERF-443-webp-quality-50.md
@@ -1,0 +1,51 @@
+---
+id: PERF-443
+slug: webp-quality-50
+status: unclaimed
+claimed_by: ""
+created: 2025-05-24
+completed: ""
+result: ""
+---
+
+# PERF-443: Use WebP with Low Quality for All Intermediate Formats
+
+## Focus Area
+DOM Rendering phase 4: Strategy Preparation (`DomStrategy.ts`).
+
+## Background Research
+Currently, `DomStrategy` defaults to `png` for non-alpha formats and only uses `webp` if an alpha channel is detected or if specifically requested. From prior experiments, we've found that `png` encoding inside headless Chrome is heavily CPU-bound and produces large payloads that slow down IPC transfer and Node GC. WebP at quality 50 is known to be significantly faster to encode than PNG in Chromium, and the smaller payload sizes relieve V8's GC and Node's IPC bottlenecks. We will change the default intermediate format to `webp` at quality `50` for ALL renders (both alpha and non-alpha).
+
+## Benchmark Configuration
+- **Composition URL**: `dom-benchmark`
+- **Render Settings**: 1280x720, 30fps, 3s duration (90 frames)
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~42.2s (with all current optimizations)
+- **Bottleneck analysis**: PNG encoding in Chromium and large IPC payload transfers between Chromium and Node.js.
+
+## Implementation Spec
+
+### Step 1: Update Default Format in `DomStrategy.ts`
+**File**: `packages/renderer/src/strategies/DomStrategy.ts`
+**What to change**:
+In `prepare()`, change the default `format` assignment to always use `webp` with a default `quality` of `50`.
+
+```typescript
+    // Cache parameters
+    let format = this.options.intermediateImageFormat;
+    let quality = this.options.intermediateImageQuality;
+
+    if (!format) {
+      format = 'webp';
+      quality = quality ?? 50;
+    }
+```
+**Why**: WebP encoding at quality 50 in Chromium is faster and produces significantly smaller IPC payloads than PNG, reducing V8 overhead and IPC latency.
+**Risk**: Minor compression artifacts due to q=50, but it is an acceptable tradeoff for the raw performance benchmark, and users can override it if they need lossless quality.
+
+## Correctness Check
+Run `npm run build:examples && npm run build -w packages/renderer && cd packages/renderer && npx tsx scripts/benchmark-test.js` to ensure the strategy correctly pipes WebP frames to FFmpeg without crashing.


### PR DESCRIPTION
Change default intermediate format in DomStrategy from PNG to WebP with quality 50.

---
*PR created automatically by Jules for task [1350678061430523236](https://jules.google.com/task/1350678061430523236) started by @BintzGavin*