### PR TITLE
📋 CLI: Plan regression tests for registry manifest

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -173,3 +173,11 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.46.18] - Identify Uncovered Util Files
 **Learning:** The CLI status file indicates that we need to find remaining work when no active delta exists, utilizing the "NOTHING TO DO PROTOCOL". While `cli/src/commands/` test files are extensively covered, the `cli/src/utils/` directory lacks tests for core logic (`ffmpeg.ts`, `package-manager.ts`, `uninstall.ts`).
 **Action:** When a domain is marked stable, prioritize filling testing gaps in utility files to ensure robustness of CLI components. Created a plan to implement these utility regression tests.
+
+## [0.46.19] - Identify Uncovered Util Files (Duplication)
+**Learning:** The fallback action from [0.46.18] to write regression tests for `cli/src/utils/` (`ffmpeg.ts`, `package-manager.ts`, `uninstall.ts`) was an IMPOSSIBLE: DUPLICATION. Tests for all these utility files are already fully implemented in `packages/cli/src/utils/__tests__/` and are passing.
+**Action:** When a domain is marked stable and falling back to tests, always exhaustively verify if the tests exist in the target directory (e.g. `src/utils/__tests__/`) before declaring a gap.
+
+## [0.46.20] - Identify Uncovered Registry Files
+**Learning:** The fallback action from [0.46.18] for utility files was impossible due to duplication. Searching for uncovered areas in a stable domain requires thoroughly checking tests against source files. `packages/cli/src/registry/manifest.ts` currently lacks test coverage while being a core piece of the fallback registry.
+**Action:** When falling back to regression testing under the NOTHING TO DO PROTOCOL, target non-obvious core files (like manifest singletons) that handle fallback or structural data when command and utility coverage is 100%.

--- a/.sys/plans/2027-06-03-CLI-Utils-Regression-Tests.md
+++ b/.sys/plans/2027-06-03-CLI-Utils-Regression-Tests.md
@@ -1,41 +1,20 @@
 #### 1. Context & Goal
-- **Objective**: Implement comprehensive unit tests for the remaining uncovered utilities in `packages/cli/src/utils/`.
-- **Trigger**: Following the "NOTHING TO DO PROTOCOL" from `AGENTS.md`, the CLI domain is currently feature-complete and stable. As a fallback action, we are improving test coverage by adding regression tests for utility functions that are currently only mocked in command tests.
-- **Impact**: Ensures core CLI utilities (`ffmpeg.ts`, `package-manager.ts`, `uninstall.ts`) are robust against future changes, preventing regressions in deployment, installation, and cleanup workflows.
+- **Objective**: Document that the plan to write regression tests for CLI utility files (`packages/cli/src/utils/ffmpeg.ts`, `packages/cli/src/utils/package-manager.ts`, `packages/cli/src/utils/uninstall.ts`) is an impossibility due to duplication.
+- **Trigger**: The `.jules/CLI.md` journal (entry [0.46.18]) suggested writing tests for these files as a fallback action under the NOTHING TO DO PROTOCOL.
+- **Impact**: Prevents rewriting identical tests or creating unnecessary code churn.
 
 #### 2. File Inventory
-- **Create**:
-  - `packages/cli/src/utils/__tests__/ffmpeg.test.ts` (Unit tests for transcodeMerge)
-  - `packages/cli/src/utils/__tests__/package-manager.test.ts` (Unit tests for package manager detection and installation)
-  - `packages/cli/src/utils/__tests__/uninstall.test.ts` (Unit tests for component uninstallation logic)
-- **Modify**: None
-- **Read-Only**:
-  - `packages/cli/src/utils/ffmpeg.ts`
-  - `packages/cli/src/utils/package-manager.ts`
-  - `packages/cli/src/utils/uninstall.ts`
+- **Create**: None
+- **Modify**: `.jules/CLI.md` (to append finding)
+- **Read-Only**: `packages/cli/src/utils/__tests__/ffmpeg.test.ts`, `packages/cli/src/utils/__tests__/package-manager.test.ts`, `packages/cli/src/utils/__tests__/uninstall.test.ts`
 
 #### 3. Implementation Spec
