### PR TITLE
✨ RENDERER: Discard PERF-537 (Replace Runtime.evaluate with Runtime.callFunctionOn)

### DIFF
--- a/.sys/plans/PERF-537-cdptimedriver-callfunctionon.md
+++ b/.sys/plans/PERF-537-cdptimedriver-callfunctionon.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-537
 slug: cdptimedriver-callfunctionon
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-05-17
-completed: ""
-result: ""
+completed: 2026-05-18
+result: "discarded"
 ---
 
 # PERF-537: Replace Runtime.evaluate with Runtime.callFunctionOn in CdpTimeDriver
@@ -87,3 +87,9 @@ Change `defaultSyncMedia` implementation:
 
 ## Correctness Check
 Run the `npx tsx packages/renderer/tests/fixtures/benchmark.ts` script to test performance, followed by `npm run test -w packages/renderer -- --run` to verify correctness.
+
+## Results Summary
+- **Best render time**: 18.790s (vs baseline ~15.594s)
+- **Improvement**: Regressed
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-537]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -103,3 +103,7 @@ Last updated by: PERF-529
 - **Use WebP with image2pipe for Intermediate Formats** (PERF-535)
   - Tried changing the default intermediate screenshot format to `webp` and using the `image2pipe` FFmpeg demuxer (`-vcodec webp`).
   - **WHY it didn't work**: The benchmark immediately crashed with a pipeline error from FFmpeg: `Could not find codec parameters for stream 0 (Video: webp, none): unspecified size` and `Cannot determine format of input stream 0:0 after EOF`. FFmpeg's `image2pipe` parser natively failed to derive the dimensions of the initial incoming headless Chromium-produced base64-decoded WEBP frames, breaking the pipe before any valid video stream was initiated.
+- **PERF-537**: Replace Runtime.evaluate with Runtime.callFunctionOn in CdpTimeDriver
+  - **What I tried**: Attempted to replace `Runtime.evaluate` with `Runtime.callFunctionOn` in the `defaultSyncMedia` function of `CdpTimeDriver.ts`.
+  - **WHY it didn't work**: Render time regressed to a median of ~18.790s vs baseline ~15.594s. Passing arguments and executing pre-compiled static functions over CDP `callFunctionOn` caused more protocol serialization overhead than just concatenating the strings and executing them via `Runtime.evaluate`, negating the V8 re-parsing savings.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -95,3 +95,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 2	17.328	600	34.63	37.4	discard	inline stability check response evaluation
 3	17.344	600	34.59	35.7	discard	inline stability check response evaluation
 538	17.462	600	34.36	37.5	discard	PERF-538: Replace Runtime.evaluate with Runtime.callFunctionOn in CdpTimeDriver
+2	18.790	600	31.93	40.0	discard	CdpTimeDriver Runtime.callFunctionOn


### PR DESCRIPTION
✨ RENDERER: Discard PERF-537 (Replace Runtime.evaluate with Runtime.callFunctionOn)

💡 **What**: Replaced `Runtime.evaluate` with `Runtime.callFunctionOn` in the `defaultSyncMedia` function of `CdpTimeDriver.ts`.
🎯 **Why**: To test if passing arguments and executing a pre-compiled static function over CDP would eliminate V8 string parsing overhead during the frame capture loop.
📊 **Impact**: Render time regressed to a median of ~18.790s (vs baseline ~15.594s). The additional CDP protocol serialization overhead for `callFunctionOn` negated the V8 re-parsing savings.
🔬 **Verification**: Code reverted as the experiment degraded performance. Test changes omitted for discarded experiments. Results logged in `perf-results.tsv` and `RENDERER-EXPERIMENTS.md`.
📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-537-cdptimedriver-callfunctionon.md`)

```tsv
2	18.790	600	31.93	40.0	discard	CdpTimeDriver Runtime.callFunctionOn
```

---
*PR created automatically by Jules for task [10224989863484353921](https://jules.google.com/task/10224989863484353921) started by @BintzGavin*