### PR TITLE
✨ STUDIO: ExportJobSpec is already implemented

### DIFF
--- a/.jules/STUDIO.md
+++ b/.jules/STUDIO.md
@@ -5,3 +5,6 @@
 ## 0.121.10 - Update Keyboard Shortcuts Documentation
 **Learning:** IMPOSSIBLE: DUPLICATION. The requested feature in `2026-11-14-STUDIO-Update-Keyboard-Shortcuts-Documentation.md` to add JKL shortcuts to `KeyboardShortcutsModal.tsx` is already implemented. The `Playback` section already includes `J`, `K`, and `L` shortcuts.
 **Action:** Always check the codebase before implementing documentation updates to avoid duplicating effort.
+## v0.121.11 - ExportJobSpec is already implemented
+**Learning:** The "Export Job Spec" feature in the Renders Panel was found to be fully implemented, representing an "IMPOSSIBLE: DUPLICATION" scenario. This shows the importance of always checking the current codebase state before assuming missing functionality.
+**Action:** Before executing a feature addition, comprehensively search the UI code (e.g. RendersPanel.tsx, StudioContext.tsx) and API endpoints to verify the gap actually exists.

--- a/docs/PROGRESS-STUDIO.md
+++ b/docs/PROGRESS-STUDIO.md
@@ -1,3 +1,6 @@
+### STUDIO v0.121.11
+- ✅ Completed: STUDIO-ExportJobSpec - Verified that the Export Job Spec feature in Renders Panel was already fully implemented (IMPOSSIBLE: DUPLICATION).
+
 ### STUDIO v0.119.5
 - ✅ Completed: Refine CLI Component Removal - Verified existing implementation of component file deletion and interactive confirmation prompts in `helios remove` command (2026-10-23-STUDIO-Refine-CLI-Component-Removal.md).
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### STUDIO v0.121.11
+- ✅ Completed: STUDIO-ExportJobSpec - Verified that the Export Job Spec feature in Renders Panel was already fully implemented (IMPOSSIBLE: DUPLICATION).
+
 ### PLAYER v0.77.27
 - ✅ Completed: Document API Parity Gap - Deleted lingering plan file as the README already contained the required documentation updates.
 - ✅ Completed: Add Media Session properties to README

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,8 +1,9 @@
-**Version**: 0.121.10
+**Version**: 0.121.11
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
 # Studio Domain Status
+- [v0.121.11] ✅ Completed: STUDIO-ExportJobSpec - Verified that the Export Job Spec feature in Renders Panel was already fully implemented (IMPOSSIBLE: DUPLICATION).
 - [v0.121.10] ✅ Completed: Update Keyboard Shortcuts - Implemented missing JKL keyboard shortcuts documentation in the Help Modal.
 
 - [v0.121.8] ✅ Completed: STUDIO-Timeline-Drag-Drop - Verified timeline drag and drop for assets is already implemented (2026-11-13-STUDIO-Timeline-Drag-Drop.md).


### PR DESCRIPTION
Verified that the 'Export Job Spec' functionality (as described in `2025-05-25-STUDIO-ExportJobSpec.md`) is already completely implemented within the Studio UI. Updated tracking docs to record this as an impossible duplication.

---
*PR created automatically by Jules for task [483181394462343467](https://jules.google.com/task/483181394462343467) started by @BintzGavin*