### PR TITLE
✨ RENDERER: Discard PERF-507 (inline stability check)

### DIFF
--- a/packages/renderer/.sys/perf-results-PERF-507.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-507.tsv
@@ -1,0 +1,5 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	19.070	600	31.46	42.9	discard	PERF-507: Inline stability check (await client.send directly)
+2	17.631	600	34.03	37.3	discard	PERF-507: Inline stability check (await client.send directly)
+3	17.778	600	33.75	38.0	discard	PERF-507: Inline stability check (await client.send directly)
+4	17.773	600	33.76	40.8	discard	PERF-507: Inline stability check (await client.send directly)


### PR DESCRIPTION
💡 **What**: Attempted to inline `defaultStabilityCheck` to completely eliminate method invocation, returning the direct CDP promise, and awaiting it directly in `runSetTime`.
🎯 **Why**: Optimize orchestrator/CDP interaction by avoiding a `.then()` and microtask promise chain closure overhead.
📊 **Impact**: Did not improve performance over baseline (median ~17.773s vs baseline ~17.687s). Any theoretical V8 optimizations from avoiding a `.then()` and microtask promise chain closure are completely eclipsed by Playwright and CDP IPC latency over the local bridge.
🔬 **Verification**: 4-gate verification failed (Benchmark didn't show improvement). Discarded. Code reverted.
📎 **Plan**: .sys/plans/PERF-507-inline-stability-check.md

### Results Summary
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	19.070	600	31.46	42.9	discard	PERF-507: Inline stability check (await client.send directly)
2	17.631	600	34.03	37.3	discard	PERF-507: Inline stability check (await client.send directly)
3	17.778	600	33.75	38.0	discard	PERF-507: Inline stability check (await client.send directly)
4	17.773	600	33.76	40.8	discard	PERF-507: Inline stability check (await client.send directly)

---
*PR created automatically by Jules for task [5060103099607610812](https://jules.google.com/task/5060103099607610812) started by @BintzGavin*