### PR TITLE
✨ RENDERER: [Discarded] Use webp_pipe demuxer for WEBP format

### DIFF
--- a/.sys/plans/PERF-566-webp-pipe-demuxer.md
+++ b/.sys/plans/PERF-566-webp-pipe-demuxer.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-566
 slug: webp-pipe-demuxer
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-22
-completed: ""
-result: ""
+completed: 2024-05-22
+result: failed
 ---
 
 # PERF-566: Use webp_pipe Demuxer for WEBP Intermediate Format
@@ -45,3 +45,9 @@ N/A - this only affects `DomStrategy` with `webp` intermediate format.
 
 ## Correctness Check
 Run `npm run test -w packages/renderer` to ensure baseline rendering is not broken, and run a manual test with WEBP format to ensure it completes without crashing.
+
+## Results Summary
+- **Best render time**: N/A (Crashed)
+- **Improvement**: N/A
+- **Kept experiments**: None
+- **Discarded experiments**: Used `webp_pipe` instead of `image2pipe` for WEBP intermediate format demuxing. This crashed with "Could not find codec parameters for stream 0 (Video: webp, none): unspecified size", so `webp` pipe over FFmpeg is still not working.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -252,3 +252,6 @@ Last updated by: PERF-565
   - **What I tried**: Appended `IsolateOrigins,site-per-process` to the `--disable-features` array in `BrowserPool.ts` to strictly disable background site isolation trials.
   - **WHY it didn't work**: Render time did not meaningfully improve compared to the baseline (~0.582s median with flags). Disabling these features didn't suppress background processes enough to gain speed on the deterministic `beginFrame` capture loop, likely because they were already practically suppressed or inactive in a single-domain `file://` context in a microVM headless state.
   - **Outcome**: discard
+
+## What Doesn't Work (and Why)
+- **PERF-566: Use webp_pipe Demuxer for WEBP Intermediate Format:** Tried to use `webp_pipe` instead of `image2pipe` to handle WEBP format frames coming from CDP. The FFmpeg process still crashes with "Could not find codec parameters for stream 0 (Video: webp, none): unspecified size" and "pipe:: Invalid argument". It seems decoding raw WEBP piped streams in this version of FFmpeg still requires explicit dimensions or different demuxing, making WEBP format over pipe unusable currently.

--- a/packages/renderer/.sys/perf-results-PERF-566.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-566.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	baseline - webp intermediate format crashes with image2pipe
+2	0.000	0	0.00	0.0	discard	webp_pipe intermediate format crashes

--- a/submission.txt
+++ b/submission.txt
@@ -1,0 +1,11 @@
+✨ RENDERER: [Discarded] Use webp_pipe demuxer for WEBP format
+
+💡 What: Tried using the webp_pipe demuxer instead of image2pipe in FFmpeg when using the WEBP intermediate image format.
+🎯 Why: Piping base64-decoded WEBP frames into image2pipe crashes FFmpeg. We hoped webp_pipe would handle the continuous stream of WEBP frames over stdin correctly, allowing us to benchmark WEBP as a potentially faster intermediate format.
+📊 Impact: The experiment crashed. FFmpeg still failed to determine codec parameters (unspecified size), meaning WEBP pipeline is still fundamentally broken in this environment.
+🔬 Verification: Ran the benchmark script with WEBP mode, checked FFmpeg error logs. Output video generation failed.
+📎 Plan: Reference PERF-566
+
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	baseline - webp intermediate format crashes with image2pipe
+2	0.000	0	0.00	0.0	discard	webp_pipe intermediate format crashes


### PR DESCRIPTION
✨ RENDERER: [Discarded] Use webp_pipe demuxer for WEBP format

💡 What: Tried using the webp_pipe demuxer instead of image2pipe in FFmpeg when using the WEBP intermediate image format.
🎯 Why: Piping base64-decoded WEBP frames into image2pipe crashes FFmpeg. We hoped webp_pipe would handle the continuous stream of WEBP frames over stdin correctly, allowing us to benchmark WEBP as a potentially faster intermediate format.
📊 Impact: The experiment crashed. FFmpeg still failed to determine codec parameters (unspecified size), meaning WEBP pipeline is still fundamentally broken in this environment.
🔬 Verification: Ran the benchmark script with WEBP mode, checked FFmpeg error logs. Output video generation failed.
📎 Plan: Reference PERF-566

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	baseline - webp intermediate format crashes with image2pipe
2	0.000	0	0.00	0.0	discard	webp_pipe intermediate format crashes

---
*PR created automatically by Jules for task [878033646611403859](https://jules.google.com/task/878033646611403859) started by @BintzGavin*