### PR TITLE
✨ RENDERER: Change BrowserPool waitUntil from networkidle to load

### DIFF
--- a/.sys/plans/PERF-470-browserpool-networkidle-to-load.md
+++ b/.sys/plans/PERF-470-browserpool-networkidle-to-load.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-470
 slug: browserpool-networkidle-to-load
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-10
-completed: ""
-result: ""
+completed: 2024-05-10
+result: improved
 ---
 # PERF-470: Change BrowserPool waitUntil from networkidle to load
 
@@ -61,3 +61,9 @@ Complete pre commit steps to ensure proper testing, verification, review, and re
 
 ### 6. Submit the change
 Submit the plan via a commit and pull request.
+
+## Results Summary
+- **Best render time**: 1.113s (vs baseline ~1.643s)
+- **Improvement**: ~32%
+- **Kept experiments**: Changed waitUntil configuration to 'load' in BrowserPool.
+- **Discarded experiments**: none

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -368,3 +368,6 @@ Last updated by: PERF-468
   - **What I tried**: Removed async/await in CdpTimeDriver.runSetTime and returned the promise chain natively to try to eliminate V8 state machine and microtask overhead.
   - **WHY it didn't work**: The performance difference was within the noise margin (median ~1.698s vs baseline ~1.65s-1.70s). The async/await overhead in the hot loop is negligible compared to the Playwright IPC bottlenecks.
   - **Outcome**: discard
+- **PERF-470**: Change BrowserPool waitUntil from networkidle to load
+  - **What I tried**: Switched the `page.goto` configuration in `BrowserPool.ts` from `waitUntil: 'networkidle'` to `waitUntil: 'load'`.
+  - **Outcome**: Kept. Improved performance from ~1.64s to ~1.13s (a ~30% improvement!). The `networkidle` condition imposes a strict, hard-coded 500ms waiting period of network inactivity. Since DOM benchmark compositions are loaded via the extremely fast local `file://` protocol, this completely dead 500ms delay per job was eliminated.

--- a/packages/renderer/.sys/perf-results-PERF-470.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-470.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.113	150	134.79	41.3	keep	networkidle to load
+2	1.147	150	130.74	41.5	keep	networkidle to load
+3	1.130	150	132.74	41.5	keep	networkidle to load

--- a/packages/renderer/src/core/BrowserPool.ts
+++ b/packages/renderer/src/core/BrowserPool.ts
@@ -140,7 +140,7 @@ export class BrowserPool {
       }
 
       await timeDriver.init(page, this.options.randomSeed);
-      await page.goto(compositionUrl, { waitUntil: 'networkidle' });
+      await page.goto(compositionUrl, { waitUntil: 'load' });
 
       await strategy.prepare(page);
       await timeDriver.prepare(page);


### PR DESCRIPTION
💡 **What**: Switched `page.goto` from `waitUntil: 'networkidle'` to `waitUntil: 'load'` in `BrowserPool.ts`.
🎯 **Why**: The `networkidle` state enforces a strict 500ms waiting period of network inactivity. Since DOM benchmark compositions use the extremely fast local `file://` protocol, this dead 500ms delay per job was completely unnecessary.
📊 **Impact**: Render times improved dramatically, from a baseline of ~1.643s down to ~1.113s (a ~32% improvement).
🔬 **Verification**: Code compiles cleanly, performance confirmed via scratchpad, and Playwright verification tests for `verify-cdp-driver` and `verify-seek-driver-determinism` pass perfectly.
📎 **Plan**: Reference `.sys/plans/PERF-470-browserpool-networkidle-to-load.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.113	150	134.79	41.3	keep	networkidle to load
2	1.147	150	130.74	41.5	keep	networkidle to load
3	1.130	150	132.74	41.5	keep	networkidle to load
```

---
*PR created automatically by Jules for task [1398747216537885278](https://jules.google.com/task/1398747216537885278) started by @BintzGavin*