### PR TITLE
📋 RENDERER: Eliminate Spurious Wakeups and Redundant Checks in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-488-eliminate-spurious-wakeups-and-redundant-checks.md
+++ b/.sys/plans/PERF-488-eliminate-spurious-wakeups-and-redundant-checks.md
@@ -1,5 +1,5 @@
 ---
-id: PERF-486
+id: PERF-488
 slug: eliminate-spurious-wakeups-and-redundant-checks
 status: unclaimed
 claimed_by: ""
@@ -7,8 +7,7 @@ created: 2026-05-12
 completed: ""
 result: ""
 ---
-
-# PERF-486: Eliminate Spurious Wakeups and Redundant Checks in CaptureLoop
+# PERF-488: Eliminate Spurious Wakeups and Redundant Checks in CaptureLoop
 
 ## Focus Area
 The `CaptureLoop` orchestrator in `packages/renderer/src/core/CaptureLoop.ts`. Specifically, the event loop Wakeup mechanisms (`writerWaiterResolve`) and the orchestrator state verification (`checkState()`).


### PR DESCRIPTION
📋 RENDERER: Eliminate Spurious Wakeups and Redundant Checks in CaptureLoop

💡 What: Created experiment plan PERF-488 to eliminate spurious Wakeups (`writerWaiterResolve`) and redundant synchronous `checkState()` calls in `CaptureLoop.ts`.
🎯 Why: V8 event loop microtask overhead and redundant synchronous loops are taking CPU time away from Playwright IPC and frame processing.
🔬 Approach: Restrict `writerWaiterResolve` to the specific expected frame and remove the redundant `checkState()` loop tail call.
📎 Plan: `.sys/plans/PERF-488-eliminate-spurious-wakeups-and-redundant-checks.md`

---
*PR created automatically by Jules for task [2876110932810858601](https://jules.google.com/task/2876110932810858601) started by @BintzGavin*