### PR TITLE
📋 PLAYER: Document Missing Events in README

### DIFF
--- a/.sys/plans/2026-12-30-PLAYER-README-Events-Update.md
+++ b/.sys/plans/2026-12-30-PLAYER-README-Events-Update.md
@@ -1,0 +1,24 @@
+#### 1. Context & Goal
+- **Objective**: Document the `seeking`, `seeked`, and `error` events in the `README.md`.
+- **Trigger**: Discovered that `seeking`, `seeked`, and `error` events are implemented in `packages/player/src/index.ts` and dispatch events, but are missing from the `packages/player/README.md` list of events.
+- **Impact**: Provides complete and accurate documentation of the `HeliosPlayer` Web Component's events, which is crucial for developers integrating the player.
+
+#### 2. File Inventory
+- **Create**: [None]
+- **Modify**: `packages/player/README.md` - Add the missing events to the Events section.
+- **Read-Only**: `packages/player/src/index.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Update Markdown documentation to match the implemented `HeliosPlayer` Web Component events.
+- **Pseudo-Code**:
+  - Edit `packages/player/README.md`.
+  - Add `- \`seeking\`: Fired when a seek operation begins.` to the "Events" section.
+  - Add `- \`seeked\`: Fired when a seek operation completes.` to the "Events" section.
+  - Add `- \`error\`: Fired when an error occurs.` to the "Events" section.
+- **Public API Changes**: None (documentation only).
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `grep -E "\- \`seeking\`|\- \`seeked\`|\- \`error\`" packages/player/README.md`
+- **Success Criteria**: The output should contain the newly added event descriptions.
+- **Edge Cases**: Ensure the events are added to the correct list and formatting matches the existing document.


### PR DESCRIPTION
Created a plan to document the `seeking`, `seeked`, and `error` events in the `README.md` for the `HeliosPlayer` Web Component. These events are properly dispatched in `index.ts` but were not listed in the public API documentation.

---
*PR created automatically by Jules for task [12120124256353014159](https://jules.google.com/task/12120124256353014159) started by @BintzGavin*