### PR TITLE
✨ RENDERER: Test Page.captureScreenshot instead of beginFrame

### DIFF
--- a/.sys/plans/PERF-567-cdp-capture-screenshot.md
+++ b/.sys/plans/PERF-567-cdp-capture-screenshot.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-567
 slug: cdp-capture-screenshot
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-22
-completed: ""
-result: ""
+completed: 2024-05-22
+result: failed
 ---
 
 # PERF-567: Test `Page.captureScreenshot` vs `HeadlessExperimental.beginFrame`
@@ -46,3 +46,9 @@ Run `npm run test -w packages/renderer -- tests/verify-codecs.ts` to ensure Canv
 
 ## Correctness Check
 Run a visual check on the output video of `examples/dom-benchmark` to ensure frames are not torn or skipping. Run `npm run test -w packages/renderer` to ensure baseline rendering is not broken.
+
+## Results Summary
+- **Best render time**: N/A (Hung/Stalled)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-567]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -301,6 +301,10 @@ Last updated by: PERF-565
   - **What I tried**: Appended `IsolateOrigins,site-per-process` to the `--disable-features` array in `BrowserPool.ts` to strictly disable background site isolation trials.
   - **WHY it didn't work**: Render time did not meaningfully improve compared to the baseline (~0.582s median with flags). Disabling these features didn't suppress background processes enough to gain speed on the deterministic `beginFrame` capture loop, likely because they were already practically suppressed or inactive in a single-domain `file://` context in a microVM headless state.
   - **Outcome**: discard
+- **PERF-567**: Test `Page.captureScreenshot` vs `HeadlessExperimental.beginFrame`
+  - **What I tried**: Replaced Playwright's `HeadlessExperimental.beginFrame` with `Page.captureScreenshot` in `DomStrategy.ts` using the existing `CdpTimeDriver.ts` virtual time advancement.
+  - **WHY it didn't work**: The renderer process completely hung and timed out during the benchmark. Without the explicit compositor synchronization provided by `HeadlessExperimental.beginFrame`, `Page.captureScreenshot` stalled in headless mode when time was explicitly paused/controlled. `beginFrame` is strictly required to force the compositor to produce deterministic frames when time is frozen.
+  - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
 - **PERF-507: Eliminate defaultStabilityCheck method and inline logic**

--- a/packages/renderer/.sys/perf-results-PERF-567.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-567.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	400.000	0	0	0	discard	Page.captureScreenshot hangs/stalls without HeadlessExperimental.beginFrame


### PR DESCRIPTION
💡 **What**: Tested replacing `HeadlessExperimental.beginFrame` with `Page.captureScreenshot` in `DomStrategy.ts`.
🎯 **Why**: Attempted to bypass the latency floor of `beginFrame` by using raw screenshot capture combined with virtual time driver explicitly pausing time.
📊 **Impact**: The renderer process completely hung and timed out without explicit compositor synchronization from `beginFrame`. Result is 0% improvement (N/A) due to stalling.
🔬 **Verification**: Code built, ran benchmark but stalled. Discarded changes and reverted `DomStrategy.ts` back to baseline. Recorded results in TSV and journal.
📎 **Plan**: `PERF-567` (Failed / Discarded).

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	400.000	0	0	0	discard	Page.captureScreenshot hangs/stalls without HeadlessExperimental.beginFrame
```

---
*PR created automatically by Jules for task [14432484486350654653](https://jules.google.com/task/14432484486350654653) started by @BintzGavin*