### PR TITLE
✨ RENDERER: Discard PERF-502 tune zerolatency

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -451,5 +451,8 @@ Last updated by: PERF-468
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-502**: Tune ZeroLatency
+  - **What I tried**: Added `-tune zerolatency` to FFmpeg builder arguments for `libx264`.
+  - **WHY it didn't work**: The performance degraded compared to the baseline (~18.675s vs baseline ~17.574s). Forcing the encoder to skip its internal frame buffering didn't improve throughput over the IPC/Playwright bottleneck, and might have caused the encoder to work inefficiently, blocking standard input more frequently.
 - **PERF-499: Raw WebSocket CDP Connection for Hot Loop**:
   Bypassing Playwright's `CDPSession` with a raw Node.js TCP/WebSocket connection to reduce IPC and JSON overhead did not improve performance. The render time (18.578s) was slower than the baseline (17.978s). The overhead of managing the WebSocket frames and native Node buffer handling in JavaScript might outweigh the Playwright IPC overhead.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -64,3 +64,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 63	18.077	600	33.19	37.3	discard	optimize orchestrator state checks
 64	18.077	600	33.19	37.3	discard	optimize orchestrator state checks
 1	18.321	600	32.75	39.4	discard	Inline CDP Screenshot Params
+1	18.675	600	32.13	41.3	discard	PERF-502 tune zerolatency

--- a/packages/renderer/.sys/plans/PERF-502-tune-zerolatency.md
+++ b/packages/renderer/.sys/plans/PERF-502-tune-zerolatency.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-502
 slug: tune-zerolatency
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-14
-completed: ""
-result: ""
+completed: "2024-05-14"
+result: "discarded"
 ---
 
 # PERF-502: Optimize FFmpeg Args for Zero-Latency Output


### PR DESCRIPTION
💡 **What**: Executed the PERF-502 experiment to add `-tune zerolatency` to FFmpeg builder arguments for `libx264`. The code was reverted as the experiment failed.
🎯 **Why**: Attempted to optimize the FFmpeg args for zero-latency output by bypassing internal frame buffering, aiming to reduce backpressure on the Playwright capture loop.
📊 **Impact**: The performance degraded compared to the baseline (~18.675s vs baseline ~17.574s). Forcing the encoder to skip its internal buffering didn't overcome the core Playwright IPC bottleneck and potentially introduced inefficiencies.
🔬 **Verification**:
- Compilation passed
- Benchmark 3-run median recorded
- Test suite passed
- Code was successfully reverted
📎 **Plan**: `/.sys/plans/PERF-502-tune-zerolatency.md`

### Benchmark Results
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	18.675	600	32.13	41.3	discard	PERF-502 tune zerolatency
```

---
*PR created automatically by Jules for task [10821949850206469422](https://jules.google.com/task/10821949850206469422) started by @BintzGavin*