### PR TITLE
✨ PLAYER: Document API Parity Gap

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -1,6 +1,6 @@
 # Context: PLAYER
 
-**Version**: 0.77.30
+**Version**: 0.77.32
 
 ## Section A: Component Structure
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -583,3 +583,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### PLAYER v0.77.29
 - ✅ Completed: Discovered that `2026-03-01-PLAYER-Click-To-Play.md` is an IMPOSSIBLE: DUPLICATION plan. The Click-To-Play functionality with `.click-layer` and the `interactive` attribute were already fully implemented in `packages/player/src/index.ts`. Documented as impossible and discarded.
+
+### PLAYER v0.77.32
+- ✅ Completed: Document API Parity Gap - Updated README to document existing methods (captureStream, startAudioMetering, stopAudioMetering) and events (enterpictureinpicture, leavepictureinpicture).

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: 0.77.31
+**Version**: 0.77.32
 [v0.77.30] ✅ Completed: Document Tracks API - Added audioTracks and videoTracks properties to README.md API parity list.
 [v0.77.27] ✅ Completed: Document API Parity Gap - Deleted lingering plan file as the README already contained the required documentation updates.
 [v0.77.27] ✅ Completed: Add Media Session properties to README
@@ -228,3 +228,4 @@
 [v0.77.29] ✅ Completed: Discovered that `2026-03-01-PLAYER-Click-To-Play.md` is an IMPOSSIBLE: DUPLICATION plan. The `.click-layer` and `interactive` attributes are already fully implemented. Documented as impossible and discarded.
 [v0.77.30] ✅ Completed: Discovered undocumented API properties and events in README.md. Created plan `.sys/plans/2026-12-30-PLAYER-README-API-Update.md` to document `audioTracks`, `videoTracks`, `enterpictureinpicture`, and `leavepictureinpicture`.
 [v0.77.31] ✅ Completed: Discovered undocumented API properties, methods and events in README.md. Created plan `.sys/plans/2026-12-30-PLAYER-README-API-Update.md` to document `enterpictureinpicture`, `leavepictureinpicture`, `captureStream`, `startAudioMetering`, and `stopAudioMetering`.
+[v0.77.32] ✅ Completed: Document API Parity Gap - Updated README to document existing methods (captureStream, startAudioMetering, stopAudioMetering) and events (enterpictureinpicture, leavepictureinpicture).

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -144,6 +144,9 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `export(options?: HeliosExportOptions): Promise<void>` - Programmatically trigger client-side export.
 - `fastSeek(time: number): void` - Seeks to the specified time as fast as possible (currently equivalent to setting `currentTime`).
 - `canPlayType(type: string): CanPlayTypeResult` - Returns whether the player can play the specified media type (e.g., `'probably'`, `'maybe'`, or `''`).
+- `captureStream(): Promise<MediaStream>` - Returns a MediaStream capturing the player's canvas (if same-origin).
+- `startAudioMetering(): void` - Starts audio metering calculation.
+- `stopAudioMetering(): void` - Stops audio metering calculation.
 
 ### Properties
 
@@ -211,6 +214,8 @@ The element dispatches the following custom events:
 - `canplay`: Fired when the browser can resume playback of the media.
 - `canplaythrough`: Fired when the browser estimates it can play through the media without buffering.
 - `resize`: Fired when the player dimensions change.
+- `enterpictureinpicture`: Fired when the player enters Picture-in-Picture mode.
+- `leavepictureinpicture`: Fired when the player leaves Picture-in-Picture mode.
 
 ## Client-Side Export
 


### PR DESCRIPTION
Updated the `README.md` in `packages/player` to document several existing but previously undocumented API methods and events, improving the documentation parity with the actual codebase. Updated the PLAYER domain status and tracking files according to strict agent protocols.

---
*PR created automatically by Jules for task [15692616097380653719](https://jules.google.com/task/15692616097380653719) started by @BintzGavin*