### PR TITLE
📋 RENDERER: Bypass Runtime.evaluate Stability Check in CdpTimeDriver When Unused

### DIFF
--- a/.sys/plans/PERF-461-bypass-stability-check.md
+++ b/.sys/plans/PERF-461-bypass-stability-check.md
@@ -1,0 +1,56 @@
+---
+id: PERF-461
+slug: bypass-stability-check
+status: unclaimed
+claimed_by: ""
+created: 2024-06-03
+completed: ""
+result: ""
+---
+
+# PERF-461: Bypass Runtime.evaluate Stability Check in CdpTimeDriver When Unused
+
+## Focus Area
+`CdpTimeDriver.ts` inside the hot loop (`runSetTime`).
+
+## Background Research
+Currently, `CdpTimeDriver` executes a `Runtime.evaluate` call to `window.__helios_wait_until_stable()` on *every single frame* and wraps it in a `Promise.race` with a Node.js `setTimeout` for safety. This incurs IPC overhead, V8 garbage collection churn (from new Promises and closures), and event loop delays.
+Most compositions do not define a custom `window.helios.waitUntilStable` function. In PERF-460, we successfully bypassed the media sync `Runtime.evaluate` call via closure assignment during initialization, which yielded a render time improvement. Applying the exact same pattern to the stability check will eliminate another unnecessary CDP call per frame, reducing the CDP chatter in the hot loop from 3 calls per frame down to 2 for standard compositions.
+
+## Benchmark Configuration
+- **Composition URL**: A standard benchmark composition.
+- **Render Settings**: 1280x720, 30fps, 3s duration (90 frames)
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Bottleneck analysis**: Unnecessary `Runtime.evaluate` IPC overhead and `Promise.race` allocation for non-existent stability checks.
+
+## Implementation Spec
+
+### Step 1: Conditionally define the stability check execution path
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+1. Add a private property `stabilityCheckFn` to the `CdpTimeDriver` class, initialized to return a resolved promise or execute immediately.
+2. Move the stability checking logic (from `const evaluatePromise = ...` to the end of the `finally` block) inside `runSetTime` into a new private method, `defaultStabilityCheck(): Promise<void>`.
+3. In `prepare(page: Page)`, use `waitForFunction` to ensure initialization finishes if a global object like `helios` or a custom timeline exists.
+4. During `prepare`, check for the stability function using the CDP client:
+   `const { result } = await this.client!.send('Runtime.evaluate', { expression: "typeof window.helios !== 'undefined' && typeof window.helios.waitUntilStable === 'function'", returnByValue: true });`
+5. If it exists, assign `this.stabilityCheckFn = this.defaultStabilityCheck.bind(this);`.
+6. Update `runSetTime` to simply call `this.stabilityCheckFn()`.
+
+**Why**: Removes the `Runtime.evaluate` call, `Promise.race`, and timeout timers for standard compositions without adding branch checks to the hot loop.
+**Risk**: If `window.helios.waitUntilStable` is injected *after* initialization, it won't be called. Since Helios APIs are typically defined synchronously at the top level of the composition, this risk is negligible.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run `cd packages/renderer && npx tsx tests/verify-cdp-driver.ts` to ensure no regressions in time synchronization.
+
+## Correctness Check
+Run the DOM render benchmark script (`npm run build:examples && cd packages/renderer && npx tsx scripts/render-dom.ts` or similar) to verify the speedup and ensure successful render completion.
+
+## Prior Art
+- PERF-460: Successfully bypassed `Runtime.evaluate` for media sync using closure assignment.


### PR DESCRIPTION
This PR introduces a performance experiment plan (PERF-461) aimed at optimizing `CdpTimeDriver`. It proposes conditionally bypassing the `Runtime.evaluate` call for `window.__helios_wait_until_stable()` when the function is not defined, thereby eliminating unnecessary IPC overhead and `Promise.race` allocations per frame.

---
*PR created automatically by Jules for task [14167263521847855803](https://jules.google.com/task/14167263521847855803) started by @BintzGavin*