-- **Architecture**:
-  - Use `vitest` for unit testing.
-  - Mock external dependencies such as `child_process.spawn`, `fs.existsSync`, `fs.readFileSync`, `fs.unlinkSync`, `fs.rmdirSync`, and `path` to ensure tests are isolated and do not perform actual filesystem or execution side effects.
-  - For `ffmpeg.ts`, mock `child_process.spawn` to capture FFmpeg arguments and test success/error events.
-  - For `package-manager.ts`, mock file system checks to verify detection of `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, and fallback to `npm`. Mock `spawn` to verify correct installation commands.
-  - For `uninstall.ts`, mock `loadConfig` and `saveConfig` to verify state changes, and mock `RegistryClient` to simulate component file discovery and deletion.
-- **Pseudo-Code**:
-  - In `ffmpeg.test.ts`: Create a fake `spawn` process with an event emitter. Verify `transcodeMerge` sends the correct `file` list via stdin and passes options like `-c:v` and `-c:a`.
-  - In `package-manager.test.ts`: Setup `fs.existsSync` mock to return true for specific lockfiles and assert `detectPackageManager` returns the correct string.
-  - In `uninstall.test.ts`: Mock `fs.unlinkSync`, test that files are deleted when `removeFiles: true`, and that the `helios.config.json` components array is correctly updated.
-- **Public API Changes**: None.
-- **Dependencies**: None.
+- **Architecture**: N/A (IMPOSSIBLE: DUPLICATION)
+- **Pseudo-Code**: N/A
+- **Public API Changes**: None
+- **Dependencies**: None
 
 #### 4. Test Plan
-- **Verification**: Run `npm run test -w packages/cli` after creating the test files.
-- **Success Criteria**: Vitest reports that `ffmpeg.test.ts`, `package-manager.test.ts`, and `uninstall.test.ts` pass successfully, increasing overall coverage for `packages/cli/src/utils/`.
-- **Edge Cases**:
-  - Test `ffmpeg` with missing input paths.
-  - Test package manager installation failing (spawn exit code non-zero).
-  - Test uninstallation when a component is not listed in `helios.config.json` or when file deletion fails.
-
-#### 5. Result
-- **Status**: IMPOSSIBLE: DUPLICATION
-- **Reason**: Discovered during implementation that the utility regression tests for `ffmpeg.ts`, `package-manager.ts`, and `uninstall.ts` are already fully implemented and pass successfully.
+- **Verification**: N/A
+- **Success Criteria**: The task is marked complete because no action is required.
+- **Edge Cases**: N/A

--- a/.sys/plans/2027-06-04-CLI-Registry-Regression-Tests.md
+++ b/.sys/plans/2027-06-04-CLI-Registry-Regression-Tests.md
@@ -1,0 +1,57 @@
+#### 1. Context & Goal
+- **Objective**: Implement missing regression tests for `packages/cli/src/registry/manifest.ts`.
+- **Trigger**: The CLI domain is in a "STABLE" posture (NOTHING TO DO PROTOCOL). As per AGENTS.md, fallback actions include filling regression test gaps. While `src/commands` and `src/utils` are fully tested, `src/registry/manifest.ts` lacks test coverage.
+- **Impact**: Ensures that the core component registry manifest (the fallback source of truth for component scaffolding) functions correctly and returns components correctly via `findComponent()`.
+
+#### 2. File Inventory
+- **Create**: `packages/cli/src/registry/__tests__/manifest.test.ts`
+- **Modify**: None
+- **Read-Only**: `packages/cli/src/registry/manifest.ts`, `packages/cli/src/registry/types.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Create a Vitest test suite that verifies the core functionality of `manifest.ts`:
+  - `registry` export is an array of valid `ComponentDefinition` objects.
+  - `registry` contains known default components (e.g., `use-video-frame`, `timer`, `progress-bar`, `watermark`).
+  - `findComponent()` correctly retrieves an existing component by name.
+  - `findComponent()` returns `undefined` for a non-existent component.
+- **Pseudo-Code**:
+  ```typescript
+  import { describe, it, expect } from 'vitest';
+  import { registry, findComponent } from '../manifest.js';
+
+  describe('registry manifest', () => {
+    it('exports a valid registry array', () => {
+      expect(Array.isArray(registry)).toBe(true);
+      expect(registry.length).toBeGreaterThan(0);
+    });
+
+    it('contains known core components', () => {
+      const names = registry.map(c => c.name);
+      expect(names).toContain('use-video-frame');
+      expect(names).toContain('timer');
+      expect(names).toContain('progress-bar');
+      expect(names).toContain('watermark');
+    });
+
+    describe('findComponent', () => {
+      it('finds an existing component', () => {
+        const component = findComponent('timer');
+        expect(component).toBeDefined();
+        expect(component?.name).toBe('timer');
+        expect(component?.type).toBe('react');
+      });
+
+      it('returns undefined for non-existent component', () => {
+        const component = findComponent('does-not-exist');
+        expect(component).toBeUndefined();
+      });
+    });
+  });
+  ```
+- **Public API Changes**: None
+- **Dependencies**: None
+
+#### 4. Test Plan
+- **Verification**: `npm run test -w packages/cli`
+- **Success Criteria**: Vitest executes the new `manifest.test.ts` test suite and all tests pass.
+- **Edge Cases**: Unknown component names must return `undefined` gracefully.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -141,3 +141,4 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 ## Blocked Items
 - [x] [v0.46.14] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/
 - [x] STUDIO: 2026-11-14-STUDIO-Update-Keyboard-Shortcuts-Documentation is structurally obsolete.
+- [x] [v0.46.20] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -7,6 +7,7 @@
 [v0.46.19] ✅ Completed: CLI Utils Regression Tests - Implemented comprehensive unit tests for ffmpeg, package-manager, and uninstall utilities in packages/cli/src/utils/.
 
 ## Recent Completions
+[v0.46.21] ✅ Completed: Registry Manifest Regression Tests Spec - Created specification plan for implementing regression tests for packages/cli/src/registry/manifest.ts to ensure structural data retrieval works as expected.
 [v0.46.18] ✅ Completed: CLI Utils Regression Tests Spec - Created specification plan for implementing regression tests for the remaining uncovered utilities in packages/cli/src/utils/ to ensure core functions are robust.
 [v0.46.16] ✅ Completed: Remaining CLI Regression Tests - Identified as duplicate plan; tests for preview, skills, and studio are already implemented.
 [v0.46.15] ✅ Completed: Document duplicated Remaining Regression Tests plan - Logged the duplicated plan as impossible.


### PR DESCRIPTION
Identified that the previously planned fallback task for utility file regression tests was a duplication. Created a new execution plan to implement missing test coverage for `packages/cli/src/registry/manifest.ts`. Updated the CLI status, backlog, and journal accordingly.

---
*PR created automatically by Jules for task [13077688616333947615](https://jules.google.com/task/13077688616333947615) started by @BintzGavin*