### PR TITLE
✨ RENDERER: Disable IPC Flooding Protection Experiment (Discarded)

### DIFF
--- a/.sys/plans/PERF-555-disable-ipc-flooding-protection.md
+++ b/.sys/plans/PERF-555-disable-ipc-flooding-protection.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-555
 slug: disable-ipc-flooding-protection
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2024-05-31
-completed: ""
-result: ""
+completed: 2024-06-01
+result: no-improvement
 ---
 
 # PERF-555: Disable Chromium IPC Flooding Protection
@@ -44,3 +44,9 @@ Run `npm run test -w packages/renderer -- --run` to ensure the flags do not brea
 
 ## Correctness Check
 Run `npm run test -w packages/renderer -- --run` to verify DOM output correctly resolves without regressions.
+
+## Results Summary
+- **Best render time**: 10.851s (vs baseline 10.002s)
+- **Improvement**: -8.5%
+- **Kept experiments**:
+- **Discarded experiments**: `--disable-ipc-flooding-protection` and `--disable-hang-monitor` in BrowserPool.ts

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -39,6 +39,10 @@ Last updated by: PERF-542
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-555**: Disable Chromium IPC Flooding Protection
+  - **What I tried**: Added `--disable-ipc-flooding-protection` and `--disable-hang-monitor` to the `DEFAULT_BROWSER_ARGS` array in `BrowserPool.ts`.
+  - **WHY it didn't work**: The median render time degraded to ~10.851s compared to the baseline ~10.002s. While the intention was to prevent Chromium from throttling our high-frequency CDP commands, these flags did not yield a performance improvement and actually introduced a measurable slowdown, likely due to side effects in process scheduling or event loop polling in headless mode.
+  - **Outcome**: discard
 - **PERF-514**: Optimize BrowserPool Concurrency Formula
   - **What I tried**: Changed the concurrency calculation in `BrowserPool.ts` from `Math.max(1, (os.cpus().length || 4) - 1)` to a hardcoded `2`.
   - **WHY it didn't work**: The median render time significantly degraded to ~25.049s compared to the baseline of ~10.002s. By lowering the concurrency from the dynamically calculated 3 down to 2, the total capture throughput dropped. It appears the CPU still benefits from having at least 3 active workers generating frames simultaneously even if they are in the same or separate processes.


### PR DESCRIPTION
✨ RENDERER: Disable IPC Flooding Protection Experiment (Discarded)

💡 What: Evaluated adding `--disable-ipc-flooding-protection` and `--disable-hang-monitor` to Chromium launch arguments to bypass internal command throttling during the hot loop. The code changes were discarded and only the documentation updates remain.
🎯 Why: To attempt to remove any micro-delays or overhead Chromium introduces when flooded with high-frequency CDP IPC messages.
📊 Impact: Degraded performance. Median render time increased to ~10.851s compared to the baseline ~10.002s (-8.5%).
🔬 Verification: 3 benchmark runs executed on the DOM path, tests checked (time out safely acknowledged), and source changes manually restored via `git restore`.
📎 Plan: `/.sys/plans/PERF-555-disable-ipc-flooding-protection.md`

---
*PR created automatically by Jules for task [4120683563168670948](https://jules.google.com/task/4120683563168670948) started by @BintzGavin*