### PR TITLE
📋 RENDERER: Remove explicit frameTimeTicks from beginFrame

### DIFF
--- a/.sys/plans/PERF-569-remove-frame-time-ticks.md
+++ b/.sys/plans/PERF-569-remove-frame-time-ticks.md
@@ -1,0 +1,61 @@
+---
+id: PERF-569
+slug: remove-frame-time-ticks
+status: unclaimed
+claimed_by: ""
+created: 2024-06-13
+completed: ""
+result: ""
+---
+
+# PERF-569: Remove explicit frameTimeTicks from beginFrame to reduce IPC overhead
+
+## Focus Area
+`DomStrategy.ts` hot loop (`capture`).
+
+## Background Research
+Currently, `DomStrategy` explicitly calculates and sends `frameTimeTicks` on every single frame:
+`this.beginFrameParams.frameTimeTicks = 10000 + (frameTime * 1000);`
+This requires computing the value, mutating the `beginFrameParams` object, and serializing this extra field over the CDP JSON payload to Chromium on every frame.
+
+According to Chromium's headless compositor logic, when `Emulation.setVirtualTimePolicy` is active (which it is, managed by `CdpTimeDriver.ts`), if `frameTimeTicks` is omitted from `HeadlessExperimental.beginFrame`, the headless compositor will automatically use the current virtual time. Since `CdpTimeDriver.ts` rigorously advances and syncs the virtual time before we call `capture()`, explicitly passing `frameTimeTicks` is redundant.
+
+Removing this parameter entirely from `beginFrameParams` and `targetBeginFrameParams` will reduce the JSON stringification size, reduce IPC bytes sent, and remove math/mutation from the Node.js hot loop, potentially yielding a measurable latency reduction across hundreds of frames.
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark (Simple Animation)
+- **Render Settings**: 600 frames, 60fps
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~0.960s (for 150 frames in microVM)
+- **Bottleneck analysis**: The Playwright CDP IPC serialization and V8 hot loop execution.
+
+## Implementation Spec
+
+### Step 1: Remove `frameTimeTicks` from `DomStrategy.ts`
+**File**: `packages/renderer/src/strategies/DomStrategy.ts`
+**What to change**:
+1. Remove `frameTimeTicks: 0` from the initialization of `beginFrameParams`.
+2. Remove `frameTimeTicks: 0` from the initialization of `targetBeginFrameParams`.
+3. In `capture()`, delete the lines:
+   `this.targetBeginFrameParams.frameTimeTicks = 10000 + (frameTime * 1000);`
+   and
+   `this.beginFrameParams.frameTimeTicks = 10000 + (frameTime * 1000);`
+
+**Why**: Rely on Chromium's native virtual time synchronization. This shrinks the IPC payload and removes per-frame arithmetic and property assignment.
+**Risk**: If Chromium does not correctly fall back to the virtual time when `frameTimeTicks` is missing in this specific version, animations might stall or frames might be duplicated. We will verify correctness via standard tests.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+N/A (DomStrategy specific).
+
+## Correctness Check
+Run `npm run test -w packages/renderer -- tests/verify-cdp-driver.ts` and standard build tasks to ensure animations progress correctly.
+
+## Prior Art
+- PERF-559: Fixed the scaling of `frameTimeTicks`, proving we have been manually massaging this value.


### PR DESCRIPTION
Created a new performance experiment plan to remove the explicit `frameTimeTicks` parameter from `HeadlessExperimental.beginFrame` calls in `DomStrategy.ts`. This aims to reduce the JSON serialization payload over the CDP IPC and bypass unnecessary per-frame arithmetic in the Node.js hot loop.

---
*PR created automatically by Jules for task [67550488910470585](https://jules.google.com/task/67550488910470585) started by @BintzGavin*