### PR TITLE
✨ RENDERER: Document failed CaptureLoop runWorker promise chain experiment

### DIFF
--- a/.sys/plans/PERF-476-optimize-runworker-promise-chain.md
+++ b/.sys/plans/PERF-476-optimize-runworker-promise-chain.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-476
 slug: optimize-runworker-promise-chain
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2026-05-11
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -385,3 +385,7 @@ Last updated by: PERF-468
 - **PERF-470**: Change BrowserPool waitUntil from networkidle to load
   - **What I tried**: Switched the `page.goto` configuration in `BrowserPool.ts` from `waitUntil: 'networkidle'` to `waitUntil: 'load'`.
   - **Outcome**: Kept. Improved performance from ~1.64s to ~1.13s (a ~30% improvement!). The `networkidle` condition imposes a strict, hard-coded 500ms waiting period of network inactivity. Since DOM benchmark compositions are loaded via the extremely fast local `file://` protocol, this completely dead 500ms delay per job was eliminated.
+- **PERF-476**: Optimize runWorker Promise Chain
+  - **What I tried**: Attempted to rewrite the async `runWorker` execution loop in `CaptureLoop.ts` using a recursive `.then()` promise chain to eliminate V8's generator state machine overhead for async/await.
+  - **WHY it didn't work**: The recursive promise implementation crashed the renderer because FFmpeg closed the pipe and the synchronous recursion caused the `frameReadyRing` / backpressure to deadlock, breaking the pipeline.
+  - **Outcome**: discard


### PR DESCRIPTION
Run and document experiment PERF-476, which investigated removing `async/await` overhead in the `CaptureLoop` `runWorker` function. The approach was safely executed, documented as a failure due to FFmpeg pipe backpressure deadlocking the synchronous recursion, and fully reverted to maintain codebase stability.

| run | render_time_s | frames | fps_effective | peak_mem_mb | status  | description |
|---|---|---|---|---|---|---|
| 1 | 0.000 | 0 | 0.00 | 0.0 | crash | recursive promise implementation caused pipeline deadlock during ffmpeg write |

---
*PR created automatically by Jules for task [3853725618365714601](https://jules.google.com/task/3853725618365714601) started by @BintzGavin*