### PR TITLE
✨ RENDERER: [DISCARD] Eliminate SetVirtualTimePolicy Event Loop Wait

### DIFF
--- a/.sys/plans/PERF-471-eliminate-virtual-time-wait.md
+++ b/.sys/plans/PERF-471-eliminate-virtual-time-wait.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-471
 slug: eliminate-virtual-time-wait
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-10
-completed: ""
-result: ""
+completed: "2024-05-10"
+result: "discard"
 ---
 # PERF-471: Eliminate SetVirtualTimePolicy Event Loop Wait
 
@@ -50,3 +50,6 @@ Run `npm run bench:canvas` in `packages/renderer/` or manually verify that canva
 
 ## Correctness Check
 Run `npm run bench:dom` and manually verify that `output/dom-animation.mp4` renders cleanly.
+## Results Summary
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	bypassed virtualTimePromiseExecutor logic in CdpTimeDriver

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -61,6 +61,11 @@ Last updated by: PERF-468
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+
+- **PERF-471**: Eliminate SetVirtualTimePolicy Event Loop Wait
+  - **What I tried**: Attempted to bypass the parallel event listener `Emulation.virtualTimeBudgetExpired` and `this.virtualTimePromiseExecutor` logic in `CdpTimeDriver.ts`, instead awaiting `this.client!.send('Emulation.setVirtualTimePolicy')` directly in `runSetTime`.
+  - **WHY it didn't work**: Awaiting the `setVirtualTimePolicy` CDP response directly does not guarantee that the virtual time budget has actually been consumed by Chromium and that the browser has fully advanced its internal rendering clock. Skipping the `virtualTimeBudgetExpired` event synchronization resulted in a corrupted frame pipeline where FFmpeg encountered unspecified WebP stream dimensions, causing a crash (`Conversion failed!`). The double-wait (CDP send + Event wait) is strictly necessary for IPC synchronization.
+  - **Outcome**: discard
 - **PERF-469**: Replace `drainPromiseExecutor` with a pre-allocated thenable.
   - **What I tried**: Attempted to replace the `new Promise` allocation in `CaptureLoop.ts` when encountering backpressure with a statically bound thenable object.
   - **WHY it didn't work**: The overhead of the promise allocation was not a bottleneck. In fact, bypassing native Promises and injecting a custom thenable caused play-out regressions and degraded render time (from ~1.711s to ~2.945s). V8 optimally handles basic `new Promise` instantiation natively in the async/await machinery better than non-native thenable adapters in this hot loop.

--- a/packages/renderer/.sys/perf-results-PERF-471.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-471.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	bypassed virtualTimePromiseExecutor logic in CdpTimeDriver


### PR DESCRIPTION
💡 **What**: Attempted to bypass the parallel event listener `Emulation.virtualTimeBudgetExpired` and `this.virtualTimePromiseExecutor` logic in `CdpTimeDriver.ts`, instead awaiting `this.client!.send('Emulation.setVirtualTimePolicy')` directly in `runSetTime`.
🎯 **Why**: To eliminate unnecessary event listener allocation and IPC synchronization wait overhead in the virtual time hot loop.
📊 **Impact**: 0.000s (Crash).
🔬 **Verification**: Running the benchmark locally caused a catastrophic failure during the FFmpeg image2pipe execution due to corrupted frames not matching the WebP stream (`Could not find codec parameters for stream 0 (Video: webp, none): unspecified size`), confirming that the double-wait synchronization logic is strictly required for correct deterministic rendering output. The code changes were discarded.
📎 **Plan**: `/.sys/plans/PERF-471-eliminate-virtual-time-wait.md`

## Results Summary
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	bypassed virtualTimePromiseExecutor logic in CdpTimeDriver

---
*PR created automatically by Jules for task [7399730093322371387](https://jules.google.com/task/7399730093322371387) started by @BintzGavin*