### PR TITLE
✨ RENDERER: Discard PERF-509 Inline Stability Check Await

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -474,3 +474,8 @@ Last updated by: PERF-468
   - **What I tried**: Attempted to replace the single shared browser context in `BrowserPool.ts` with dedicated `browser.newContext()` contexts for each individual worker page to improve Chromium process isolation and CPU utilization.
   - **WHY it didn't work**: The overall render time worsened (median ~19.487s vs baseline ~18.763s). The additional overhead required to instantiate, trace, and coordinate multiple isolated browser contexts inside the Playwright microVM likely outweighs any potential thread contention benefits during DOM capture.
   - **Outcome**: discard
+
+- **PERF-509**: Inline Stability Check Await
+  - **What I tried**: Returned direct promise from defaultStabilityCheck without .then() closure overhead
+  - **WHY it didn't work**: Did not improve performance over baseline (median ~18.03s vs baseline ~17.37s-19.93s).
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -68,3 +68,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	28.421	600	21.11	0.0	discard	reduce-jpeg-quality
 2	18.887	600	31.77	44.4	discard	PERF-503 enable software rasterizer
 1	16.729	600	35.87	47.5	discard	reduce jpeg quality to 50
+1	18.033	600	33.27	42.1	discard	PERF-509 inline-stability-check-await

--- a/packages/renderer/.sys/plans/PERF-509-inline-stability-check-await.md
+++ b/packages/renderer/.sys/plans/PERF-509-inline-stability-check-await.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-509
 slug: inline-stability-check-await
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-15
 completed: ""
-result: ""
+result: failed
 ---
 
 # PERF-509: Inline Stability Check Await
@@ -67,3 +67,9 @@ Modify `defaultStabilityCheck` to return the promise without `.then()`, and upda
 ```
 **Why**: Avoids creating a secondary Promise object via `.then()` and an anonymous closure per frame.
 **Risk**: None.
+
+## Results Summary
+- **Best render time**: 18.033s (vs baseline ~17.37s-19.93s)
+- **Improvement**: 0%
+- **Kept experiments**: None
+- **Discarded experiments**: Inline Stability Check Await


### PR DESCRIPTION
✨ RENDERER: Discard PERF-509 Inline Stability Check Await

💡 What: Implemented and tested an experiment to return the Playwright CDP promise directly from `defaultStabilityCheck` and await it inline within `runSetTime` in `CdpTimeDriver.ts`. The experiment was discarded and the code changes were reverted.
🎯 Why: To eliminate the secondary V8 Promise allocation and anonymous closure overhead created by the `.then()` chain in the hot loop.
📊 Impact: Did not improve performance over baseline (median render time was ~18.033s vs baseline range of ~17.37s-19.93s).
🔬 Verification: 3-run benchmark recorded a median render time of 18.033s. Tests passed. Code was correctly reverted.
📎 Plan: PERF-509

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	18.033	600	33.27	42.1	discard	PERF-509 inline-stability-check-await
```

---
*PR created automatically by Jules for task [17206649905613150783](https://jules.google.com/task/17206649905613150783) started by @BintzGavin*