### PR TITLE
✨ RENDERER: Discard PERF-535 webp image2pipe experiment

### DIFF
--- a/.sys/plans/PERF-535-webp-image2pipe.md
+++ b/.sys/plans/PERF-535-webp-image2pipe.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-535
 slug: webp-image2pipe
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-25
 completed: ""
-result: ""
+result: "discarded"
 ---
 
 # PERF-535: Use WebP with image2pipe for Intermediate Formats
@@ -96,3 +96,9 @@ Run the benchmark script (`npx tsx packages/renderer/tests/fixtures/benchmark.ts
 
 ## Prior Art
 - PERF-447: Identified `image2pipe` with `-vcodec webp` as a solution to previous `webp_pipe` crashes.
+
+## Results Summary
+- **Best render time**: 0.000s (crashed vs baseline 15.594s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [Step 1: Default to WebP for All Renders]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -90,3 +90,8 @@ Last updated by: PERF-529
   - **What I tried**: Removed `--disable-breakpad` from the `DEFAULT_BROWSER_ARGS` array in `BrowserPool.ts`.
   - **WHY it didn't work**: The performance regressed heavily. The median render time increased to ~19.939s compared to the baseline ~15.594s. Leaving breakpad enabled likely introduced overhead in the headless chromium processes during high-frequency frame capture.
   - **Outcome**: discard
+
+## What Doesn't Work (and Why)
+- **Use WebP with image2pipe for Intermediate Formats** (PERF-535)
+  - Tried changing the default intermediate screenshot format to `webp` and using the `image2pipe` FFmpeg demuxer (`-vcodec webp`).
+  - **WHY it didn't work**: The benchmark immediately crashed with a pipeline error from FFmpeg: `Could not find codec parameters for stream 0 (Video: webp, none): unspecified size` and `Cannot determine format of input stream 0:0 after EOF`. FFmpeg's `image2pipe` parser natively failed to derive the dimensions of the initial incoming headless Chromium-produced base64-decoded WEBP frames, breaking the pipe before any valid video stream was initiated.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -90,3 +90,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 3	20.648	600	29.06	41.3	discard	remove --disable-breakpad
 4	17.388	600	34.51	48.3	discard	remove --disable-breakpad
 5	18.451	600	32.52	44.1	discard	remove --disable-breakpad
+1	0.000	0	0.00	0.0	crash	webp image2pipe format change


### PR DESCRIPTION
✨ RENDERER: Discard PERF-535 webp image2pipe experiment

💡 What: Tested changing intermediate format to WebP with image2pipe. Experiment failed due to a pipeline crash. Code changes were discarded.
🎯 Why: To reduce IPC payload size and Node.js encoding overhead compared to JPEG/PNG.
📊 Impact: Crashed immediately (0.000s vs 15.594s baseline) due to FFmpeg unable to determine initial stream dimensions.
🔬 Verification: Tested via npx tsx packages/renderer/tests/fixtures/benchmark.ts.
📎 Plan: .sys/plans/PERF-535-webp-image2pipe.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	webp image2pipe format change

---
*PR created automatically by Jules for task [15193389160072392593](https://jules.google.com/task/15193389160072392593) started by @BintzGavin*