### PR TITLE
✨ RENDERER: Discard raw screencast without external compositor experiment

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -480,6 +480,10 @@ Last updated by: PERF-468
   - **WHY it didn't work**: Did not improve performance over baseline (median ~18.03s vs baseline ~17.37s-19.93s).
   - **Outcome**: discard
 ## What Doesn't Work (and Why)
+- **PERF-513**: Raw Screencast without External Compositor
+  - **What I tried**: Dropped `--enable-begin-frame-control` and `--run-all-compositor-stages-before-draw` flags and replaced `HeadlessExperimental.beginFrame` capture loop with a passive `Page.startScreencast` event listener strategy with a timeout fallback.
+  - **WHY it didn't work**: Regression of ~7% (median 21.406s vs baseline 19.93s). While `Page.startScreencast` does capture frames without needing external compositor control, the lack of deterministic frame emission requires arbitrary fallback timeouts (or waiting passively) when there is no visual damage. This passive wait mechanism delays the pipeline significantly compared to the proactive, deterministic pumping of `beginFrame`.
+  - **Outcome**: discard
 - Inlining stability check promise resolution in CdpTimeDriver.ts
 - The bottleneck is likely in V8 runtime boundaries or Playwright CDP IPC, meaning microtask queue optimizations yield no measurable performance improvement over the baseline.
 - Plan ID: PERF-506

--- a/packages/renderer/.sys/perf-results-PERF-513.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-513.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	21.948	600	27.34	40.6	discard	raw screencast without external compositor (1/3)
+2	21.406	600	28.03	35.6	discard	raw screencast without external compositor (2/3)
+3	21.394	600	28.05	35.4	discard	raw screencast without external compositor (3/3)

--- a/packages/renderer/.sys/plans/PERF-513-test-raw-cdp-screencast-no-external-compositor.md
+++ b/packages/renderer/.sys/plans/PERF-513-test-raw-cdp-screencast-no-external-compositor.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-513
 slug: test-raw-cdp-screencast-no-external-compositor
-status: unclaimed
+status: claimed
 claimed_by: ""
 created: 2024-05-15
-completed: ""
-result: ""
+completed: "2024-05-15"
+result: "discard"
 ---
 # PERF-513: Test Raw CDP Screencast without External Compositor Control
 


### PR DESCRIPTION
💡 **What**: Dropped `--enable-begin-frame-control` and `--run-all-compositor-stages-before-draw` flags from `BrowserPool.ts` and replaced the `HeadlessExperimental.beginFrame` capture hot loop in `DomStrategy.ts` with a passive `Page.startScreencast` event listener strategy paired with a 100ms fallback timeout for periods with no visual damage.

🎯 **Why**: Previous attempts to use `Page.startScreencast` caused deadlocks during static scenes because Chromium's external compositor flags suppressed damage-driven screencast frames when there was no visual damage. This experiment aimed to test if dropping the flags and relying on the natural screencast emissions combined with a fallback timeout would yield a faster, more stable pipeline than the deterministic `beginFrame` pumping.

📊 **Impact**: The render time degraded significantly, showing a performance regression of ~7%. The baseline was ~19.93s, and the raw screencast approach yielded a median render time of 21.406s across 3 runs. The passive wait mechanism and the arbitrary fallback timeouts required to handle non-damage frames severely delayed the capture pipeline compared to the proactive, deterministic pumping of `beginFrame`. The experiment was discarded and source code modifications were reverted.

🔬 **Verification**:
- Baseline: ~19.93s
- Run 1: 21.948s
- Run 2: 21.406s
- Run 3: 21.394s
- Median: ~21.406s
Code changes were fully reverted after the regression was identified. Test suite execution was skipped due to reversion.

📎 **Plan**: `/.sys/plans/PERF-513-test-raw-cdp-screencast-no-external-compositor.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	21.948	600	27.34	40.6	discard	raw screencast without external compositor (1/3)
2	21.406	600	28.03	35.6	discard	raw screencast without external compositor (2/3)
3	21.394	600	28.05	35.4	discard	raw screencast without external compositor (3/3)
```

---
*PR created automatically by Jules for task [996225370354295061](https://jules.google.com/task/996225370354295061) started by @BintzGavin*