### PR TITLE
✨ RENDERER: [Discard] Raw CDP Screencast Experiment

### DIFF
--- a/.sys/plans/PERF-005-cdp-screencast.md
+++ b/.sys/plans/PERF-005-cdp-screencast.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-005
 slug: cdp-screencast
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2026-10-18
-completed: ""
-result: ""
+completed: "true"
+result: "discarded - regression"
 ---
 
 # PERF-005: Bypass Playwright Overhead with Raw CDP Screencast

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -108,6 +108,10 @@ Last updated by: PERF-541
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-005**: Raw CDP Screencast
+  - **What I tried**: Replaced `HeadlessExperimental.beginFrame` with `Page.startScreencast` in `DomStrategy.ts` to stream frames natively via CDP without compositor synchronization.
+  - **WHY it didn't work**: Severe performance regression and pipeline breakage (render time ~101s vs baseline ~18.5s). `Page.startScreencast` natively pushes frames inconsistently, dropping them when visual changes do not meet damage thresholds, which creates deadlock timeouts and truncates the FFmpeg `mjpeg` bitstream in our deterministic capture pipeline.
+  - **Outcome**: discard
 - **Use WebP with image2pipe for Intermediate Formats** (PERF-535)
   - Tried changing the default intermediate screenshot format to `webp` and using the `image2pipe` FFmpeg demuxer (`-vcodec webp`).
   - **WHY it didn't work**: The benchmark immediately crashed with a pipeline error from FFmpeg: `Could not find codec parameters for stream 0 (Video: webp, none): unspecified size` and `Cannot determine format of input stream 0:0 after EOF`. FFmpeg's `image2pipe` parser natively failed to derive the dimensions of the initial incoming headless Chromium-produced base64-decoded WEBP frames, breaking the pipe before any valid video stream was initiated.


### PR DESCRIPTION
💡 **What**: Evaluated replacing `HeadlessExperimental.beginFrame` with `Page.startScreencast` in `DomStrategy.ts` to stream frames natively via CDP without compositor synchronization.
🎯 **Why**: To bypass Playwright IPC overhead during the Frame Capture Loop.
📊 **Impact**: Severe performance regression and pipeline breakage (render time ~101s vs baseline ~18.5s). `Page.startScreencast` natively pushes frames inconsistently, dropping them when visual changes do not meet damage thresholds, which creates deadlock timeouts and truncates the FFmpeg `mjpeg` bitstream in our deterministic capture pipeline.
🔬 **Verification**: Ran the benchmark script (`tests/fixtures/benchmark.ts`), capturing outputs.
📎 **Plan**: `/.sys/plans/PERF-005-cdp-screencast.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	101.172	600	5.93	35.8	discard	PERF-005: Raw CDP Screencast
```

---
*PR created automatically by Jules for task [9463393767805225678](https://jules.google.com/task/9463393767805225678) started by @BintzGavin*