### PR TITLE
✨ RENDERER: Evaluate removing beginFrame interval

### DIFF
--- a/.sys/plans/PERF-570-remove-begin-frame-interval.md
+++ b/.sys/plans/PERF-570-remove-begin-frame-interval.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-570
 slug: remove-begin-frame-interval
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2024-06-14
-completed: ""
-result: ""
+completed: "2024-06-14"
+result: "no-improvement"
 ---
 
 # PERF-570: Remove interval from beginFrameParams
@@ -48,3 +48,9 @@ N/A.
 
 ## Correctness Check
 Run standard DOM render tests to ensure animations progress correctly.
+
+## Results Summary
+- **Best render time**: 13.530s (vs baseline 12.413s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-570]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -336,3 +336,7 @@ Last updated by: PERF-569
   - **What I tried**: Removed `--single-process` and added `--process-per-tab` to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts` to allow Chromium to distribute the rendering workload across multiple processes.
   - **WHY it didn't work**: The median render time (1.600s to 2.303s) actually improved slightly over the microVM baseline (2.209s), but variance was huge, and in general, managing multiple renderer processes per tab caused higher instability and CPU contention without consistent throughput improvements compared to the highly optimized single-process headless architecture. The experiment was discarded because it didn't demonstrate a consistent, clear win over the established baseline and introduced noise.
   - **Outcome**: discard
+- **PERF-570**: Remove interval from beginFrameParams
+  - **What I tried**: Removed the interval property from beginFrameParams and targetBeginFrameParams in DomStrategy.ts.
+  - **WHY it didn't work**: The median render time regressed to ~13.530s (vs baseline ~12.413s). Even though CdpTimeDriver explicitly steps virtual time, Chromium's compositor likely still uses the explicitly provided interval parameter to calculate frame pacing or expected vsync offsets internally. Removing it forces it to fall back to a default interval which causes internal synchronization stuttering.
+  - **Plan ID**: PERF-570

--- a/packages/renderer/.sys/perf-results-PERF-570.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-570.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	12.579	600	47.70	45.3	keep	baseline
+2	12.266	600	48.92	45.0	keep	baseline
+3	12.413	600	48.34	38.4	keep	baseline
+4	13.784	600	43.53	46.7	discard	remove-interval-1
+5	12.310	600	48.74	45.3	discard	remove-interval-2
+6	13.530	600	44.35	44.9	discard	remove-interval-3

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	12.579	600	47.70	45.3	keep	baseline
+2	12.266	600	48.92	45.0	keep	baseline
+3	12.413	600	48.34	38.4	keep	baseline
+4	13.784	600	43.53	46.7	discard	remove-interval-1
+5	12.310	600	48.74	45.3	discard	remove-interval-2
+6	13.530	600	44.35	44.9	discard	remove-interval-3


### PR DESCRIPTION
💡 **What**: Evaluated removing the interval property from beginFrameParams and targetBeginFrameParams.
🎯 **Why**: To reduce CDP payload size and rely strictly on CdpTimeDriver virtual time advancement.
📊 **Impact**: Regressed median time to ~13.530s from ~12.413s. Discarded and restored DomStrategy.ts.
🔬 **Verification**: Ran 3 benchmarks.
📎 **Plan**: PERF-570

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	12.579	600	47.70	45.3	keep	baseline
2	12.266	600	48.92	45.0	keep	baseline
3	12.413	600	48.34	38.4	keep	baseline
4	13.784	600	43.53	46.7	discard	remove-interval-1
5	12.310	600	48.74	45.3	discard	remove-interval-2
6	13.530	600	44.35	44.9	discard	remove-interval-3
```

---
*PR created automatically by Jules for task [14129114714978815234](https://jules.google.com/task/14129114714978815234) started by @BintzGavin*