### PR TITLE
📋 RENDERER: Optimize media sync closure in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-483-cache-media-element-check.md
+++ b/.sys/plans/PERF-483-cache-media-element-check.md
@@ -1,14 +1,14 @@
 ---
-id: PERF-482
+id: PERF-483
 slug: cache-media-element-check
 status: unclaimed
 claimed_by: ""
-created: 2024-05-12
+created: 2026-05-12
 completed: ""
 result: ""
 ---
 
-# PERF-482: Eliminate Closure in CDP Media Sync
+# PERF-483: Eliminate Closure in CDP Media Sync
 
 ## Focus Area
 The `prepare()` setup and execution of the `syncMediaFn` closure in `CdpTimeDriver.ts`. This targets the closure allocation and branching overhead in the hot `runSetTime` loop when no media elements are present.


### PR DESCRIPTION
💡 **What**: Replaces the `syncMediaFn` dynamic function closure in `CdpTimeDriver.ts` with a primitive integer state machine.
🎯 **Why**: Eliminates closure assignment overhead and branching in the hot `runSetTime` loop, similar to the proven `stabilityCheckState` optimization. Expected to further reduce median render time.
🔬 **Approach**: Track media existence using an integer state (`syncMediaState`), deferring the CDP evaluation to the first virtual clock tick and avoiding closure invocation when no media exists.
📎 **Plan**: /.sys/plans/PERF-483-cache-media-element-check.md

---
*PR created automatically by Jules for task [3713361904936941911](https://jules.google.com/task/3713361904936941911) started by @BintzGavin*