### PR TITLE
✨ RENDERER: Skip Media Sync CDP Call in CdpTimeDriver When No Media Exists

### DIFF
--- a/.sys/plans/PERF-449-cdptimedriver-skip-media-sync.md
+++ b/.sys/plans/PERF-449-cdptimedriver-skip-media-sync.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-449
 slug: cdptimedriver-skip-media-sync
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2026-05-06
-completed: ""
-result: ""
+completed: "2026-05-06"
+result: "improved"
 ---
 
 # PERF-449: Skip Media Sync CDP Call in CdpTimeDriver When No Media Exists
@@ -107,3 +107,8 @@ Run the `npm run test` suite for the renderer.
 
 ## Prior Art
 PERF-408: "Cache Media Elements in CdpTimeDriver to avoid per-frame DOM scans." (We are building upon this by extending the cache logic to the Node.js process).
+
+## Results Summary
+- **Outcome**: Kept
+- **Median Render Time**: 10.516s
+- **Baseline**: 10.640s

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -9,6 +9,10 @@ Last updated by: PERF-542
 - **In-Memory Frame Encoding Optimization (PERF-541)**
   - Replaced `--process-per-tab` with `--single-process` in `DEFAULT_BROWSER_ARGS` to eliminate Chromium's internal process-to-process IPC.
   - Render time improved to ~10.046s from the ~10.760s baseline.
+- **PERF-449**: Skip Media Sync CDP Call in CdpTimeDriver When No Media Exists
+  - **What I did**: Evaluated media presence during driver initialization and bypassed the `sync_media` CDP IPC call in the `runSetTime` hot loop if no media elements are present.
+  - **How much it improved**: ~1% faster (median ~10.516s vs baseline ~10.640s).
+  - **Plan ID**: PERF-449
 - **Dedicated Browser Instances (PERF-526)**
   - **What I did**: Updated `BrowserPool.ts` to launch a dedicated Chromium browser instance per worker page instead of sharing a single browser context.
   - **How much it improved**: ~37% faster (median ~10.760s vs baseline ~17.071s).

--- a/packages/renderer/.sys/perf-results-PERF-449.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-449.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	10.390	600	57.75	42.2	keep	Skip Media Sync CDP Call in CdpTimeDriver When No Media Exists
+2	10.516	600	57.06	42.7	keep	Skip Media Sync CDP Call in CdpTimeDriver When No Media Exists
+3	10.553	600	56.86	38.5	keep	Skip Media Sync CDP Call in CdpTimeDriver When No Media Exists

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -20,6 +20,7 @@ export class CdpTimeDriver implements TimeDriver {
   private multiFrameSyncMediaParams: any[] = [];
   private syncMediaState: number = 0; // 0 = unknown, 1 = true, 2 = false
   private stabilityCheckState: number = 0; // 0 = unknown, 1 = true, 2 = false
+  private hasMedia: boolean = true;
 
   private virtualTimePromiseExecutor = (resolve: () => void, reject: (err: Error) => void) => {
     this.cdpResolve = resolve;
@@ -151,6 +152,7 @@ export class CdpTimeDriver implements TimeDriver {
           for (let i = 0; i < numMedia; i++) {
             syncMedia(cachedMediaElements[i], t);
           }
+          return numMedia;
         };
 
         window.__helios_wait_until_stable = () => {
@@ -174,6 +176,24 @@ export class CdpTimeDriver implements TimeDriver {
     }
 
     this.cachedFrames = page.frames();
+
+    try {
+      this.hasMedia = false;
+      for (const frame of this.cachedFrames) {
+         const count = await frame.evaluate(() => {
+            if (typeof (window as any).__helios_sync_media === 'function') {
+               return (window as any).__helios_sync_media(0);
+            }
+            return 0;
+         });
+         if (count > 0) {
+            this.hasMedia = true;
+            break;
+         }
+      }
+    } catch (e) {
+      this.hasMedia = true;
+    }
 
     try {
       const { result } = await this.client!.send('Runtime.evaluate', {
@@ -228,7 +248,7 @@ export class CdpTimeDriver implements TimeDriver {
     const budget = delta * 1000;
 
 // 1. Synchronize media elements
-    if (this.syncMediaState === 1) {
+    if (this.syncMediaState === 1 && this.hasMedia) {
       this.defaultSyncMedia(timeInSeconds);
     }
 


### PR DESCRIPTION
💡 **What**: The experiment run and its outcome
Evaluated media presence during driver initialization and bypassed the `sync_media` CDP IPC call in the `runSetTime` hot loop if no media elements are present.

🎯 **Why**: The performance bottleneck targeted
Most compositions do not contain `<video>` or `<audio>` elements. Bypassing the CDP IPC call reduces overhead and V8 string parsing on every frame.

📊 **Impact**: Before/after render times and percentage improvement
Render time improved to ~10.516s from the ~10.640s baseline (~1% faster).

🔬 **Verification**: What was tested (4-gate verification, benchmark results)
- Compilation: Passed
- Test Suite: Passed
- Output Validation: Passed
- Benchmark Consistency: Passed (Median of 3 runs)

📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-NNN-slug.md`)
`/.sys/plans/PERF-449-cdptimedriver-skip-media-sync.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 10.390 | 600 | 57.75 | 42.2 | keep | Skip Media Sync CDP Call in CdpTimeDriver When No Media Exists |
| 2 | 10.516 | 600 | 57.06 | 42.7 | keep | Skip Media Sync CDP Call in CdpTimeDriver When No Media Exists |
| 3 | 10.553 | 600 | 56.86 | 38.5 | keep | Skip Media Sync CDP Call in CdpTimeDriver When No Media Exists |

---
*PR created automatically by Jules for task [18308809584853195874](https://jules.google.com/task/18308809584853195874) started by @BintzGavin*