### PR TITLE
✨ RENDERER: PERF-464 Discard direct promise chain in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-464-cdptimedriver-promise-chain.md
+++ b/.sys/plans/PERF-464-cdptimedriver-promise-chain.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-464
 slug: cdptimedriver-promise-chain
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-09
-completed: ""
-result: ""
+completed: "2024-05-24"
+result: "failed"
 ---
 
 # PERF-464: Return direct promise chain in CdpTimeDriver.runSetTime
@@ -83,3 +83,9 @@ Also verify `tests/verify-cdp-driver.ts` test passes.
 ## Prior Art
 - PERF-432 (Eliminated `await` in `DomStrategy.ts` capture hot loop)
 - PERF-368 (Eliminated `TimeDriver.setTime` Promise return overhead - though this was later reverted/adjusted to support await).
+
+## Results Summary
+- **Best render time**: 1.651s (vs baseline ~1.65s)
+- **Improvement**: ~0%
+- **Kept experiments**: None
+- **Discarded experiments**: Direct promise chain in CdpTimeDriver.runSetTime.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -361,3 +361,7 @@ Last updated by: PERF-468
   - **What I tried**: Attempted to replace the `new Promise<void>(this.drainPromiseExecutor)` object allocation in the `CaptureLoop.ts` hot loop with a static, pre-allocated thenable object (`this.drainAwaitable`) to eliminate V8 allocation overhead when encountering FFmpeg pipe backpressure.
   - **WHY it didn't work**: The performance improvement was non-existent or slightly worse (median ~1.713s vs baseline ~1.717s). V8 is already highly optimized for instantiating small native Promise objects in hot loops via hidden classes and inline caching. Bypassing the native Promise structure with a custom thenable object introduces deoptimizations when the `await` keyword integrates it into the microtask queue, negating any allocation savings. The manual micro-optimization yielded zero measurable benefit.
   - **Outcome**: discard
+- **PERF-464**: Return direct promise chain in CdpTimeDriver.runSetTime
+  - **What I tried**: Removed async/await in CdpTimeDriver.runSetTime and returned the promise chain natively to try to eliminate V8 state machine and microtask overhead.
+  - **WHY it didn't work**: The performance difference was within the noise margin (median ~1.698s vs baseline ~1.65s-1.70s). The async/await overhead in the hot loop is negligible compared to the Playwright IPC bottlenecks.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-464.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-464.tsv
@@ -1,0 +1,6 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.702	150	88.14	41.7	discard	PERF-464-cdptimedriver-promise-chain
+2	1.651	150	90.88	41.5	discard	PERF-464-cdptimedriver-promise-chain
+3	1.714	150	87.50	41.0	discard	PERF-464-cdptimedriver-promise-chain
+4	1.689	150	88.80	41.0	discard	PERF-464-cdptimedriver-promise-chain
+5	1.698	150	88.31	41.0	discard	PERF-464-cdptimedriver-promise-chain


### PR DESCRIPTION
💡 What: Discarded replacing async/await with native promise chains in CdpTimeDriver.runSetTime.
🎯 Why: To verify if state machine allocation overhead existed in the hot loop.
📊 Impact: No improvement (~1.651s vs baseline ~1.650s).
🔬 Verification: Build and run test script.
📎 Plan: PERF-464

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.702	150	88.14	41.7	discard	PERF-464-cdptimedriver-promise-chain
2	1.651	150	90.88	41.5	discard	PERF-464-cdptimedriver-promise-chain
3	1.714	150	87.50	41.0	discard	PERF-464-cdptimedriver-promise-chain
4	1.689	150	88.80	41.0	discard	PERF-464-cdptimedriver-promise-chain
5	1.698	150	88.31	41.0	discard	PERF-464-cdptimedriver-promise-chain

---
*PR created automatically by Jules for task [746306210729886452](https://jules.google.com/task/746306210729886452) started by @BintzGavin*