### PR TITLE
✨ CLI: Cloud Templates Regression Tests

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### CLI v0.46.30
+- ✅ Completed: CLI Cloud Templates Tests - Implemented unit tests for remaining cloud deployment templates.
+
 ### STUDIO v0.121.13
 - ✅ Completed: Expand Reverse Speeds - Added -4x and -2x reverse playback options to the PlaybackControls component.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,3 +1,7 @@
+**Version**: 0.46.30
+
+[v0.46.30] ✅ Completed: CLI Cloud Templates Tests - Implemented unit tests for remaining cloud deployment templates.
+
 [v0.46.29] 🟢 Completed: CLI Cloud Templates Regression Tests Spec - Created strictly new specification plan `2027-06-05-CLI-Cloud-Templates-Regression-Tests-V2.md` to address the missing tests for cloud infrastructure templates in `packages/cli/src/templates/__tests__/cloud.test.ts`.
 [v0.46.28] 🟢 Completed: CLI Cloud Templates Regression Tests Spec - Created specification plan `2027-06-05-CLI-Cloud-Templates-Regression-Tests.md` to add missing tests for Docker, Deno, Vercel, Modal, Hetzner, and Fly.io templates to `packages/cli/src/templates/__tests__/cloud.test.ts`.
 [v0.46.28] 🟢 Completed: CLI Cloud Templates Regression Tests Spec - Created specification plan `2027-06-05-CLI-Cloud-Templates-Regression-Tests.md` to add missing tests for Docker, Deno, Vercel, Modal, Hetzner, and Fly.io templates to `packages/cli/src/templates/__tests__/cloud.test.ts`.

--- a/packages/cli/src/templates/__tests__/cloud.test.ts
+++ b/packages/cli/src/templates/__tests__/cloud.test.ts
@@ -5,6 +5,12 @@ import { WRANGLER_TOML_TEMPLATE as CLOUDFLARE_WRANGLER_TOML_TEMPLATE, CLOUDFLARE
 import { WRANGLER_TOML_TEMPLATE as CLOUDFLARE_SANDBOX_WRANGLER_TOML_TEMPLATE } from '../cloudflare-sandbox';
 import { CLOUD_RUN_JOB_TEMPLATE } from '../gcp';
 import { KUBERNETES_JOB_TEMPLATE } from '../kubernetes';
+import { DOCKERFILE_TEMPLATE, DOCKER_COMPOSE_TEMPLATE } from '../docker';
+import { README_DENO_TEMPLATE } from '../deno';
+import { README_VERCEL_TEMPLATE } from '../vercel';
+import { README_MODAL_TEMPLATE } from '../modal';
+import { README_HETZNER_TEMPLATE } from '../hetzner';
+import { FLY_TOML_TEMPLATE, FLY_DOCKERFILE_TEMPLATE, README_FLY_TEMPLATE } from '../fly';
 
 describe('Cloud Templates', () => {
   it('should export AWS_DOCKERFILE_TEMPLATE containing correct properties', () => {
@@ -39,5 +45,41 @@ describe('Cloud Templates', () => {
   it('should export KUBERNETES_JOB_TEMPLATE containing correct properties', () => {
     expect(KUBERNETES_JOB_TEMPLATE).toBeDefined();
     expect(KUBERNETES_JOB_TEMPLATE).toContain('apiVersion: batch/v1');
+  });
+
+  it('should export Docker templates containing correct properties', () => {
+    expect(DOCKERFILE_TEMPLATE).toBeDefined();
+    expect(DOCKERFILE_TEMPLATE).toContain('FROM node:18-slim');
+    expect(DOCKER_COMPOSE_TEMPLATE).toBeDefined();
+    expect(DOCKER_COMPOSE_TEMPLATE).toContain('version: \'3.8\'');
+  });
+
+  it('should export Deno Deploy templates containing correct properties', () => {
+    expect(README_DENO_TEMPLATE).toBeDefined();
+    expect(README_DENO_TEMPLATE).toContain('# Deno Deploy Guide');
+  });
+
+  it('should export Vercel templates containing correct properties', () => {
+    expect(README_VERCEL_TEMPLATE).toBeDefined();
+    expect(README_VERCEL_TEMPLATE).toContain('# Vercel Deployment Guide');
+  });
+
+  it('should export Modal templates containing correct properties', () => {
+    expect(README_MODAL_TEMPLATE).toBeDefined();
+    expect(README_MODAL_TEMPLATE).toContain('# Modal Deployment Guide');
+  });
+
+  it('should export Hetzner Cloud templates containing correct properties', () => {
+    expect(README_HETZNER_TEMPLATE).toBeDefined();
+    expect(README_HETZNER_TEMPLATE).toContain('# Hetzner Cloud Deployment');
+  });
+
+  it('should export Fly.io templates containing correct properties', () => {
+    expect(FLY_TOML_TEMPLATE).toBeDefined();
+    expect(FLY_TOML_TEMPLATE).toContain('app = "helios-render-worker"');
+    expect(FLY_DOCKERFILE_TEMPLATE).toBeDefined();
+    expect(FLY_DOCKERFILE_TEMPLATE).toContain('FROM mcr.microsoft.com/playwright:v1.49.1-jammy');
+    expect(README_FLY_TEMPLATE).toBeDefined();
+    expect(README_FLY_TEMPLATE).toContain('# Helios Fly.io Deployment');
   });
 });


### PR DESCRIPTION
Implemented unit tests for the missing cloud and container templates in `packages/cli/src/templates/__tests__/cloud.test.ts` (Docker, Deno, Vercel, Modal, Hetzner, and Fly.io). This ensures structural soundness and prevents silent regressions during deployment scaffolding generation, closing the gap in code coverage for cloud infrastructure templates. Tests pass correctly.

---
*PR created automatically by Jules for task [14625388152676061550](https://jules.google.com/task/14625388152676061550) started by @BintzGavin*