### PR TITLE
✨ RENDERER: Discard PERF-466 conditionally bypass await for stability check

### DIFF
--- a/.sys/plans/PERF-466-bypass-await-stability-check.md
+++ b/.sys/plans/PERF-466-bypass-await-stability-check.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-466
 slug: bypass-await-stability-check
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-09
 completed: ""

--- a/commit-msg.txt
+++ b/commit-msg.txt
@@ -1,0 +1,12 @@
+✨ RENDERER: Discard PERF-466 conditionally bypass await for stability check
+
+💡 **What**: Executed PERF-466 to check if the result of `this.stabilityCheckFn()` is a Promise before awaiting it in `CdpTimeDriver`. The experiment was discarded because it worsened median execution time.
+🎯 **Why**: To test if avoiding V8 microtask overhead for no-ops in the `runSetTime` hot loop would improve performance.
+📊 **Impact**: Degraded. The median execution time was worse (~3.475s vs 3.020s baseline). The overhead of the `instanceof` check outweighed the V8 promise resolution optimization in the Node.js event loop context.
+🔬 **Verification**: Code built successfully. Verified CdpTimeDriver logic using standalone manual test. Benchmark data collected and written to TSV. Test suite run against CDP/Seek drivers locally. Code changes were reverted because the experiment was discarded.
+📎 **Plan**: /.sys/plans/PERF-466-bypass-await-stability-check.md
+
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	3.610	150	41.55	40.0	discard	bypass stability check await via conditional
+2	3.453	150	43.44	40.0	discard	bypass stability check await via conditional
+3	3.475	150	43.17	40.0	discard	bypass stability check await via conditional

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -53,6 +53,10 @@ Last updated by: PERF-463
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-466**: Conditionally bypass await for stability check in CdpTimeDriver.
+  - **What I tried**: Checked if stability check result was a promise before awaiting to avoid V8 microtask overhead for no-ops.
+  - **WHY it didn't work**: The median execution time was worse (~3.475s vs 3.020s baseline). The overhead of the instanceof check seems to outweigh the V8 promise resolution optimization in the Node.js event loop context when paired with Playwright.
+  - **Outcome**: discard
 - **PERF-459**: Skip Media Sync CDP Call in CdpTimeDriver via closure assignment
   - **What I tried**: Attempted to implement the PERF-459 plan to conditionally bypass the media sync CDP evaluate call using closure assignment.
   - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. Code inspection revealed that `CdpTimeDriver.ts` already implements this exact optimization (added in PERF-460). Documented duplication and discarded.

--- a/packages/renderer/.sys/perf-results-PERF-466.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-466.tsv
@@ -2,3 +2,6 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	24.061	600	24.94	4.5	discard	direct promise chain in runSetTime
 2	23.913	600	25.09	4.5	discard	direct promise chain in runSetTime
 3	22.733	600	26.39	4.5	discard	direct promise chain in runSetTime
+1	3.610	150	41.55	40.0	discard	bypass stability check await via conditional
+2	3.453	150	43.44	40.0	discard	bypass stability check await via conditional
+3	3.475	150	43.17	40.0	discard	bypass stability check await via conditional


### PR DESCRIPTION
💡 **What**: Executed PERF-466 to check if the result of `this.stabilityCheckFn()` is a Promise before awaiting it in `CdpTimeDriver`. The experiment was discarded because it worsened median execution time.
🎯 **Why**: To test if avoiding V8 microtask overhead for no-ops in the `runSetTime` hot loop would improve performance.
📊 **Impact**: Degraded. The median execution time was worse (~3.475s vs 3.020s baseline). The overhead of the `instanceof` check outweighed the V8 promise resolution optimization in the Node.js event loop context.
🔬 **Verification**: Code built successfully. Verified CdpTimeDriver logic using standalone manual test. Benchmark data collected and written to TSV. Test suite run against CDP/Seek drivers locally. Code changes were reverted because the experiment was discarded.
📎 **Plan**: /.sys/plans/PERF-466-bypass-await-stability-check.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	3.610	150	41.55	40.0	discard	bypass stability check await via conditional
2	3.453	150	43.44	40.0	discard	bypass stability check await via conditional
3	3.475	150	43.17	40.0	discard	bypass stability check await via conditional

---
*PR created automatically by Jules for task [1532668379419098932](https://jules.google.com/task/1532668379419098932) started by @BintzGavin*