### PR TITLE
✨ STUDIO: Document duplicated Timeline Scrubber plan

### DIFF
--- a/.sys/llmdocs/context-studio.md
+++ b/.sys/llmdocs/context-studio.md
@@ -23,7 +23,7 @@ The Studio is invoked via `npx helios studio` (or `npm run dev` in development).
 
 ## Section D: UI Components
 - **Stage**: Renders the `<helios-player>` and handles resolution, panning, zooming, and snapshot captures. Includes Safe Area Guides.
-- **Timeline**: Visualizes the composition duration, current playhead, draggable In/Out point markers, audio waveforms, and snap-to guides. Supports dragging and dropping assets.
+- **Timeline**: Visualizes the composition duration, current playhead with scrubbing support, draggable In/Out point markers, audio waveforms, and snap-to guides. Supports dragging and dropping assets.
 - **Props Editor**: Dynamically generated input fields based on the active composition's schema, allowing real-time modification of props. Includes specialized editors (JSON, Color, Enum, Asset Inputs).
 - **Assets Panel**: Displays and manages project assets (images, videos, audio, fonts, 3D models). Supports rich preview, drag & drop uploading, and directory organization.
 - **Renders Panel**: Manages remote and local rendering jobs, showing progress and providing export options. Generates distributed render job JSON specs (`exportJobSpec`).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -626,5 +626,8 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### PLAYER v0.77.35
 - ✅ Completed: Improve index.ts test coverage - Added tests for captureStream and audio metering edge cases.
+### STUDIO v0.121.15
+- ✅ Completed: Document duplicated Timeline-Scrubber plan - Logged the duplicated plan as impossible since Timeline already supports scrubbing.
+
 ### STUDIO v0.121.14
 - ✅ Completed: Document duplicated Update-Keyboard-Shortcuts-Documentation plan - Logged the duplicated plan as impossible.

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.121.14
+**Version**: 0.121.15
 
 [v0.121.13] ✅ Completed: Expand Reverse Speeds - Added -4x and -2x reverse playback options to the PlaybackControls component.
 
@@ -210,4 +210,5 @@
 - [v0.121.4] ✅ Completed: STUDIO-Timeline-Drag-Drop - Added visual styling when dragging an asset over the Timeline component for visual feedback.
 - [v0.121.7] ✅ Completed: STUDIO-Timeline-Drag-Drop - Verified timeline drag and drop for assets is already implemented (2026-11-13-STUDIO-Timeline-Drag-Drop.md).
 - ❌ Blocked: 2026-11-14-STUDIO-Update-Keyboard-Shortcuts-Documentation is structurally obsolete as changes are already present.
+[v0.121.15] ✅ Completed: Document duplicated Timeline-Scrubber plan - Logged the duplicated plan as impossible since Timeline already supports scrubbing.
 [v0.121.14] ✅ Completed: Document duplicated Update-Keyboard-Shortcuts-Documentation plan - Logged the duplicated plan as impossible.


### PR DESCRIPTION
Updated the STUDIO domain documentation to reflect that the "Timeline Scrubber" plan from `2026-11-14` is a duplicate. The existing `Timeline.tsx` component already fully supports playhead scrubbing.

- Updated `docs/status/STUDIO.md` to increment the patch version to `0.121.15` and logged the duplicate status.
- Added a completion record to `docs/PROGRESS.md` under `### STUDIO v0.121.15`.
- Regenerated `/.sys/llmdocs/context-studio.md` to explicitly mention timeline scrubbing support.
- All workspace tests passed successfully.

---
*PR created automatically by Jules for task [6883963497956336569](https://jules.google.com/task/6883963497956336569) started by @BintzGavin*