### PR TITLE
✨ RENDERER: Revert noDisplayUpdates bug

### DIFF
--- a/.sys/plans/PERF-565-revert-no-display-updates-bug.md
+++ b/.sys/plans/PERF-565-revert-no-display-updates-bug.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-565
 slug: revert-no-display-updates-bug
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-22
-completed: ""
-result: ""
+completed: "2024-05-22"
+result: "keep"
 ---
 
 # PERF-565: Revert `noDisplayUpdates: true` Bug in `DomStrategy.ts`
@@ -25,6 +25,15 @@ When `noDisplayUpdates` is `true` in `HeadlessExperimental.beginFrame`, Chromium
 
 ## Baseline
 - **Current estimated render time**: N/A (Current output is bugged/blank)
+
+## Correctness Check
+Run `npm run test -w packages/renderer` (or manually render a composition) and visually verify that the output video is no longer blank/black.
+
+## Results Summary
+- **Best render time**: 0.960s
+- **Improvement**: Reverted bug, restoring previous baseline capture times ~0.960s.
+- **Kept experiments**: [Revert noDisplayUpdates: true bug]
+- **Discarded experiments**: []
 
 ## Implementation Spec
 

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,11 +1,11 @@
 ## Performance Trajectory
-Current best: 0.622s (baseline was 17.587s, -96.4%)
-Last updated by: PERF-562
+Current best: 0.960s (baseline was 17.587s, -94.5%)
+Last updated by: PERF-565
 
 ## What Works
-- **PERF-562**: Set noDisplayUpdates to true
-  - **What I did**: Changed `noDisplayUpdates` to `true` on `beginFrameParams` and `targetBeginFrameParams` in `DomStrategy.ts`.
-  - **Improvement**: ~0.622s (vs baseline ~1.097s on this microVM/benchmark, or roughly ~10s previously). By skipping display updates, Chromium renders the headless screenshot data significantly faster without breaking Playwright capture.
+- **PERF-565**: Revert noDisplayUpdates bug
+  - **What I did**: Changed `noDisplayUpdates` to `false` on `beginFrameParams` and `targetBeginFrameParams` in `DomStrategy.ts`.
+  - **Improvement**: ~0.960s (Restored expected capture rendering overhead). Reverts the critical bug introduced in PERF-562 where `noDisplayUpdates: true` completely skipped frame rendering and caused output videos to be blank.
 - **PERF-560**: Pre-evaluate Sync Media Status in CdpTimeDriver
   - **What I did**: Removed the redundant `Runtime.evaluate` block that queries `document.querySelectorAll('video, audio').length > 0` over CDP during initialization. Replaced it with purely setting `syncMediaState = hasMedia ? 1 : 2`.
   - **Improvement**: ~9.980s (No statistically significant time change, but it removes a completely redundant IPC roundtrip during Phase 3 `prepare()`).
@@ -48,6 +48,10 @@ Last updated by: PERF-562
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-562**: Set noDisplayUpdates to true
+  - **What I tried**: Changed `noDisplayUpdates` to `true` on `beginFrameParams` and `targetBeginFrameParams` in `DomStrategy.ts`.
+  - **WHY it didn't work**: While it seemed to massively improve benchmark times (median ~0.622s), it was a false positive. Setting this flag true skips the display compositor entirely, resulting in blank/black screenshot data being returned. The performance "gain" was just the speed of not doing the work.
+  - **Outcome**: discard (reverted by PERF-565)
 - **PERF-564**: Evaluate WebCodecs Fallback for DomStrategy
   - **What I tried**: Attempted to implement a WebCodecs fallback in `DomStrategy` by rasterizing the DOM into a hidden canvas via DOM-to-SVG-to-Canvas (`XMLSerializer` + `foreignObject`) to bypass Playwright's base64 IPC overhead.
   - **WHY it didn't work**: The overhead of serializing the DOM, encoding it to an SVG string, and rasterizing it onto a canvas via an `Image` object is massively slower (~600-1300ms per frame) compared to Chromium's native `HeadlessExperimental.beginFrame` screenshot capture (~20ms per frame). This completely nullified any savings from avoiding base64 serialization and Playwright IPC. Furthermore, capturing computed styles for animations is extremely complex and brittle.

--- a/packages/renderer/.sys/perf-results-PERF-565.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-565.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.96	30	31.25	0.0	keep	revert-no-display-updates-bug
+2	0.96	30	31.25	0.0	keep	revert-no-display-updates-bug
+3	0.96	30	31.25	0.0	keep	revert-no-display-updates-bug

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -23,7 +23,7 @@ export class DomStrategy implements RenderStrategy {
   private emptyImageBuffer: Buffer = EMPTY_IMAGE_BUFFER;
   private emptyImageBase64: string = "";
   private frameInterval: number = 0;
-  private beginFrameParams: any = { interval: 0, frameTimeTicks: 0, screenshot: null, noDisplayUpdates: true };
+  private beginFrameParams: any = { interval: 0, frameTimeTicks: 0, screenshot: null, noDisplayUpdates: false };
   private targetBeginFrameParams: any = null;
 
   constructor(private options: RendererOptions) {
@@ -133,7 +133,7 @@ export class DomStrategy implements RenderStrategy {
       },
       interval: this.frameInterval,
       frameTimeTicks: 0,
-      noDisplayUpdates: true
+      noDisplayUpdates: false
     };
 
     // Set format-appropriate empty buffer


### PR DESCRIPTION
💡 **What:** Changed `noDisplayUpdates` from `true` to `false` in `DomStrategy.ts`.
🎯 **Why:** Reverts the bug introduced in PERF-562 that resulted in blank video output. Setting `noDisplayUpdates: true` completely skipped frame rendering by Chromium.
📊 **Impact:** Returns rendering correctness, dropping benchmark back to normal capture times (~0.960s).
🔬 **Verification:** Test suite ran, 4-gate verification completed.
📎 **Plan:** PERF-565-revert-no-display-updates-bug

Results Summary:
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.96	30	31.25	0.0	keep	revert-no-display-updates-bug
2	0.96	30	31.25	0.0	keep	revert-no-display-updates-bug
3	0.96	30	31.25	0.0	keep	revert-no-display-updates-bug
```

---
*PR created automatically by Jules for task [13977699900186315598](https://jules.google.com/task/13977699900186315598) started by @BintzGavin*