### PR TITLE
📋 PLAYER: Document missing API properties and events in README

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -42,3 +42,6 @@
 ## 0.77.29 - IMPOSSIBLE DUPLICATION Plan
 **Learning:** Found a plan `2026-03-01-PLAYER-Click-To-Play.md` that requested implementing a `.click-layer` with `pointer-events: none` and click events. However, this feature was already completely implemented in the source code.
 **Action:** When picking up plans, strictly verify their requested changes against the current state of the codebase. Do not blindly overwrite or duplicate existing features if they are already present. If found to be a duplication, document it as impossible and close it.
+## v0.77.30 - Updating README for missing properties and events
+**Learning:** Properties like `audioTracks` and `videoTracks`, and events like `enterpictureinpicture` and `leavepictureinpicture` were implemented but missed in the documentation. `setPlaybackRange` and `clearPlaybackRange` exist on the `HeliosController` and not the Web Component directly.
+**Action:** Created a plan to document the missing properties and events on the Web Component, ensuring exact matches between the API capabilities and documentation.

--- a/.sys/plans/2026-12-30-PLAYER-README-API-Update.md
+++ b/.sys/plans/2026-12-30-PLAYER-README-API-Update.md
@@ -1,0 +1,24 @@
+#### 1. Context & Goal
+- **Objective**: Update `README.md` to document missing properties, events, and API members that exist in the codebase but are undocumented.
+- **Trigger**: The Vision vs Reality analysis revealed that `audioTracks`, `videoTracks` properties and `enterpictureinpicture`, `leavepictureinpicture` events exist in the implementation but are not documented in the README.
+- **Impact**: Ensures that users have an accurate and up-to-date reference for the `<helios-player>` API and its features.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**: `packages/player/README.md` (Update API documentation)
+- **Read-Only**: `packages/player/src/index.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Documentation updates.
+- **Pseudo-Code**:
+  - Add `- \`audioTracks\` (AudioTrackList, read-only): The audio tracks associated with the media element.` under the Properties section.
+  - Add `- \`videoTracks\` (VideoTrackList, read-only): The video tracks associated with the media element.` under the Properties section.
+  - Add `- \`enterpictureinpicture\`: Fired when the player enters Picture-in-Picture mode.` under the Events section.
+  - Add `- \`leavepictureinpicture\`: Fired when the player leaves Picture-in-Picture mode.` under the Events section.
+- **Public API Changes**: No changes to the code, only to the README.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm run build -w packages/player`
+- **Success Criteria**: The README includes the new properties and events.
+- **Edge Cases**: None.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -225,3 +225,4 @@
 [v0.77.25] ✅ Completed: Discovered broken test due to missing vitest environment pragma. Created plan .sys/plans/2026-12-29-PLAYER-Fix-Export-Options-Test.md to fix test configuration.
 [v0.77.28] ✅ Completed: Fix Export Options Test - Deleted obsolete plan file as export-options.test.ts is already configured and passing.
 [v0.77.29] ✅ Completed: Discovered that `2026-03-01-PLAYER-Click-To-Play.md` is an IMPOSSIBLE: DUPLICATION plan. The `.click-layer` and `interactive` attributes are already fully implemented. Documented as impossible and discarded.
+[v0.77.30] ✅ Completed: Discovered undocumented API properties and events in README.md. Created plan `.sys/plans/2026-12-30-PLAYER-README-API-Update.md` to document `audioTracks`, `videoTracks`, `enterpictureinpicture`, and `leavepictureinpicture`.


### PR DESCRIPTION
Created a plan to document `audioTracks`, `videoTracks` properties and `enterpictureinpicture`, `leavepictureinpicture` events which exist in the source code but are missing from the `README.md`.

---
*PR created automatically by Jules for task [14950735436259724661](https://jules.google.com/task/14950735436259724661) started by @BintzGavin*