### PR TITLE
✨ RENDERER: Disable Chromium Logging (Discarded)

### DIFF
--- a/.sys/plans/PERF-551-disable-logging.md
+++ b/.sys/plans/PERF-551-disable-logging.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-551
 slug: disable-logging
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2026-05-20
-completed: ""
-result: ""
+completed: "2026-05-20"
+result: "no-improvement"
 ---
 
 # PERF-551: Disable Chromium Logging
@@ -49,3 +49,9 @@ Run `npm run test -w packages/renderer -- --run` to ensure DOM output is still c
 
 ## Prior Art
 PERF-542 successfully removed `--disable-dev-shm-usage` to reduce IPC overhead. Eliminating logging I/O is a similar strategy targeting communication overhead between Chromium and Node.js.
+
+## Results Summary
+- **Best render time**: 9.787s (vs baseline 9.908s) / Median: 10.148s (vs baseline 9.958s)
+- **Improvement**: ~-1.9%
+- **Kept experiments**: None
+- **Discarded experiments**: Added `--disable-logging` and `--log-level=3` to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -183,3 +183,7 @@ Last updated by: PERF-542
   - **What I tried**: Attempted to replace the pre-allocated `singleFrameSyncMediaParams` object mutation with fresh inline object literals in the `defaultSyncMedia` function of `CdpTimeDriver.ts`.
   - **WHY it didn't work**: The performance regressed significantly. The median render time increased to ~14.046s compared to the baseline ~10.002s. In the extremely hot frame loop, rapidly allocating fresh object literals for every single frame and relying on the V8 nursery for garbage collection introduced more overhead (likely due to GC pauses or un-optimized object shapes) than simply mutating a pre-allocated object whose hidden classes were already stabilized.
   - **Outcome**: discard
+- **PERF-551**: Disable Chromium Logging
+  - **What I tried**: Added `--disable-logging` and `--log-level=3` to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
+  - **WHY it didn't work**: The median render time did not improve meaningfully (median ~10.148s vs baseline ~9.958s). Suppressing the internal logs in headless mode does not significantly decrease IPC or CPU overhead, likely because the headless Chromium instance does not produce enough background logs in a deterministic environment to cause measurable pipeline latency. The benefits of hiding output do not outweigh the cost to debuggability.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-551.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-551.tsv
@@ -1,0 +1,11 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	20.398	600	29.41	48.2	keep	baseline
+2	12.219	600	49.11	43.3	keep	baseline
+3	10.043	600	59.74	41.8	keep	baseline
+4	9.958	600	60.25	43.2	keep	baseline
+5	9.908	600	60.56	43.9	keep	baseline
+6	12.433	600	48.26	43.7	discard	experiment
+7	10.148	600	59.13	46.3	discard	experiment
+8	11.841	600	50.67	44.9	discard	experiment
+9	9.937	600	60.38	43.0	discard	experiment
+10	9.787	600	61.30	51.8	discard	experiment


### PR DESCRIPTION
✨ RENDERER: Disable Chromium Logging (Discarded)

💡 **What**: The experiment run and its outcome
Added `--disable-logging` and `--log-level=3` to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.

🎯 **Why**: The performance bottleneck targeted
To attempt eliminating string formatting and stderr IPC overhead for Chromium's internal background logging mechanisms in the microVM.

📊 **Impact**: Before/after render times and percentage improvement
The median render time did not improve meaningfully (median ~10.148s vs baseline ~9.958s). Suppressing the internal logs in headless mode does not significantly decrease IPC or CPU overhead, likely because the headless Chromium instance does not produce enough background logs in a deterministic environment to cause measurable pipeline latency. The benefits of hiding output do not outweigh the cost to debuggability.

🔬 **Verification**: What was tested (4-gate verification, benchmark results)
Ran the standard dom benchmark 5 times. Reverted the codebase since performance didn't improve.

📎 **Plan**: Reference the plan file
`/.sys/plans/PERF-551-disable-logging.md`

Results:
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	20.398	600	29.41	48.2	keep	baseline
2	12.219	600	49.11	43.3	keep	baseline
3	10.043	600	59.74	41.8	keep	baseline
4	9.958	600	60.25	43.2	keep	baseline
5	9.908	600	60.56	43.9	keep	baseline
6	12.433	600	48.26	43.7	discard	experiment
7	10.148	600	59.13	46.3	discard	experiment
8	11.841	600	50.67	44.9	discard	experiment
9	9.937	600	60.38	43.0	discard	experiment
10	9.787	600	61.30	51.8	discard	experiment
```

---
*PR created automatically by Jules for task [16448651085548925076](https://jules.google.com/task/16448651085548925076) started by @BintzGavin*