### PR TITLE
📋 RENDERER: Eliminate closure in evaluate stability

### DIFF
--- a/.sys/plans/PERF-478-eliminate-closure-in-evaluate-stability.md
+++ b/.sys/plans/PERF-478-eliminate-closure-in-evaluate-stability.md
@@ -1,0 +1,106 @@
+---
+id: PERF-478
+slug: eliminate-closure-in-evaluate-stability
+status: unclaimed
+claimed_by: ""
+created: 2026-05-11
+completed: ""
+result: ""
+---
+
+# PERF-478: Eliminate evaluateStabilityParams Closure Overhead
+
+## Focus Area
+`CdpTimeDriver.ts` in `@helios-project/renderer` package. Specifically, the stability check execution inside the `runSetTime` hot loop.
+
+## Background Research
+Currently, `CdpTimeDriver.ts` optimizes the stability check CDP call using a dynamically assigned closure property `this.stabilityCheckFn`.
+
+In `prepare()`, it delays checking the function until the first frame evaluation to allow for synchronous timeline injection during initialization:
+```typescript
+this.stabilityCheckFn = async () => {
+  try {
+    const { result } = await this.client!.send('Runtime.evaluate', {
+      expression: "typeof window.helios !== 'undefined' && typeof window.helios.waitUntilStable === 'function'",
+      returnByValue: true
+    });
+    if (result && result.value) {
+      this.stabilityCheckFn = this.defaultStabilityCheck.bind(this);
+      return this.defaultStabilityCheck();
+    } else {
+      this.stabilityCheckFn = () => {};
+    }
+  } catch (e) {
+    this.stabilityCheckFn = this.defaultStabilityCheck.bind(this);
+    return this.defaultStabilityCheck();
+  }
+};
+```
+
+And in the `runSetTime` hot loop, it simply executes:
+```typescript
+// Wait for custom stability checks
+const stabilityResult = this.stabilityCheckFn();
+if (stabilityResult) {
+  await stabilityResult;
+}
+```
+
+A previous experiment (PERF-477) optimized `syncMediaFn` by replacing the closure assignment with a primitive boolean check (`hasMedia`) and calling the method directly. We can apply the exact same optimization to `stabilityCheckFn` to eliminate dynamic function invocation overhead.
+
+Instead of reassigning the function, we can use a boolean flag or a state variable (`hasStabilityCheck`) and invoke `defaultStabilityCheck` directly if true. Since the check needs to run on the *first* frame, we can use a ternary state: `unknown` (0), `has` (1), `none` (2).
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark composition
+- **Render Settings**: 600x600, 30fps, mode: dom
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~1.13s (from PERF-470)
+- **Bottleneck analysis**: Minor execution overhead from dynamic closure invocation (`this.stabilityCheckFn`) inside the per-frame `runSetTime` execution path.
+
+## Implementation Spec
+
+### Step 1: Replace stabilityCheckFn with a state variable
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+1. Remove the `private stabilityCheckFn: () => Promise<void> | void = () => {};` property.
+2. Add a `private stabilityCheckState: number = 0; // 0 = unknown, 1 = true, 2 = false` property.
+3. In `prepare()`, reset the state:
+   ```typescript
+   this.stabilityCheckState = 0;
+   ```
+4. Modify `runSetTime` to handle the state checking:
+   ```typescript
+   // Wait for custom stability checks
+   if (this.stabilityCheckState === 0) {
+     try {
+       const { result } = await this.client!.send('Runtime.evaluate', {
+         expression: "typeof window.helios !== 'undefined' && typeof window.helios.waitUntilStable === 'function'",
+         returnByValue: true
+       });
+       if (result && result.value) {
+         this.stabilityCheckState = 1;
+       } else {
+         this.stabilityCheckState = 2;
+       }
+     } catch (e) {
+       this.stabilityCheckState = 1;
+     }
+   }
+
+   if (this.stabilityCheckState === 1) {
+     const stabilityResult = this.defaultStabilityCheck();
+     if (stabilityResult) {
+       await stabilityResult;
+     }
+   }
+   ```
+
+**Why**: Direct boolean/integer evaluation and static method invocation is generally optimized extremely well by V8's Turbofan JIT compiler. It avoids the indirection of invoking a bound function (`.bind(this)`) or an anonymous empty function (`() => {}`), potentially saving a few micro-operations on every single frame tick.
+**Risk**: Negligible. The functional behavior remains identical.
+
+## Correctness Check
+Run `npm test` in the `packages/renderer` directory to ensure test suites pass, verifying that the new implementation is logically equivalent and doesn't introduce bugs.
+Run the benchmark script to compare performance.


### PR DESCRIPTION
I've created a new experiment plan (`PERF-478`) to eliminate the overhead associated with the `evaluateStabilityParams` closure inside the `CdpTimeDriver.ts` hot loop. It utilizes the same optimization principles used in `PERF-477` to replace dynamic closure assignment with a primitive state machine.

---
*PR created automatically by Jules for task [3038692287624731869](https://jules.google.com/task/3038692287624731869) started by @BintzGavin*