### PR TITLE
✨ RENDERER: Bypass Runtime.evaluate in CdpTimeDriver when no media exists

### DIFF
--- a/.sys/plans/PERF-460-bypass-media-sync.md
+++ b/.sys/plans/PERF-460-bypass-media-sync.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-460
 slug: bypass-media-sync
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-06-03
 completed: ""
-result: ""
+result: "keep"
 ---
 
 # PERF-460: Bypass Runtime.evaluate in CdpTimeDriver When No Media Exists

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -4,6 +4,7 @@ Last updated by: PERF-451
 
 
 ## What Works
+- Conditionally bypassed Runtime.evaluate in CdpTimeDriver (PERF-460), improving time to 3.511s
 - **Pre-allocate targetBeginFrameParams object for targeted elements**: (PERF-227) Reused `targetBeginFrameParams` instead of recreating object tree on every frame. Improved performance in targeted element mode from timeouts (>32s) to ~5.0s.
 
 - **PERF-451**: Swapped SeekTimeDriver for CdpTimeDriver in BrowserPool DOM mode.

--- a/packages/renderer/.sys/perf-results-PERF-460.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-460.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	3.851	90	23.37	38.9	keep	bypass Runtime.evaluate in CdpTimeDriver via closure
+2	2.879	90	31.27	39.4	keep	bypass Runtime.evaluate in CdpTimeDriver via closure
+3	3.511	90	25.64	39.3	keep	bypass Runtime.evaluate in CdpTimeDriver via closure

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -18,6 +18,7 @@ export class CdpTimeDriver implements TimeDriver {
   private evaluateStabilityParams: any = { expression: "if (typeof window.__helios_wait_until_stable === 'function') window.__helios_wait_until_stable();", awaitPromise: true, returnByValue: false };
   private singleFrameSyncMediaParams: any = { expression: "", awaitPromise: false, returnByValue: false };
   private multiFrameSyncMediaParams: any[] = [];
+  private syncMediaFn: (timeInSeconds: number) => void = () => {};
 
   private stabilityTimeoutId: NodeJS.Timeout | null = null;
   private stabilityTimeoutReject: ((err: Error) => void) | null = null;
@@ -39,6 +40,38 @@ export class CdpTimeDriver implements TimeDriver {
 
     this.client!.send('Emulation.setVirtualTimePolicy', this.setVirtualTimePolicyParams).catch(this.handleVirtualTimeBudgetError);
   };
+
+  private defaultSyncMedia(timeInSeconds: number) {
+    const frames = this.cachedFrames;
+    if (frames.length === 1) {
+      this.singleFrameSyncMediaParams.expression = "if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");";
+      this.client!.send('Runtime.evaluate', this.singleFrameSyncMediaParams);
+    } else {
+        if (this.executionContextIds.length > 0) {
+          const expression = "if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");";
+          if (this.multiFrameSyncMediaParams.length !== this.executionContextIds.length) {
+            this.multiFrameSyncMediaParams.length = this.executionContextIds.length;
+            for (let i = 0; i < this.executionContextIds.length; i++) {
+              this.multiFrameSyncMediaParams[i] = {
+                expression: "",
+                contextId: this.executionContextIds[i],
+                awaitPromise: false,
+                returnByValue: false
+              };
+            }
+          }
+          for (let i = 0; i < this.executionContextIds.length; i++) {
+            this.multiFrameSyncMediaParams[i].expression = expression;
+            this.client!.send('Runtime.evaluate', this.multiFrameSyncMediaParams[i]);
+          }
+        } else {
+          for (let i = 0; i < frames.length; i++) {
+            const frame = frames[i];
+            frame.evaluate("if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");");
+          }
+        }
+    }
+  }
 
   private handleSyncMediaError = (e: any) => {
     console.warn('[CdpTimeDriver] Failed to sync media:', e);
@@ -156,6 +189,20 @@ export class CdpTimeDriver implements TimeDriver {
 
     this.cachedFrames = page.frames();
 
+    try {
+      const { result } = await this.client!.send('Runtime.evaluate', {
+        expression: "document.querySelectorAll('video, audio').length > 0",
+        returnByValue: true
+      });
+      if (result && result.value) {
+        this.syncMediaFn = this.defaultSyncMedia.bind(this);
+      } else {
+        this.syncMediaFn = () => {};
+      }
+    } catch (e) {
+      this.syncMediaFn = this.defaultSyncMedia.bind(this);
+    }
+
     // Enable Runtime so we actually receive executionContextCreated events
     // Catch errors in case another driver instance sharing this session already enabled it.
     await this.client!.send('Runtime.enable').catch(() => {});
@@ -191,40 +238,8 @@ export class CdpTimeDriver implements TimeDriver {
     // Convert to milliseconds for CDP
     const budget = delta * 1000;
 
-    // 1. Synchronize media elements (video, audio)
-    // We do this manually BEFORE advancing time so that when the frame renders (rAF),
-    // the video elements are already at the correct time.
-    // Execute in all frames (including main frame) to support iframes
-    const frames = this.cachedFrames;
-    if (frames.length === 1) {
-      this.singleFrameSyncMediaParams.expression = "if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");";
-      this.client!.send('Runtime.evaluate', this.singleFrameSyncMediaParams);
-    } else {
-        if (this.executionContextIds.length > 0) {
-          const expression = "if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");";
-          if (this.multiFrameSyncMediaParams.length !== this.executionContextIds.length) {
-            this.multiFrameSyncMediaParams.length = this.executionContextIds.length;
-            for (let i = 0; i < this.executionContextIds.length; i++) {
-              this.multiFrameSyncMediaParams[i] = {
-                expression: "",
-                contextId: this.executionContextIds[i],
-                awaitPromise: false,
-                returnByValue: false
-              };
-            }
-          }
-          for (let i = 0; i < this.executionContextIds.length; i++) {
-            this.multiFrameSyncMediaParams[i].expression = expression;
-            this.client!.send('Runtime.evaluate', this.multiFrameSyncMediaParams[i]);
-          }
-        } else {
-          // Fallback if execution contexts couldn't be resolved (e.g. reused CDP session)
-          for (let i = 0; i < frames.length; i++) {
-            const frame = frames[i];
-            frame.evaluate("if(typeof window.__helios_sync_media==='function') window.__helios_sync_media(" + timeInSeconds + ");");
-          }
-        }
-    }
+// 1. Synchronize media elements
+    this.syncMediaFn(timeInSeconds);
 
     // 2. Advance virtual time
     // This triggers the browser event loop and requestAnimationFrame


### PR DESCRIPTION
💡 **What**: Executed PERF-460 experiment. Conditionally bypassed `Runtime.evaluate` in `CdpTimeDriver.ts` when no media elements exist by using a closure assignment. The experiment was kept.
🎯 **Why**: To eliminate unnecessary IPC overhead during `runSetTime` for non-media compositions.
📊 **Impact**: Improved median render time from ~4.54s (baseline) to ~3.51s.
🔬 **Verification**: Code passed test suite (`verify-cdp-driver.ts`, `verify-seek-driver-determinism.ts`). Benchmark showed consistent improvements.
📎 **Plan**: `/.sys/plans/PERF-460-bypass-media-sync.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	3.851	90	23.37	38.9	keep	bypass Runtime.evaluate in CdpTimeDriver via closure
2	2.879	90	31.27	39.4	keep	bypass Runtime.evaluate in CdpTimeDriver via closure
3	3.511	90	25.64	39.3	keep	bypass Runtime.evaluate in CdpTimeDriver via closure
```

---
*PR created automatically by Jules for task [16442753910893555233](https://jules.google.com/task/16442753910893555233) started by @BintzGavin*