### PR TITLE
📋 RENDERER: Raw WebSocket CDP Connection for Hot Loop

### DIFF
--- a/.sys/plans/PERF-494-raw-websocket-cdp-connection.md
+++ b/.sys/plans/PERF-494-raw-websocket-cdp-connection.md
@@ -1,0 +1,65 @@
+---
+id: PERF-494
+slug: raw-websocket-cdp-connection
+status: unclaimed
+claimed_by: ""
+created: 2026-05-13
+completed: ""
+result: ""
+---
+
+# PERF-494: Raw WebSocket CDP Connection for Hot Loop
+
+## Focus Area
+The DOM capture hot loop, specifically `DomStrategy.ts` (for `beginFrame`) and `CdpTimeDriver.ts` (for `setVirtualTimePolicy`).
+
+## Background Research
+Currently, the renderer uses Playwright's `CDPSession` to send commands to Chromium. In the hot loop, we call `cdpSession.send()` at least twice per frame (`setVirtualTimePolicy` and `beginFrame`).
+Playwright's `CDPSession` adds significant overhead:
+1. It dynamically serializes the request objects using `JSON.stringify`.
+2. It routes the message through Playwright's internal IPC pipe to the Playwright driver process, which then sends it to the Chromium browser process.
+3. It allocates dynamic Promises and registers callbacks in Maps.
+
+By bypassing Playwright's IPC and connecting directly to Chromium's native WebSocket debugging port using the `ws` package, we can:
+1. Send pre-serialized, static JSON strings for `beginFrame` and `setVirtualTimePolicy` (mutating only the ID and timestamp integers), eliminating `JSON.stringify` overhead.
+2. Communicate directly with Chromium's process, bypassing the Playwright driver process entirely.
+3. Manage a highly optimized, allocation-free message tracking ring buffer for the native promises.
+
+## Benchmark Configuration
+- **Composition URL**: The standard DOM benchmark composition
+- **Render Settings**: Same as baseline
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~0.60s (PERF-492)
+- **Bottleneck analysis**: Playwright IPC overhead and JSON serialization in the hot loop.
+
+## Implementation Spec
+
+### Step 1: Expose Chromium Debugging Port
+**File**: `packages/renderer/src/core/BrowserPool.ts`
+**What to change**:
+Add `--remote-debugging-port=0` to the Chromium launch args. After `chromium.launch()`, extract the assigned port from the browser or by inspecting the local debug URL, or simply launch with a fixed port for the benchmark.
+Alternatively, explore if Playwright exposes the underlying websocket endpoint.
+
+### Step 2: Implement Raw WebSocket Driver
+**File**: `packages/renderer/src/core/RawCdpSocket.ts` (New File)
+**What to change**:
+Create a simple wrapper around the `ws` library that connects to the page's target WebSocket URL.
+Implement a `sendRaw(message: string): Promise<any>` method using a pre-allocated array for callback resolution (indexed by the CDP request ID) to avoid Map allocations.
+
+### Step 3: Integrate Raw Socket into Hot Paths
+**File**: `packages/renderer/src/strategies/DomStrategy.ts` and `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+Replace `cdpSession.send()` with `rawSocket.sendRaw()`. Construct the JSON strings manually in the hot loop, mutating only the necessary integers (e.g., `frameTimeTicks`, `budget`) to avoid object allocation and `JSON.stringify`.
+
+## Variations
+- **Variation A**: Only optimize `beginFrame` in `DomStrategy`, keeping `CdpTimeDriver` on Playwright's session, to isolate the impact of raw string payloads for the screenshot data.
+
+## Canvas Smoke Test
+Run a standard Canvas mode benchmark to ensure no regressions (Canvas mode won't use the raw socket).
+
+## Correctness Check
+Run the standard DOM benchmark to ensure FFmpeg successfully encodes all frames and virtual time still ticks deterministically.


### PR DESCRIPTION
📋 RENDERER: Raw WebSocket CDP Connection for Hot Loop

💡 What: Creating an experiment plan to implement a direct raw WebSocket connection to Chromium's debugging port using the `ws` package.
🎯 Why: Playwright's `CDPSession` introduces significant overhead through JSON serialization (`JSON.stringify`), dynamic Promise allocation, Map callbacks, and routing through its internal IPC pipe to the driver process before hitting Chromium. Bypassing this with a pre-serialized string payload via a raw socket could eliminate this serialization overhead in the tight DOM capture hot loop.
🔬 Approach: Establish a raw `ws` connection directly to Chromium and send manually constructed JSON strings for `beginFrame` and `setVirtualTimePolicy` calls, managing a zero-allocation integer-indexed ring buffer for native promise resolution.
📎 Plan: `/.sys/plans/PERF-494-raw-websocket-cdp-connection.md`

---
*PR created automatically by Jules for task [2204565976238562077](https://jules.google.com/task/2204565976238562077) started by @BintzGavin*