### PR TITLE
✨ RENDERER: Discard PERF-447 (WebP with image2pipe crashed)

### DIFF
--- a/.sys/plans/PERF-447-webp-image2pipe.md
+++ b/.sys/plans/PERF-447-webp-image2pipe.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-447
 slug: webp-image2pipe
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-24
 completed: ""
@@ -83,3 +83,10 @@ Run the DOM render benchmark script (`npm run build:examples && npm run build -w
 
 ## Prior Art
 - PERF-441, PERF-445: Both crashed because they tried using `webp_pipe`. This plan specifically fixes the FFmpeg demuxer configuration to use `image2pipe` with `-vcodec webp`.
+
+## Results Summary
+
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	Use WebP with image2pipe and -vcodec webp
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -291,3 +291,8 @@ Last updated by: PERF-432
   - **What I tried**: Attempted to disable font subpixel positioning by passing `--disable-font-subpixel-positioning` as a default browser argument in `BrowserPool.ts`.
   - **WHY it didn't work**: The performance improvement was negligible or worse (median ~32.733s vs baseline ~32.6s). This indicates that the CPU overhead for font subpixel rendering is minimal within our headless test cases, and disabling it does not yield a measurable improvement in the context of the larger DOM rendering pipeline.
   - **Outcome**: discard
+
+- **PERF-447**: Use WebP with image2pipe and `-vcodec webp`.
+  - **What I tried**: Attempted to use the `image2pipe` input format for WebP frames, combined with the `-vcodec webp` flag, instead of using `webp_pipe`.
+  - **WHY it didn't work**: The same crash occurred as with `webp_pipe`: `Could not find codec parameters for stream 0 (Video: webp, none): unspecified size` followed by `pipe:: Invalid argument`. This confirms that even when explicitly telling `image2pipe` to expect a `webp` video codec, the static FFmpeg build provided (N-47683) fails to infer WebP frame parameters or container metadata from a raw pipe of single images. The PNG pipeline handles this natively but WebP does not in this version of FFmpeg without a container format.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-447.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-447.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	Use WebP with image2pipe and -vcodec webp


### PR DESCRIPTION
💡 **What**: Executed PERF-447 to use WebP (quality 50) via the `image2pipe` demuxer and `-vcodec webp` flag instead of `webp_pipe`. The experiment was discarded because FFmpeg crashed.
🎯 **Why**: To address the `pipe:: Invalid argument` crash of previous WebP experiments by using a native image sequence demuxer that correctly supports sequential images.
📊 **Impact**: 0.000s render time (Crashed). No performance improvement.
🔬 **Verification**: Ran the DOM renderer benchmark tests. FFmpeg threw `Could not find codec parameters for stream 0 (Video: webp, none): unspecified size` and `pipe:: Invalid argument`. This confirms that even when explicitly telling `image2pipe` to expect a `webp` video codec, the static FFmpeg build provided (N-47683) fails to infer WebP frame parameters or container metadata from a raw pipe of single images. The PNG pipeline handles this natively but WebP does not in this version of FFmpeg without a container format.
📎 **Plan**: `/.sys/plans/PERF-447-webp-image2pipe.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	Use WebP with image2pipe and -vcodec webp
```

---
*PR created automatically by Jules for task [16698585350779861610](https://jules.google.com/task/16698585350779861610) started by @BintzGavin*