### PR TITLE
✨ RENDERER: Test disabling IPC flooding protection

### DIFF
--- a/.sys/plans/PERF-554-disable-ipc-flooding-protection.md
+++ b/.sys/plans/PERF-554-disable-ipc-flooding-protection.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-554
 slug: disable-ipc-flooding-protection
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-31
-completed: ""
-result: ""
+completed: "2024-06-01"
+result: "no-improvement"
 ---
 
 # PERF-554: Disable Chromium IPC Flooding Protection
@@ -45,3 +45,9 @@ Run `npm run test -w packages/renderer -- --run` to ensure the flags do not brea
 
 ## Correctness Check
 Run `npm run test -w packages/renderer -- --run` to verify DOM output correctly resolves without regressions.
+
+## Results Summary
+- **Best render time**: 1.150s (vs baseline 1.131s)
+- **Improvement**: -1.6%
+- **Kept experiments**: []
+- **Discarded experiments**: [`--disable-ipc-flooding-protection` and `--disable-hang-monitor`]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -225,3 +225,9 @@ Last updated by: PERF-562
   - **What I tried**: Removed the conditional `stabilityCheckState === 0` logic from the `runSetTime` hot loop in `CdpTimeDriver.ts` and moved it entirely into the `prepare` phase to evaluate if the custom stability function (`waitUntilStable`) existed before the capture loop started.
   - **WHY it didn't work**: Although the unit test for `CdpTimeDriver` passing indicated that moving the check works logically (since we can confirm evaluation at setup), performance-wise it offered no measurable improvement (median simulated advance time remained ~101ms, identical to baseline). More critically, the implementation change triggered downstream dependency import failures in integration layers (`@helios-project/core` couldn't resolve `TimeDriver`), meaning it broke fundamental contract expectations of Playwright's shared CDP session when applied out-of-order in the initialization lifecycle. Given no performance gain and severe pipeline brittleness, it was rolled back.
   - **Outcome**: discard
+
+## What Doesn't Work (and Why)
+- **PERF-554**: Disable Chromium IPC Flooding Protection
+  - **What I tried**: Added `--disable-ipc-flooding-protection` and `--disable-hang-monitor` to the `DEFAULT_BROWSER_ARGS` array in `BrowserPool.ts`.
+  - **WHY it didn't work**: Render time regressed compared to the highly optimized baseline (median ~1.193s with flags vs baseline ~1.147s). While intended to prevent Chromium from throttling our high-frequency CDP commands, these flags introduced a measurable slowdown, likely due to side effects in process scheduling or event loop polling in the single-process headless mode environment.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-554.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-554.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.251	600	479.50	47.5	discard	PERF-554 test 1
+2	1.193	600	503.03	47.1	discard	PERF-554 test 2 (median)
+3	1.150	600	521.70	47.0	discard	PERF-554 test 3


### PR DESCRIPTION
💡 **What**: The experiment run and its outcome (PERF-554). Tested adding `--disable-ipc-flooding-protection` and `--disable-hang-monitor` to Chromium args, resulting in a performance regression. Code changes were discarded.
🎯 **Why**: To see if disabling Chromium's internal IPC message throttling would improve headless render throughput for high-frequency CDP commands.
📊 **Impact**: Render time regressed to a median of ~1.193s compared to a baseline of ~1.147s (-4.0% improvement).
🔬 **Verification**: Code built successfully, performance benchmarked 3 times on DOM composition (median reported), and baseline reverted to maintain performance.
📎 **Plan**: Reference the plan file (/.sys/plans/PERF-554-disable-ipc-flooding-protection.md)

### Results Summary
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.251	600	479.50	47.5	discard	PERF-554 test 1
2	1.193	600	503.03	47.1	discard	PERF-554 test 2 (median)
3	1.150	600	521.70	47.0	discard	PERF-554 test 3

---
*PR created automatically by Jules for task [2427949266519107265](https://jules.google.com/task/2427949266519107265) started by @BintzGavin*