### PR TITLE
✨ RENDERER: Discard PERF-003 (Duplicate)

### DIFF
--- a/.sys/plans/PERF-003-concurrent-dom-capture.md
+++ b/.sys/plans/PERF-003-concurrent-dom-capture.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-003
 slug: concurrent-dom-capture
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-10-18
 completed: ""
-result: ""
+result: "discard"
 ---
 
 # PERF-003: Concurrent DOM Capture Pool

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -53,6 +53,10 @@ Last updated by: PERF-463
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-003**: Concurrent DOM Capture Pool
+  - **What I tried**: Attempted to implement a multi-page concurrency pool in `BrowserPool.ts`.
+  - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. Code inspection revealed that `BrowserPool.ts` already implements concurrent pages (`const concurrency = Math.max(1, (os.cpus().length || 4) - 1);`). Documented duplication and discarded.
+  - **Outcome**: discard
 - **PERF-466**: Conditionally bypass await for stability check in CdpTimeDriver.
   - **What I tried**: Checked if stability check result was a promise before awaiting to avoid V8 microtask overhead for no-ops.
   - **WHY it didn't work**: The median execution time was worse (~3.475s vs 3.020s baseline). The overhead of the instanceof check seems to outweigh the V8 promise resolution optimization in the Node.js event loop context when paired with Playwright.


### PR DESCRIPTION
Discarded PERF-003 plan for concurrent DOM capture.

The plan was determined to be IMPOSSIBLE: DUPLICATION because the codebase already implements multi-page concurrency in `BrowserPool.ts`. I updated `.sys/plans/PERF-003-concurrent-dom-capture.md` to show it's complete and documented it in `docs/status/RENDERER-EXPERIMENTS.md` as a discarded experiment due to duplication. I also ran tests to verify system stability.

---
*PR created automatically by Jules for task [6690165387511700932](https://jules.google.com/task/6690165387511700932) started by @BintzGavin*