### PR TITLE
✨ CLI: Registry Manifest Regression Tests

### DIFF
--- a/.sys/llmdocs/context-cli.md
+++ b/.sys/llmdocs/context-cli.md
@@ -43,6 +43,11 @@ packages/cli/
 │   │   ├── studio.ts
 │   │   └── update.ts
 │   ├── registry/
+│   │   ├── __tests__/
+│   │   │   ├── client.test.ts
+│   │   │   └── manifest.test.ts
+│   │   ├── manifest.ts
+│   │   ├── types.ts
 │   │   └── client.ts
 │   ├── utils/
 │   │   ├── __tests__/

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -330,3 +330,6 @@ This file tracks progress for the CLI domain (`packages/cli`).
 
 ### CLI v0.46.19
 - ✅ Completed: CLI Utils Regression Tests - Implemented comprehensive unit tests for ffmpeg, package-manager, and uninstall utilities in packages/cli/src/utils/.
+
+### CLI v0.46.22
+- ✅ Completed: Registry Manifest Regression Tests - Implemented unit tests for packages/cli/src/registry/manifest.ts

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,7 +1,8 @@
 # CLI Status
 
-**Version**: 0.46.21
+**Version**: 0.46.22
 
+[v0.46.22] ✅ Completed: Registry Manifest Regression Tests - Implemented unit tests for packages/cli/src/registry/manifest.ts
 [v0.46.21] ✅ Completed: Document duplicated Cloudflare Sandbox Execution plan - Logged the duplicated plan as impossible.
 [v0.46.20] ✅ Completed: Document duplicated CLI Utils Regression Tests plan - Logged the duplicated plan as impossible.
 

--- a/packages/cli/src/registry/__tests__/manifest.test.ts
+++ b/packages/cli/src/registry/__tests__/manifest.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { registry, findComponent } from '../manifest.js';
+
+describe('registry manifest', () => {
+  it('registry contains expected components', () => {
+    const names = registry.map(c => c.name);
+    expect(names).toContain('use-video-frame');
+    expect(names).toContain('timer');
+    expect(names).toContain('progress-bar');
+    expect(names).toContain('watermark');
+  });
+
+  it('registry entries have correct fields', () => {
+    const watermark = registry.find(c => c.name === 'watermark');
+    expect(watermark).toBeDefined();
+    expect(watermark?.type).toBe('react');
+    expect(watermark?.dependencies).toBeDefined();
+    expect(watermark?.files.length).toBeGreaterThan(0);
+  });
+
+  describe('findComponent', () => {
+    it('returns the component if it exists', () => {
+      const component = findComponent('use-video-frame');
+      expect(component).toBeDefined();
+      expect(component?.name).toBe('use-video-frame');
+    });
+
+    it('returns undefined if component does not exist', () => {
+      const component = findComponent('non-existent-component');
+      expect(component).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Implemented Vitest unit tests for `packages/cli/src/registry/manifest.ts` to improve test coverage in the CLI package. The test validates the fallback component registry definitions, ensuring that `findComponent` and the `registry` array function correctly. This prevents structural regressions as the default components are modified. Additionally, updated `CLI.md` and `PROGRESS-CLI.md` to reflect `v0.46.22`.

---
*PR created automatically by Jules for task [3457127416639281870](https://jules.google.com/task/3457127416639281870) started by @BintzGavin*