### PR TITLE
✨ RENDERER: [Discarded] Disable Font Subpixel Positioning

### DIFF
--- a/.sys/plans/PERF-217-disable-font-subpixel-positioning.md
+++ b/.sys/plans/PERF-217-disable-font-subpixel-positioning.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-217
 slug: disable-font-subpixel-positioning
-status: claimed
+status: complete
 claimed_by: "executor-session"
 created: 2024-06-03
 completed: 2024-06-03
@@ -41,7 +41,7 @@ Run `npx tsx packages/renderer/tests/verify-canvas-strategy.ts`.
 ## Correctness Check
 Run the DOM render tests to ensure no visual regressions break tests.
 ## Results Summary
-- **Best render time**: 43.842s (vs baseline ~32.6s)
+- **Best render time**: 32.733s (vs baseline ~32.6s)
 - **Improvement**: Regressed
 - **Kept experiments**: None
 - **Discarded experiments**: Adding `--disable-font-subpixel-positioning` to BrowserPool.ts

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -286,3 +286,8 @@ Last updated by: PERF-432
   - **What I tried**: Attempted to eliminate the `Promise.all(cachedPromises)` allocation overhead in `window.__helios_seek` by manually counting down resolved promises.
   - **WHY it didn't work**: The performance difference was negligible or worse (median ~32.651s vs baseline ~32.462s). Tracking asynchronous state with manual countdown logic and inline closures actually slightly adds to the overhead compared to letting V8's highly optimized `Promise.all` implementation handle the small array of native promises. Discarded to maintain code simplicity and performance.
   - **Outcome**: discard
+
+- **PERF-217**: Disable Font Subpixel Positioning in Chromium
+  - **What I tried**: Attempted to disable font subpixel positioning by passing `--disable-font-subpixel-positioning` as a default browser argument in `BrowserPool.ts`.
+  - **WHY it didn't work**: The performance improvement was negligible or worse (median ~32.733s vs baseline ~32.6s). This indicates that the CPU overhead for font subpixel rendering is minimal within our headless test cases, and disabling it does not yield a measurable improvement in the context of the larger DOM rendering pipeline.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-217.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-217.tsv
@@ -1,2 +1,4 @@
 run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
-1	43.842	150	3.42	39.6	discard	disable-font-subpixel-positioning
+1	32.683	90	2.75	37.8	keep	baseline
+2	32.955	90	2.73	38.6	discard	--disable-font-subpixel-positioning
+3	32.733	90	2.75	38.7	discard	--disable-font-subpixel-positioning


### PR DESCRIPTION
✨ RENDERER: [Discarded] Disable Font Subpixel Positioning

💡 What: Attempted to disable font subpixel positioning by passing --disable-font-subpixel-positioning as a default browser argument in BrowserPool.ts.
🎯 Why: To reduce CPU cycles spent in Skia text rendering paths.
📊 Impact: Regressed (~32.6s -> ~32.73s).
🔬 Verification: 3 runs. Resulted in no measurable improvement.
📎 Plan: PERF-217

---
*PR created automatically by Jules for task [11479885909159839585](https://jules.google.com/task/11479885909159839585) started by @BintzGavin*