### PR TITLE
✨ RENDERER: Discard PERF-531 maxPipelineDepth increase

### DIFF
--- a/.sys/plans/PERF-531-increase-max-pipeline-depth-buffer.md
+++ b/.sys/plans/PERF-531-increase-max-pipeline-depth-buffer.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-531
 slug: increase-max-pipeline-depth-buffer
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-01
-completed: ""
-result: ""
+completed: "2026-05-17"
+result: "discarded"
 ---
 
 # PERF-531: Increase CaptureLoop maxPipelineDepth Buffer
@@ -63,3 +63,9 @@ Run the DOM benchmark and inspect `output.mp4` to verify that all 600 frames wer
 ## Prior Art
 - PERF-498 (Restored FFmpeg backpressure to fix OOM on long renders, but introduced tight coupling due to the shallow buffer)
 - PERF-524 (Unclaimed earlier hypothesis proposing a similar pipeline depth increase)
+
+## Results Summary
+- **Best render time**: 19.206s (vs baseline 15.594s)
+- **Improvement**: -23.16%
+- **Kept experiments**: none
+- **Discarded experiments**: Increased maxPipelineDepth buffer multiplier to 64

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -75,3 +75,7 @@ Last updated by: PERF-529
   - **What I tried**: Inlined the Base64 frame buffer decoding inside `runWorker` in `CaptureLoop.ts` to improve L1 cache locality, and inlined `runSetTime` logic in `CdpTimeDriver.ts`.
   - **WHY it didn't work**: The performance regressed heavily. The median render time increased to ~28.552s compared to the baseline. Eagerly decoding Base64 in the worker closure actually caused a slowdown, likely due to blocking the worker promise resolution while parsing the buffer, thus delaying the next frame cycle in a multi-worker pipeline.
   - **Outcome**: discard
+- **PERF-531**: Increase CaptureLoop maxPipelineDepth Buffer
+  - **What I tried**: Increased the `maxPipelineDepth` buffer multiplier in `CaptureLoop.ts` from `8` to `64`.
+  - **WHY it didn't work**: The performance regressed. The median render time increased to ~19.206s compared to the baseline ~15.594s. Deepening the backpressure ring buffer likely increased memory overhead or V8 GC pressure without significantly improving throughput in this environment.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -80,3 +80,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 3	15.640	600	38.36	44.3	keep	process-per-tab (PERF-529)
 4	15.594	600	38.48	44.4	keep	process-per-tab (PERF-529)
 5	15.421	600	38.91	43.6	keep	process-per-tab (PERF-529)
+1	19.206	600	31.24	46.4	discard	increase maxPipelineDepth buffer multiplier to 64 (PERF-531)


### PR DESCRIPTION
💡 **What**: Executed and discarded PERF-531 (increasing `maxPipelineDepth` buffer multiplier to 64). Recorded findings in TSV and RENDERER-EXPERIMENTS.md.
🎯 **Why**: The experiment was intended to alleviate backpressure micro-stalls between DOM workers and the FFmpeg encoder.
📊 **Impact**: Caused a performance regression. Render time increased to ~19.206s (vs baseline ~15.594s).
🔬 **Verification**: Validated compilation, executed benchmarks, verified 600 frames successfully. Output was valid. Code was reverted to baseline.
📎 **Plan**: Reference `.sys/plans/PERF-531-increase-max-pipeline-depth-buffer.md`

```tsv
1	19.206	600	31.24	46.4	discard	increase maxPipelineDepth buffer multiplier to 64 (PERF-531)
```

---
*PR created automatically by Jules for task [5618356493220210112](https://jules.google.com/task/5618356493220210112) started by @BintzGavin*