### PR TITLE
✨ RENDERER: Use WebP with image2pipe for intermediate format

### DIFF
--- a/.sys/plans/PERF-446-webp-intermediate-format.md
+++ b/.sys/plans/PERF-446-webp-intermediate-format.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-446
 slug: webp-intermediate-format
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-24
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -4,6 +4,11 @@ Last updated by: PERF-468
 
 
 ## What Works
+
+- **PERF-446**: Use WebP with Low Quality for All Intermediate Formats
+  - **What I tried**: Changed default format to WebP with `image2pipe` demuxer and `-vcodec webp`
+  - **Result**: Median render time ~1.542s
+  - **Outcome**: keep
 - **PERF-468**: Bypassed `await` for undefined `stabilityCheckFn` via a simple truthiness check in `CdpTimeDriver.ts`.
   - Avoids `Promise.resolve` wrapping and microtask queue suspension overhead when no stability check is defined.
   - Unlike `instanceof Promise` checks which degraded performance (PERF-466), a direct truthiness check improved median render time slightly (~3.072s vs ~3.08s) without V8 prototype traversal overhead. Kept.

--- a/packages/renderer/.sys/perf-results-PERF-446.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-446.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.988	90	30.13	46.7	keep	webp image2pipe
+2	1.542	90	58.38	46.6	keep	webp image2pipe
+3	1.499	90	60.04	46.7	keep	webp image2pipe

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -111,8 +111,8 @@ export class DomStrategy implements RenderStrategy {
         format = 'webp';
         quality = quality ?? 75;
       } else {
-        format = 'jpeg';
-        quality = quality ?? 80;
+        format = 'webp';
+        quality = quality ?? 50;
       }
     }
 
@@ -212,7 +212,7 @@ export class DomStrategy implements RenderStrategy {
     const format = this.cdpScreenshotParams?.format || 'png';
 
     if (format === 'webp') {
-      inputFormat = 'webp_pipe';
+      inputFormat = 'image2pipe';
     } else if (format === 'jpeg') {
       inputFormat = 'mjpeg';
     } else if (format === 'png') {
@@ -221,6 +221,7 @@ export class DomStrategy implements RenderStrategy {
 
     const videoInputArgs = [
       '-f', inputFormat,
+      ...(format === 'webp' ? ['-vcodec', 'webp'] : []),
       '-framerate', `${options.fps}`,
       '-thread_queue_size', '512',
       '-i', '-',


### PR DESCRIPTION
✨ RENDERER: Use WebP with image2pipe for intermediate format

💡 What: Changed the default intermediate image format for non-alpha streams in `DomStrategy.ts` from `jpeg` to `webp` at quality 50. Updated FFmpeg arguments to use the `image2pipe` input format with the `-vcodec webp` flag instead of `webp_pipe`.
🎯 Why: WebP encoding in Chromium is extremely fast and produces smaller payloads over IPC. Previous attempts to use WebP (PERF-441) failed because FFmpeg crashed when reading raw WebP streams via `webp_pipe` without container sizing. Using `image2pipe` with `-vcodec webp` correctly demuxes the raw frames and unlocks WebP's performance benefits.
📊 Impact: Kept. Improved render times significantly. The benchmark rendered a 90-frame composition with a median time of ~1.542s (fps: ~58.38).
🔬 Verification: Passed TypeScript compilation (`npm run build`). Verified FFmpeg handles the stream and benchmarks execute without the prior missing size crash. Verified metrics extraction dynamically.
📎 Plan: `.sys/plans/PERF-446-webp-intermediate-format.md`

### Results Summary
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.988	90	30.13	46.7	keep	webp image2pipe
2	1.542	90	58.38	46.6	keep	webp image2pipe
3	1.499	90	60.04	46.7	keep	webp image2pipe

---
*PR created automatically by Jules for task [16262575745965504759](https://jules.google.com/task/16262575745965504759) started by @BintzGavin*