### PR TITLE
✨ RENDERER: Document discarded PERF-451 experiment

### DIFF
--- a/.sys/plans/PERF-451-skip-capture-on-no-damage.md
+++ b/.sys/plans/PERF-451-skip-capture-on-no-damage.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-451
 slug: skip-capture-on-no-damage
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-05-30
 completed: ""
 result: ""
@@ -50,3 +50,7 @@ Run `npm run build:examples && npm run build -w packages/renderer && cd packages
 
 ## Correctness Check
 Render `output/example-build/examples/dom-benchmark/composition.html` and visually inspect the output MP4. Ensure animations do not freeze.
+
+## Results Summary
+- Status: discarded
+- Reason: Chromium's `HeadlessExperimental.beginFrame` always returns `hasDamage: true` if the `screenshot` parameter is included in the request, even for static scenes. It is impossible to both request a screenshot and accurately detect lack of damage in the same CDP call.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -300,3 +300,7 @@ Last updated by: PERF-432
   - **What I tried**: Added a check during `prepare()` in `CdpTimeDriver.ts` to count the number of media elements on the page. If no media elements are present (`this.hasMedia === false`), the per-frame `Runtime.evaluate` call for `__helios_sync_media` is skipped entirely to reduce IPC overhead.
   - **WHY it didn't work**: The performance improvement was slightly worse than the baseline (median ~32.638s vs baseline ~32.474s). The additional `this.hasMedia` branch check inside the hot loop (`runSetTime`), along with the async setup during `prepare()`, offsets the theoretical gains of dropping the fire-and-forget `Runtime.evaluate` call. The CDP infrastructure is already efficient at dispatching fire-and-forget evaluations with `returnByValue: false`.
   - **Outcome**: discard
+- **PERF-451**: Skip Capture on No Damage in DomStrategy
+  - **What I tried**: Attempted to optimize static scenes by checking `result.hasDamage` from `HeadlessExperimental.beginFrame` to skip processing identical frames.
+  - **WHY it didn't work**: Chromium always reports `hasDamage: true` when the `screenshot` parameter is included in the `beginFrame` request. It is impossible to request a frame screenshot and simultaneously rely on `hasDamage` to detect static scenes in a single CDP call. A multi-pass approach (check damage, then request screenshot if damaged) would introduce more overhead than it saves.
+  - **Outcome**: discard


### PR DESCRIPTION
Investigated skipping frame capture on static scenes using HeadlessExperimental.beginFrame's hasDamage property. Discarded because Chromium forces hasDamage=true whenever a screenshot is requested, preventing single-pass static scene detection.

---
*PR created automatically by Jules for task [5586696052116987804](https://jules.google.com/task/5586696052116987804) started by @BintzGavin*