### PR TITLE
✨ RENDERER: [Discard] BrowserPool goto commit optimization

### DIFF
--- a/.sys/plans/PERF-483-browserpool-goto-commit.md
+++ b/.sys/plans/PERF-483-browserpool-goto-commit.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-483
 slug: browserpool-goto-commit
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-05-12
-completed: ""
-result: ""
+completed: 2026-05-12
+result: no-improvement
 ---
 
 # PERF-483: Change BrowserPool waitUntil from load to commit
@@ -61,3 +61,9 @@ Run the canvas tests to ensure the fallback doesn't break canvas initialization.
 
 ## Correctness Check
 Run tests in the `packages/renderer` directory. Ensure the final video output is still generated correctly without missing frames.
+
+## Results Summary
+- **Best render time**: 1.286s (vs baseline 1.130s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [BrowserPool goto commit]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -417,3 +417,8 @@ Last updated by: PERF-468
   - **What I tried**: Added `-threads 0` and increased `-thread_queue_size` to `1024` for FFmpeg `videoInputArgs` in `DomStrategy.ts`.
   - **WHY it didn't work**: The performance difference was non-existent (median ~1.583s vs baseline ~1.578s). Node.js sending the frames over the pipe and Playwright IPC remain the bottlenecks. Allocating more FFmpeg decoding threads for incoming PNG/WebP pipe frames does not speed up the overall pipeline because FFmpeg is already decoding faster than the DOM loop can capture and write to the pipe.
   - **Outcome**: discard
+
+- **PERF-483**: Change BrowserPool waitUntil from load to commit
+  - **What I tried**: Attempted to change `page.goto` configuration from `waitUntil: 'load'` to `waitUntil: 'commit'` to return control to the orchestration loop sooner during pipeline initialization in `BrowserPool.ts`.
+  - **WHY it didn't work**: The median render time increased (~1.286s-1.328s vs baseline ~1.130s). The `commit` state in Playwright implies the network response has started but the DOM is completely unparsed. Calling `timeDriver.prepare(page)` or injecting scripts at `commit` requires additional synchronization overhead in Playwright and the browser engine compared to letting the document reach `load` naturally for instantaneous local `file://` navigations.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-483.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-483.tsv
@@ -1,0 +1,1 @@
+1	1.286	150	116.67	44.5	discard	waitUntil: 'commit'

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -57,3 +57,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 4	1.543	150	97.21	40.5	discard	optimize-ffmpeg-threads (PERF-481)
 5	1.580	150	94.94	40.4	discard	optimize-ffmpeg-threads (PERF-481)
 6	1.515	150	99.01	40.4	keep	PERF-482: Eliminate closure in evaluate stability by using integer state machine
+1	1.286	150	116.67	44.5	discard	PERF-483: BrowserPool goto commit


### PR DESCRIPTION
💡 **What**: Tested changing BrowserPool page initialization `waitUntil` condition from `load` to `commit`. The code was reverted upon discovering a regression, and the result logged as `discard`.
🎯 **Why**: To see if giving control back to Node immediately after the response was committed would bypass DOM parsing time and speed up initial capture orchestration.
📊 **Impact**: The median render time increased (e.g. `1.286s` vs baseline `1.130s`). The optimization attempt failed as it actually slowed down the total execution, possibly due to Playwright internal synchronization overhead vs relying on standard local file system events.
🔬 **Verification**: Code built successfully. Custom benchmark was run to confirm performance regression. Correctness tests passed.
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-483-browserpool-goto-commit.md`

### Performance Data
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.286	150	116.67	44.5	discard	waitUntil: 'commit'
```

---
*PR created automatically by Jules for task [5743271307402303441](https://jules.google.com/task/5743271307402303441) started by @BintzGavin*