### PR TITLE
📋 RENDERER: Test noDisplayUpdates: true in beginFrame

### DIFF
--- a/.sys/plans/PERF-562-beginframe-nodisplayupdates-true.md
+++ b/.sys/plans/PERF-562-beginframe-nodisplayupdates-true.md
@@ -1,0 +1,80 @@
+---
+id: PERF-562
+slug: beginframe-nodisplayupdates-true
+status: unclaimed
+claimed_by: ""
+created: 2024-06-13
+completed: ""
+result: ""
+---
+
+# PERF-562: Test `noDisplayUpdates: true` in `beginFrameParams`
+
+## Focus Area
+The Frame Capture Loop (phase 4) in DOM rendering. Specifically, the `HeadlessExperimental.beginFrame` CDP call in `DomStrategy.ts`.
+
+## Background Research
+In PERF-561, explicitly setting `noDisplayUpdates: false` on `HeadlessExperimental.beginFrame` was found to bypass unoptimized synchronization paths inside Chromium, reducing latency from ~40-55ms per call to ~21ms per call. The plan's Variation A proposed testing `noDisplayUpdates: true` instead. Although `false` forces the browser to perform display updates, `true` might still yield the same ~21ms fast path (since it's explicitly set rather than undefined/omitted) and additionally skip the actual display update calculations if the screenshot data is generated differently, which could lead to further performance gains if it still captures correct frame data. We should test if `true` improves performance further while maintaining the correctness of the capture.
+
+## Benchmark Configuration
+- **Composition URL**: DOM benchmark composition (`examples/dom-benchmark/composition.html`)
+- **Render Settings**: 600x600 resolution, 30 FPS, 5s duration (150 frames)
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: 9.980s (150 frames benchmark in microVM), ~10.00s for standard 600-frame test suite
+- **Bottleneck analysis**: The bottleneck is the per-frame overhead of `HeadlessExperimental.beginFrame`.
+
+## Implementation Spec
+
+### Step 1: Add `noDisplayUpdates` to parameters
+**File**: `packages/renderer/src/strategies/DomStrategy.ts`
+**What to change**:
+In `DomStrategy.ts`, locate the `beginFrameParams` initialization and the `targetBeginFrameParams` initialization. Update them to set `noDisplayUpdates: true`.
+
+Change:
+```typescript
+  private beginFrameParams: any = { interval: 0, frameTimeTicks: 0, screenshot: null, noDisplayUpdates: false };
+```
+To:
+```typescript
+  private beginFrameParams: any = { interval: 0, frameTimeTicks: 0, screenshot: null, noDisplayUpdates: true };
+```
+
+And change `targetBeginFrameParams` initialization in `prepare()` from:
+```typescript
+    this.targetBeginFrameParams = {
+      screenshot: {
+        format: cdpScreenshotParams.format,
+        quality: cdpScreenshotParams.quality,
+        clip: { x: 0, y: 0, width: 0, height: 0, scale: 1 }
+      },
+      interval: this.frameInterval,
+      frameTimeTicks: 0,
+      noDisplayUpdates: false
+    };
+```
+To:
+```typescript
+    this.targetBeginFrameParams = {
+      screenshot: {
+        format: cdpScreenshotParams.format,
+        quality: cdpScreenshotParams.quality,
+        clip: { x: 0, y: 0, width: 0, height: 0, scale: 1 }
+      },
+      interval: this.frameInterval,
+      frameTimeTicks: 0,
+      noDisplayUpdates: true
+    };
+```
+
+**Why**: To test if skipping display updates while capturing screenshots further improves performance or breaks capture correctness.
+**Risk**: Chromium might handle `noDisplayUpdates: true` by refusing to capture a screenshot or by capturing a stale display state.
+
+## Canvas Smoke Test
+Run `npm run test -w packages/renderer -- tests/verify-codecs.ts` to ensure Canvas Strategy continues to function.
+
+## Correctness Check
+Verify all standard `DomStrategy` tests pass.


### PR DESCRIPTION
Create plan to test setting noDisplayUpdates: true on HeadlessExperimental.beginFrame in DomStrategy.ts to evaluate further optimization of the CDP screenshot capture phase while verifying correctness.

---
*PR created automatically by Jules for task [1151364415952141716](https://jules.google.com/task/1151364415952141716) started by @BintzGavin*