### PR TITLE
📋 RENDERER: Document failure of PERF-533 (limit FFmpeg threads)

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -25,6 +25,10 @@ Last updated by: PERF-529
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-533**: Limit FFmpeg Threads to Reduce CPU Contention
+  - **What I tried**: Added `-threads 1` to the FFmpeg builder arguments for video encoding in `FFmpegBuilder.ts` to limit thread contention with Chromium and Node on the CPU.
+  - **WHY it didn't work**: The render time regressed to a median of ~17.431s (and as bad as ~26.641s in one run) compared to the baseline of ~15.594s. Limiting FFmpeg to a single thread likely introduced a bottleneck on the encoding side that backed up the pipeline, forcing Chromium workers to wait, which negatively offset any thread contention gains.
+  - **Outcome**: discard
 - **PERF-532**: Inline defaultSyncMedia inside CdpTimeDriver.ts
   - **What I tried**: Attempted to reduce function call overhead in the hot loop by replacing the call to `this.defaultSyncMedia(timeInSeconds)` with the inline logic directly inside `runSetTime()`.
   - **WHY it didn't work**: Render time regressed to a median of ~18.669s vs baseline ~15.594s. Inlining a heavy block with complex looping directly into the main execution function increased V8 deoptimization risk and memory footprint, overriding any minor function call dispatch savings.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -82,3 +82,6 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 5	15.421	600	38.91	43.6	keep	process-per-tab (PERF-529)
 1	19.206	600	31.24	46.4	discard	increase maxPipelineDepth buffer multiplier to 64 (PERF-531)
 1	18.669	600	32.14	47.3	discard	inline defaultSyncMedia in CdpTimeDriver
+1	16.640	600	36.06	41.4	discard	limit FFmpeg threads to 1 (PERF-533)
+2	17.431	600	34.42	46.9	discard	limit FFmpeg threads to 1 (PERF-533)
+3	26.641	600	22.52	40.0	discard	limit FFmpeg threads to 1 (PERF-533)


### PR DESCRIPTION
This PR documents the failure of the `PERF-533` experiment.

### What
The experiment tested adding `-threads 1` to FFmpeg in `FFmpegBuilder.ts`.
### Why
The goal was to limit thread contention with Chromium and Node on the CPU.
### Results
It failed and caused a performance regression because the single thread introduced an encoding bottleneck that backed up the pipeline and forced Chromium workers to wait. The median render time went from `~15.594s` up to `~17.431s`. The code changes were reverted, but `RENDERER-EXPERIMENTS.md` and `perf-results.tsv` were updated to document the failure.

---
*PR created automatically by Jules for task [4272448105053923163](https://jules.google.com/task/4272448105053923163) started by @BintzGavin*