### PR TITLE
✨ RENDERER: Optimize Await Usage in CdpTimeDriver RunSetTime Loop

### DIFF
--- a/.sys/plans/PERF-467-optimize-cdp-time-driver-await.md
+++ b/.sys/plans/PERF-467-optimize-cdp-time-driver-await.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-467
 slug: optimize-cdp-time-driver-await
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-10
-completed: ""
-result: ""
+completed: "2024-05-10"
+result: "improved"
 ---
 
 # PERF-467: Optimize Await Usage in CdpTimeDriver RunSetTime Loop
@@ -100,3 +100,9 @@ Remove the unused stability timeout handlers:
 ## Prior Art
 - PERF-430: Optimized CDP evaluate stability by forcing `returnByValue: false`.
 - Memory tests indicating that removing the `Promise.race` allocation wrapper and timeout variables significantly boosts tight-loop performance.
+
+## Results Summary
+- **Best render time**: 1.569s (vs baseline 3.020s)
+- **Improvement**: ~48%
+- **Kept experiments**: Optimized `defaultStabilityCheck` to directly return the promise, bypassing array allocation and `Promise.race` logic.
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,6 +1,6 @@
 ## Performance Trajectory
-Current best: 3.020s (baseline was 32.776s, -90.8%)
-Last updated by: PERF-463
+Current best: 1.569s (baseline was 32.776s, -90.8%)
+Last updated by: PERF-467
 
 
 ## What Works
@@ -217,8 +217,8 @@ Last updated by: PERF-463
   - **WHY it didn't work**: The median render time improved slightly from ~46.546s to ~46.003s, which represents a ~1.1% gain. However, this is well within the ~5% environmental noise margin. V8 handles the occasional integer modulo arithmetic efficiently enough that manual counter management does not provide a definitive, clear-cut performance gain. Discarded to maintain code simplicity.
 
 ## Performance Trajectory
-Current best: 3.020s (baseline was 32.776s, -90.8%)
-Last updated by: PERF-463
+Current best: 1.569s (baseline was 32.776s, -90.8%)
+Last updated by: PERF-467
 
 ## What Works
 - **PERF-463**: Changed default intermediate image format for non-alpha frames to JPEG in DomStrategy.
@@ -350,3 +350,7 @@ Last updated by: PERF-463
   - **What I tried**: Removed async/await in CdpTimeDriver.runSetTime and returned the promise chain natively to try to eliminate V8 state machine and microtask overhead.
   - **WHY it didn't work**: The performance improvement was non-existent or worse (median ~3.412s vs baseline ~3.046s). The async/await overhead in the hot loop is negligible compared to the IPC and DOM evaluation bottlenecks. The V8 engine already handles async/await for native promises efficiently.
   - **Outcome**: discard
+
+- **PERF-467**: Optimize Await Usage in CdpTimeDriver RunSetTime Loop
+  - **What I tried**: Modified `defaultStabilityCheck` to return the `Runtime.evaluate` promise directly and removed the `Promise.race` logic and timeout properties inside the `runSetTime` hot loop.
+  - **Outcome**: Kept. Improved performance from baseline ~3.020s down to ~1.569s. Directly returning the evaluate promise eliminates the overhead of instantiating `Promise.race`, parallel arrays, and timeout mechanisms in the per-frame loop, greatly speeding up the virtual clock tick execution.

--- a/packages/renderer/.sys/perf-results-PERF-467.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-467.tsv
@@ -1,0 +1,1 @@
+2	1.569	150	95.59	41.1	keep	bypass stability check await via returning direct promise

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -21,20 +21,6 @@ export class CdpTimeDriver implements TimeDriver {
   private syncMediaFn: (timeInSeconds: number) => void = () => {};
   private stabilityCheckFn: () => Promise<void> | void = () => {};
 
-  private stabilityTimeoutId: NodeJS.Timeout | null = null;
-  private stabilityTimeoutReject: ((err: Error) => void) | null = null;
-
-  private stabilityTimeoutCallback = () => {
-    if (this.stabilityTimeoutReject) {
-      this.stabilityTimeoutReject(new Error('Stability check timed out'));
-    }
-  };
-
-  private stabilityTimeoutExecutor = (_: () => void, reject: (err: Error) => void) => {
-    this.stabilityTimeoutReject = reject;
-    this.stabilityTimeoutId = setTimeout(this.stabilityTimeoutCallback, this.timeout);
-  };
-
   private virtualTimePromiseExecutor = (resolve: () => void, reject: (err: Error) => void) => {
     this.cdpResolve = resolve;
     this.cdpReject = reject;
@@ -100,33 +86,12 @@ export class CdpTimeDriver implements TimeDriver {
     }
   };
 
-  private async defaultStabilityCheck(): Promise<void> {
-    const evaluatePromise = this.client!.send('Runtime.evaluate', this.evaluateStabilityParams);
-    const timeoutPromise = new Promise<void>(this.stabilityTimeoutExecutor);
-
-    try {
-        const res = await Promise.race([evaluatePromise, timeoutPromise]);
-        if (res) {
-            this.handleStabilityCheckResponse(res);
-        }
-    } catch (e: any) {
-        if (e.message === 'Stability check timed out') {
-            console.warn(`[CdpTimeDriver] Stability check timed out after ${this.timeout}ms. Terminating execution.`);
-            try {
-                await this.client?.send('Runtime.terminateExecution');
-            } catch (termErr) {
-                console.warn('[CdpTimeDriver] Failed to terminate hanging script (might have finished race):', termErr);
-            }
-        } else {
-            throw e;
-        }
-    } finally {
-        if (this.stabilityTimeoutId !== null) {
-            clearTimeout(this.stabilityTimeoutId);
-            this.stabilityTimeoutId = null;
-        }
-        this.stabilityTimeoutReject = null;
-    }
+  private defaultStabilityCheck(): Promise<void> | void {
+    return this.client!.send('Runtime.evaluate', this.evaluateStabilityParams).then((res) => {
+      if (res) {
+        this.handleStabilityCheckResponse(res);
+      }
+    }) as unknown as Promise<void>;
   }
 
   constructor(timeout: number = 30000) {


### PR DESCRIPTION
💡 **What**: Modified `defaultStabilityCheck` in `CdpTimeDriver` to directly return the native `Runtime.evaluate` promise chain. Removed `Promise.race` logic, parallel arrays, and timeout mechanisms in the `runSetTime` hot loop.
🎯 **Why**: The setup overhead for `Promise.race`, including object and array allocations, was found to be a significant bottleneck in the virtual clock tick execution loop. Directly returning the evaluate promise bypasses this overhead entirely.
📊 **Impact**: Render times improved significantly. The baseline median render time of ~3.020s decreased to ~1.569s (~48% improvement).
🔬 **Verification**: 
- Compilation succeeds (`npm run build`).
- `verify-cdp-driver.ts` and `verify-seek-driver-determinism.ts` tests run successfully and deterministically.
- Benchmarks show significant performance gains.

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
2	1.569	150	95.59	41.1	keep	bypass stability check await via returning direct promise
```
📎 **Plan**: `/.sys/plans/PERF-467-optimize-cdp-time-driver-await.md`

---
*PR created automatically by Jules for task [14659888330404732621](https://jules.google.com/task/14659888330404732621) started by @BintzGavin*