### PR TITLE
📋 RENDERER: Skip Media Sync evaluate in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-455-skip-media-sync-evaluate.md
+++ b/.sys/plans/PERF-455-skip-media-sync-evaluate.md
@@ -1,0 +1,59 @@
+---
+id: PERF-455
+slug: skip-media-sync-evaluate
+status: unclaimed
+claimed_by: ""
+created: 2026-05-08
+completed: ""
+result: ""
+---
+
+# PERF-455: Skip Media Sync Runtime.evaluate in CdpTimeDriver When No Media Exists
+
+## Focus Area
+`CdpTimeDriver.ts` media synchronization logic inside the hot loop (`runSetTime`).
+
+## Background Research
+Currently, `CdpTimeDriver` executes a fire-and-forget `Runtime.evaluate` call on every frame to invoke `window.__helios_sync_media` to keep HTML5 video/audio elements in sync with the Chromium virtual time.
+
+While PERF-448 previously attempted to optimize this by introducing a `hasMedia` state flag, it failed because the overhead of checking the branch condition inside the hot loop offset the gains of skipping the CDP call. However, a different approach can completely eliminate the CDP call for compositions without media elements *without* adding branch conditions to the hot loop: conditionally assigning the `syncMedia` function reference during `prepare()`.
+
+If no media elements exist, we can assign a no-op function to the internal media sync handler, completely avoiding the `Runtime.evaluate` overhead over IPC for the vast majority of compositions (which are purely DOM/CSS/Canvas). This builds upon the `CdpTimeDriver` migration (PERF-453) which successfully decoupled virtual time from JS execution.
+
+## Benchmark Configuration
+- **Composition URL**: `examples/dom-benchmark/composition.html` (contains no media elements)
+- **Render Settings**: 1280x720, 30fps, 3s duration (90 frames)
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~2.102s (from PERF-454)
+- **Bottleneck analysis**: IPC overhead from dispatching unnecessary `Runtime.evaluate` calls to the browser for every frame when no media elements need synchronization.
+
+## Implementation Spec
+
+### Step 1: Conditionally define the media sync execution path
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+1. Add a private property `syncMediaFn` to the `CdpTimeDriver` class.
+2. During `prepare()`, check if media elements exist using a simple evaluation (e.g., `document.querySelectorAll('video, audio').length > 0`).
+3. If media exists, assign `syncMediaFn` to a closure that performs the actual `Runtime.evaluate` call.
+4. If no media exists, assign `syncMediaFn` to a no-op function (e.g., `() => {}`).
+5. Update `runSetTime` to simply call `this.syncMediaFn(time)` instead of always calling `Runtime.evaluate`.
+
+**Why**: This removes the `Runtime.evaluate` IPC call entirely for non-media compositions without adding any conditional branching (`if (hasMedia)`) to the hot loop, maximizing throughput.
+**Risk**: If media elements are injected dynamically *after* `prepare()` runs, they won't be synced. However, Helios compositions are deterministic and media elements are present in the initial DOM tree or preloaded, so this risk is minimal for standard workloads.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run `cd packages/renderer && npx tsx tests/verify-cdp-determinism.ts` to ensure time synchronization is unaffected.
+
+## Correctness Check
+Run the DOM render benchmark script (`cd packages/renderer && npm run build:examples && npm run build && npx tsx scripts/benchmark-test.js`) to verify the speedup and ensure successful render completion.
+
+## Prior Art
+- PERF-448: Failed attempt to optimize this using a boolean branch check.
+- PERF-453: Successful migration to CdpTimeDriver.


### PR DESCRIPTION
Created a detailed experiment plan (PERF-455) to conditionally bypass the media sync `Runtime.evaluate` call in `CdpTimeDriver` via function reference assignment when no media elements exist. This approach aims to eliminate IPC overhead for compositions without media elements while avoiding branch checks in the hot loop.

---
*PR created automatically by Jules for task [13622884009929530482](https://jules.google.com/task/13622884009929530482) started by @BintzGavin*