### PR TITLE
✨ PLAYER: Improve index.ts test coverage

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -611,3 +611,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### PLAYER v0.77.34
 - ✅ Completed: Discovered that 2026-11-26-PLAYER-Add-Undocumented-Shortcuts-UI.md is an IMPOSSIBLE: DUPLICATION plan. The shortcuts are already fully implemented in the UI overlay inside index.ts. Documented as impossible and discarded.
+
+### PLAYER v0.77.35
+- ✅ Completed: Improve index.ts test coverage - Added tests for captureStream and audio metering edge cases.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,5 @@
-**Version**: 0.77.34
+**Version**: 0.77.35
+[v0.77.35] ✅ Completed: Improve index.ts test coverage - Added tests for captureStream and audio metering edge cases.
 [v0.77.34] ✅ Completed: Discovered that 2026-11-26-PLAYER-Add-Undocumented-Shortcuts-UI.md is an IMPOSSIBLE: DUPLICATION plan. The shortcuts are already fully implemented in the UI overlay inside index.ts. Documented as impossible and discarded.
 [v0.77.33] ✅ Completed: Discovered that 2026-03-01-PLAYER-Client-Side-Video-Inlining.md is an IMPOSSIBLE: DUPLICATION plan. The inlineVideos functionality is already fully implemented and tested in dom-capture.ts. Documented as impossible and discarded.
 [v0.77.30] ✅ Completed: Document Tracks API - Added audioTracks and videoTracks properties to README.md API parity list.

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -1745,6 +1745,82 @@ describe('Input Props', () => {
     });
   });
 
+  describe('Export Menu Behavior', () => {
+    it('should show error when export clicked without controller', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const exportBtn = player.shadowRoot!.querySelector('.export-btn') as HTMLButtonElement;
+
+      // Ensure controller is null
+      (player as any).controller = null;
+      exportBtn.disabled = false;
+      exportBtn.click();
+
+      expect(consoleSpy).toHaveBeenCalledWith("Export not available: Not connected.");
+      consoleSpy.mockRestore();
+    });
+
+    it('should abort export if abortController is set', () => {
+      const exportBtn = player.shadowRoot!.querySelector('.export-btn') as HTMLButtonElement;
+
+      const abortMock = vi.fn();
+      (player as any).abortController = { abort: abortMock };
+      exportBtn.disabled = false;
+      exportBtn.click();
+
+      expect(abortMock).toHaveBeenCalled();
+    });
+
+    it('should toggle export menu when export clicked with controller', () => {
+      const exportBtn = player.shadowRoot!.querySelector('.export-btn') as HTMLButtonElement;
+      const toggleMock = vi.spyOn(player as any, 'toggleExportMenu').mockImplementation(() => {});
+
+      (player as any).controller = { pause: vi.fn(), dispose: vi.fn() }; // Mock controller
+      (player as any).abortController = null;
+      exportBtn.disabled = false;
+      exportBtn.click();
+
+      expect(toggleMock).toHaveBeenCalled();
+      toggleMock.mockRestore();
+    });
+  });
+
+  describe('captureStream API Coverage', () => {
+    it('should throw error if canvas not found for captureStream', async () => {
+      (player as any).mode = 'direct';
+      const mockController = Object.create(DirectController.prototype);
+      mockController.instance = { getCanvas: () => null, fps: { peek: () => 30 } };
+      mockController.pause = vi.fn();
+      mockController.dispose = vi.fn();
+      (player as any).controller = mockController;
+
+      await expect(player.captureStream()).rejects.toThrow('Canvas not found for captureStream().');
+    });
+  });
+
+  describe('Audio Metering APIs Coverage', () => {
+    it('should call controller.startAudioMetering', () => {
+      (player as any).controller = { startAudioMetering: vi.fn(), pause: vi.fn(), dispose: vi.fn() };
+      player.startAudioMetering();
+      expect((player as any).controller.startAudioMetering).toHaveBeenCalled();
+    });
+
+    it('should handle startAudioMetering without controller', () => {
+      (player as any).controller = null;
+      expect(() => player.startAudioMetering()).not.toThrow();
+    });
+
+    it('should call controller.stopAudioMetering', () => {
+      (player as any).controller = { stopAudioMetering: vi.fn(), pause: vi.fn(), dispose: vi.fn() };
+      player.stopAudioMetering();
+      expect((player as any).controller.stopAudioMetering).toHaveBeenCalled();
+    });
+
+    it('should handle stopAudioMetering without controller', () => {
+      (player as any).controller = null;
+      expect(() => player.stopAudioMetering()).not.toThrow();
+    });
+  });
+
   describe('ControlsList', () => {
     it('should hide export button when controlslist="nodownload"', () => {
         player.setAttribute('controlslist', 'nodownload');


### PR DESCRIPTION
Implemented unit test coverage expansion for `index.ts` within the `packages/player` domain. Specifically, we've covered the edge case logic around the export menu button being clicked when the controller is missing, testing the abort signals, testing the `captureStream` missing canvas fallback, and the `startAudioMetering`/`stopAudioMetering` methods when the controller is undefined.

---
*PR created automatically by Jules for task [12024118795151138358](https://jules.google.com/task/12024118795151138358) started by @BintzGavin*