### PR TITLE
✨ RENDERER: discard PERF-503: Enable Software Rasterizer

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -457,3 +457,8 @@ Last updated by: PERF-468
   - **WHY it didn't work**: The performance degraded compared to the baseline (~18.675s vs baseline ~17.574s). Forcing the encoder to skip its internal frame buffering didn't improve throughput over the IPC/Playwright bottleneck, and might have caused the encoder to work inefficiently, blocking standard input more frequently.
 - **PERF-499: Raw WebSocket CDP Connection for Hot Loop**:
   Bypassing Playwright's `CDPSession` with a raw Node.js TCP/WebSocket connection to reduce IPC and JSON overhead did not improve performance. The render time (18.578s) was slower than the baseline (17.978s). The overhead of managing the WebSocket frames and native Node buffer handling in JavaScript might outweigh the Playwright IPC overhead.
+
+- **PERF-503**: Enable Software Rasterizer
+  - **What I tried**: Removed `--disable-software-rasterizer` and `--disable-gpu-compositing` from `GPU_DISABLED_ARGS` in `BrowserPool.ts`.
+  - **WHY it didn't work**: The software rasterizer overhead in a completely headless microVM environment was significantly worse than Playwright's default behavior, degrading median render time to 18.887s (baseline 17.687s).
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -66,3 +66,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	18.321	600	32.75	39.4	discard	Inline CDP Screenshot Params
 1	18.675	600	32.13	41.3	discard	PERF-502 tune zerolatency
 1	28.421	600	21.11	0.0	discard	reduce-jpeg-quality
+2	18.887	600	31.77	44.4	discard	PERF-503 enable software rasterizer

--- a/packages/renderer/.sys/plans/PERF-503-enable-software-rasterizer.md
+++ b/packages/renderer/.sys/plans/PERF-503-enable-software-rasterizer.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-503
 slug: enable-software-rasterizer
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-15
-completed: ""
-result: ""
+completed: "2024-05-15"
+result: "discard"
 ---
 
 # PERF-503: Enable CPU Compositing and Software Rasterizer


### PR DESCRIPTION
✨ RENDERER: discard PERF-503: Enable Software Rasterizer

💡 **What**: Discarded an experiment that removed the `--disable-software-rasterizer` and `--disable-gpu-compositing` arguments from `GPU_DISABLED_ARGS` in `BrowserPool.ts`.
🎯 **Why**: To test if enabling SwiftShader multithreading could decrease the latency of the internal Chromium compositor frame generation.
📊 **Impact**: The performance degraded significantly (~18.887s vs baseline ~17.687s). The overhead of running the software rasterizer inside a completely headless microVM container was worse than the legacy unaccelerated single-threaded path.
🔬 **Verification**: Code built successfully. Ran the benchmark script `tests/fixtures/benchmark.ts` multiple times. Extracted median metrics. Confirmed degradation, updated tracking files (tsv and markdown journal), and discarded the code changes.
📎 **Plan**: `packages/renderer/.sys/plans/PERF-503-enable-software-rasterizer.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
2	18.887	600	31.77	44.4	discard	PERF-503 enable software rasterizer
```

---
*PR created automatically by Jules for task [5000141892086883202](https://jules.google.com/task/5000141892086883202) started by @BintzGavin*