### PR TITLE
✨ RENDERER: Discard PERF-544 Remove try-catch blocks from hot loop in DomStrategy

### DIFF
--- a/.sys/plans/PERF-544-remove-try-catch-dom-strategy.md
+++ b/.sys/plans/PERF-544-remove-try-catch-dom-strategy.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-544
 slug: remove-try-catch-dom-strategy
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-18
-completed: ""
-result: ""
+completed: "2024-05-19"
+result: "discard"
 ---
 
 # PERF-544: Eliminate try-catch blocks from hot loop in DomStrategy
@@ -115,3 +115,9 @@ Run the DOM render benchmark script (`npx tsx packages/renderer/tests/fixtures/b
 
 ## Prior Art
 None.
+
+## Results Summary
+- **Best render time**: 10.440s (vs baseline 10.046s)
+- **Improvement**: 0% (Regression)
+- **Kept experiments**: []
+- **Discarded experiments**: [Remove try-catch blocks from hot loop in DomStrategy]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -32,6 +32,11 @@ Last updated by: PERF-541
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-544**: Remove try-catch blocks from hot loop in DomStrategy
+  - **What I tried**: Rewrote the `capture()` method in `DomStrategy.ts` so that the await uses a native promise chain with `.catch()` instead of setting up a `try...catch` scope on every frame.
+  - **WHY it didn't work**: The performance regressed or showed no clear improvement. The median render time was ~10.509s compared to the baseline ~10.046s. The V8 overhead of setting up a block scope to capture exceptions on every loop iteration is extremely small and chaining a promise `.catch()` likely introduces comparable or worse microtask scheduling overhead.
+  - **Outcome**: discard
+
 - **Removed `--disable-dev-shm-usage` from DEFAULT_BROWSER_ARGS**: Discarded. Removing this argument caused a slight performance regression (median ~10.950s vs baseline ~10.820s) instead of improving performance. While `/dev/shm` is faster, the flag's removal might lead Chromium to use IPC memory mechanisms that are less efficient for this specific microVM environment or workload. (PERF-543)
 - **PERF-538**: Replace Runtime.evaluate with Runtime.callFunctionOn
   - **What I tried**: Updated `CdpTimeDriver.ts` to use `Runtime.callFunctionOn` instead of `Runtime.evaluate` to synchronize media elements, which passes static function declarations with arguments to bypass V8 string parsing per frame.

--- a/packages/renderer/.sys/perf-results-PERF-544.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-544.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	10.509	600	57.09	43.6	discard	Remove try-catch blocks from hot loop in DomStrategy
+2	10.440	600	57.47	43.1	discard	Remove try-catch blocks from hot loop in DomStrategy
+3	10.805	600	55.53	42.6	discard	Remove try-catch blocks from hot loop in DomStrategy


### PR DESCRIPTION
💡 **What**: Tested replacing the `try...catch` block in `DomStrategy.capture()` with a promise chain `.catch()`. The change caused a performance regression, so it was discarded and the code was reverted.
🎯 **Why**: The experiment aimed to eliminate V8 overhead from setting up a block scope to capture exceptions on every loop iteration.
📊 **Impact**: The median render time regressed to ~10.440s compared to the baseline ~10.046s. The overhead of setting up a block scope to capture exceptions on every loop iteration is extremely small and chaining a promise `.catch()` likely introduces comparable or worse microtask scheduling overhead.
🔬 **Verification**:
- Dom strategy benchmarked
- Discarded experiment: all code modifications to `DomStrategy.ts` reverted
📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-544-remove-try-catch-dom-strategy.md`)

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	10.509	600	57.09	43.6	discard	Remove try-catch blocks from hot loop in DomStrategy
2	10.440	600	57.47	43.1	discard	Remove try-catch blocks from hot loop in DomStrategy
3	10.805	600	55.53	42.6	discard	Remove try-catch blocks from hot loop in DomStrategy
```

---
*PR created automatically by Jules for task [787292435154008122](https://jules.google.com/task/787292435154008122) started by @BintzGavin*