### PR TITLE
✨ RENDERER: [Discarded] Test WebP quality 50 as default intermediate format

### DIFF
--- a/.sys/plans/PERF-443-webp-quality-50.md
+++ b/.sys/plans/PERF-443-webp-quality-50.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-443
 slug: webp-quality-50
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2025-05-24
-completed: ""
-result: ""
+completed: "2025-05-24"
+result: "failed"
 ---
 
 # PERF-443: Use WebP with Low Quality for All Intermediate Formats
@@ -49,3 +49,9 @@ In `prepare()`, change the default `format` assignment to always use `webp` with
 
 ## Correctness Check
 Run `npm run build:examples && npm run build -w packages/renderer && cd packages/renderer && npx tsx scripts/benchmark-test.js` to ensure the strategy correctly pipes WebP frames to FFmpeg without crashing.
+
+## Results Summary
+- **Best render time**: 32.622s (vs baseline 43.633s)
+- **Improvement**: ~25%
+- **Kept experiments**: None
+- **Discarded experiments**: Use WebP at quality 50 as default format for all intermediate captures.

--- a/commit-body.txt
+++ b/commit-body.txt
@@ -1,0 +1,15 @@
+💡 **What**: Tested using WebP at quality 50 as the default intermediate format instead of PNG for all renders (PERF-443).
+🎯 **Why**: PNG encoding in headless Chrome is CPU-bound and produces large payloads, slowing down IPC and Node GC. WebP at q=50 significantly reduces encoding overhead and payload size.
+📊 **Impact**: The benchmark showed a ~25% improvement (32.6s vs baseline 43.6s). However, the experiment was DISCARDED because FFmpeg's `webp_pipe` demuxer fails to infer the stream resolution when receiving non-alpha webp frames one by one without a container, causing it to crash with "Could not find codec parameters for stream 0: unspecified size". `image2pipe` handles raw PNG frames flawlessly by contrast.
+🔬 **Verification**: Code compiled successfully, but crashed during benchmark tests for non-alpha formats.
+📎 **Plan**: `/.sys/plans/PERF-443-webp-quality-50.md`
+
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	43.633	90	2.06	39.0	keep	baseline
+2	32.622	90	2.76	37.7	keep	webp quality 50
+3	32.720	90	2.75	37.8	keep	webp quality 50
+4	32.699	90	2.75	37.8	keep	webp quality 50
+5	32.717	90	2.75	37.7	keep	webp quality 50
+6	0.000	0	0.00	0.0	discard	webp_pipe crashes with non-alpha frames
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -41,6 +41,7 @@ Last updated by: PERF-432
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-443**: Use WebP at quality 50 as default intermediate format for all non-alpha frames. Although it provides a ~25% speedup over PNG, `image2pipe` correctly parses PNGs but using `webp_pipe` for non-alpha causes FFmpeg (version N-47683) to crash with "Could not find codec parameters for stream 0 (Video: webp, none): unspecified size". The `webp_pipe` demuxer in this older FFmpeg build fails to infer frame size when frames arrive strictly one by one without a container header, whereas `image2pipe` handles raw PNG frames flawlessly.
 - **PERF-441**: Changed default format to webp quality 50.
   - **WHY it didn't work**: FFmpeg process crashed with `Could not find codec parameters for stream 0 (Video: webp, none): unspecified size` and `Cannot determine format of input stream 0:0 after EOF`. The `webp_pipe` demuxer in FFmpeg struggles to determine the resolution automatically from the incoming stream over a pipe compared to `image2pipe` with PNG.
   - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-443.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-443.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	43.633	90	2.06	39.0	keep	baseline
+2	32.622	90	2.76	37.7	keep	webp quality 50
+3	32.720	90	2.75	37.8	keep	webp quality 50
+4	32.699	90	2.75	37.8	keep	webp quality 50
+5	32.717	90	2.75	37.7	keep	webp quality 50
+6	0.000	0	0.00	0.0	discard	webp_pipe crashes with non-alpha frames


### PR DESCRIPTION
💡 **What**: Tested using WebP at quality 50 as the default intermediate format instead of PNG for all renders (PERF-443).
🎯 **Why**: PNG encoding in headless Chrome is CPU-bound and produces large payloads, slowing down IPC and Node GC. WebP at q=50 significantly reduces encoding overhead and payload size.
📊 **Impact**: The benchmark showed a ~25% improvement (32.6s vs baseline 43.6s). However, the experiment was DISCARDED because FFmpeg's `webp_pipe` demuxer fails to infer the stream resolution when receiving non-alpha webp frames one by one without a container, causing it to crash with "Could not find codec parameters for stream 0: unspecified size". `image2pipe` handles raw PNG frames flawlessly by contrast.
🔬 **Verification**: Code compiled successfully, but crashed during benchmark tests for non-alpha formats.
📎 **Plan**: `/.sys/plans/PERF-443-webp-quality-50.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	43.633	90	2.06	39.0	keep	baseline
2	32.622	90	2.76	37.7	keep	webp quality 50
3	32.720	90	2.75	37.8	keep	webp quality 50
4	32.699	90	2.75	37.8	keep	webp quality 50
5	32.717	90	2.75	37.7	keep	webp quality 50
6	0.000	0	0.00	0.0	discard	webp_pipe crashes with non-alpha frames
```

---
*PR created automatically by Jules for task [17398385895773838821](https://jules.google.com/task/17398385895773838821) started by @BintzGavin*