### PR TITLE
✨ RENDERER: Discarded PERF-466 direct promise chain in runSetTime

### DIFF
--- a/packages/renderer/.sys/perf-results-PERF-466.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-466.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	24.061	600	24.94	4.5	discard	direct promise chain in runSetTime
+2	23.913	600	25.09	4.5	discard	direct promise chain in runSetTime
+3	22.733	600	26.39	4.5	discard	direct promise chain in runSetTime

--- a/packages/renderer/.sys/plans/PERF-466-direct-promise-chain.md
+++ b/packages/renderer/.sys/plans/PERF-466-direct-promise-chain.md
@@ -1,0 +1,42 @@
+---
+id: PERF-466
+slug: direct-promise-chain
+status: complete
+claimed_by: "jules"
+created: "2024-05-20"
+completed: ""
+result: "discarded"
+---
+
+# PERF-466: Direct Promise Chain in CdpTimeDriver.runSetTime
+
+## Focus Area
+The `runSetTime` function in `CdpTimeDriver.ts` is the hot loop function called for each frame in DOM mode. It's defined as an `async` function, which adds `async/await` state machine overhead.
+
+## Background Research
+Returning a direct promise chain instead of using `async/await` avoids the allocation of the state machine and can slightly reduce GC churn and microtask overhead in hot loops.
+
+## Benchmark Configuration
+- **Composition URL**: standard dom benchmark composition
+- **Render Settings**: 1920x1080, 60fps, 10s, libx264
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~20.4s
+- **Bottleneck analysis**: Microtask and state machine overhead in hot loop.
+
+## Implementation Spec
+
+### Step 1: Replace async runSetTime
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**: Change `private async runSetTime` to return a direct promise chain.
+**Why**: Avoid `async/await` state machine overhead.
+**Risk**: Potential unhandled rejections if errors are thrown synchronously before the promise chain starts.
+
+## Results Summary
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	24.061	600	24.94	4.5	discard	direct promise chain in runSetTime
+2	23.913	600	25.09	4.5	discard	direct promise chain in runSetTime
+3	22.733	600	26.39	4.5	discard	direct promise chain in runSetTime

--- a/packages/renderer/docs/status/RENDERER-EXPERIMENTS.md
+++ b/packages/renderer/docs/status/RENDERER-EXPERIMENTS.md
@@ -6,6 +6,7 @@ Last updated by: PERF-271
 - [PERF-271] Combined `.catch` and `.then` handlers into a single `.then(resolve, reject)` in `CaptureLoop.ts` to reduce GC overhead and microtask serialization delays (~26.9% faster).
 
 ## What Doesn't Work (and Why)
+- [PERF-466] Attempted to return direct promise chain in CdpTimeDriver.runSetTime instead of using async/await. DISCARDED because performance did not improve (median 23.91s vs 20.43s baseline). The overhead of async/await state machine in the hot loop is negligible compared to other factors like IPC, and the structural change slightly degraded execution time.
 - [PERF-409] Attempted to replace `Promise.race` with a manual wrapper promise in `CdpTimeDriver.ts` stability check. DISCARDED as IMPOSSIBLE DUPLICATION. Previous experiments (PERF-361/PERF-411) showed V8 handles Promise.race arrays very efficiently, and manual tracking adds overhead.
 - [PERF-361] Attempted to avoid `Promise.race` allocation in `SeekTimeDriver` injected script. DISCARDED because it was slower (48.761s vs 46.298s baseline). V8 handles the Promise.race array wrapper very efficiently, and the manual state machine added overhead.
 


### PR DESCRIPTION
💡 **What**: Executed and discarded PERF-466, attempting to replace async/await with a direct promise chain in CdpTimeDriver.runSetTime.
🎯 **Why**: To reduce V8 state machine overhead during the frame capture hot loop.
📊 **Impact**: Performance degraded. The median render time increased from ~20.4s (baseline) to ~23.9s. The structural change added more overhead than the async state machine.
🔬 **Verification**:
- `npm run build` completed successfully.
- `verify-cdp-driver.ts` tests passed.
- Benchmarked 3 times with `benchmark-466.ts`.

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	24.061	600	24.94	4.5	discard	direct promise chain in runSetTime
2	23.913	600	25.09	4.5	discard	direct promise chain in runSetTime
3	22.733	600	26.39	4.5	discard	direct promise chain in runSetTime
```

📎 **Plan**: `packages/renderer/.sys/plans/PERF-466-direct-promise-chain.md`

---
*PR created automatically by Jules for task [17033555290592049366](https://jules.google.com/task/17033555290592049366) started by @BintzGavin*