### PR TITLE
📋 RENDERER: Raw WebSocket CDP Connection for Hot Loop

### DIFF
--- a/.sys/plans/PERF-487-raw-websocket-cdp-connection.md
+++ b/.sys/plans/PERF-487-raw-websocket-cdp-connection.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-487
 slug: raw-websocket-cdp-connection
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2026-05-12
 completed: ""
-result: ""
+result: "discard"
 ---
 
 # PERF-487: Raw WebSocket CDP Connection for Hot Loop

--- a/.sys/plans/PERF-495-raw-websocket-cdp-connection.md
+++ b/.sys/plans/PERF-495-raw-websocket-cdp-connection.md
@@ -1,14 +1,14 @@
 ---
-id: PERF-494
+id: PERF-495
 slug: raw-websocket-cdp-connection
-status: complete
-claimed_by: "jules"
+status: unclaimed
+claimed_by: ""
 created: 2026-05-13
 completed: ""
-result: "discard"
+result: ""
 ---
 
-# PERF-494: Raw WebSocket CDP Connection for Hot Loop
+# PERF-495: Raw WebSocket CDP Connection for Hot Loop
 
 ## Focus Area
 The DOM capture hot loop, specifically `DomStrategy.ts` (for `beginFrame`) and `CdpTimeDriver.ts` (for `setVirtualTimePolicy`).
@@ -33,7 +33,7 @@ By bypassing Playwright's IPC and connecting directly to Chromium's native WebSo
 - **Minimum runs**: 3 per experiment, report median
 
 ## Baseline
-- **Current estimated render time**: ~0.60s (PERF-492)
+- **Current estimated render time**: ~4.169s (PERF-493)
 - **Bottleneck analysis**: Playwright IPC overhead and JSON serialization in the hot loop.
 
 ## Implementation Spec


### PR DESCRIPTION
📋 RENDERER: Raw WebSocket CDP Connection for Hot Loop

💡 What: A detailed experiment plan to test bypassing Playwright's `CDPSession` IPC and JSON serialization by using a direct `ws` raw connection to the Chromium debugging port for the `beginFrame` and `setVirtualTimePolicy` hot loop.
🎯 Why: Playwright's CDP IPC and `JSON.stringify` overhead is the dominant remaining bottleneck per frame. Sending raw JSON string mutations over a direct WebSocket should eliminate IPC hopping and JSON serialization overhead, significantly improving DOM capture throughput over the current ~4.169s baseline.
🔬 Approach: Launch Chromium with `--remote-debugging-port=0`, implement a minimal `ws` driver with allocation-free message tracking, and integrate it into `DomStrategy.ts` and `CdpTimeDriver.ts`.
📎 Plan: `/.sys/plans/PERF-495-raw-websocket-cdp-connection.md`

---
*PR created automatically by Jules for task [17905306745536590864](https://jules.google.com/task/17905306745536590864) started by @BintzGavin*