### PR TITLE
✨ RENDERER: Document crash for WebP intermediate format experiment (PERF-445)

### DIFF
--- a/.sys/plans/PERF-445-webp-intermediate-format.md
+++ b/.sys/plans/PERF-445-webp-intermediate-format.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-445
 slug: webp-intermediate-format
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2025-05-24
 completed: ""
-result: ""
+result: crash
 ---
 
 # PERF-445: Use WebP with Low Quality for All Intermediate Formats
@@ -55,3 +55,9 @@ None.
 
 ## Test Plan
 - Run `npm run build:examples && npm run build -w packages/renderer && cd packages/renderer && npx tsx scripts/benchmark-test.js` to verify FFmpeg handles the stream and performance is benchmarked.
+
+## Results Summary
+- **Best render time**: 0.000s (vs baseline 32.776s)
+- **Improvement**: Crash
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-445]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -39,6 +39,8 @@ Last updated by: PERF-432
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-445**: Defaulting to webp intermediate format and webp image2pipe codec.
+  - **Why**: Sending raw webp frames sequentially over stdin without a container format to FFmpeg fails with `pipe:: Invalid argument`, as FFmpeg requires `webp_pipe` to handle raw stream data, but `webp_pipe` inherently crashes due to an FFmpeg bug without alpha channels, making raw webp pipes unusable via stdin.
 - **PERF-441**: Changed default intermediate format to webp with quality 50.
   - **What I tried**: Modified `DomStrategy.ts` to use `webp` and `quality: 50` by default.
   - **WHY it didn't work**: The `webp` format when sent through FFmpeg `webp_pipe` without an alpha channel crashes with `pipe:: Invalid argument`. This suggests `webp_pipe` requires specific conditions or is unsupported for non-alpha streams in this specific FFmpeg build/configuration.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -46,3 +46,4 @@ PERF-408	49.135	600	12.21	43.1	keep	Cache Media Elements in CdpTimeDriver to avo
 3	32.530	90	2.77	37.7	discard	PERF-438 eliminate try/catch in CdpTimeDriver stability check
 1	32.662	90	2.76	38.7	keep	PERF-440 baseline (median of 32.662, 32.649, 33.560)
 2	32.680	90	2.75	37.8	discard	PERF-440 inline beginFrame allocation
+1	0.000	0	0.00	0.0	crash	PERF-445: WebP intermediate format with image2pipe


### PR DESCRIPTION
💡 **What**: Tested using WebP (quality 50) as the intermediate image format alongside the `image2pipe` demuxer and `-vcodec webp` FFmpeg argument. It was ultimately discarded because it resulted in an FFmpeg crash.
🎯 **Why**: To attempt to utilize WebP's faster Chromium encoding speeds and smaller IPC payloads. Prior experiments (PERF-441/443) also tried WebP using `webp_pipe` but failed.
📊 **Impact**: The experiment failed to run (Crash - 0.000s) because FFmpeg cannot easily probe raw WebP streams over stdin without container markers.
🔬 **Verification**: The code modifications crashed during `benchmark-test.js` execution, yielding `pipe:: Invalid argument` and `Cannot determine format of input stream 0:0 after EOF`.
📎 **Plan**: Reference `/.sys/plans/PERF-445-webp-intermediate-format.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | 0.000 | 0 | 0.00 | 0.0 | crash | PERF-445: WebP intermediate format with image2pipe |

---
*PR created automatically by Jules for task [14442278305483920163](https://jules.google.com/task/14442278305483920163) started by @BintzGavin*