### PR TITLE
✨ RENDERER: [Discarded] Restore jpeg as Default Intermediate Image Format

### DIFF
--- a/.sys/plans/PERF-462-restore-jpeg-default.md
+++ b/.sys/plans/PERF-462-restore-jpeg-default.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-462
 slug: restore-jpeg-default
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-30
-completed: ""
-result: ""
+completed: "2026-05-09"
+result: "discard"
 ---
 
 # PERF-462: Restore `jpeg` as Default Intermediate Image Format
@@ -77,3 +77,9 @@ Run the DOM render benchmark script (\`cd packages/renderer && npm run build:exa
 
 ## Prior Art
 - PERF-010, PERF-011, PERF-012, PERF-346: Previous conflicting experiments around JPEG fallback and FFmpeg pipe formats. This plan re-tests these hypotheses under the newly optimized CdpTimeDriver pipeline.
+
+## Results Summary
+- **Best render time**: 3.528s
+- **Improvement**: ~-0.7%
+- **Kept experiments**: []
+- **Discarded experiments**: [Restored `jpeg` as Default Intermediate Image Format]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -50,6 +50,10 @@ Last updated by: PERF-461
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-462**: Restored `jpeg` as Default Intermediate Image Format.
+  - **What I tried**: Changed default image format for non-alpha frames to `jpeg` with quality 80 in `DomStrategy.ts`.
+  - **Why it didn't work**: The overhead of JPEG encoding/decoding and base64 handling in Playwright IPC did not yield an improvement over PNG in this environment, resulting in a slight regression (~-0.7%). Baseline remains 3.505s.
+
 - **PERF-445**: Defaulting to webp intermediate format and webp image2pipe codec.
   - **Why**: Sending raw webp frames sequentially over stdin without a container format to FFmpeg fails with `pipe:: Invalid argument`, as FFmpeg requires `webp_pipe` to handle raw stream data, but `webp_pipe` inherently crashes due to an FFmpeg bug without alpha channels, making raw webp pipes unusable via stdin.
 - **PERF-441**: Changed default intermediate format to webp with quality 50.

--- a/packages/renderer/.sys/perf-results-PERF-462.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-462.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	5.508	150	27.23	39	discard	restore jpeg intermediate image default
+2	3.528	150	42.51	39	discard	restore jpeg intermediate image default
+3	3.078	150	48.73	39	discard	restore jpeg intermediate image default


### PR DESCRIPTION
💡 **What**: The experiment run and its outcome: Discarded restoring `jpeg` as the default intermediate image format for frames without alpha.
🎯 **Why**: The performance bottleneck targeted: Base64 string decoding overhead and IPC payload sizes.
📊 **Impact**: The render time degraded slightly (median 3.528s vs baseline 3.505s).
🔬 **Verification**: 4-gate verification failed because benchmark consistency showed a regression (-0.7% improvement). Code changes were discarded.
📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-462-restore-jpeg-default.md`)

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	5.508	150	27.23	39	discard	restore jpeg intermediate image default
2	3.528	150	42.51	39	discard	restore jpeg intermediate image default
3	3.078	150	48.73	39	discard	restore jpeg intermediate image default
```

---
*PR created automatically by Jules for task [10691904365721119969](https://jules.google.com/task/10691904365721119969) started by @BintzGavin*