### PR TITLE
✨ RENDERER: Discard PERF-540 Eliminate Virtual Time Wait

### DIFF
--- a/.sys/plans/PERF-540-eliminate-virtual-time-wait.md
+++ b/.sys/plans/PERF-540-eliminate-virtual-time-wait.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-540
 slug: eliminate-virtual-time-wait
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-18
-completed: ""
-result: ""
+completed: 2024-05-18
+result: "discarded"
 ---
 
 # PERF-540: Eliminate Double Await for Virtual Time Policy in CDP Driver
@@ -59,3 +59,9 @@ Run a basic canvas render (`npm run test -w packages/renderer -- --run` if neces
 
 ## Correctness Check
 Run the DOM benchmark (`npx tsx packages/renderer/tests/fixtures/benchmark.ts`) and inspect the output video to verify animations still play correctly without freezing.
+
+## Results Summary
+- **Best render time**: 21.970s (vs baseline ~10.760s)
+- **Improvement**: Regressed
+- **Kept experiments**: []
+- **Discarded experiments**: [Eliminate Double Await for Virtual Time Policy]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -119,3 +119,7 @@ Last updated by: PERF-526
   - **What I tried**: Added `--no-sandbox` and `--disable-setuid-sandbox` to the `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
   - **WHY it didn't work**: The median render time did not improve over the baseline (~17.513s vs baseline ~17.175s). Although we disable process isolation in headless microVM, disabling the sandbox mechanisms directly does not decrease IPC overhead enough to speed up the high-frequency `beginFrame` capture loop.
   - **Outcome**: discard
+- **PERF-540**: Eliminate Double Await for Virtual Time Policy in CDP Driver
+  - **What I tried**: Replaced the double-wait promise architecture for advancing virtual time via CDP (`await new Promise(virtualTimePromiseExecutor)` and waiting for `Emulation.virtualTimeBudgetExpired`) with a simple `await this.client!.send('Emulation.setVirtualTimePolicy', ...).catch(() => {})`.
+  - **WHY it didn't work**: The performance regressed significantly. The median render time increased to ~21.970s compared to the baseline (~10.7s with dedicated instances). The `Emulation.virtualTimeBudgetExpired` event listener is functionally required by Chromium to ensure that the headless compositor has fully resolved the requested time budget and flushed frame paints before the pipeline can request a new `beginFrame`. Without the event listener wait, the time budget loop falls out of sync, severely degrading capture loop throughput or causing excessive frame stalling.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -106,3 +106,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 3	10.781	600	55.65	43.0	keep	dedicated browser instances (PERF-526)
 4	10.537	600	56.94	43.0	keep	dedicated browser instances (PERF-526)
 5	10.760	600	55.76	43.6	keep	dedicated browser instances (PERF-526)
+33	21.970	600	27.31	41.5	discard	eliminate-virtual-time-wait (PERF-540)


### PR DESCRIPTION
💡 **What**: Replaced the double-wait promise architecture for advancing virtual time via CDP with a simple direct await.
🎯 **Why**: To reduce unnecessary V8 Promise instantiations, event loop overhead, and function allocations in the tightest loop of the rendering pipeline (`runSetTime`).
📊 **Impact**: The performance regressed heavily. The median render time increased to 21.970s compared to the baseline ~10.760s.
🔬 **Verification**:
- Compilation: Passed
- Benchmark: 21.970s render time.
- Correctness Check: Failed/Regressed. The pipeline stalls severely without the event listener.
- The source files were fully reverted to their baseline state.
📎 **Plan**: `/.sys/plans/PERF-540-eliminate-virtual-time-wait.md`

33	21.970	600	27.31	41.5	discard	eliminate-virtual-time-wait (PERF-540)

---
*PR created automatically by Jules for task [1091267053083257477](https://jules.google.com/task/1091267053083257477) started by @BintzGavin*