### PR TITLE
STUDIO: Document Timeline Scrubber Vision Gap

### DIFF
--- a/.sys/plans/2026-11-14-STUDIO-Timeline-Scrubber.md
+++ b/.sys/plans/2026-11-14-STUDIO-Timeline-Scrubber.md
@@ -1,0 +1,20 @@
+#### 1. Context & Goal
+- **Objective**: Identify that the "Timeline Scrubber" feature listed in the README vision gap is already fully implemented as the `Timeline.tsx` component.
+- **Trigger**: The Studio domain vision specifies a "Timeline Scrubber", but comparing the promised features to reality shows that `packages/studio/src/components/Timeline.tsx` already fulfills this requirement (with scrubbing, in/out markers, zoom, tracks, etc).
+- **Impact**: Documents that this feature is complete, preventing redundant work and allowing the Planner to focus on actual missing features.
+
+#### 2. File Inventory
+- **Create**: []
+- **Modify**: [docs/status/STUDIO.md] - Note the documentation of the duplicated/completed feature.
+- **Read-Only**: [packages/studio/src/components/Timeline.tsx]
+
+#### 3. Implementation Spec
+- **Architecture**: No implementation needed. The `Timeline.tsx` component already functions as a fully-featured timeline scrubber, managing playhead state, markers, in/out points, and zoom.
+- **Pseudo-Code**: None.
+- **Public API Changes**: None.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npx helios studio` and verify the Timeline component allows scrubbing.
+- **Success Criteria**: The `.sys/plans` file is created and the gap is marked as already implemented.
+- **Edge Cases**: N/A


### PR DESCRIPTION
Identified that the "Timeline Scrubber" feature listed in the README vision gap is already fully implemented via the `Timeline.tsx` component. Created a plan spec to document this to avoid duplicate work.

---
*PR created automatically by Jules for task [6242665783134161321](https://jules.google.com/task/6242665783134161321) started by @BintzGavin*