### PR TITLE
✨ RENDERER: PERF-558 disable v8 idle tasks experiment

### DIFF
--- a/.sys/plans/PERF-558-disable-v8-idle-tasks.md
+++ b/.sys/plans/PERF-558-disable-v8-idle-tasks.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-558
 slug: disable-v8-idle-tasks
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2024-05-24"
+result: "discard"
 ---
 
 # PERF-558: Disable V8 Idle Tasks in Headless Chromium
@@ -50,3 +50,11 @@ Run the full test suite (`npm run test -w packages/renderer -- --run`) to verify
 
 ## Prior Art
 - PERF-305 attempted this, but was on an older baseline, re-testing on the highly-optimized single-process baseline is warranted.
+
+## Results Summary
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	12.147	600	49.39	47.4	discard	run 1
+2	10.932	600	54.89	44.0	discard	run 2
+3	11.118	600	53.96	51.7	discard	run 3 (median)
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -148,6 +148,10 @@ Last updated by: PERF-542
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-558**: Disable V8 Idle Tasks
+  - **What I tried**: Added `--disable-v8-idle-tasks` to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.
+  - **WHY it didn't work**: The median render time regressed to ~11.118s (vs baseline ~10.002s). While preventing V8 from running background garbage collection and idle tasks was intended to reduce CPU contention, it likely forced those necessary tasks to run synchronously or accumulate, causing larger micro-stutters that delayed the frame capture loop.
+  - **Outcome**: discard
 - **PERF-005**: Raw CDP Screencast
   - **What I tried**: Replaced `HeadlessExperimental.beginFrame` with `Page.startScreencast` in `DomStrategy.ts` to stream frames natively via CDP without compositor synchronization.
   - **WHY it didn't work**: Severe performance regression and pipeline breakage (render time ~101s vs baseline ~18.5s). `Page.startScreencast` natively pushes frames inconsistently, dropping them when visual changes do not meet damage thresholds, which creates deadlock timeouts and truncates the FFmpeg `mjpeg` bitstream in our deterministic capture pipeline.


### PR DESCRIPTION
💡 **What**: Added `--disable-v8-idle-tasks` to `BrowserPool.ts`.
🎯 **Why**: To reduce CPU contention from V8 background tasks during the frame rendering loop.
📊 **Impact**: The median render time regressed to ~11.118s vs the baseline of ~10.002s.
🔬 **Verification**: Ran `npm run build -w packages/renderer`, `npm run benchmark -w packages/renderer`, `npm run test -w packages/renderer -- --run`, and checked the output using `ffprobe`.
📎 **Plan**: `/.sys/plans/PERF-558-disable-v8-idle-tasks.md`

Results Summary:
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	12.147	600	49.39	47.4	discard	run 1
2	10.932	600	54.89	44.0	discard	run 2
3	11.118	600	53.96	51.7	discard	run 3 (median)
```

---
*PR created automatically by Jules for task [12346326607511640663](https://jules.google.com/task/12346326607511640663) started by @BintzGavin*