### PR TITLE
✨ CLI: Index Regression Tests

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### CLI v0.46.25
+- ✅ Completed: CLI Index Regression Tests - Implemented unit tests for the CLI entry point in index.ts.
+
 ### STUDIO v0.121.11
 - ✅ Completed: STUDIO-ExportJobSpec - Verified that the Export Job Spec feature in Renders Panel was already fully implemented (IMPOSSIBLE: DUPLICATION).
 
@@ -46,6 +49,7 @@
 ## INFRASTRUCTURE v0.28.3
 - ✅ Completed: Documentation Orchestration - Updated README.md to document Orchestration, Job Management, Cloud Execution Adapters, and Worker Runtime abstractions.
 # Helios Project Progress Log
+
 
 ### CLI v0.46.12
 - ✅ Completed: Regression Tests Remaining Commands - Verified comprehensive unit tests for `helios preview`, `helios skills`, and `helios studio`.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,7 @@
 # CLI Status
 
-**Version**: 0.46.24
+**Version**: 0.46.25
+[v0.46.25] ✅ Completed: CLI Index Regression Tests - Implemented unit tests for the CLI entry point in index.ts.
 [v0.46.23] ✅ Completed: Document duplicated Registry Manifest Regression Tests plan - Logged the duplicated plan as impossible.
 
 [v0.46.22] ✅ Completed: Registry Manifest Regression Tests - Implemented unit tests for packages/cli/src/registry/manifest.ts

--- a/packages/cli/src/__tests__/index.test.ts
+++ b/packages/cli/src/__tests__/index.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Command } from 'commander';
+
+// Mock commander
+const mockParse = vi.fn();
+const mockVersion = vi.fn().mockReturnThis();
+const mockDescription = vi.fn().mockReturnThis();
+const mockName = vi.fn().mockReturnThis();
+
+vi.mock('commander', () => {
+  const CommandMock = vi.fn().mockImplementation(function() {
+    return {
+      name: mockName,
+      description: mockDescription,
+      version: mockVersion,
+      parse: mockParse,
+    };
+  });
+  return {
+    Command: CommandMock,
+  };
+});
+
+// Mock all command registrations
+vi.mock('../commands/studio.js', () => ({ registerStudioCommand: vi.fn() }));
+vi.mock('../commands/init.js', () => ({ registerInitCommand: vi.fn() }));
+vi.mock('../commands/add.js', () => ({ registerAddCommand: vi.fn() }));
+vi.mock('../commands/components.js', () => ({ registerComponentsCommand: vi.fn() }));
+vi.mock('../commands/render.js', () => ({ registerRenderCommand: vi.fn() }));
+vi.mock('../commands/merge.js', () => ({ registerMergeCommand: vi.fn() }));
+vi.mock('../commands/list.js', () => ({ registerListCommand: vi.fn() }));
+vi.mock('../commands/remove.js', () => ({ registerRemoveCommand: vi.fn() }));
+vi.mock('../commands/update.js', () => ({ registerUpdateCommand: vi.fn() }));
+vi.mock('../commands/build.js', () => ({ registerBuildCommand: vi.fn() }));
+vi.mock('../commands/preview.js', () => ({ registerPreviewCommand: vi.fn() }));
+vi.mock('../commands/job.js', () => ({ registerJobCommand: vi.fn() }));
+vi.mock('../commands/skills.js', () => ({ registerSkillsCommand: vi.fn() }));
+vi.mock('../commands/diff.js', () => ({ registerDiffCommand: vi.fn() }));
+vi.mock('../commands/deploy.js', () => ({ registerDeployCommand: vi.fn() }));
+
+describe('CLI Entry Point (index.ts)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('should initialize commander and register all commands', async () => {
+    // Dynamically import index.ts to trigger the execution
+    await import('../index.js');
+
+    expect(Command).toHaveBeenCalled();
+    expect(mockName).toHaveBeenCalledWith('helios');
+    expect(mockDescription).toHaveBeenCalledWith('Helios CLI');
+    expect(mockVersion).toHaveBeenCalled();
+
+    // Verify that all commands were registered with the program instance
+    const { registerStudioCommand } = await import('../commands/studio.js');
+    const { registerInitCommand } = await import('../commands/init.js');
+    const { registerAddCommand } = await import('../commands/add.js');
+    const { registerComponentsCommand } = await import('../commands/components.js');
+    const { registerRenderCommand } = await import('../commands/render.js');
+    const { registerMergeCommand } = await import('../commands/merge.js');
+    const { registerListCommand } = await import('../commands/list.js');
+    const { registerRemoveCommand } = await import('../commands/remove.js');
+    const { registerUpdateCommand } = await import('../commands/update.js');
+    const { registerBuildCommand } = await import('../commands/build.js');
+    const { registerPreviewCommand } = await import('../commands/preview.js');
+    const { registerJobCommand } = await import('../commands/job.js');
+    const { registerSkillsCommand } = await import('../commands/skills.js');
+    const { registerDiffCommand } = await import('../commands/diff.js');
+    const { registerDeployCommand } = await import('../commands/deploy.js');
+
+    const programInstance = vi.mocked(Command).mock.results[0].value;
+
+    expect(registerStudioCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerInitCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerAddCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerComponentsCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerRenderCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerMergeCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerListCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerRemoveCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerUpdateCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerBuildCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerPreviewCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerJobCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerSkillsCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerDiffCommand).toHaveBeenCalledWith(programInstance);
+    expect(registerDeployCommand).toHaveBeenCalledWith(programInstance);
+
+    // Verify parse was called
+    expect(mockParse).toHaveBeenCalledWith(process.argv);
+  });
+});


### PR DESCRIPTION
✨ CLI: Index Regression Tests

💡 What: Implemented unit tests for the CLI entry point in `packages/cli/src/index.ts`.
🎯 Why: To saturate test coverage for the CLI package, resolving the "NOTHING TO DO PROTOCOL" fallback requirement.
📊 Impact: Completes regression testing coverage for the CLI domain.
🔬 Verification: Run `npm run test -w packages/cli` and verify `index.test.ts` passes.

---
*PR created automatically by Jules for task [442974713669736736](https://jules.google.com/task/442974713669736736) started by @BintzGavin*