### PR TITLE
✨ RENDERER: Discard PERF-552 (Inline multiFrameSyncMediaParams)

### DIFF
--- a/.sys/perf-results-PERF-552.tsv
+++ b/.sys/perf-results-PERF-552.tsv
@@ -1,0 +1,6 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	10.190	600	58.88	43.2	discard	inline multiFrameSyncMediaParams
+2	9.994	600	60.04	47.7	discard	inline multiFrameSyncMediaParams
+3	9.839	600	60.98	43.5	discard	inline multiFrameSyncMediaParams
+4	9.955	600	60.27	44.2	discard	inline multiFrameSyncMediaParams
+5	9.489	600	63.23	44.5	discard	inline multiFrameSyncMediaParams

--- a/.sys/plans/PERF-552-inline-multi-frame-sync-media-params.md
+++ b/.sys/plans/PERF-552-inline-multi-frame-sync-media-params.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-552
 slug: inline-multi-frame-sync-media-params
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-05-20
-completed: ""
-result: ""
+completed: "2026-05-20"
+result: "discard"
 ---
 
 # PERF-552: Inline `multiFrameSyncMediaParams` allocation
@@ -80,3 +80,13 @@ Run `npm run test -w packages/renderer -- --run` to ensure DOM output is still c
 
 ## Prior Art
 PERF-550 attempted to inline `singleFrameSyncMediaParams` and was discarded because it caused a regression. This experiment tests if the multi-frame array mutation logic suffers from different overhead characteristics where inlining might be beneficial.
+
+## Results Summary
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	10.190	600	58.88	43.2	discard	inline multiFrameSyncMediaParams
+2	9.994	600	60.04	47.7	discard	inline multiFrameSyncMediaParams
+3	9.839	600	60.98	43.5	discard	inline multiFrameSyncMediaParams
+4	9.955	600	60.27	44.2	discard	inline multiFrameSyncMediaParams
+5	9.489	600	63.23	44.5	discard	inline multiFrameSyncMediaParams
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -187,3 +187,7 @@ Last updated by: PERF-542
   - **What I tried**: Added `--disable-logging` and `--log-level=3` to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
   - **WHY it didn't work**: The median render time did not improve meaningfully (median ~10.148s vs baseline ~9.958s). Suppressing the internal logs in headless mode does not significantly decrease IPC or CPU overhead, likely because the headless Chromium instance does not produce enough background logs in a deterministic environment to cause measurable pipeline latency. The benefits of hiding output do not outweigh the cost to debuggability.
   - **Outcome**: discard
+- **PERF-552**: Inline multiFrameSyncMediaParams allocation
+  - **What I tried**: Replaced the `multiFrameSyncMediaParams` array allocation and object mutation logic in `CdpTimeDriver.ts` with direct inline object literal allocations sent to `Runtime.evaluate` in the hot loop.
+  - **WHY it didn't work**: The median render time (~9.955s) did not significantly improve over the baseline (~10.002s). Any minor optimization from avoiding array management was offset or negated by V8 having to rapidly allocate and garbage-collect new inline object literals on every frame loop instead of mutating a pre-allocated structure.
+  - **Outcome**: discard


### PR DESCRIPTION
💡 **What**: Tested replacing `multiFrameSyncMediaParams` array allocation and mutation with direct inline object literal allocations sent to `Runtime.evaluate` in the hot loop.
🎯 **Why**: To bypass array management overhead and see if V8 optimizes inline literals better than an array of mutated objects for multi-frame syncing.
📊 **Impact**: The median render time (~9.955s) did not meaningfully improve over the baseline (~10.002s). Any minor optimization was likely offset by increased V8 GC pressure from rapidly allocating fresh objects.
🔬 **Verification**: Code built successfully. Verification tests and the full test suite passed. Benchmarked 5 times. Output verified with `ffprobe`. Experiment discarded.
📎 **Plan**: `/.sys/plans/PERF-552-inline-multi-frame-sync-media-params.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	10.190	600	58.88	43.2	discard	inline multiFrameSyncMediaParams
2	9.994	600	60.04	47.7	discard	inline multiFrameSyncMediaParams
3	9.839	600	60.98	43.5	discard	inline multiFrameSyncMediaParams
4	9.955	600	60.27	44.2	discard	inline multiFrameSyncMediaParams
5	9.489	600	63.23	44.5	discard	inline multiFrameSyncMediaParams
```

---
*PR created automatically by Jules for task [8683119522531824581](https://jules.google.com/task/8683119522531824581) started by @BintzGavin*