### PR TITLE
✨ RENDERER: Discard PERF-563 disable additional chromium features

### DIFF
--- a/.sys/plans/PERF-563-disable-additional-chromium-features.md
+++ b/.sys/plans/PERF-563-disable-additional-chromium-features.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-563
 slug: disable-additional-chromium-features
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-13
-completed: ""
-result: ""
+completed: 2024-05-21
+result: no-improvement
 ---
 
 # PERF-563: Disable Additional Chromium Features
@@ -51,3 +51,9 @@ Run the Canvas strategy tests to ensure Chromium still launches and renders corr
 
 ## Correctness Check
 Run the `DomStrategy` test suite to verify no regressions in capture logic.
+
+## Results Summary
+- **Best render time**: 0.581s (vs baseline ~0.622s)
+- **Improvement**: Inconclusive/noise
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-563]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -235,3 +235,7 @@ Last updated by: PERF-562
   - **What I tried**: Added `--disable-ipc-flooding-protection` and `--disable-hang-monitor` to the `DEFAULT_BROWSER_ARGS` array in `BrowserPool.ts`.
   - **WHY it didn't work**: Render time did not improve and slightly regressed compared to the highly optimized baseline (median ~0.646s with flags vs baseline ~0.636s). While intended to prevent Chromium from throttling our high-frequency CDP commands, these flags did not improve throughput in our headless single-process microVM setup, confirming findings from PERF-554.
   - **Outcome**: discard
+- **PERF-563**: Disable Additional Chromium Features
+  - **What I tried**: Appended `IsolateOrigins,site-per-process` to the `--disable-features` array in `BrowserPool.ts` to strictly disable background site isolation trials.
+  - **WHY it didn't work**: Render time did not meaningfully improve compared to the baseline (~0.582s median with flags). Disabling these features didn't suppress background processes enough to gain speed on the deterministic `beginFrame` capture loop, likely because they were already practically suppressed or inactive in a single-domain `file://` context in a microVM headless state.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-563.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-563.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.581	150	258.24	41.8	discard	IsolateOrigins,site-per-process added to disable-features
+2	0.585	150	256.54	38.6	discard	IsolateOrigins,site-per-process added to disable-features
+3	0.582	150	257.91	38.7	discard	IsolateOrigins,site-per-process added to disable-features

--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,11 +1,13 @@
-💡 **What**: Executed and discarded PERF-472 (Replace async runWorker with recursive promise chain). The changes crashed the FFmpeg pipe so they were reverted.
-🎯 **Why**: Attempted to remove async state machine overhead from the `runWorker` execution loop.
-📊 **Impact**: N/A (crashing).
-🔬 **Verification**: Code compilation, output benchmark testing (crashed).
-📎 **Plan**: Reference `/.sys/plans/PERF-472-optimize-worker-run-loop.md`
+💡 **What**: Tested appending `IsolateOrigins,site-per-process` to `--disable-features` in BrowserPool.ts.
+🎯 **Why**: To see if suppressing more background isolation features reduces CPU/memory overhead and speeds up the deterministic capture loop.
+📊 **Impact**: No meaningful improvement. Median time with flags was ~0.582s (vs baseline ~0.622s). The difference is inconclusive/noise.
+🔬 **Verification**: Ran `examples/dom-benchmark/composition.html` at 600x600, 30FPS, 5s duration in `dom` mode. Since the result was negligible, the changes to `BrowserPool.ts` were reverted.
+📎 **Plan**: `/.sys/plans/PERF-563-disable-additional-chromium-features.md`
 
-Results summary:
+### Results
 ```
 run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
-1	0.00	0	0	0.0	crash	Recursive loop promise chain FFmpeg pipe EOF crash
+1	0.581	150	258.24	41.8	discard	IsolateOrigins,site-per-process added to disable-features
+2	0.585	150	256.54	38.6	discard	IsolateOrigins,site-per-process added to disable-features
+3	0.582	150	257.91	38.7	discard	IsolateOrigins,site-per-process added to disable-features
 ```


### PR DESCRIPTION
💡 **What**: Tested appending `IsolateOrigins,site-per-process` to `--disable-features` in BrowserPool.ts.
🎯 **Why**: To see if suppressing more background isolation features reduces CPU/memory overhead and speeds up the deterministic capture loop.
📊 **Impact**: No meaningful improvement. Median time with flags was ~0.582s (vs baseline ~0.622s). The difference is inconclusive/noise.
🔬 **Verification**: Ran `examples/dom-benchmark/composition.html` at 600x600, 30FPS, 5s duration in `dom` mode. Since the result was negligible, the changes to `BrowserPool.ts` were reverted.
📎 **Plan**: `/.sys/plans/PERF-563-disable-additional-chromium-features.md`

### Results
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.581	150	258.24	41.8	discard	IsolateOrigins,site-per-process added to disable-features
2	0.585	150	256.54	38.6	discard	IsolateOrigins,site-per-process added to disable-features
3	0.582	150	257.91	38.7	discard	IsolateOrigins,site-per-process added to disable-features
```

---
*PR created automatically by Jules for task [15734205598993634525](https://jules.google.com/task/15734205598993634525) started by @BintzGavin*