### PR TITLE
PLAYER: Plan API Documentation Update

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -45,3 +45,6 @@
 ## v0.77.30 - Updating README for missing properties and events
 **Learning:** Properties like `audioTracks` and `videoTracks`, and events like `enterpictureinpicture` and `leavepictureinpicture` were implemented but missed in the documentation. `setPlaybackRange` and `clearPlaybackRange` exist on the `HeliosController` and not the Web Component directly.
 **Action:** Created a plan to document the missing properties and events on the Web Component, ensuring exact matches between the API capabilities and documentation.
+## v0.77.31 - Accurate Verification of Documented API
+**Learning:** During planning to update `README.md` for undocumented API members (`audioTracks`, `videoTracks`, `setPlaybackRange`, etc.), I found that some of these were actually either already documented or they belonged to the controller interface rather than the public web component API.
+**Action:** Always carefully check the target documentation file (`README.md`) using strict grep patterns to ensure the gap actually exists, and verify if the member belongs to the public API or internal interfaces before adding it to the plan.

--- a/.sys/plans/2026-12-30-PLAYER-README-API-Update.md
+++ b/.sys/plans/2026-12-30-PLAYER-README-API-Update.md
@@ -1,6 +1,6 @@
 #### 1. Context & Goal
-- **Objective**: Update `README.md` to document missing properties, events, and API members that exist in the codebase but are undocumented.
-- **Trigger**: The Vision vs Reality analysis revealed that `audioTracks`, `videoTracks` properties and `enterpictureinpicture`, `leavepictureinpicture` events exist in the implementation but are not documented in the README.
+- **Objective**: Document `enterpictureinpicture`, `leavepictureinpicture` events, and `captureStream`, `startAudioMetering`, `stopAudioMetering` methods in `README.md`.
+- **Trigger**: The Vision vs Reality analysis revealed that `enterpictureinpicture`, `leavepictureinpicture` events and `captureStream`, `startAudioMetering`, `stopAudioMetering` methods exist in the implementation but are not documented in the README.
 - **Impact**: Ensures that users have an accurate and up-to-date reference for the `<helios-player>` API and its features.
 
 #### 2. File Inventory
@@ -11,14 +11,16 @@
 #### 3. Implementation Spec
 - **Architecture**: Documentation updates.
 - **Pseudo-Code**:
-  - Add `- \`audioTracks\` (AudioTrackList, read-only): The audio tracks associated with the media element.` under the Properties section.
-  - Add `- \`videoTracks\` (VideoTrackList, read-only): The video tracks associated with the media element.` under the Properties section.
+  - Update `packages/player/README.md`
+  - Add `- \`captureStream(): Promise<MediaStream>\` - Returns a MediaStream capturing the player's canvas (if same-origin).` to the Methods section.
+  - Add `- \`startAudioMetering(): void\` - Starts audio metering calculation.` to the Methods section.
+  - Add `- \`stopAudioMetering(): void\` - Stops audio metering calculation.` to the Methods section.
   - Add `- \`enterpictureinpicture\`: Fired when the player enters Picture-in-Picture mode.` under the Events section.
   - Add `- \`leavepictureinpicture\`: Fired when the player leaves Picture-in-Picture mode.` under the Events section.
 - **Public API Changes**: No changes to the code, only to the README.
 - **Dependencies**: None.
 
 #### 4. Test Plan
-- **Verification**: `npm run build -w packages/player`
-- **Success Criteria**: The README includes the new properties and events.
+- **Verification**: `npm run test`
+- **Success Criteria**: The README includes the new methods and events.
 - **Edge Cases**: None.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: 0.77.30
+**Version**: 0.77.31
 [v0.77.30] ✅ Completed: Document Tracks API - Added audioTracks and videoTracks properties to README.md API parity list.
 [v0.77.27] ✅ Completed: Document API Parity Gap - Deleted lingering plan file as the README already contained the required documentation updates.
 [v0.77.27] ✅ Completed: Add Media Session properties to README
@@ -227,3 +227,4 @@
 [v0.77.28] ✅ Completed: Fix Export Options Test - Deleted obsolete plan file as export-options.test.ts is already configured and passing.
 [v0.77.29] ✅ Completed: Discovered that `2026-03-01-PLAYER-Click-To-Play.md` is an IMPOSSIBLE: DUPLICATION plan. The `.click-layer` and `interactive` attributes are already fully implemented. Documented as impossible and discarded.
 [v0.77.30] ✅ Completed: Discovered undocumented API properties and events in README.md. Created plan `.sys/plans/2026-12-30-PLAYER-README-API-Update.md` to document `audioTracks`, `videoTracks`, `enterpictureinpicture`, and `leavepictureinpicture`.
+[v0.77.31] ✅ Completed: Discovered undocumented API properties, methods and events in README.md. Created plan `.sys/plans/2026-12-30-PLAYER-README-API-Update.md` to document `enterpictureinpicture`, `leavepictureinpicture`, `captureStream`, `startAudioMetering`, and `stopAudioMetering`.


### PR DESCRIPTION
This patch fulfills the Planner role by creating the `.sys/plans/2026-12-30-PLAYER-README-API-Update.md` execution spec to document missing API properties (`enterpictureinpicture`, `leavepictureinpicture`, `captureStream`, `startAudioMetering`, `stopAudioMetering`) found in `packages/player/src/index.ts`. It also records learnings to `.jules/PLAYER.md` and updates `docs/status/PLAYER.md` reflecting the completion of the planning task.

---
*PR created automatically by Jules for task [11595408761161085629](https://jules.google.com/task/11595408761161085629) started by @BintzGavin*