### PR TITLE
📋 CLI: CLI Templates Regression Tests Spec

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -185,3 +185,7 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [0.46.21] - Identify Uncovered Registry Files
 **Learning:** The fallback action from [0.46.18] for utility files was impossible due to duplication. Searching for uncovered areas in a stable domain requires thoroughly checking tests against source files. `packages/cli/src/registry/manifest.ts` currently lacks test coverage while being a core piece of the fallback registry.
 **Action:** When falling back to regression testing under the NOTHING TO DO PROTOCOL, target non-obvious core files (like manifest singletons) that handle fallback or structural data when command and utility coverage is 100%. Created plan `2027-06-05-CLI-Registry-Manifest-Regression-Tests.md`.
+
+## [0.46.22] - Identify Uncovered Templates Files
+**Learning:** The fallback action from [0.46.20] for registry files was completed. Searching for uncovered areas in a stable domain requires thoroughly checking tests against source files. `packages/cli/src/templates/` currently lacks test coverage while being a core piece of the CLI's scaffolding (`init` and `deploy`) commands.
+**Action:** When falling back to regression testing under the NOTHING TO DO PROTOCOL, target static data files (like templates) that are critical for command execution when command, utility, and registry coverage is 100%. Created plan `2027-06-05-CLI-Templates-Regression-Tests.md`.

--- a/.sys/plans/2027-06-05-CLI-Templates-Regression-Tests.md
+++ b/.sys/plans/2027-06-05-CLI-Templates-Regression-Tests.md
@@ -1,0 +1,27 @@
+#### 1. Context & Goal
+- **Objective**: Implement comprehensive regression tests for all file generation templates in `packages/cli/src/templates`.
+- **Trigger**: Following the NOTHING TO DO PROTOCOL, there are currently no active deltas or feature gaps in the `cli` package according to `AGENTS.md` and `docs/BACKLOG.md`. The `packages/cli/src/templates` directory is completely devoid of test coverage despite being the core data source for the CLI's scaffolding (`init` and `deploy`) commands.
+- **Impact**: Ensures that critical templates (e.g. Dockerfiles, cloud resource manifests, scaffolding configurations) maintain their expected structure, preventing accidental regressions when these hardcoded templates are updated.
+
+#### 2. File Inventory
+- **Create**:
+  - `packages/cli/src/templates/__tests__/frameworks.test.ts` (Tests React, Vue, Svelte, Solid, Vanilla templates)
+  - `packages/cli/src/templates/__tests__/cloud.test.ts` (Tests AWS, Azure, Cloudflare, GCP, etc. deployment templates)
+- **Modify**: None
+- **Read-Only**: `packages/cli/src/templates/*.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Create standard Vitest suites to validate the exported template objects.
+- **Pseudo-Code**:
+  - `frameworks.test.ts`: Import each framework template (e.g., `REACT_TEMPLATE`, `VUE_TEMPLATE`). Iterate over expected files (`package.json`, `vite.config.ts`, `tsconfig.json`, etc.) and assert they exist and contain framework-specific keywords (e.g., `@vitejs/plugin-react` for React).
+  - `cloud.test.ts`: Import cloud templates (e.g., `AWS_SAM_TEMPLATE`, `KUBERNETES_JOB_TEMPLATE`). Assert that the templates are valid strings and contain critical configurations (e.g., `apiVersion: batch/v1` for K8s, `AWSTemplateFormatVersion` for SAM).
+- **Public API Changes**: None.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: Run `npx vitest run packages/cli/src/templates/__tests__` from the `packages/cli` directory.
+- **Success Criteria**: All template tests pass, validating that no exported template string or object is undefined and they all contain the expected core properties/strings.
+- **Edge Cases**: Ensure JSON parseability is tested for templates that represent JSON files (e.g., the `package.json` entries in framework templates).
+
+#### 5. Pre-commit
+- Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -143,4 +143,5 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] STUDIO: 2026-11-14-STUDIO-Update-Keyboard-Shortcuts-Documentation is structurally obsolete.
 - [x] [v0.46.20] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/
 - [x] [v0.46.21] CLI Unblocked: Generated plan /.sys/plans/2027-06-05-CLI-Registry-Manifest-Regression-Tests.md
-- [ ] [v0.46.22] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/
+- [x] [v0.46.22] CLI Unblocked: Generated plan /.sys/plans/2027-06-05-CLI-Templates-Regression-Tests.md
+- [ ] [v0.46.23] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -126,3 +126,5 @@ The Helios CLI is the primary user interface for component registry, project sca
 [v0.39.1] ✅ Completed: CLI Scaffold Components - Verified existing implementation of helios components command fulfills the scaffolding requirements.
 [v0.41.2] ✅ Completed: Scaffold Cloudflare Sandbox Adapter - Exposed the Cloudflare Sandbox adapter in the `helios job run` command options and configuration block.
 [v0.46.17] ✅ Completed: Document duplicated Deploy Command Regression Tests plan - Logged the duplicated plan as impossible.
+
+[v0.46.22] 🟢 Completed: CLI Templates Regression Tests Spec - Created specification plan `2027-06-05-CLI-Templates-Regression-Tests.md` for implementing regression tests for all file generation templates in `packages/cli/src/templates`.


### PR DESCRIPTION
Created specification plan `2027-06-05-CLI-Templates-Regression-Tests.md` for implementing regression tests for all file generation templates in `packages/cli/src/templates`.

Impact: Ensures that critical templates (e.g. Dockerfiles, cloud resource manifests, scaffolding configurations) maintain their expected structure, preventing accidental regressions when these hardcoded templates are updated.

---
*PR created automatically by Jules for task [2755215036595617449](https://jules.google.com/task/2755215036595617449) started by @BintzGavin*