### PR TITLE
✨ RENDERER: Execute PERF-501 (Inline CDP Screenshot Params)

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -70,6 +70,8 @@ Last updated by: PERF-482
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- Inlined CDP screenshot params into beginFrameParams (PERF-501)
+  - **WHY it didn't work**: Did not provide significant serialization savings over Baseline ~17.687s. Time: 18.321s
 - **PERF-478**: Eliminate Closure in evaluateStabilityParams
   - **What I tried**: Attempted to replace the `stabilityCheckFn` closure assignment in `CdpTimeDriver.ts` with a primitive `stabilityCheckState` state machine (0=unknown, 1=true, 2=false) to avoid dynamic function invocation overhead.
   - **WHY it didn't work**: The performance improvement was non-existent (baseline ~0.60s vs ~0.59s median). The overhead of a closure assignment and invocation in V8 is completely negligible compared to Playwright IPC and CDP communication bottlenecks. The manual micro-optimization introduced unnecessary state tracking without meaningful performance gains.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -63,3 +63,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	17.687	600	33.92	43.9	keep	Restore FFmpeg backpressure
 63	18.077	600	33.19	37.3	discard	optimize orchestrator state checks
 64	18.077	600	33.19	37.3	discard	optimize orchestrator state checks
+1	18.321	600	32.75	39.4	discard	Inline CDP Screenshot Params

--- a/packages/renderer/.sys/plans/PERF-501-inline-cdp-screenshot-params.md
+++ b/packages/renderer/.sys/plans/PERF-501-inline-cdp-screenshot-params.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-501
 slug: inline-cdp-screenshot-params
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-05-14
-completed: ""
-result: ""
+completed: "2024-05-14"
+result: "discard"
 ---
 
 # PERF-501: Inline CDP Screenshot Params
@@ -36,3 +36,7 @@ Run the benchmark and ensure `output.mp4` is valid.
 
 ## Canvas Smoke Test
 Run a basic canvas test to ensure no breakage.
+## Results Summary
+| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
+|-----|---------------|--------|---------------|-------------|--------|-------------|
+| 1   | 18.321        | 600    | 32.75         | 39.4        | discard| Inline CDP Screenshot Params |


### PR DESCRIPTION
Executed PERF-501 experiment to inline CDP screenshot params into beginFrameParams in DomStrategy.ts. 
The benchmark showed a degradation in render time (18.321s compared to a baseline of 17.687s), so the experiment was **discarded** and the code changes to DomStrategy.ts were reverted.

The following files were updated to document the results:
- `docs/status/RENDERER-EXPERIMENTS.md` was updated with a failure entry under the "What Doesn't Work (and Why)" section.
- `packages/renderer/.sys/perf-results.tsv` was updated with the new 18.321s median time and marked as `discard`.
- `packages/renderer/.sys/plans/PERF-501-inline-cdp-screenshot-params.md` had its status changed to complete and appended a result summary table.

## Results Summary
| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|-----|---------------|--------|---------------|-------------|--------|-------------|
| 1   | 18.321        | 600    | 32.75         | 39.4        | discard| Inline CDP Screenshot Params |

---
*PR created automatically by Jules for task [11876691418101522244](https://jules.google.com/task/11876691418101522244) started by @BintzGavin*