### PR TITLE
✨ RENDERER: Disable Chromium Sandbox experiment (discarded)

### DIFF
--- a/.sys/plans/PERF-539-disable-chromium-sandbox.md
+++ b/.sys/plans/PERF-539-disable-chromium-sandbox.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-539
 slug: disable-chromium-sandbox
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-31
-completed: ""
-result: ""
+completed: 2025-02-13
+result: "no-improvement"
 ---
 
 # PERF-539: Disable Chromium Sandbox for IPC Efficiency
@@ -63,3 +63,9 @@ Run the DOM benchmark (`npx tsx packages/renderer/tests/fixtures/benchmark.ts`) 
 
 ## Prior Art
 - PERF-529 implemented `--process-per-tab`, which successfully optimized multi-core utilization by dedicating a renderer process to each tab. Disabling the sandbox optimizes those newly separated processes.
+
+## Results Summary
+- **Best render time**: 17.362s (vs baseline 17.137s)
+- **Improvement**: -1.3%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-539: Disable Chromium Sandbox]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -111,3 +111,7 @@ Last updated by: PERF-529
   - **What I tried**: Added `-threads 1` to the FFmpeg builder arguments for video encoding in `FFmpegBuilder.ts` to limit thread contention with Chromium and Node on the CPU.
   - **WHY it didn't work**: The render time regressed to a median of ~16.696s (and as bad as ~28.173s in one run) compared to the baseline of ~15.594s. Limiting FFmpeg to a single thread likely introduced a bottleneck on the encoding side that backed up the pipeline, forcing Chromium workers to wait, which negatively offset any thread contention gains.
   - **Outcome**: discard
+- **PERF-539**: Disable Chromium Sandbox
+  - **What I tried**: Added `--no-sandbox` and `--disable-setuid-sandbox` to the `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
+  - **WHY it didn't work**: The median render time did not improve over the baseline (~17.513s vs baseline ~17.175s). Although we disable process isolation in headless microVM, disabling the sandbox mechanisms directly does not decrease IPC overhead enough to speed up the high-frequency `beginFrame` capture loop.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-539.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-539.tsv
@@ -1,0 +1,9 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	17.175	600	34.93	37.5	keep	baseline
+2	17.137	600	35.01	46.6	keep	baseline
+3	17.383	600	34.52	37.1	keep	baseline
+4	18.104	600	33.14	37.8	keep	baseline
+5	17.362	600	34.56	41.2	discard	disable-sandbox
+6	17.716	600	33.87	43.7	discard	disable-sandbox
+7	17.513	600	34.26	36.8	discard	disable-sandbox
+8	17.615	600	34.06	44.7	discard	disable-sandbox


### PR DESCRIPTION
## Summary
Tested adding `--no-sandbox` and `--disable-setuid-sandbox` to the `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts` to reduce IPC overhead.

## Outcomes
The experiment was discarded due to a performance regression (median ~17.5s vs baseline ~17.1s). Disabling the sandbox mechanisms directly did not decrease IPC overhead enough to speed up the high-frequency `beginFrame` capture loop.

## Results
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	17.175	600	34.93	37.5	keep	baseline
2	17.137	600	35.01	46.6	keep	baseline
3	17.383	600	34.52	37.1	keep	baseline
4	18.104	600	33.14	37.8	keep	baseline
5	17.362	600	34.56	41.2	discard	disable-sandbox
6	17.716	600	33.87	43.7	discard	disable-sandbox
7	17.513	600	34.26	36.8	discard	disable-sandbox
8	17.615	600	34.06	44.7	discard	disable-sandbox
```

---
*PR created automatically by Jules for task [4874999045496328121](https://jules.google.com/task/4874999045496328121) started by @BintzGavin*