### PR TITLE
✨ RENDERER: Disable Skia Wait and Color Profile Overheads

### DIFF
--- a/.sys/plans/PERF-547-disable-skia-optimizations.md
+++ b/.sys/plans/PERF-547-disable-skia-optimizations.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-547
 slug: disable-skia-optimizations
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2024-05-19
-completed: ""
-result: ""
+completed: 2024-05-19
+result: failed
 ---
 
 # PERF-547: Disable Skia Wait and Color Profile Overheads
@@ -44,3 +44,9 @@ Complete pre-commit steps to ensure proper testing, verification, review, and re
 
 ### Step 4: Submit change
 Submit the plan via PR.
+
+## Results Summary
+- **Best render time**: 10.306s (vs baseline 10.002s)
+- **Improvement**: -3.0%
+- **Kept experiments**:
+- **Discarded experiments**: added disable-color-correct-rendering and disable-skia-runtime-opts

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -109,6 +109,10 @@ Last updated by: PERF-542
 - Plan ID: PERF-518
 
 ## What Doesn't Work (and Why)
+- **PERF-547**: Disable Skia Wait and Color Profile Overheads
+  - **What I tried**: Added `--disable-color-correct-rendering` and `--disable-skia-runtime-opts` to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
+  - **WHY it didn't work**: The performance degraded (median ~10.306s vs baseline ~10.002s). Disabling these runtime optimizations likely interfered with Chromium's internal rendering assumptions for the headless software rasterizer, introducing more overhead than they saved.
+  - **Outcome**: discard
 - **PERF-545**: Disable GPU Memory Buffer Optimization
   - **What I tried**: Added `--disable-gpu-memory-buffer-video-frames` and `--disable-gpu-memory-buffer-compositor-resources` to `GPU_DISABLED_ARGS` in `BrowserPool.ts`.
   - **WHY it didn't work**: The performance degraded (median ~10.977s vs baseline ~10.046s). Forcing Chromium to disable GPU memory buffers likely interfered with some internal optimization or hardware abstraction layer paths, negating the expected CPU-memory allocation benefits.

--- a/packages/renderer/.sys/perf-results-PERF-547.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-547.tsv
@@ -1,0 +1,4 @@
+1	10.309	600	58.20	54.5	discard	disable skia and color correct rendering
+2	10.222	600	58.70	45.9	discard	disable skia and color correct rendering
+3	10.317	600	58.15	43.5	discard	disable skia and color correct rendering
+4	10.304	600	58.23	43.6	discard	disable skia and color correct rendering


### PR DESCRIPTION
✨ RENDERER: Disable Skia Wait and Color Profile Overheads (PERF-547)

💡 **What**: Tested adding `--disable-color-correct-rendering` and `--disable-skia-runtime-opts` to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`. The changes degraded performance and were discarded.
🎯 **Why**: To reduce CPU overhead within the headless Chromium compositor and Skia graphics layer during high-frequency screenshot generation by preventing Skia from performing color profile conversions and disabling dynamic runtime optimizations.
📊 **Impact**: The performance degraded to a median render time of ~10.306s (vs baseline ~10.002s). Disabling these runtime optimizations likely interfered with Chromium's internal rendering assumptions for the headless software rasterizer, introducing more overhead than they saved.
🔬 **Verification**:
- Compilation: Passed.
- Benchmark: Ran 5 times, discarded outlier. Median of ~10.306s.
- Output Validation: Skipped as experiment was discarded.
- Canvas Smoke: Skipped as experiment was discarded.
- Test Suite: Skipped as experiment was discarded.
📎 **Plan**: `/.sys/plans/PERF-547-disable-skia-optimizations.md`

TSV Results:
```
1	10.309	600	58.20	54.5	discard	disable skia and color correct rendering
2	10.222	600	58.70	45.9	discard	disable skia and color correct rendering
3	10.317	600	58.15	43.5	discard	disable skia and color correct rendering
4	10.304	600	58.23	43.6	discard	disable skia and color correct rendering
```

---
*PR created automatically by Jules for task [9212417739129623542](https://jules.google.com/task/9212417739129623542) started by @BintzGavin*