### PR TITLE
✨ RENDERER: Documented PERF-459 as IMPOSSIBLE DUPLICATION

### DIFF
--- a/.sys/plans/PERF-459-skip-media-sync.md
+++ b/.sys/plans/PERF-459-skip-media-sync.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-459
 slug: skip-media-sync
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-06-03
 completed: ""
-result: ""
+result: "discard"
 ---
 
 # PERF-459: Bypass Runtime.evaluate in CdpTimeDriver When No Media Exists
@@ -65,3 +65,9 @@ Run the DOM render benchmark script (\`cd packages/renderer && npm run build:exa
 ## Prior Art
 - PERF-448: Failed attempt using a boolean branch.
 - PERF-458: Proposed plan for closure assignment.
+
+## Results Summary
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	IMPOSSIBLE: DUPLICATION
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -53,6 +53,11 @@ Last updated by: PERF-463
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-459**: Skip Media Sync CDP Call in CdpTimeDriver via closure assignment
+  - **What I tried**: Attempted to implement the PERF-459 plan to conditionally bypass the media sync CDP evaluate call using closure assignment.
+  - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. Code inspection revealed that `CdpTimeDriver.ts` already implements this exact optimization (added in PERF-460). Documented duplication and discarded.
+  - **Outcome**: discard
+
 - **PERF-462**: Restored `jpeg` as Default Intermediate Image Format.
   - **What I tried**: Changed default image format for non-alpha frames to `jpeg` with quality 80 in `DomStrategy.ts`.
   - **Why it didn't work**: The overhead of JPEG encoding/decoding and base64 handling in Playwright IPC did not yield an improvement over PNG in this environment, resulting in a slight regression (~-0.7%). Baseline remains 3.505s.

--- a/packages/renderer/.sys/perf-results-PERF-459.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-459.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	IMPOSSIBLE: DUPLICATION


### PR DESCRIPTION
✨ RENDERER: Documented PERF-459 as IMPOSSIBLE DUPLICATION

💡 **What**: Attempted to execute PERF-459 to optimize CdpTimeDriver media syncing, but identified it as already completed in PERF-460. Documented the failure.
🎯 **Why**: CdpTimeDriver already utilizes the closure-assignment optimization targeted by this plan.
📊 **Impact**: N/A (Baseline remains the same)
🔬 **Verification**: Codebase verified, duplicate logic detected, plan status updated to discarded.
📎 **Plan**: `/.sys/plans/PERF-459-skip-media-sync.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	IMPOSSIBLE: DUPLICATION
```

---
*PR created automatically by Jules for task [1959487801270341768](https://jules.google.com/task/1959487801270341768) started by @BintzGavin*