### PR TITLE
✨ RENDERER: Optimize FFmpeg threading (PERF-481 - Discarded)

### DIFF
--- a/.sys/plans/PERF-481-optimize-ffmpeg-threads.md
+++ b/.sys/plans/PERF-481-optimize-ffmpeg-threads.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-481
 slug: optimize-ffmpeg-threads
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-05-11
-completed: ""
-result: ""
+completed: "2026-05-11"
+result: "discard"
 ---
 
 # PERF-481: Optimize FFmpeg Threading Arguments
@@ -72,3 +72,9 @@ Update the `videoInputArgs` array to include threading optimizations.
 
 ## Correctness Check
 Run the benchmark and ensure the video renders successfully without corrupted frames or "queue too small" warnings from FFmpeg.
+
+## Results Summary
+- **Best render time**: 1.543s (median ~1.583s vs baseline ~1.578s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-481]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -409,3 +409,8 @@ Last updated by: PERF-468
   - **What I tried**: Attempted to rewrite the async `runWorker` execution loop in `CaptureLoop.ts` using a recursive `.then()` promise chain to eliminate V8's generator state machine overhead for async/await.
   - **WHY it didn't work**: The performance improvement was non-existent and in some cases worse than the baseline (~2.71-2.78s vs baseline ~2.68-2.77s). It confirmed the previous failures with PERF-472, PERF-474, PERF-475, and PERF-476, that the Promise machinery of asynchronous recursion actually adds more overhead than the optimized async/await state machine which is better optimized by V8.
   - **Outcome**: discard
+
+- **PERF-481**: Optimize FFmpeg Threading Arguments
+  - **What I tried**: Added `-threads 0` and increased `-thread_queue_size` to `1024` for FFmpeg `videoInputArgs` in `DomStrategy.ts`.
+  - **WHY it didn't work**: The performance difference was non-existent (median ~1.583s vs baseline ~1.578s). Node.js sending the frames over the pipe and Playwright IPC remain the bottlenecks. Allocating more FFmpeg decoding threads for incoming PNG/WebP pipe frames does not speed up the overall pipeline because FFmpeg is already decoding faster than the DOM loop can capture and write to the pipe.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -51,3 +51,8 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	0.636	600	942.73	43.5	keep	eliminate evaluateStabilityParams closure overhead
 2	0.612	600	981.09	43.4	keep	eliminate evaluateStabilityParams closure overhead
 3	0.593	600	1011.25	45.3	keep	eliminate evaluateStabilityParams closure overhead
+1	2.302	150	65.16	40.4	discard	optimize-ffmpeg-threads (PERF-481)
+2	1.583	150	94.76	43.1	discard	optimize-ffmpeg-threads (PERF-481)
+3	1.601	150	93.69	39.7	discard	optimize-ffmpeg-threads (PERF-481)
+4	1.543	150	97.21	40.5	discard	optimize-ffmpeg-threads (PERF-481)
+5	1.580	150	94.94	40.4	discard	optimize-ffmpeg-threads (PERF-481)

--- a/packages/renderer/scripts/benchmark-perf.ts
+++ b/packages/renderer/scripts/benchmark-perf.ts
@@ -1,0 +1,39 @@
+import { Renderer } from '../src/index';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+
+async function main() {
+  const renderer = new Renderer({
+    width: 600,
+    height: 600,
+    fps: 30,
+    durationInSeconds: 5,
+    mode: 'dom',
+    intermediateImageFormat: 'png'
+  });
+
+  const compositionPath = path.resolve(
+    process.cwd(),
+    'output/example-build/examples/dom-benchmark/composition.html'
+  );
+  const compositionUrl = `file://${compositionPath}`;
+  const outputPath = path.resolve(process.cwd(), 'output/dom-benchmark.mp4');
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+
+  const start = performance.now();
+  await renderer.render(compositionUrl, outputPath);
+  const elapsed = (performance.now() - start) / 1000;
+
+  const TOTAL_FRAMES = 30 * 5;
+
+  console.log('---');
+  console.log(`render_time_s:      ${elapsed.toFixed(3)}`);
+  console.log(`total_frames:       ${TOTAL_FRAMES}`);
+  console.log(`fps_effective:      ${(TOTAL_FRAMES / elapsed).toFixed(2)}`);
+  console.log(`peak_mem_mb:        ${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(1)}`);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
✨ RENDERER: Optimize FFmpeg threading (PERF-481 - Discarded)

💡 **What**: Added `-threads 0` and increased `-thread_queue_size` to `1024` for FFmpeg `videoInputArgs` in `DomStrategy.ts` and benchmarked. The experiment was discarded because it didn't yield an improvement.
🎯 **Why**: Attempted to increase FFmpeg decoding speeds when handling incoming PNG/WebP pipe frames.
📊 **Impact**: Median 1.583s vs baseline 1.578s (0% improvement). The pipe isn't bottlenecked on the decoder side.
🔬 **Verification**: Executed the test benchmark `packages/renderer/scripts/benchmark-perf.ts` manually.
📎 **Plan**: `/.sys/plans/PERF-481-optimize-ffmpeg-threads.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.302	150	65.16	40.4	discard	optimize-ffmpeg-threads (PERF-481)
2	1.583	150	94.76	43.1	discard	optimize-ffmpeg-threads (PERF-481)
3	1.601	150	93.69	39.7	discard	optimize-ffmpeg-threads (PERF-481)
4	1.543	150	97.21	40.5	discard	optimize-ffmpeg-threads (PERF-481)
5	1.580	150	94.94	40.4	discard	optimize-ffmpeg-threads (PERF-481)
```

---
*PR created automatically by Jules for task [1059897538149545516](https://jules.google.com/task/1059897538149545516) started by @BintzGavin*