### PR TITLE
✨ RENDERER: Discard increase maxPipelineDepth buffer

### DIFF
--- a/.sys/plans/PERF-524-increase-max-pipeline-depth.md
+++ b/.sys/plans/PERF-524-increase-max-pipeline-depth.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-524
 slug: increase-max-pipeline-depth
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-30
-completed: ""
-result: ""
+completed: "2024-05-30"
+result: "failed"
 ---
 
 # PERF-524: Increase CaptureLoop maxPipelineDepth
@@ -63,3 +63,9 @@ Run the DOM benchmark and inspect `output.mp4` to verify that all 600 frames wer
 ## Prior Art
 - PERF-498 (restored FFmpeg backpressure to fix OOM on long renders, but introduced tight coupling)
 - PERF-484 (unclaimed scratchpad plan that hypothesized this exact fix)
+
+## Results Summary
+- **Best render time**: 10.107s (vs baseline ~10.046s)
+- **Improvement**: -0.6%
+- **Kept experiments**: []
+- **Discarded experiments**: [Increase maxPipelineDepth buffer multiplier to 64]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -151,3 +151,7 @@ Last updated by: PERF-542
   - **What I tried**: Replaced the double-wait promise architecture for advancing virtual time via CDP (`await new Promise(virtualTimePromiseExecutor)` and waiting for `Emulation.virtualTimeBudgetExpired`) with a simple `await this.client!.send('Emulation.setVirtualTimePolicy', ...).catch(() => {})`.
   - **WHY it didn't work**: The performance regressed significantly. The median render time increased to ~21.970s compared to the baseline (~10.7s with dedicated instances). The `Emulation.virtualTimeBudgetExpired` event listener is functionally required by Chromium to ensure that the headless compositor has fully resolved the requested time budget and flushed frame paints before the pipeline can request a new `beginFrame`. Without the event listener wait, the time budget loop falls out of sync, severely degrading capture loop throughput or causing excessive frame stalling.
   - **Outcome**: discard
+- **PERF-524**: Increase CaptureLoop maxPipelineDepth Buffer
+  - **What I tried**: Increased the `maxPipelineDepth` buffer multiplier in `CaptureLoop.ts` from `8` to `64`.
+  - **WHY it didn't work**: The performance regressed or showed no meaningful improvement. The median render time was ~10.107s, which is slightly worse than the baseline ~10.046s. Deepening the backpressure ring buffer likely increased memory overhead or V8 GC pressure without significantly improving throughput in this environment.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-524.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-524.tsv
@@ -1,0 +1,6 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	10.257	600	58.50	44.7	discard	Increase maxPipelineDepth buffer multiplier to 64
+2	9.940	600	60.36	39.8	discard	Increase maxPipelineDepth buffer multiplier to 64
+3	10.006	600	59.96	46.1	discard	Increase maxPipelineDepth buffer multiplier to 64
+4	10.107	600	59.37	47.3	discard	Increase maxPipelineDepth buffer multiplier to 64
+5	10.131	600	59.23	46.8	discard	Increase maxPipelineDepth buffer multiplier to 64


### PR DESCRIPTION
💡 **What**: Tested increasing the `maxPipelineDepth` buffer multiplier in `CaptureLoop.ts` from 8 to 64. Discarded the experiment because performance regressed/remained similar.
🎯 **Why**: To prevent orchestrator stalls caused by FFmpeg micro-stalls waiting on OS disk I/O, allowing Chromium to run unblocked.
📊 **Impact**: The median render time was ~10.107s, which is slightly worse than the baseline ~10.046s. Memory overhead or V8 GC pressure likely increased, offsetting any benefits.
🔬 **Verification**: Code compiles, DOM benchmark results logged, changes successfully reverted.
📎 **Plan**: `/.sys/plans/PERF-524-increase-max-pipeline-depth.md`

### Results
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	10.257	600	58.50	44.7	discard	Increase maxPipelineDepth buffer multiplier to 64
2	9.940	600	60.36	39.8	discard	Increase maxPipelineDepth buffer multiplier to 64
3	10.006	600	59.96	46.1	discard	Increase maxPipelineDepth buffer multiplier to 64
4	10.107	600	59.37	47.3	discard	Increase maxPipelineDepth buffer multiplier to 64
5	10.131	600	59.23	46.8	discard	Increase maxPipelineDepth buffer multiplier to 64
```

---
*PR created automatically by Jules for task [7490389341369215061](https://jules.google.com/task/7490389341369215061) started by @BintzGavin*