### PR TITLE
✨ RENDERER: Discard PERF-478 evaluateStabilityParams closure experiment

### DIFF
--- a/.sys/plans/PERF-478-eliminate-closure-in-evaluate-stability.md
+++ b/.sys/plans/PERF-478-eliminate-closure-in-evaluate-stability.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-478
 slug: eliminate-closure-in-evaluate-stability
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-05-11
-completed: ""
-result: ""
+completed: 2026-05-11
+result: no-improvement
 ---
 
 # PERF-478: Eliminate evaluateStabilityParams Closure Overhead
@@ -104,3 +104,9 @@ Instead of reassigning the function, we can use a boolean flag or a state variab
 ## Correctness Check
 Run `npm test` in the `packages/renderer` directory to ensure test suites pass, verifying that the new implementation is logically equivalent and doesn't introduce bugs.
 Run the benchmark script to compare performance.
+
+## Results Summary
+- **Best render time**: 0.544s (vs baseline 0.599s)
+- **Improvement**: ~9% (highly variable, not consistently beating noise margin)
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-478]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -61,6 +61,11 @@ Last updated by: PERF-468
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-478**: Eliminate Closure in evaluateStabilityParams
+  - **What I tried**: Attempted to replace the `stabilityCheckFn` closure assignment in `CdpTimeDriver.ts` with a primitive `stabilityCheckState` state machine (0=unknown, 1=true, 2=false) to avoid dynamic function invocation overhead.
+  - **WHY it didn't work**: The performance improvement was non-existent (baseline ~0.60s vs ~0.59s median). The overhead of a closure assignment and invocation in V8 is completely negligible compared to Playwright IPC and CDP communication bottlenecks. The manual micro-optimization introduced unnecessary state tracking without meaningful performance gains.
+  - **Outcome**: discard
+
 - **PERF-472**: Replace async runWorker with recursive promise chain
   - **What I tried**: Converted the `async` `runWorker` method in `CaptureLoop.ts` to a standard function returning a Promise, using a recursive inner `loop()` to traverse frames.
   - **WHY it didn't work**: The change introduced a subtle unhandled microtask queue interaction that caused the pipeline to break early, crashing the FFmpeg encoder with a "pipe:: Invalid argument / Cannot determine format of input stream 0:0 after EOF" error. The async/await state machine correctly yielded and managed the tight `drain` backpressure in the Node event loop, but the recursive chain failed to pace it properly, leading to broken data streams into FFmpeg.

--- a/packages/renderer/.sys/perf-results-PERF-478.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-478.tsv
@@ -1,0 +1,9 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.603	600	994.38	43.6	keep	baseline
+2	0.599	600	1001.46	43.6	keep	baseline
+3	0.609	600	985.63	43.5	discard	eliminate-closure-in-evaluate-stability
+4	0.617	600	972.71	43.5	discard	eliminate-closure-in-evaluate-stability
+5	0.576	600	1041.20	43.5	discard	eliminate-closure-in-evaluate-stability
+6	0.586	600	1023.29	45.0	discard	eliminate-closure-in-evaluate-stability
+7	0.544	600	1103.03	45.0	discard	eliminate-closure-in-evaluate-stability
+8	0.582	600	1031.78	43.7	discard	eliminate-closure-in-evaluate-stability


### PR DESCRIPTION
💡 **What**: Attempted to replace the `stabilityCheckFn` closure logic in `CdpTimeDriver.ts` with a primitive state machine (`stabilityCheckState`) to avoid dynamic function invocation overhead. Discarded the changes due to lack of performance gains.

🎯 **Why**: The overhead of V8 evaluating a simple closure was hypothesized to be a bottleneck inside the virtual clock `runSetTime` tick loop.

📊 **Impact**: Render time showed no statistically significant improvement (baseline ~0.60s vs experimental median ~0.59s), indicating the closure allocation overhead is negligible compared to the CDP socket communications.

🔬 **Verification**: Ran the benchmark via `npx tsx benchmark.ts` repeatedly. The modifications to `CdpTimeDriver.ts` were reverted, and the `verify-cdp-driver.ts` test passed to ensure no regressions.

📎 **Plan**: `/.sys/plans/PERF-478-eliminate-closure-in-evaluate-stability.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.603	600	994.38	43.6	keep	baseline
2	0.599	600	1001.46	43.6	keep	baseline
3	0.609	600	985.63	43.5	discard	eliminate-closure-in-evaluate-stability
4	0.617	600	972.71	43.5	discard	eliminate-closure-in-evaluate-stability
5	0.576	600	1041.20	43.5	discard	eliminate-closure-in-evaluate-stability
6	0.586	600	1023.29	45.0	discard	eliminate-closure-in-evaluate-stability
7	0.544	600	1103.03	45.0	discard	eliminate-closure-in-evaluate-stability
8	0.582	600	1031.78	43.7	discard	eliminate-closure-in-evaluate-stability
```

---
*PR created automatically by Jules for task [10027807182293858006](https://jules.google.com/task/10027807182293858006) started by @BintzGavin*