### PR TITLE
✨ RENDERER: Discarded reducing intermediate JPEG quality

### DIFF
--- a/.sys/plans/PERF-500-reduce-jpeg-quality.md
+++ b/.sys/plans/PERF-500-reduce-jpeg-quality.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-500
 slug: reduce-jpeg-quality
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-10-19
-completed: ""
-result: ""
+completed: "2026-05-14"
+result: "failed"
 ---
 
 # PERF-500: Reduce Intermediate JPEG Quality
@@ -72,3 +72,9 @@ Inspect the final MP4 output visually to ensure the quality degradation is not n
 
 ## Prior Art
 - PERF-010: Changed default CDP screenshot format from webp/png to jpeg (quality 90).
+
+## Results Summary
+- **Best render time**: 16.634s (vs baseline 16.634s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [Reduce JPEG quality to 50]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -462,3 +462,7 @@ Last updated by: PERF-468
   - **What I tried**: Removed `--disable-software-rasterizer` and `--disable-gpu-compositing` from `GPU_DISABLED_ARGS` in `BrowserPool.ts`.
   - **WHY it didn't work**: The software rasterizer overhead in a completely headless microVM environment was significantly worse than Playwright's default behavior, degrading median render time to 18.887s (baseline 17.687s).
   - **Outcome**: discard
+- **PERF-500**: Reduce Intermediate JPEG Quality
+  - **What I tried**: Reduced intermediate JPEG quality from 90 to 50 in `DomStrategy.ts`.
+  - **WHY it didn't work**: Performance degraded (median ~16.729 vs baseline ~16.634). Visual degradation plus no speed improvements means this is a failure.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -67,3 +67,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	18.675	600	32.13	41.3	discard	PERF-502 tune zerolatency
 1	28.421	600	21.11	0.0	discard	reduce-jpeg-quality
 2	18.887	600	31.77	44.4	discard	PERF-503 enable software rasterizer
+1	16.729	600	35.87	47.5	discard	reduce jpeg quality to 50


### PR DESCRIPTION
✨ RENDERER: Discarded reducing intermediate JPEG quality

💡 **What**: Attempted to reduce intermediate JPEG quality from 90 to 50 in `DomStrategy.ts`.
🎯 **Why**: To minimize CDP IPC payload sizes and Node.js Base64 decoding bottlenecks.
📊 **Impact**: Performance degraded (median ~16.729s vs baseline ~16.634s). The combination of visual degradation plus no measurable speed improvements means this approach is a failure.
🔬 **Verification**: Benchmarked against `tests/fixtures/benchmark.ts`. Output correctly reverted.
📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-500-reduce-jpeg-quality.md`)

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	16.729	600	35.87	47.5	discard	reduce jpeg quality to 50
```

---
*PR created automatically by Jules for task [16043879543912486223](https://jules.google.com/task/16043879543912486223) started by @BintzGavin*