### PR TITLE
chore: record failed performance experiment PERF-504

### DIFF
--- a/.sys/plans/PERF-504-browser-pool-concurrency.md
+++ b/.sys/plans/PERF-504-browser-pool-concurrency.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-504
 slug: browser-pool-concurrency
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor"
 created: 2024-05-14
-completed: ""
-result: ""
+completed: "2024-05-14"
+result: "failed"
 ---
 # PERF-504: Optimize BrowserPool Concurrency Formula
 

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -452,6 +452,10 @@ Last updated by: PERF-468
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-504**: Optimize BrowserPool Concurrency Formula
+  - **What I tried**: Modified `BrowserPool.ts` concurrency logic to `const concurrency = Math.max(1, Math.min(8, cpus * 2));` to increase parallel capture capacity.
+  - **WHY it didn't work**: The performance regressed heavily. Increasing Playwright instances/concurrency to 8 exhausted memory and CPU resources, causing the render time to slow down significantly to ~26.429s (compared to baseline ~17.687s).
+  - **Outcome**: discard
 - **PERF-502**: Tune ZeroLatency
   - **What I tried**: Added `-tune zerolatency` to FFmpeg builder arguments for `libx264`.
   - **WHY it didn't work**: The performance degraded compared to the baseline (~18.675s vs baseline ~17.574s). Forcing the encoder to skip its internal frame buffering didn't improve throughput over the IPC/Playwright bottleneck, and might have caused the encoder to work inefficiently, blocking standard input more frequently.


### PR DESCRIPTION
Reverted an experiment attempting to increase the `BrowserPool` concurrency from (cpus - 1) up to `8` pages. The goal was to parallelize the DOM pipeline, but the result heavily regressed wall-clock render times (~17.6s -> ~26.4s) due to exhausting CPU and memory resources on the microVM. Documented the failure in RENDERER-EXPERIMENTS.md.

---
*PR created automatically by Jules for task [15746173529600044810](https://jules.google.com/task/15746173529600044810) started by @BintzGavin*