### PR TITLE
📋 RENDERER: Remove --disable-dev-shm-usage Optimization

### DIFF
--- a/.sys/plans/PERF-542-disable-dev-shm-usage.md
+++ b/.sys/plans/PERF-542-disable-dev-shm-usage.md
@@ -1,0 +1,49 @@
+---
+id: PERF-542
+slug: disable-dev-shm-usage
+status: unclaimed
+claimed_by: ""
+created: 2024-05-18
+completed: ""
+result: ""
+---
+
+# PERF-542: Remove --disable-dev-shm-usage Optimization
+
+## Focus Area
+`packages/renderer/src/core/BrowserPool.ts` - Chromium launch arguments.
+
+## Background Research
+Currently, `--disable-dev-shm-usage` is included in `DEFAULT_BROWSER_ARGS`. This forces Chromium to use `/tmp` instead of `/dev/shm` for shared memory. While often recommended for Docker environments with limited `/dev/shm` size, `/tmp` can be significantly slower than RAM-backed `/dev/shm` for IPC. In our CPU-bound microVM, if `/dev/shm` is sufficiently large (which `df -h /dev/shm` shows is 3.9G), removing this flag might allow Chromium to use faster RAM-backed shared memory for IPC and buffer transfers, potentially improving frame capture throughput.
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark (Simple Animation)
+- **Render Settings**: 600 frames, mode dom
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~10.443s
+- **Bottleneck analysis**: IPC bottleneck between Chromium and Playwright.
+
+## Implementation Spec
+
+### Step 1: Remove dev-shm-usage argument
+**File**: `packages/renderer/src/core/BrowserPool.ts`
+**What to change**:
+Remove `--disable-dev-shm-usage` from the `DEFAULT_BROWSER_ARGS` array.
+**Why**: Allows Chromium to use faster `/dev/shm` shared memory instead of `/tmp`.
+**Risk**: If `/dev/shm` is too small in the VM, the browser might crash.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+None.
+
+## Correctness Check
+Run the DOM render benchmark script (`npx tsx packages/renderer/tests/fixtures/benchmark.ts`) to ensure it produces valid outputs without regressions.
+
+## Prior Art
+None.

--- a/.sys/plans/PERF-542-disable-gpu-memory-buffer.md
+++ b/.sys/plans/PERF-542-disable-gpu-memory-buffer.md
@@ -1,0 +1,49 @@
+---
+id: PERF-542
+slug: disable-gpu-memory-buffer
+status: unclaimed
+claimed_by: ""
+created: 2024-05-18
+completed: ""
+result: ""
+---
+
+# PERF-542: Disable GPU Memory Buffer Optimization
+
+## Focus Area
+`packages/renderer/src/core/BrowserPool.ts` - Chromium launch arguments.
+
+## Background Research
+By default, Chromium allocates shared memory buffers for GPU interaction even when running headlessly without a real GPU (especially on Linux VMs). In our CPU-only rendering pipeline, this can result in additional memory and CPU overhead for buffer creation, mapping, and teardown across renderer processes for every frame. Appending `--disable-gpu-memory-buffer-video-frames` and `--disable-gpu-memory-buffer-compositor-resources` forces Chromium to keep all resources in standard CPU RAM allocations.
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark (Simple Animation)
+- **Render Settings**: 600 frames, mode dom
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~10.443s
+- **Bottleneck analysis**: Unnecessary GPU abstraction layer memory management overhead on CPU-bound microVM.
+
+## Implementation Spec
+
+### Step 1: Append Memory Arguments
+**File**: `packages/renderer/src/core/BrowserPool.ts`
+**What to change**:
+Add `--disable-gpu-memory-buffer-video-frames` and `--disable-gpu-memory-buffer-compositor-resources` to the `GPU_DISABLED_ARGS` array.
+**Why**: Avoids setting up unnecessary GPU buffer mapping in our CPU-only context.
+**Risk**: Negligible. Chromium has stable CPU fallback paths when these are disabled.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+None.
+
+## Correctness Check
+Run the DOM render benchmark script (`npx tsx packages/renderer/tests/fixtures/benchmark.ts`) to ensure it produces valid outputs without regressions.
+
+## Prior Art
+None.


### PR DESCRIPTION
💡 What: Experiment to remove --disable-dev-shm-usage flag.
🎯 Why: Targets unnecessary IPC memory bottlenecks on a CPU microVM with sufficient /dev/shm, potentially improving capture time.
🔬 Approach: Remove flag from BrowserPool.ts.
📎 Plan: /.sys/plans/PERF-542-disable-dev-shm-usage.md

---
*PR created automatically by Jules for task [3275611682764045872](https://jules.google.com/task/3275611682764045872) started by @BintzGavin*