### PR TITLE
📋 RENDERER: Eliminate evaluateStabilityParams Closure Overhead

### DIFF
--- a/.sys/plans/PERF-479-eliminate-closure-in-evaluate-stability.md
+++ b/.sys/plans/PERF-479-eliminate-closure-in-evaluate-stability.md
@@ -1,0 +1,105 @@
+---
+id: PERF-479
+slug: eliminate-closure-in-evaluate-stability
+status: unclaimed
+claimed_by: ""
+created: 2026-05-11
+completed: ""
+result: ""
+---
+
+# PERF-479: Eliminate evaluateStabilityParams Closure Overhead
+
+## Focus Area
+`CdpTimeDriver.ts` in `@helios-project/renderer` package. Specifically, the stability check execution inside the `runSetTime` hot loop.
+
+## Background Research
+Currently, `CdpTimeDriver.ts` optimizes the stability check CDP call using a dynamically assigned closure property `this.stabilityCheckFn`.
+
+In `prepare()`, it delays checking the function until the first frame evaluation to allow for synchronous timeline injection during initialization:
+```typescript
+this.stabilityCheckFn = async () => {
+  try {
+    const { result } = await this.client!.send('Runtime.evaluate', {
+      expression: "typeof window.helios !== 'undefined' && typeof window.helios.waitUntilStable === 'function'",
+      returnByValue: true
+    });
+    if (result && result.value) {
+      this.stabilityCheckFn = this.defaultStabilityCheck.bind(this);
+      return this.defaultStabilityCheck();
+    } else {
+      this.stabilityCheckFn = () => {};
+    }
+  } catch (e) {
+    this.stabilityCheckFn = this.defaultStabilityCheck.bind(this);
+    return this.defaultStabilityCheck();
+  }
+};
+```
+
+And in the `runSetTime` hot loop, it simply executes:
+```typescript
+// Wait for custom stability checks
+const stabilityResult = this.stabilityCheckFn();
+if (stabilityResult) {
+  await stabilityResult;
+}
+```
+
+We can optimize `stabilityCheckFn` to eliminate dynamic function invocation overhead by replacing the closure assignment with a primitive state integer check (`this.stabilityCheckState`).
+
+Instead of reassigning the function, we can use a state variable (`this.stabilityCheckState`) and invoke `defaultStabilityCheck` directly if true. Since the check needs to run on the *first* frame, we can use a ternary state: `0` (unknown), `1` (true), `2` (false).
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark composition
+- **Render Settings**: 600x600, 30fps, mode: dom
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~1.13s (from PERF-470)
+- **Bottleneck analysis**: Minor execution overhead from dynamic closure invocation (`this.stabilityCheckFn`) inside the per-frame `runSetTime` execution path.
+
+## Implementation Spec
+
+### Step 1: Replace stabilityCheckFn with a state variable
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+1. Remove the `private stabilityCheckFn: () => Promise<void> | void = () => {};` property.
+2. Add a `private stabilityCheckState: number = 0; // 0 = unknown, 1 = true, 2 = false` property.
+3. In `prepare()`, remove the assignment of `this.stabilityCheckFn` and reset the state:
+   ```typescript
+   this.stabilityCheckState = 0;
+   ```
+4. Modify `runSetTime` to handle the state checking and execute stability checks if needed:
+   ```typescript
+    // Wait for custom stability checks
+    if (this.stabilityCheckState === 0) {
+      try {
+        const { result } = await this.client!.send('Runtime.evaluate', {
+          expression: "typeof window.helios !== 'undefined' && typeof window.helios.waitUntilStable === 'function'",
+          returnByValue: true
+        });
+        if (result && result.value) {
+          this.stabilityCheckState = 1;
+        } else {
+          this.stabilityCheckState = 2;
+        }
+      } catch (e) {
+        this.stabilityCheckState = 1;
+      }
+    }
+
+    if (this.stabilityCheckState === 1) {
+      const stabilityResult = this.defaultStabilityCheck();
+      if (stabilityResult) {
+        await stabilityResult;
+      }
+    }
+   ```
+
+**Why**: Direct boolean/integer evaluation and static method invocation is generally optimized extremely well by V8's Turbofan JIT compiler. It avoids the indirection of invoking a bound function (`.bind(this)`) or an anonymous empty function (`() => {}`), potentially saving a few micro-operations on every single frame tick.
+**Risk**: Negligible. The functional behavior remains identical.
+
+## Correctness Check
+Run `npm run build` and tests in the `packages/renderer` directory.


### PR DESCRIPTION
💡 **What**: Created an experiment plan to eliminate dynamic function invocation overhead by replacing the closure assignment for stabilityCheckFn with a primitive state integer check in CdpTimeDriver.
🎯 **Why**: Direct boolean/integer evaluation and static method invocation is generally optimized extremely well by V8's Turbofan JIT compiler, potentially saving micro-operations on every single frame tick.
🔬 **Approach**: Replace `stabilityCheckFn` closure with a `stabilityCheckState` variable (0, 1, 2) and call the method directly based on the state.
📎 **Plan**: `/.sys/plans/PERF-479-eliminate-closure-in-evaluate-stability.md`

---
*PR created automatically by Jules for task [6957087995886572285](https://jules.google.com/task/6957087995886572285) started by @BintzGavin*