### PR TITLE
✨ RENDERER: Discard PERF-469 prebind capture promises

### DIFF
--- a/.sys/plans/PERF-469-prebind-capture-promises.md
+++ b/.sys/plans/PERF-469-prebind-capture-promises.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-469
 slug: prebind-capture-promises
-status: claimed
+status: complete
 claimed_by: "executor-session"
 created: 2024-05-10
 completed: "2024-05-10"

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -56,6 +56,9 @@ Last updated by: PERF-468
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-469**: Replace `drainPromiseExecutor` with a pre-allocated thenable.
+  - **What I tried**: Attempted to replace the `new Promise` allocation in `CaptureLoop.ts` when encountering backpressure with a statically bound thenable object.
+  - **WHY it didn't work**: The overhead of the promise allocation was not a bottleneck. In fact, bypassing native Promises and injecting a custom thenable caused play-out regressions and degraded render time (from ~1.711s to ~2.945s). V8 optimally handles basic `new Promise` instantiation natively in the async/await machinery better than non-native thenable adapters in this hot loop.
 - **PERF-003**: Concurrent DOM Capture Pool
   - **What I tried**: Attempted to implement a multi-page concurrency pool in `BrowserPool.ts`.
   - **WHY it didn't work**: IMPOSSIBLE: DUPLICATION. Code inspection revealed that `BrowserPool.ts` already implements concurrent pages (`const concurrency = Math.max(1, (os.cpus().length || 4) - 1);`). Documented duplication and discarded.

--- a/packages/renderer/.sys/perf-results-PERF-469.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-469.tsv
@@ -9,3 +9,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 8	1.761	150	85.16	40.3	discard	revert test
 9	1.733	150	86.58	49.7	discard	revert test
 10	1.711	150	87.66	40.2	discard	revert test
+11	2.945	150	50.93	49.4	discard	prebind capture promises


### PR DESCRIPTION
Run experiment PERF-469 to prebind capture promises using a custom thenable.
Result: Discarded due to performance degradation. Updated plan and experiment journal.

Results:
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
11	2.945	150	50.93	49.4	discard	prebind capture promises
```

---
*PR created automatically by Jules for task [11912013700070965869](https://jules.google.com/task/11912013700070965869) started by @BintzGavin*