### PR TITLE
✨ RENDERER: Discard Raw WebSocket CDP Connection experiment

### DIFF
--- a/.sys/plans/PERF-499-raw-websocket-cdp-connection.md
+++ b/.sys/plans/PERF-499-raw-websocket-cdp-connection.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-499
 slug: raw-websocket-cdp-connection
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-05-13
-completed: ""
-result: ""
+completed: "2026-05-13"
+result: "discarded"
 ---
 # PERF-499: Raw WebSocket CDP Connection for Hot Loop
 
@@ -62,3 +62,8 @@ Run a standard Canvas mode benchmark to ensure no regressions (Canvas mode won't
 
 ## Correctness Check
 Run the standard DOM benchmark to ensure FFmpeg successfully encodes all frames and virtual time still ticks deterministically.
+## Results Summary
+- **Best render time**: 18.578s (vs baseline 17.978s)
+- **Improvement**: -3.3%
+- **Kept experiments**: None
+- **Discarded experiments**: Raw WebSocket CDP Connection (PERF-499)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -447,3 +447,7 @@ Last updated by: PERF-468
   - **What I tried**: Moved checkState() call from top of while loop to after nextFrameToWrite++ inside the loop.
   - **WHY it didn't work**: Render time of 18.077s was not better than baseline of 17.687s.
   - **Outcome**: discard
+
+## What Doesn't Work (and Why)
+- **PERF-499: Raw WebSocket CDP Connection for Hot Loop**:
+  Bypassing Playwright's `CDPSession` with a raw Node.js TCP/WebSocket connection to reduce IPC and JSON overhead did not improve performance. The render time (18.578s) was slower than the baseline (17.978s). The overhead of managing the WebSocket frames and native Node buffer handling in JavaScript might outweigh the Playwright IPC overhead.


### PR DESCRIPTION
Discarded PERF-499 experiment. It caused a performance regression.

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	18.578	600	32.30	83.6	discard	PERF-499: Raw WebSocket CDP Connection
```

---
*PR created automatically by Jules for task [15727114595775066875](https://jules.google.com/task/15727114595775066875) started by @BintzGavin*