### PR TITLE
✨ RENDERER: Evaluate PERF-568 Prebind stability check to remove branch in hot loop

### DIFF
--- a/.sys/plans/PERF-568-prebind-stability-check.md
+++ b/.sys/plans/PERF-568-prebind-stability-check.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-568
 slug: prebind-stability-check
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-27
-completed: ""
-result: ""
+completed: 2024-05-27
+result: no-improvement
 ---
 
 # PERF-568: Prebind Stability Check to avoid branching in hot loop
@@ -55,3 +55,9 @@ Run the DOM render benchmark script (`npm run test -w packages/renderer`) to ens
 
 ## Prior Art
 - PERF-461: Evaluated bypassing the stability check using a closure assignment, but wasn't fully integrated into a branchless model.
+
+## Results Summary
+- **Best render time**: 4.792s (vs baseline 4.768s)
+- **Improvement**: 0% (slight regression)
+- **Kept experiments**: []
+- **Discarded experiments**: [Prebind stability check to remove branch in hot loop]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -305,6 +305,10 @@ Last updated by: PERF-565
   - **What I tried**: Replaced Playwright's `HeadlessExperimental.beginFrame` with `Page.captureScreenshot` in `DomStrategy.ts` using the existing `CdpTimeDriver.ts` virtual time advancement.
   - **WHY it didn't work**: The renderer process completely hung and timed out during the benchmark. Without the explicit compositor synchronization provided by `HeadlessExperimental.beginFrame`, `Page.captureScreenshot` stalled in headless mode when time was explicitly paused/controlled. `beginFrame` is strictly required to force the compositor to produce deterministic frames when time is frozen.
   - **Outcome**: discard
+- **PERF-568**: Prebind Stability Check in CdpTimeDriver.ts
+  - **What I tried**: Replaced the `stabilityCheckState` variable with a dynamic function property `performStabilityCheck` to implement a state machine and remove the conditional `if (this.stabilityCheckState === 0)` branch from the hot loop `runSetTime`.
+  - **WHY it didn't work**: The median render time (4.792s) did not improve and slightly regressed compared to the baseline (4.768s). While V8 branch prediction is highly optimized, the overhead of invoking a dynamic function reference on every frame loop iteration is marginally higher than a well-predicted simple integer comparison.
+  - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
 - **PERF-507: Eliminate defaultStabilityCheck method and inline logic**

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -107,3 +107,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 4	10.537	600	56.94	43.0	keep	dedicated browser instances (PERF-526)
 5	10.760	600	55.76	43.6	keep	dedicated browser instances (PERF-526)
 33	21.970	600	27.31	41.5	discard	eliminate-virtual-time-wait (PERF-540)
+1	4.792	600	125.21	45.2	discard	PERF-568 Prebind stability check to remove branch in hot loop


### PR DESCRIPTION
💡 **What**: Evaluated prebinding the stability check via a state machine pattern to eliminate the `if (this.stabilityCheckState === 0)` branch from the hot loop in `CdpTimeDriver.ts`. The median render time was 4.792s vs baseline 4.768s. The experiment was discarded and the code was reverted.
🎯 **Why**: To bypass V8 hot loop branching logic and optimize the capture mechanism.
📊 **Impact**: No improvement (0% change / slight regression).
🔬 **Verification**: Code built, tests passed, benchmark validated using 3-run median in DOM mode.
📎 **Plan**: `/.sys/plans/PERF-568-prebind-stability-check.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 4.792 | 600 | 125.21 | 45.2 | discard | PERF-568 Prebind stability check to remove branch in hot loop |

---
*PR created automatically by Jules for task [14221167435248992805](https://jules.google.com/task/14221167435248992805) started by @BintzGavin*