### PR TITLE
✨ RENDERER: Document failed PERF-516 raw CDP evaluate experiment

### DIFF
--- a/.sys/plans/PERF-516-raw-cdp-evaluate.md
+++ b/.sys/plans/PERF-516-raw-cdp-evaluate.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-516
 slug: raw-cdp-evaluate
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2024-05-16
-completed: ""
-result: ""
+completed: 2024-05-16
+result: failed
 ---
 
 # PERF-516: Bypass Playwright Evaluate
@@ -50,3 +50,9 @@ Complete pre commit steps to make sure proper testing, verifications, reviews an
 
 ### Step 4: Submit change
 Submit change, PR creation.
+
+## Results Summary
+- **Best render time**: 11.414s (vs baseline ~10.046s)
+- **Improvement**: -13.6%
+- **Kept experiments**:
+- **Discarded experiments**: Replaced `frame.evaluate` with a raw `Runtime.evaluate` in `CdpTimeDriver.ts`.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -109,6 +109,10 @@ Last updated by: PERF-542
 - Plan ID: PERF-518
 
 ## What Doesn't Work (and Why)
+- **PERF-516**: Bypass Playwright Evaluate
+  - **What I tried**: Replaced `await frame.evaluate(...)` with a raw CDP `Runtime.evaluate` in `CdpTimeDriver.ts` to check if a page has media before running media synchronization.
+  - **WHY it didn't work**: Performance regressed to ~11.414s compared to the baseline of ~10.046s. This one-time evaluation happens during page initialization/setup, not in the hot loop (unlike `defaultSyncMedia` which was already optimized). Inlining this single check offered no measurable improvement in the hot loop, but likely suffered from slightly less optimized Playwright setup code paths.
+  - **Outcome**: discard
 - **PERF-547**: Disable Skia Wait and Color Profile Overheads
   - **What I tried**: Added `--disable-color-correct-rendering` and `--disable-skia-runtime-opts` to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
   - **WHY it didn't work**: The performance degraded (median ~10.306s vs baseline ~10.002s). Disabling these runtime optimizations likely interfered with Chromium's internal rendering assumptions for the headless software rasterizer, introducing more overhead than they saved.


### PR DESCRIPTION
💡 **What**: Executed and documented PERF-516, which attempted to replace `await frame.evaluate(...)` with a raw CDP `Runtime.evaluate` in `CdpTimeDriver.ts` to bypass Playwright IPC overhead.
🎯 **Why**: To reduce Playwright evaluation wrapper overhead when checking for the presence of media elements during page initialization.
📊 **Impact**: The performance regressed to ~11.414s compared to the baseline of ~10.046s. This one-time evaluation happens during page setup, not in the hot loop, so inlining it offered no measurable improvement and likely suffered from less optimized Playwright setup code paths.
🔬 **Verification**: 
- Benchmarked 5 runs (medians: 22.8, 13.2, 11.4, 10.8, 10.9)
- Run code fully reverted. Only `.sys/plans/PERF-516-raw-cdp-evaluate.md` and `docs/status/RENDERER-EXPERIMENTS.md` are committed.
📎 **Plan**: `/.sys/plans/PERF-516-raw-cdp-evaluate.md`

### Results Summary
```
render_time_s:      11.414
total_frames:       600
fps_effective:      52.57
peak_mem_mb:        54.0
```

---
*PR created automatically by Jules for task [4346852185555043347](https://jules.google.com/task/4346852185555043347) started by @BintzGavin*