### PR TITLE
✨ RENDERER: Evaluate dedicated browser contexts per worker

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -470,3 +470,7 @@ Last updated by: PERF-468
   - **What I tried**: Reduced intermediate JPEG quality from 90 to 50 in `DomStrategy.ts`.
   - **WHY it didn't work**: Performance degraded (median ~16.729 vs baseline ~16.634). Visual degradation plus no speed improvements means this is a failure.
   - **Outcome**: discard
+- **PERF-505**: Dedicated Browser Contexts per Worker
+  - **What I tried**: Attempted to replace the single shared browser context in `BrowserPool.ts` with dedicated `browser.newContext()` contexts for each individual worker page to improve Chromium process isolation and CPU utilization.
+  - **WHY it didn't work**: The overall render time worsened (median ~19.487s vs baseline ~18.763s). The additional overhead required to instantiate, trace, and coordinate multiple isolated browser contexts inside the Playwright microVM likely outweighs any potential thread contention benefits during DOM capture.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-505.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-505.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	18.763	600	31.98	37.5	keep	baseline
+2	19.487	600	30.79	39.3	discard	dedicated browser contexts per worker

--- a/packages/renderer/.sys/plans/PERF-505-dedicated-browser-contexts.md
+++ b/packages/renderer/.sys/plans/PERF-505-dedicated-browser-contexts.md
@@ -1,0 +1,26 @@
+---
+status: complete
+completed: 2024-05-15
+result: failed
+claimed_by: "executor-session"
+---
+
+# PERF-505: Dedicated Browser Contexts
+
+## Objective
+Optimize DOM capture by replacing the single shared browser context with dedicated browser contexts (`browser.newContext()`) for each worker in `BrowserPool.ts` to improve Chromium process isolation and CPU utilization.
+
+## Background
+Currently, all concurrent workers in `BrowserPool.ts` share a single `sharedContext`. In Chromium, a single browser context might share renderer processes or have shared state that causes thread contention. By giving each worker its own dedicated browser context, Chromium can better isolate the processes, potentially increasing parallel capture capacity and overall pipeline throughput on CPU-bound microVM environments.
+
+## Steps
+1. Modify `BrowserPool.ts` to create a dedicated context for each worker in `createPage`.
+2. Ensure tracing, if enabled, is started on each context.
+3. Update the `close` method to close all individual contexts instead of just the first worker's shared context.
+
+
+## Results Summary
+- **Best render time**: 19.487s (vs baseline 18.763s)
+- **Improvement**: -3.8%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-505]


### PR DESCRIPTION
Evaluated replacing the single shared browser context in `BrowserPool.ts` with dedicated `browser.newContext()` instances per worker page.

The overhead of instantiating, tracing, and coordinating multiple isolated contexts negated any benefits. Performance degraded: median ~19.487s vs baseline ~18.763s (-3.8%).

Code built successfully. Benchmark run yielded a slower median render time. File changes were fully reverted, and documentation (`.sys/plans/PERF-505-dedicated-browser-contexts.md`, `.sys/perf-results-PERF-505.tsv`, `docs/status/RENDERER-EXPERIMENTS.md`) was updated to reflect the failure and logic.

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	18.763	600	31.98	37.5	keep	baseline
2	19.487	600	30.79	39.3	discard	dedicated browser contexts per worker

---
*PR created automatically by Jules for task [11815384506131206034](https://jules.google.com/task/11815384506131206034) started by @BintzGavin*