### PR TITLE
✨ RENDERER: Evaluate PERF-500 - Reduce JPEG Quality

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -70,6 +70,7 @@ Last updated by: PERF-482
 - **PERF-337**: Prebound `frameWaiterResolve` executor into `frameWaiterExecutor` to avoid dynamic inline closure allocations during the CaptureLoop actor pipeline backpressure events. This adheres to the "simplicity and GC reduction" principle that guided keeping `writerWaiterExecutor`. Render time: 46.464s (Baseline: 57.022s), though baseline was inflated by initial run. Median render times of subsequent runs were around 46.6s, slightly better than PERF-336's ~47.4s. Kept to reduce V8 GC churn in the main event loop.
 
 ## What Doesn't Work (and Why)
+- **PERF-500**: Reduced default intermediate JPEG quality from 90 to 50 in DomStrategy.ts. WHY it didn't work: Render time did not improve over baseline (it degraded to ~28.4s).
 - Inlined CDP screenshot params into beginFrameParams (PERF-501)
   - **WHY it didn't work**: Did not provide significant serialization savings over Baseline ~17.687s. Time: 18.321s
 - **PERF-478**: Eliminate Closure in evaluateStabilityParams

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -65,3 +65,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 64	18.077	600	33.19	37.3	discard	optimize orchestrator state checks
 1	18.321	600	32.75	39.4	discard	Inline CDP Screenshot Params
 1	18.675	600	32.13	41.3	discard	PERF-502 tune zerolatency
+1	28.421	600	21.11	0.0	discard	reduce-jpeg-quality

--- a/packages/renderer/.sys/plans/PERF-500-reduce-jpeg-quality.md
+++ b/packages/renderer/.sys/plans/PERF-500-reduce-jpeg-quality.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-500
 slug: reduce-jpeg-quality
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-13
-completed: ""
-result: ""
+completed: "2024-05-14"
+result: "discarded"
 ---
 
 # PERF-500: Reduce Default JPEG Intermediate Quality
@@ -54,3 +54,7 @@ Run the `simple-animation` benchmark and inspect the `output.mp4` to ensure it i
 
 ## Canvas Smoke Test
 Run a basic canvas test to ensure the shared codebase is not broken.
+
+## Results Summary
+- **Render time**: 28.421 s
+- **Discarded experiments**: PERF-500


### PR DESCRIPTION
💡 **What**: Executed PERF-500 experiment to reduce intermediate JPEG quality from 90 to 50 in DomStrategy.ts. The experiment was discarded.
🎯 **Why**: To attempt to reduce IPC payload sizes and Base64 parsing bottlenecks in V8 during DOM capture.
📊 **Impact**: The render time degraded significantly to ~28.4s (vs baseline ~17.4-18.2s). The quality reduction resulted in slower overall pipeline throughput.
🔬 **Verification**:
- Built renderer package
- Ran DOM benchmark (`tests/fixtures/benchmark.ts`)
- Reverted code changes (`DomStrategy.ts`) because the result was worse.
- Logged result to `perf-results.tsv` and `RENDERER-EXPERIMENTS.md`.
📎 **Plan**: `packages/renderer/.sys/plans/PERF-500-reduce-jpeg-quality.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status  | description         |
|-----|---------------|--------|---------------|-------------|---------|---------------------|
| 1   | 28.421        | 600    | 21.11         | 0.0         | discard | reduce-jpeg-quality |

---
*PR created automatically by Jules for task [6820037444182748115](https://jules.google.com/task/6820037444182748115) started by @BintzGavin*