### PR TITLE
chore: document failed PERF-572 skip duplicate frames experiment

### DIFF
--- a/.sys/plans/PERF-572-skip-duplicate-frames.md
+++ b/.sys/plans/PERF-572-skip-duplicate-frames.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-572
 slug: skip-duplicate-frames
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-06-13
 completed: ""
-result: ""
+result: failed
 ---
 
 # PERF-572: Skip base64 payload serialization on identical frames

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -53,6 +53,7 @@ Last updated by: PERF-569
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- [FAILED] Skipping base64 payload serialization on identical frames via dirty tracking (PERF-572) - Flawed heuristic misses CSS animations, scrolling, Canvas/WebGL updates, etc.
 - **PERF-507: Eliminate defaultStabilityCheck method and inline logic**
   - **What I tried**: Attempted to inline `defaultStabilityCheck` directly into `runSetTime` in `CdpTimeDriver.ts`.
   - **WHY it didn't work**: The `defaultStabilityCheck` method had already been eliminated in previous iterations (likely PERF-506) and the `Runtime.evaluate` call was already inlined. This experiment was discarded as a duplicate with no code changes.


### PR DESCRIPTION
Evaluated skipping base64 payload serialization on identical frames using a dirty tracking heuristic (MutationObserver + RAF override). The experiment was discarded because the heuristic is fundamentally flawed and misses critical visual updates such as CSS animations, scrolling, form inputs, and Canvas/WebGL redraws. The renderer would output frozen frames in these scenarios. Reverted code changes and updated RENDERER-EXPERIMENTS.md with the failure analysis.

---
*PR created automatically by Jules for task [15605422094800380772](https://jules.google.com/task/15605422094800380772) started by @BintzGavin*