### PR TITLE
✨ RENDERER: [PERF-534] Discarded removing --disable-breakpad

### DIFF
--- a/.sys/plans/PERF-534-remove-disable-breakpad.md
+++ b/.sys/plans/PERF-534-remove-disable-breakpad.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-534
 slug: remove-disable-breakpad
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-17
-completed: ""
-result: ""
+completed: "2024-05-17"
+result: "discard"
 ---
 
 # PERF-534: Remove --disable-breakpad from Chromium arguments
@@ -61,3 +61,13 @@ Run the DOM benchmark and verify output video is correctly encoded. Ensure tests
 
 ## Prior Art
 - PERF-529 (Enabled `process-per-tab` which fundamentally changed how processes are launched).
+
+## Results Summary
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	20.577	600	29.16	39.6	discard	remove --disable-breakpad
+2	19.939	600	30.09	44.2	discard	remove --disable-breakpad
+3	20.648	600	29.06	41.3	discard	remove --disable-breakpad
+4	17.388	600	34.51	48.3	discard	remove --disable-breakpad
+5	18.451	600	32.52	44.1	discard	remove --disable-breakpad
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -86,3 +86,7 @@ Last updated by: PERF-529
   - **What I tried**: Increased the `maxPipelineDepth` buffer multiplier in `CaptureLoop.ts` from `8` to `64`.
   - **WHY it didn't work**: The performance regressed. The median render time increased to ~19.206s compared to the baseline ~15.594s. Deepening the backpressure ring buffer likely increased memory overhead or V8 GC pressure without significantly improving throughput in this environment.
   - **Outcome**: discard
+- **PERF-534**: Remove `--disable-breakpad` from Chromium arguments
+  - **What I tried**: Removed `--disable-breakpad` from the `DEFAULT_BROWSER_ARGS` array in `BrowserPool.ts`.
+  - **WHY it didn't work**: The performance regressed heavily. The median render time increased to ~19.939s compared to the baseline ~15.594s. Leaving breakpad enabled likely introduced overhead in the headless chromium processes during high-frequency frame capture.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -85,3 +85,8 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	16.640	600	36.06	41.4	discard	limit FFmpeg threads to 1 (PERF-533)
 2	17.431	600	34.42	46.9	discard	limit FFmpeg threads to 1 (PERF-533)
 3	26.641	600	22.52	40.0	discard	limit FFmpeg threads to 1 (PERF-533)
+1	20.577	600	29.16	39.6	discard	remove --disable-breakpad
+2	19.939	600	30.09	44.2	discard	remove --disable-breakpad
+3	20.648	600	29.06	41.3	discard	remove --disable-breakpad
+4	17.388	600	34.51	48.3	discard	remove --disable-breakpad
+5	18.451	600	32.52	44.1	discard	remove --disable-breakpad


### PR DESCRIPTION
✨ RENDERER: [PERF-534] Discarded removing --disable-breakpad

💡 What: Removed `--disable-breakpad` from the `DEFAULT_BROWSER_ARGS` array in `BrowserPool.ts` to test its impact on render time.
🎯 Why: To systematically test the impact of default Chromium launch configurations on the HeadlessExperimental.beginFrame hot loop in our microVM environment.
📊 Impact: Performance regressed heavily. Median render time increased to ~19.939s vs a baseline of ~15.594s.
🔬 Verification: 5 benchmark runs performed. Test suite was verified to compile. Code changes reverted since experiment failed.
📎 Plan: `.sys/plans/PERF-534-remove-disable-breakpad.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	20.577	600	29.16	39.6	discard	remove --disable-breakpad
2	19.939	600	30.09	44.2	discard	remove --disable-breakpad
3	20.648	600	29.06	41.3	discard	remove --disable-breakpad
4	17.388	600	34.51	48.3	discard	remove --disable-breakpad
5	18.451	600	32.52	44.1	discard	remove --disable-breakpad
```

---
*PR created automatically by Jules for task [180320050122367553](https://jules.google.com/task/180320050122367553) started by @BintzGavin*