### PR TITLE
✨ RENDERER: Discard PERF-472 (recursive worker loop)

### DIFF
--- a/.sys/perf-results-PERF-472.tsv
+++ b/.sys/perf-results-PERF-472.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.00	0	0	0.0	crash	Recursive loop promise chain FFmpeg pipe EOF crash

--- a/.sys/plans/PERF-472-optimize-worker-run-loop.md
+++ b/.sys/plans/PERF-472-optimize-worker-run-loop.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-472
 slug: optimize-worker-run-loop
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-05-10
 completed: ""
 result: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -61,6 +61,10 @@ Last updated by: PERF-468
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-472**: Replace async runWorker with recursive promise chain
+  - **What I tried**: Converted the `async` `runWorker` method in `CaptureLoop.ts` to a standard function returning a Promise, using a recursive inner `loop()` to traverse frames.
+  - **WHY it didn't work**: The change introduced a subtle unhandled microtask queue interaction that caused the pipeline to break early, crashing the FFmpeg encoder with a "pipe:: Invalid argument / Cannot determine format of input stream 0:0 after EOF" error. The async/await state machine correctly yielded and managed the tight `drain` backpressure in the Node event loop, but the recursive chain failed to pace it properly, leading to broken data streams into FFmpeg.
+  - **Outcome**: discard
 
 - **PERF-471**: Eliminate SetVirtualTimePolicy Event Loop Wait
   - **What I tried**: Attempted to bypass the parallel event listener `Emulation.virtualTimeBudgetExpired` and `this.virtualTimePromiseExecutor` logic in `CdpTimeDriver.ts`, instead awaiting `this.client!.send('Emulation.setVirtualTimePolicy')` directly in `runSetTime`.

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,11 @@
+💡 **What**: Executed and discarded PERF-472 (Replace async runWorker with recursive promise chain). The changes crashed the FFmpeg pipe so they were reverted.
+🎯 **Why**: Attempted to remove async state machine overhead from the `runWorker` execution loop.
+📊 **Impact**: N/A (crashing).
+🔬 **Verification**: Code compilation, output benchmark testing (crashed).
+📎 **Plan**: Reference `/.sys/plans/PERF-472-optimize-worker-run-loop.md`
+
+Results summary:
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.00	0	0	0.0	crash	Recursive loop promise chain FFmpeg pipe EOF crash
+```


### PR DESCRIPTION
💡 **What**: Executed and discarded PERF-472 (Replace async runWorker with recursive promise chain). The changes crashed the FFmpeg pipe so they were reverted.
🎯 **Why**: Attempted to remove async state machine overhead from the `runWorker` execution loop.
📊 **Impact**: N/A (crashing).
🔬 **Verification**: Code compilation, output benchmark testing (crashed).
📎 **Plan**: Reference `/.sys/plans/PERF-472-optimize-worker-run-loop.md`

Results summary:
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.00	0	0	0.0	crash	Recursive loop promise chain FFmpeg pipe EOF crash
```

---
*PR created automatically by Jules for task [1003628581109113175](https://jules.google.com/task/1003628581109113175) started by @BintzGavin*