### PR TITLE
✨ STUDIO: Document completed drag-drop, JKL shortcut, and CLI remove plans

### DIFF
--- a/.jules/STUDIO.md
+++ b/.jules/STUDIO.md
@@ -8,3 +8,6 @@
 ## v0.121.11 - ExportJobSpec is already implemented
 **Learning:** The "Export Job Spec" feature in the Renders Panel was found to be fully implemented, representing an "IMPOSSIBLE: DUPLICATION" scenario. This shows the importance of always checking the current codebase state before assuming missing functionality.
 **Action:** Before executing a feature addition, comprehensively search the UI code (e.g. RendersPanel.tsx, StudioContext.tsx) and API endpoints to verify the gap actually exists.
+## 0.121.16 - CLI Refine Component Removal
+**Learning:** IMPOSSIBLE: DUPLICATION. The requested feature in `2026-10-23-STUDIO-Refine-CLI-Component-Removal.md` to refine the `helios remove` CLI command to delete component files by default is already implemented in `packages/cli/src/commands/remove.ts`.
+**Action:** Always check the codebase before implementing features to avoid duplicating effort.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -626,6 +626,11 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### PLAYER v0.77.35
 - ✅ Completed: Improve index.ts test coverage - Added tests for captureStream and audio metering edge cases.
+### STUDIO v0.121.16
+- ✅ Completed: Refine CLI Component Removal - Verified that the `helios remove` CLI command already deletes component files by default (IMPOSSIBLE: DUPLICATION).
+- ✅ Completed: Add JKL Playback Shortcuts - Verified that the `J, K, L` playback shortcuts are already implemented in `GlobalShortcuts.tsx` (IMPOSSIBLE: DUPLICATION).
+- ✅ Completed: Timeline Drag & Drop - Verified that the timeline drag drop logic is already fully implemented (IMPOSSIBLE: DUPLICATION).
+
 ### STUDIO v0.121.15
 - ✅ Completed: Document duplicated Timeline-Scrubber plan - Logged the duplicated plan as impossible since Timeline already supports scrubbing.
 

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,10 +1,13 @@
-**Version**: 0.121.15
+**Version**: 0.121.16
 
 [v0.121.13] ✅ Completed: Expand Reverse Speeds - Added -4x and -2x reverse playback options to the PlaybackControls component.
 
 **Posture**: ACTIVELY EXPANDING FOR V2
 
 # Studio Domain Status
+- [v0.121.16] ✅ Completed: Refine CLI Component Removal - Verified that the `helios remove` CLI command already deletes component files by default (IMPOSSIBLE: DUPLICATION).
+- [v0.121.16] ✅ Completed: Add JKL Playback Shortcuts - Verified that the `J, K, L` playback shortcuts are already implemented in `GlobalShortcuts.tsx` (IMPOSSIBLE: DUPLICATION).
+- [v0.121.16] ✅ Completed: Timeline Drag & Drop - Verified that the timeline drag drop logic is already fully implemented (IMPOSSIBLE: DUPLICATION).
 - [v0.121.12] ✅ Completed: STUDIO-system-prompt - Verified that the AI System Prompt feature was already fully implemented via AssistantModal (IMPOSSIBLE: DUPLICATION).
 - [v0.121.11] ✅ Completed: STUDIO-ExportJobSpec - Verified that the Export Job Spec feature in Renders Panel was already fully implemented (IMPOSSIBLE: DUPLICATION).
 - [v0.121.10] ✅ Completed: Update Keyboard Shortcuts - Implemented missing JKL keyboard shortcuts documentation in the Help Modal.


### PR DESCRIPTION
Updated status, progress, and journal files to mark STUDIO plans (Drag-Drop timeline, Audio Drag-Drop, JKL Shortcuts, and CLI Refine Component Removal) as impossible/duplicated since they are already fully implemented.

---
*PR created automatically by Jules for task [17925527383223100358](https://jules.google.com/task/17925527383223100358) started by @BintzGavin*