### PR TITLE
✨ RENDERER: Discard PERF-473 optimize runWorker promise chain

### DIFF
--- a/.sys/plans/PERF-473-optimize-worker-run-loop.md
+++ b/.sys/plans/PERF-473-optimize-worker-run-loop.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-473
 slug: optimize-worker-run-loop
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-05-11
 completed: ""
-result: ""
+result: failed
 ---
 
 # PERF-473: Optimize runWorker Loop by Removing Async Await
@@ -50,3 +50,9 @@ Check if `timeDriver.setTime` or `strategy.capture` return non-promises (or inst
 ## Verification
 Run `npm test` in the `packages/renderer` directory to ensure test suites pass, verifying that the new implementation is logically equivalent and doesn't introduce bugs.
 Run the benchmark script to compare performance. Ensure to use the current working format for FFmpeg (png or jpeg) if webp causes crashes during the benchmark as noted in `RENDERER-EXPERIMENTS.md`.
+
+## Results Summary
+- **Best render time**: 2.719s (vs baseline 2.689s)
+- **Improvement**: -1%
+- **Kept experiments**: None
+- **Discarded experiments**: Replaced async runWorker with recursive promise chain

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -399,3 +399,8 @@ Last updated by: PERF-468
   - **What I tried**: Attempted to replace the dynamically assigned `syncMediaFn` closure property in `CdpTimeDriver.ts` with a primitive boolean flag `hasMedia` and an inline conditional check to call the synchronization method.
   - **WHY it didn't work**: The performance improvement was non-existent or slightly worse. The additional boolean branch check inside the `runSetTime` hot loop alongside the static method call offsets any minor gains from avoiding dynamic closure dispatch. V8 is already highly optimized for repeated closure/bound-function calls inside hot loops via inline caches.
   - **Outcome**: discard
+
+- **PERF-473**: Optimize runWorker Promise Chain (Recursive .then)
+  - **What I tried**: Attempted to rewrite the async `runWorker` execution loop in `CaptureLoop.ts` using a recursive `.then()` promise chain to eliminate V8's generator state machine overhead for async/await.
+  - **WHY it didn't work**: The performance improvement was non-existent and in some cases worse than the baseline (~2.71-2.78s vs baseline ~2.68-2.77s). It confirmed the previous failures with PERF-472, PERF-474, PERF-475, and PERF-476, that the Promise machinery of asynchronous recursion actually adds more overhead than the optimized async/await state machine which is better optimized by V8.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-473.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-473.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.777	150	54.02	4.4	keep	baseline
+2	2.715	150	55.25	4.4	keep	baseline
+3	2.689	150	55.78	4.4	keep	baseline
+4	2.719	150	55.17	4.4	discard	promise loop refactor
+5	2.734	150	54.86	4.4	discard	promise loop refactor
+6	2.785	150	53.87	4.4	discard	promise loop refactor


### PR DESCRIPTION
💡 What: Attempted to rewrite the async runWorker execution loop in CaptureLoop.ts using a recursive .then() promise chain to eliminate V8's generator state machine overhead for async/await. Discarded the experiment as performance degraded.
🎯 Why: To reduce micro-stalls from V8 async state machine overhead in the runWorker execution path.
📊 Impact: Baseline: ~2.68-2.77s. Experiment: ~2.71-2.78s. Resulted in a slight performance degradation (-1%).
🔬 Verification: 4-gate verification via benchmark execution showed performance degradation. Test suite was skipped for discarded change. Files reverted.
📎 Plan: /.sys/plans/PERF-473-optimize-worker-run-loop.md

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.777	150	54.02	4.4	keep	baseline
2	2.715	150	55.25	4.4	keep	baseline
3	2.689	150	55.78	4.4	keep	baseline
4	2.719	150	55.17	4.4	discard	promise loop refactor
5	2.734	150	54.86	4.4	discard	promise loop refactor
6	2.785	150	53.87	4.4	discard	promise loop refactor
```

---
*PR created automatically by Jules for task [11598853438413387214](https://jules.google.com/task/11598853438413387214) started by @BintzGavin*