### PR TITLE
✨ RENDERER: Discard PERF-514 (Optimize BrowserPool Concurrency Formula)

### DIFF
--- a/.sys/plans/PERF-514-optimize-browserpool-concurrency.md
+++ b/.sys/plans/PERF-514-optimize-browserpool-concurrency.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-514
 slug: optimize-browserpool-concurrency
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-16
-completed: ""
-result: ""
+completed: 2024-05-16
+result: "discard"
 ---
 
 # PERF-514: Optimize BrowserPool Concurrency Formula
@@ -40,3 +40,9 @@ Run a basic canvas render (`mode: 'canvas'`) to ensure the browser argument chan
 
 ## Correctness Check
 Verify the rendered output video to ensure the parallel frame captures are still ordered and visually correct.
+
+## Results Summary
+- **Best render time**: ~25.049s (vs baseline ~10.002s)
+- **Improvement**: -150% (Regression)
+- **Kept experiments**: []
+- **Discarded experiments**: [Step 1: Change Concurrency Formula to 2]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -39,6 +39,10 @@ Last updated by: PERF-542
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-514**: Optimize BrowserPool Concurrency Formula
+  - **What I tried**: Changed the concurrency calculation in `BrowserPool.ts` from `Math.max(1, (os.cpus().length || 4) - 1)` to a hardcoded `2`.
+  - **WHY it didn't work**: The median render time significantly degraded to ~25.049s compared to the baseline of ~10.002s. By lowering the concurrency from the dynamically calculated 3 down to 2, the total capture throughput dropped. It appears the CPU still benefits from having at least 3 active workers generating frames simultaneously even if they are in the same or separate processes.
+  - **Outcome**: discard
 - **PERF-544**: Remove try-catch blocks from hot loop in DomStrategy
   - **What I tried**: Rewrote the `capture()` method in `DomStrategy.ts` so that the await uses a native promise chain with `.catch()` instead of setting up a `try...catch` scope on every frame.
   - **WHY it didn't work**: The performance regressed or showed no clear improvement. The median render time was ~10.509s compared to the baseline ~10.046s. The V8 overhead of setting up a block scope to capture exceptions on every loop iteration is extremely small and chaining a promise `.catch()` likely introduces comparable or worse microtask scheduling overhead.

--- a/packages/renderer/.sys/perf-results-PERF-514.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-514.tsv
@@ -1,0 +1,1 @@
+1	25.049	600	23.95	39.9	discard	Change concurrency to 2 in BrowserPool.ts


### PR DESCRIPTION
✨ RENDERER: Discard PERF-514 (Optimize BrowserPool Concurrency Formula)

💡 **What**: Tested changing the concurrency calculation in `BrowserPool.ts` from `Math.max(1, (os.cpus().length || 4) - 1)` to a hardcoded `2`. The change was discarded due to poor performance.
🎯 **Why**: To see if lowering the concurrency in single-process mode reduced thread contention within Chromium's main thread enough to speed up rendering.
📊 **Impact**: The median render time significantly degraded to ~25.049s compared to the baseline of ~10.002s. By lowering the concurrency from the dynamically calculated 3 down to 2, the total capture throughput dropped. It appears the CPU still benefits from having at least 3 active workers generating frames simultaneously even if they are in the same or separate processes.
🔬 **Verification**: Ran `benchmark.ts` which produced a ~25s render time, then reverted the code changes and verified with `git diff`.
📎 **Plan**: Reference `.sys/plans/PERF-514-optimize-browserpool-concurrency.md`

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	25.049	600	23.95	39.9	discard	Change concurrency to 2 in BrowserPool.ts

---
*PR created automatically by Jules for task [3500931905382506501](https://jules.google.com/task/3500931905382506501) started by @BintzGavin*