### PR TITLE
📋 RENDERER: Bypass await for stability check in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-466-bypass-await-stability-check.md
+++ b/.sys/plans/PERF-466-bypass-await-stability-check.md
@@ -1,0 +1,57 @@
+---
+id: PERF-466
+slug: bypass-await-stability-check
+status: unclaimed
+claimed_by: ""
+created: 2024-05-09
+completed: ""
+result: ""
+---
+
+# PERF-466: Conditionally Bypassing Await for Stability Check
+
+## Focus Area
+Frame Capture Loop (Phase 4), specifically `CdpTimeDriver.runSetTime()`.
+
+## Background Research
+Currently, `runSetTime` uses `await this.stabilityCheckFn();` unconditionally. However, for the vast majority of frames in projects without a custom stability function, `this.stabilityCheckFn` is assigned a no-op function `() => {}` via `PERF-461`.
+Awaiting a function that returns `void` (or `undefined`) still forces V8 to yield execution and queue a microtask, adding measurable overhead in a hot loop that runs thousands of times.
+A standalone benchmark over 150,000 iterations shows that explicitly checking for a Promise before awaiting is significantly faster:
+- `await fn()`: ~21.1ms
+- `const res = fn(); if (res instanceof Promise) await res;`: ~3.2ms
+
+## Benchmark Configuration
+- **Composition URL**: Default `dom-benchmark` composition
+- **Render Settings**: 600x600, 30fps, 5s (150 frames)
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~3.02s
+- **Bottleneck analysis**: Microtask queueing overhead introduced by unconditionally awaiting a synchronous no-op function inside the `runSetTime` hot loop.
+
+## Implementation Spec
+
+### Step 1: Conditionally await `stabilityCheckFn` in `CdpTimeDriver`
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+Inside `runSetTime`, replace `await this.stabilityCheckFn();` with:
+```typescript
+    // Wait for custom stability checks
+    const stabilityRes = this.stabilityCheckFn();
+    if (stabilityRes instanceof Promise) {
+        await stabilityRes;
+    }
+```
+**Why**: If `stabilityCheckFn` is a no-op, it returns `undefined`. By checking if it's a Promise before awaiting, we avoid yielding execution and queuing a microtask, speeding up the hot loop.
+**Risk**: Negligible.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run `npm run build:examples && npx tsx packages/renderer/scripts/render-dom.ts` to verify nothing is fundamentally broken.
+
+## Correctness Check
+Run `npm run build:examples && npx tsx packages/renderer/scripts/render-dom.ts` and verify the output `packages/renderer/output/dom-animation.mp4` renders successfully and looks correct visually.


### PR DESCRIPTION
📋 RENDERER: Bypass await for stability check in CdpTimeDriver

💡 What: A new performance experiment plan to conditionally bypass the `await` keyword for `stabilityCheckFn` in `CdpTimeDriver.ts`.
🎯 Why: Awaiting a synchronous no-op function still forces V8 to yield execution and queue a microtask. Bypassing this when the stability function is a no-op (the default) avoids this overhead in the hot loop.
🔬 Approach: Check if the return value of `this.stabilityCheckFn()` is an instance of a Promise before awaiting it.
📎 Plan: `/.sys/plans/PERF-466-bypass-await-stability-check.md`

---
*PR created automatically by Jules for task [9280170475947432696](https://jules.google.com/task/9280170475947432696) started by @BintzGavin*