### PR TITLE
✨ RENDERER: Document PERF-450 as impossible duplication

### DIFF
--- a/.sys/plans/PERF-450-enable-cdptimedriver-for-dom.md
+++ b/.sys/plans/PERF-450-enable-cdptimedriver-for-dom.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-450
 slug: enable-cdptimedriver-for-dom
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-30
 completed: ""
-result: ""
+result: "IMPOSSIBLE: DUPLICATION"
 ---
 
 # PERF-450: Enable CdpTimeDriver for DOM Mode
@@ -58,3 +58,7 @@ Render `output/example-build/examples/dom-benchmark/composition.html` and visual
 ## Prior Art
 - `PERF-090-virtual-time` (Initial implementation of virtual time)
 - `PERF-179-cdptimedriver`
+
+## Session Completion
+
+This plan requested to swap SeekTimeDriver for CdpTimeDriver in BrowserPool.ts. However, the codebase already uses CdpTimeDriver unconditionally on line 124 of BrowserPool.ts. This is a duplicate plan for a change that has already been executed. The plan is marked as an Impossible Duplication and no code changes are required.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -310,3 +310,7 @@ Last updated by: PERF-432
   - **What I tried**: Attempted to optimize static scenes by checking `result.hasDamage` from `HeadlessExperimental.beginFrame` to skip processing identical frames.
   - **WHY it didn't work**: Chromium always reports `hasDamage: true` when the `screenshot` parameter is included in the `beginFrame` request. It is impossible to request a frame screenshot and simultaneously rely on `hasDamage` to detect static scenes in a single CDP call. A multi-pass approach (check damage, then request screenshot if damaged) would introduce more overhead than it saves.
   - **Outcome**: discard
+
+- **PERF-450**: Enable CdpTimeDriver for DOM Mode
+  - **What I tried**: Attempted to execute the PERF-450 plan to replace `SeekTimeDriver` with `CdpTimeDriver` for DOM rendering in `BrowserPool.ts`.
+  - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. Code inspection revealed that `BrowserPool.ts` already implements this change unconditionally (`const timeDriver = new CdpTimeDriver(this.options.stabilityTimeout);` at line 124). Documented duplication and discarded.


### PR DESCRIPTION
✨ RENDERER: Document PERF-450 as impossible duplication

💡 What: Documented the PERF-450 experiment plan as an impossible duplication and discarded it.
🎯 Why: The code modification proposed by the plan (`new CdpTimeDriver`) was already fully implemented unconditionally in `BrowserPool.ts`.
📊 Impact: N/A (Administrative update)
🔬 Verification: Ran `verify-cdp-driver.ts` to ensure stability.
📎 Plan: PERF-450

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
N/A	0.0	0	0.0	0.0	discard	IMPOSSIBLE: DUPLICATION

---
*PR created automatically by Jules for task [16305692603067533337](https://jules.google.com/task/16305692603067533337) started by @BintzGavin*