### PR TITLE
✨ RENDERER: In-Memory Frame Encoding Optimization

### DIFF
--- a/.sys/plans/PERF-541-single-process.md
+++ b/.sys/plans/PERF-541-single-process.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-541
 slug: single-process
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-18
-completed: ""
-result: ""
+completed: "2024-05-18"
+result: "keep"
 ---
 
 # PERF-541: In-Memory Frame Encoding Optimization

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,8 +1,11 @@
 ## Performance Trajectory
-Current best: 10.760s (baseline was 17.071s, -37%)
-Last updated by: PERF-526
+Current best: 10.046s (baseline was 10.760s, -7%)
+Last updated by: PERF-541
 
 ## What Works
+- **In-Memory Frame Encoding Optimization (PERF-541)**
+  - Replaced `--process-per-tab` with `--single-process` in `DEFAULT_BROWSER_ARGS` to eliminate Chromium's internal process-to-process IPC.
+  - Render time improved to ~10.046s from the ~10.760s baseline.
 - **Dedicated Browser Instances (PERF-526)**
   - **What I did**: Updated `BrowserPool.ts` to launch a dedicated Chromium browser instance per worker page instead of sharing a single browser context.
   - **How much it improved**: ~37% faster (median ~10.760s vs baseline ~17.071s).

--- a/packages/renderer/.sys/perf-results-PERF-541.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-541.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	22.859	600	26.25	41.9	keep	warmup
+2	10.046	600	59.72	45.0	keep	single-process flag
+3	10.007	600	59.96	43.2	keep	single-process flag

--- a/packages/renderer/src/core/BrowserPool.ts
+++ b/packages/renderer/src/core/BrowserPool.ts
@@ -22,7 +22,7 @@ const DEFAULT_BROWSER_ARGS = [
   '--allow-file-access-from-files',
   '--enable-begin-frame-control',
   '--run-all-compositor-stages-before-draw',
-  '--process-per-tab',
+  '--single-process',
   '--disable-features=PaintHolding,Translate,OptimizationHints,OptimizationGuideModelDownloading,CalculateNativeWinOcclusion',
   '--disable-lcd-text',
   '--disable-threaded-animation',


### PR DESCRIPTION
💡 **What**: Replaced `--process-per-tab` with `--single-process` in `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
🎯 **Why**: To completely eliminate Chromium's internal process-to-process IPC and shared memory brokering overhead in a dedicated worker environment.
📊 **Impact**: Render time improved to a median of ~10.046s from the ~10.760s baseline.
🔬 **Verification**: Ran the benchmark script 3 times. Validation passed via `ffprobe` (600 frames, 10.0s, h264).
📎 **Plan**: `/.sys/plans/PERF-541-single-process.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	22.859	600	26.25	41.9	keep	warmup
2	10.046	600	59.72	45.0	keep	single-process flag
3	10.007	600	59.96	43.2	keep	single-process flag
```

---
*PR created automatically by Jules for task [18262876592725696646](https://jules.google.com/task/18262876592725696646) started by @BintzGavin*