### PR TITLE
📋 RENDERER: Document failed PERF-548 remove synchronous threading flags experiment

### DIFF
--- a/.sys/plans/PERF-548-remove-synchronous-threading-flags.md
+++ b/.sys/plans/PERF-548-remove-synchronous-threading-flags.md
@@ -1,0 +1,63 @@
+---
+id: PERF-548
+slug: remove-synchronous-threading-flags
+status: unclaimed
+claimed_by: ""
+created: 2024-05-19
+completed: ""
+result: ""
+---
+
+# PERF-548: Remove Synchronous Threading Flags in Single-Process Mode
+
+## Focus Area
+`packages/renderer/src/core/BrowserPool.ts` - Chromium launch arguments.
+
+## Background Research
+Currently, `DEFAULT_BROWSER_ARGS` includes a block of flags (`--disable-threaded-animation`, `--disable-threaded-scrolling`, `--disable-checker-imaging`, `--disable-image-animation-resync`, `--disable-smooth-scrolling`) that force Chromium to execute animations, scrolling, and image decoding synchronously on the main thread.
+
+Historically, this was used to improve determinism or reduce IPC overhead in multi-process headless mode. However, in our new `--single-process` architecture (PERF-541), forcing everything onto the single main thread creates a bottleneck. By removing these flags, Chromium can utilize its internal threading model to offload animations and image decoding to background threads within the single process, taking advantage of multi-core availability in the microVM.
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark (Simple Animation)
+- **Render Settings**: 600 frames, mode dom
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~10.002s
+- **Bottleneck analysis**: The single main thread in `--single-process` mode handles all V8 execution, layout, and rendering synchronously, leaving other CPU cores underutilized.
+
+## Implementation Spec
+
+### Step 1: Remove Synchronous Threading Flags
+**File**: `packages/renderer/src/core/BrowserPool.ts`
+**What to change**:
+Remove the following flags from the `DEFAULT_BROWSER_ARGS` array:
+- `'--disable-threaded-animation'`
+- `'--disable-threaded-scrolling'`
+- `'--disable-checker-imaging'`
+- `'--disable-image-animation-resync'`
+- `'--disable-smooth-scrolling'`
+
+**Why**: Allows the single Chromium process to offload animation computation and image decoding to background threads, relieving the main V8 thread and improving multi-core utilization.
+**Risk**: Might introduce non-determinism if the compositor doesn't wait for these threads, though the `--run-all-compositor-stages-before-draw` flag should safeguard against this by ensuring the compositor waits for all stages before capturing the frame.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run `npm run test -w packages/renderer -- --run` to ensure the Canvas path still works and tests pass.
+
+## Correctness Check
+Run the full test suite (`npm run test -w packages/renderer -- --run`) to verify that removing these flags does not break deterministic rendering or cause frame synchronization regressions.
+
+## Prior Art
+- PERF-541: In-Memory Frame Encoding Optimization (`--single-process`) which made the process single-threaded from an OS perspective, increasing the value of internal thread utilization.
+
+## Results Summary
+- **Best render time**: 10.676s (vs baseline ~10.002s)
+- **Improvement**: -6.7% (Regression)
+- **Kept experiments**: []
+- **Discarded experiments**: [Step 1: Remove Synchronous Threading Flags]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -163,3 +163,7 @@ Last updated by: PERF-542
   - **What I tried**: Increased the `maxPipelineDepth` buffer multiplier in `CaptureLoop.ts` from `8` to `64`.
   - **WHY it didn't work**: The performance regressed or showed no meaningful improvement. The median render time was ~10.107s, which is slightly worse than the baseline ~10.046s. Deepening the backpressure ring buffer likely increased memory overhead or V8 GC pressure without significantly improving throughput in this environment.
   - **Outcome**: discard
+- **PERF-548**: Remove Synchronous Threading Flags in Single-Process Mode
+  - **What I tried**: Removed `--disable-threaded-animation`, `--disable-threaded-scrolling`, `--disable-checker-imaging`, `--disable-image-animation-resync`, and `--disable-smooth-scrolling` from the `DEFAULT_BROWSER_ARGS` array in `BrowserPool.ts`.
+  - **WHY it didn't work**: The median render time degraded to ~10.676s vs the baseline of ~10.002s. While `--single-process` makes the browser conceptually single-threaded, these flags actually force deterministic execution of rendering operations within the main frame loop. Removing them allows Chromium to try offloading work to threads it doesn't have in this context, or breaks the synchronous pipeline expected by the deterministic `beginFrame` capture loop, leading to wait timeouts or stalls.
+  - **Outcome**: discard


### PR DESCRIPTION
Document the failed experiment of removing synchronous threading flags in single-process mode, which resulted in a regression.

---
*PR created automatically by Jules for task [236067417258968706](https://jules.google.com/task/236067417258968706) started by @BintzGavin*