### PR TITLE
✨ RENDERER: Discard orchestrator state check optimization

### DIFF
--- a/.sys/plans/PERF-497-optimize-orchestrator-state-checks.md
+++ b/.sys/plans/PERF-497-optimize-orchestrator-state-checks.md
@@ -1,7 +1,8 @@
 ---
 id: PERF-497
 slug: optimize-orchestrator-state-checks
-status: unclaimed
+status: complete
+result: failed
 claimed_by: ""
 created: 2026-05-13
 completed: ""
@@ -86,3 +87,7 @@ Run a standard Canvas mode benchmark to ensure no regressions.
 
 ## Correctness Check
 Run the standard DOM benchmark to ensure the capture loop successfully processes all frames without deadlocking.
+## Results Summary
+- **Best render time**: 18.077s (vs baseline 17.687s)
+- **Improvement**: none
+- **Discarded experiments**: PERF-497

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -442,3 +442,8 @@ Last updated by: PERF-468
 - **PERF-498**: Restore FFmpeg Backpressure in CaptureLoop
   - **What I tried**: Restored the `previousWritePromise` await when writing to FFmpeg stdin to prevent unbounded memory buffering of frames in Node.js.
   - **Outcome**: Kept. While the raw time (~17.687s for 600 frames) seemed slower initially when mistakenly compared against a 300-frame Canvas baseline, it is actually a ~3.1% improvement over the true 600-frame baseline (~18.267s for PERF-496). Critically, it prevents unbound buffering and GC pauses, ensuring stability for long renders.
+
+- **PERF-497**: Optimize Orchestrator State Checks
+  - **What I tried**: Moved checkState() call from top of while loop to after nextFrameToWrite++ inside the loop.
+  - **WHY it didn't work**: Render time of 18.077s was not better than baseline of 17.687s.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -61,3 +61,5 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	4.169	300	71.97	40.3	keep	PERF-493 stack-free-workers
 1	18.267	600	32.85	38.1	keep	PERF-496 eliminate dead frame waiter
 1	17.687	600	33.92	43.9	keep	Restore FFmpeg backpressure
+63	18.077	600	33.19	37.3	discard	optimize orchestrator state checks
+64	18.077	600	33.19	37.3	discard	optimize orchestrator state checks


### PR DESCRIPTION
✨ RENDERER: Discard orchestrator state check optimization

💡 What: Tested moving checkState() in CaptureLoop.ts to after nextFrameToWrite++ inside the loop, and then discarded the change as it regressed performance.
🎯 Why: Attempted to eliminate redundant checkState() calls triggered by spurious wakeups.
📊 Impact: Render time regressed to 18.077s (vs baseline 17.687s for 600 frames).
🔬 Verification: Build passed, test suite passed (prior to timeout), output regression validated, change reverted.
📎 Plan: Reference the plan file (/.sys/plans/PERF-497-optimize-orchestrator-state-checks.md)

TSV Results:
64	18.077	600	33.19	37.3	discard	optimize orchestrator state checks

---
*PR created automatically by Jules for task [15418422617583416794](https://jules.google.com/task/15418422617583416794) started by @BintzGavin*