### PR TITLE
✨ CLI: Document duplicated Cloudflare Sandbox Execution plan

### DIFF
--- a/.sys/plans/2026-11-14-CLI-Cloudflare-Sandbox-Execution.md
+++ b/.sys/plans/2026-11-14-CLI-Cloudflare-Sandbox-Execution.md
@@ -44,3 +44,7 @@
 - **Verification**: Run `npx tsx packages/cli/src/index.ts job run my-job.json --adapter cloudflare-sandbox --cloudflare-account-id dummy --cloudflare-api-token dummy --cloudflare-namespace dummy` and verify it attempts to instantiate the adapter rather than falling back to `LocalWorkerAdapter` or throwing an unknown adapter error.
 - **Success Criteria**: The CLI correctly parses the arguments and initializes the `CloudflareSandboxAdapter`.
 - **Edge Cases**: Missing required options should throw a clear validation error.
+
+## Result
+
+IMPOSSIBLE: DUPLICATION. The Cloudflare Sandbox Adapter is already fully exposed in the `helios job run` command in `packages/cli/src/commands/job.ts`. The plan is therefore marked as complete/failed and discarded without code changes.

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -1,3 +1,6 @@
+## CLI v0.46.21
+- ✅ Completed: Document duplicated Cloudflare Sandbox Execution plan - Logged the duplicated plan as impossible.
+
 ## CLI v0.46.20
 - ✅ Completed: Document duplicated CLI Utils Regression Tests plan - Logged the duplicated plan as impossible.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,7 +1,8 @@
 # CLI Status
 
-**Version**: 0.46.20
+**Version**: 0.46.21
 
+[v0.46.21] ✅ Completed: Document duplicated Cloudflare Sandbox Execution plan - Logged the duplicated plan as impossible.
 [v0.46.20] ✅ Completed: Document duplicated CLI Utils Regression Tests plan - Logged the duplicated plan as impossible.
 
 [v0.46.19] ✅ Completed: CLI Utils Regression Tests - Implemented comprehensive unit tests for ffmpeg, package-manager, and uninstall utilities in packages/cli/src/utils/.


### PR DESCRIPTION
This submission marks the plan `2026-11-14-CLI-Cloudflare-Sandbox-Execution.md` as an `IMPOSSIBLE: DUPLICATION`. During execution, it was found that the `CloudflareSandboxAdapter` is already fully exposed as an option in the `helios job run` command (`packages/cli/src/commands/job.ts`). This was previously completed under version 0.41.2. The appropriate status files (`docs/status/CLI.md` and `docs/PROGRESS-CLI.md`) were updated to log this duplicate discovery. All CLI tests were successfully run to verify the domain's stability. No codebase changes were required.

---
*PR created automatically by Jules for task [7422912731250813938](https://jules.google.com/task/7422912731250813938) started by @BintzGavin*