### PR TITLE
✨ RENDERER: [Failed] Eager Base64 Decoding & CdpTimeDriver Inlining

### DIFF
--- a/.sys/plans/PERF-528-hot-loop-micro-optimizations.md
+++ b/.sys/plans/PERF-528-hot-loop-micro-optimizations.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-528
 slug: hot-loop-micro-optimizations
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-30
-completed: ""
-result: ""
+completed: "2024-05-30"
+result: "failed"
 ---
 
 # PERF-528: Hot Loop Micro-Optimizations
@@ -68,3 +68,9 @@ Merge `runSetTime` directly into `async setTime(page: Page, timeInSeconds: numbe
 
 ## Correctness Check
 Run the DOM benchmark and verify output video is correctly encoded. Ensure tests pass.
+
+## Results Summary
+- **Best render time**: 28.552s (vs baseline ~15.793s - 16.306s)
+- **Improvement**: -80.7% (regression)
+- **Kept experiments**: None
+- **Discarded experiments**: Eager Base64 decoding in CaptureLoop.ts, inlining runSetTime and handleStabilityCheckResponse in CdpTimeDriver.ts

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -68,3 +68,7 @@ Last updated by: PERF-520
 
 ## What Doesn't Work (and Why)
 - **Reducing BrowserPool Concurrency to 2 or 1 (PERF-518)**: Tested reducing `concurrency` in `BrowserPool.ts` from 3 (calculated as `Math.max(1, os.cpus().length - 1)`) to 2, and then to 1 to reduce thread contention in the single Chromium process due to `--disable-site-isolation-trials`. Results showed performance degraded. With concurrency = 2, median render time was ~20.89s (vs baseline ~18.2s-20.6s). With concurrency = 1, median render time dropped to ~28.15s. This indicates that while thread contention exists, the benefits of partial parallelism via multiple browser pages outpace the overhead. The existing formula (`Math.max(1, (os.cpus().length || 4) - 1)`) works best in this CPU environment. Discarded the change.
+- **PERF-528**: Eager Base64 Decoding & CdpTimeDriver Inlining
+  - **What I tried**: Inlined the Base64 frame buffer decoding inside `runWorker` in `CaptureLoop.ts` to improve L1 cache locality, and inlined `runSetTime` logic in `CdpTimeDriver.ts`.
+  - **WHY it didn't work**: The performance regressed heavily. The median render time increased to ~28.552s compared to the baseline. Eagerly decoding Base64 in the worker closure actually caused a slowdown, likely due to blocking the worker promise resolution while parsing the buffer, thus delaying the next frame cycle in a multi-worker pipeline.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -73,3 +73,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	17.071	600	35.15	37.4	keep	inline promise in defaultStabilityCheck
 74	19.921	600	30.12	40.3	discard	reduced worker wait promise allocation with shared promise
 75	16.306	600	36.82	35.6	keep	inlined evaluateStabilityParams await in CdpTimeDriver
+1	28.552	600	21.01	45.4	discard	hot-loop-micro-optimizations cache locality inline stability check


### PR DESCRIPTION
💡 **What**: Tried to inline Base64 frame buffer decoding inside `runWorker` in `CaptureLoop.ts` to improve L1 cache locality and inlined `runSetTime` logic in `CdpTimeDriver.ts`.
🎯 **Why**: To reduce V8 overhead and avoid dropping the cache locality from Playwright IPC string to Node Buffer conversion.
📊 **Impact**: The performance regressed heavily. The median render time increased to ~28.552s compared to the baseline (~16.306s). Eagerly decoding Base64 in the worker closure actually caused a slowdown, likely due to blocking the worker promise resolution while parsing the buffer, thus delaying the next frame cycle in a multi-worker pipeline.
🔬 **Verification**: Code built successfully. The benchmark indicated a regression so the changes were manually reverted. Documentation was updated.
📎 **Plan**: `/.sys/plans/PERF-528-hot-loop-micro-optimizations.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status  | description |
|---|---|---|---|---|---|---|
| 1 | 28.552 | 600 | 21.01 | 45.4 | discard | hot-loop-micro-optimizations cache locality inline stability check |

---
*PR created automatically by Jules for task [9791951976592379274](https://jules.google.com/task/9791951976592379274) started by @BintzGavin*