### PR TITLE
✨ RENDERER: Evaluate PERF-572 skip duplicate frames payload serialization

### DIFF
--- a/.sys/plans/PERF-572-skip-duplicate-frames.md
+++ b/.sys/plans/PERF-572-skip-duplicate-frames.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-572
 slug: skip-duplicate-frames
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-06-13
-completed: ""
-result: ""
+completed: "2024-06-13"
+result: "Render time improved to ~1.172s"
 ---
 
 # PERF-572: Skip base64 payload serialization on identical frames

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -344,3 +344,6 @@ Last updated by: PERF-569
   - **What I tried**: Removed `optimizeForSpeed: true` from the CDP screenshot parameters in `DomStrategy.ts`. Hypothesized that skipping optimization would slightly increase Chromium CPU time but produce smaller Base64 payloads to reduce Playwright IPC/JSON parsing overhead.
   - **WHY it didn't work**: Resulted in a negligible performance change/slight regression (median ~1.585s vs baseline ~1.469s) indicating the IPC payload savings from smaller images didn't outweigh the additional CPU cost in Skia compressing the JPEGs.
   - **Outcome**: discard
+
+## What Works
+- **PERF-572**: Skip duplicate frames payload serialization. By using a MutationObserver and monkey-patching `requestAnimationFrame` to detect dirty DOM states, we conditionally omit the `screenshot` parameter in `HeadlessExperimental.beginFrame` when the frame hasn't changed. This completely bypasses the massive overhead of Base64 encoding/decoding and IPC JSON parsing for identical frames. Improved render time to ~1.172s (vs baseline ~1.511s).

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -110,3 +110,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	4.792	600	125.21	45.2	discard	PERF-568 Prebind stability check to remove branch in hot loop
 1	1.511	150	99.26	42.4	keep	already implemented in baseline
 1	1.585	150	94.65	42.5	discard	Remove optimizeForSpeed: true from intermediate CDP screenshot params to reduce payload size
+572	1.172	150	127.95	47.6	keep	PERF-572 skip duplicate frames payload serialization

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -140,6 +140,21 @@ export class CdpTimeDriver implements TimeDriver {
 
         let cachedMediaElements = null;
 
+        window.__helios_is_dirty = true;
+        const observer = new MutationObserver(() => { window.__helios_is_dirty = true; });
+        observer.observe(document, { attributes: true, childList: true, subtree: true, characterData: true });
+        const origRaf = window.requestAnimationFrame;
+        window.requestAnimationFrame = (cb) => {
+            window.__helios_is_dirty = true;
+            return origRaf(cb);
+        };
+
+        window.__helios_check_and_reset_dirty = () => {
+            const dirty = window.__helios_is_dirty;
+            window.__helios_is_dirty = false;
+            return dirty;
+        };
+
         window.__helios_invalidate_cache = () => {
           cachedMediaElements = null;
         };

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -190,6 +190,21 @@ export class DomStrategy implements RenderStrategy {
     }
 
     try {
+      let isDirty = true;
+      try {
+        const { result } = await this.cdpSession!.send('Runtime.evaluate', {
+          expression: "typeof window.__helios_check_and_reset_dirty === 'function' ? window.__helios_check_and_reset_dirty() : true",
+          returnByValue: true
+        });
+        if (result && typeof result.value === 'boolean') {
+          isDirty = result.value;
+        }
+      } catch (e) {
+        // ignore
+      }
+
+      this.beginFrameParams.screenshot = isDirty ? this.cdpScreenshotParams : undefined;
+
       const result = await this.cdpSession!.send('HeadlessExperimental.beginFrame', this.beginFrameParams);
       const frameData = result.screenshotData || this.lastFrameData!;
       this.lastFrameData = frameData;


### PR DESCRIPTION
💡 **What**: Added logic to dynamically detect clean frames (via MutationObserver and requestAnimationFrame monkey patching in CdpTimeDriver.ts). This skips the screenshot request payload parameter for frames with no damage in DomStrategy.ts.
🎯 **Why**: Base64 JSON parsing and piping duplicate/unmutated frames is slow and bloated IPC transfers.
📊 **Impact**: Render times improved to ~1.17s (vs baseline ~1.511s).
🔬 **Verification**: 4-gate verification and benchmark median log values recorded.
📎 **Plan**: `/.sys/plans/PERF-572-skip-duplicate-frames.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 1.172 | 150 | 127.95 | 47.6 | keep | PERF-572 skip duplicate frames payload serialization |

---
*PR created automatically by Jules for task [11861958027000663122](https://jules.google.com/task/11861958027000663122) started by @BintzGavin*