### PR TITLE
✨ RENDERER: [Discarded] Inline Stability Evaluate Exception check in CdpTimeDriver.ts

### DIFF
--- a/.sys/plans/PERF-536-inline-stability-evaluate.md
+++ b/.sys/plans/PERF-536-inline-stability-evaluate.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-536
 slug: inline-stability-evaluate
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-25
-completed: ""
-result: ""
+completed: "2026-05-17"
+result: "discarded"
 ---
 
 # PERF-536: Inline Stability Evaluate
@@ -72,3 +72,9 @@ Remove the `handleStabilityCheckResponse` method, and inline its exception check
 
 ## Correctness Check
 Run the benchmark script (`npx tsx packages/renderer/tests/fixtures/benchmark.ts`) to measure speedups. Then run the full test suite (`npm run test -w packages/renderer -- --run`) to verify correctness and ensure no functionality is broken.
+
+## Results Summary
+- **Best render time**: 17.328s (vs baseline ~15.594s)
+- **Improvement**: Regressed
+- **Kept experiments**: []
+- **Discarded experiments**: [Inline Stability Evaluate Exception check in CdpTimeDriver.ts]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -25,6 +25,10 @@ Last updated by: PERF-529
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-536**: Inline Stability Evaluate in CdpTimeDriver.ts
+  - **What I tried**: Attempted to reduce function call dispatch and variable assignment overhead by inlining the `handleStabilityCheckResponse` exception check logic directly into `runSetTime()`.
+  - **WHY it didn't work**: Render time regressed to a median of ~17.344s vs baseline ~15.594s. Inlining the error-checking logic inside the V8 hot loop likely caused negative deoptimization side effects, overriding the minuscule savings from avoiding function dispatch.
+  - **Outcome**: discard
 - **PERF-533**: Limit FFmpeg Threads to Reduce CPU Contention
   - **What I tried**: Added `-threads 1` to the FFmpeg builder arguments for video encoding in `FFmpegBuilder.ts` to limit thread contention with Chromium and Node on the CPU.
   - **WHY it didn't work**: The render time regressed to a median of ~17.431s (and as bad as ~26.641s in one run) compared to the baseline of ~15.594s. Limiting FFmpeg to a single thread likely introduced a bottleneck on the encoding side that backed up the pipeline, forcing Chromium workers to wait, which negatively offset any thread contention gains.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -91,3 +91,6 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 4	17.388	600	34.51	48.3	discard	remove --disable-breakpad
 5	18.451	600	32.52	44.1	discard	remove --disable-breakpad
 1	0.000	0	0.00	0.0	crash	webp image2pipe format change
+1	17.332	600	34.62	46.7	discard	inline stability check response evaluation
+2	17.328	600	34.63	37.4	discard	inline stability check response evaluation
+3	17.344	600	34.59	35.7	discard	inline stability check response evaluation


### PR DESCRIPTION
💡 **What**: Attempted to reduce function call dispatch and variable assignment overhead by inlining the `handleStabilityCheckResponse` exception check logic directly into `runSetTime()` in CdpTimeDriver.ts.

🎯 **Why**: To optimize the V8 hot loop performance by removing unnecessary closure and Promise chain allocations.

📊 **Impact**: The performance regressed heavily. The median render time increased to ~17.344s compared to the baseline ~15.594s. Inlining the error-checking logic inside the V8 hot loop likely caused negative deoptimization side effects, overriding the minuscule savings from avoiding function dispatch.

🔬 **Verification**:
- Output Validation passed (video outputs manually wiped for storage constraints).
- Benchmark Consistency: 3 runs, median result taken.
- Code changes reverted entirely back to original working state.
- Journal updated.

📎 **Plan**: `/.sys/plans/PERF-536-inline-stability-evaluate.md`

### Performance Results
```tsv
1	17.332	600	34.62	46.7	discard	inline stability check response evaluation
2	17.328	600	34.63	37.4	discard	inline stability check response evaluation
3	17.344	600	34.59	35.7	discard	inline stability check response evaluation
```

---
*PR created automatically by Jules for task [17548210937362774064](https://jules.google.com/task/17548210937362774064) started by @BintzGavin*