### PR TITLE
✨ RENDERER: Discard PERF-465 (Direct Promise Chain in CdpTimeDriver)

### DIFF
--- a/.sys/plans/PERF-465-cdptimedriver-promise-chain.md
+++ b/.sys/plans/PERF-465-cdptimedriver-promise-chain.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-465
 slug: cdptimedriver-promise-chain
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-09
 completed: ""
-result: ""
+result: "discarded (see journal)"
 ---
 
 # PERF-465: Return direct promise chain in CdpTimeDriver.runSetTime

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -337,3 +337,8 @@ Last updated by: PERF-463
 - **PERF-450**: Enable CdpTimeDriver for DOM Mode
   - **What I tried**: Attempted to execute the PERF-450 plan to replace `SeekTimeDriver` with `CdpTimeDriver` for DOM rendering in `BrowserPool.ts`.
   - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. Code inspection revealed that `BrowserPool.ts` already implements this change unconditionally (`const timeDriver = new CdpTimeDriver(this.options.stabilityTimeout);` at line 124). Documented duplication and discarded.
+
+- **PERF-465**: Return direct promise chain in CdpTimeDriver.runSetTime
+  - **What I tried**: Removed async/await in CdpTimeDriver.runSetTime and returned the promise chain natively to try to eliminate V8 state machine and microtask overhead.
+  - **WHY it didn't work**: The performance improvement was non-existent or worse (median ~3.412s vs baseline ~3.046s). The async/await overhead in the hot loop is negligible compared to the IPC and DOM evaluation bottlenecks. The V8 engine already handles async/await for native promises efficiently.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-465.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-465.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	3.412	150	43.96	0.0	discard	experimental direct promise chain
+2	3.213	150	46.69	0.0	discard	experimental direct promise chain
+3	4.202	150	35.70	0.0	discard	experimental direct promise chain


### PR DESCRIPTION
✨ RENDERER: Discard PERF-465 (Direct Promise Chain in CdpTimeDriver)

💡 **What**: Executed and discarded PERF-465, which attempted to return a direct promise chain in `CdpTimeDriver.runSetTime` instead of using `async/await`. The codebase was reverted to its original state.
🎯 **Why**: To reduce V8 async/await state machine and microtask queuing overhead in the frame capture hot loop.
📊 **Impact**: Performance degraded (median ~3.412s - 4.202s vs baseline ~3.046s). The experiment proved that the `async/await` overhead in the hot loop is negligible compared to IPC bottlenecks, and removing it actually increased render times in the benchmark.
🔬 **Verification**: Code compilation passed (`npm run build -w packages/renderer`), test suite passed via `verify-cdp-driver.ts` after reversion.
📎 **Plan**: `/.sys/plans/PERF-465-cdptimedriver-promise-chain.md`

### Benchmark Results
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	3.412	150	43.96	0.0	discard	experimental direct promise chain
2	3.213	150	46.69	0.0	discard	experimental direct promise chain
3	4.202	150	35.70	0.0	discard	experimental direct promise chain
```

---
*PR created automatically by Jules for task [17036651797887152541](https://jules.google.com/task/17036651797887152541) started by @BintzGavin*