### PR TITLE
✨ STUDIO: Expand Reverse Speeds

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### STUDIO v0.121.13
+- ✅ Completed: Expand Reverse Speeds - Added -4x and -2x reverse playback options to the PlaybackControls component.
+
 ### STUDIO v0.121.12
 - ✅ Completed: STUDIO-system-prompt - Verified that the AI System Prompt feature was already fully implemented via AssistantModal (IMPOSSIBLE: DUPLICATION).
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,6 @@
-**Version**: 0.121.12
+**Version**: 0.121.13
+
+[v0.121.13] ✅ Completed: Expand Reverse Speeds - Added -4x and -2x reverse playback options to the PlaybackControls component.
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 

--- a/packages/studio/src/components/Controls/PlaybackControls.tsx
+++ b/packages/studio/src/components/Controls/PlaybackControls.tsx
@@ -188,6 +188,8 @@ export const PlaybackControls: React.FC = () => {
           outline: 'none'
         }}
       >
+        <option value="-4">⏪ -4x</option>
+        <option value="-2">⏪ -2x</option>
         <option value="-1">⏪ -1x</option>
         <option value="0.25">0.25x</option>
         <option value="0.5">0.5x</option>


### PR DESCRIPTION
💡 **What**: Added -4x and -2x reverse playback options to the playback speed `<select>` dropdown in `PlaybackControls.tsx`.
🎯 **Why**: To close the vision gap where the "J" keyboard shortcut allowed reverse playback up to -4x speed, but the PlaybackControls UI dropdown only offered a single reverse option (-1x).
📊 **Impact**: Ensures parity between keyboard shortcuts and UI controls, providing a complete variable speed playback experience.
🔬 **Verification**: Ran `npm test -w packages/studio -- --run` to ensure tests still pass, and verified the UI loads by running `npx helios studio & sleep 5; kill $!`.

---
*PR created automatically by Jules for task [8310636895137562698](https://jules.google.com/task/8310636895137562698) started by @BintzGavin*