### PR TITLE
✨ CLI: Job Types Regression Tests

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -642,3 +642,5 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### CLI v0.46.34
 - ✅ Completed: CLI Registry Types Regression Tests - Implemented structural verification tests for registry interfaces.
+### CLI v0.46.35
+- ✅ Completed: CLI Job Types Regression Tests - Implemented unit tests for job specification interfaces in packages/cli/src/types/__tests__/job.test.ts.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,4 +1,4 @@
-**Version**: 0.46.34
+**Version**: 0.46.35
 
 [v0.46.34] ✅ Completed: CLI Registry Types Regression Tests - Implemented structural verification tests for registry interfaces.
 [v0.46.33] ✅ Completed: CLI Job Regression Tests Missing Mock - Added missing mock setup for @helios-project/infrastructure to fix import resolution errors
@@ -149,3 +149,4 @@ The Helios CLI is the primary user interface for component registry, project sca
 [v0.46.31] ✅ Completed: CLI Index Regression Tests - Implemented unit tests for the main CLI entry point in packages/cli/src/__tests__/index.test.ts.
 [v0.46.33] 🟢 Completed: CLI Registry Types Regression Tests Spec - Created specification plan `2027-06-05-CLI-Registry-Types-Regression-Tests.md` for implementing structural verification tests for registry interfaces.
 [v0.46.34] 🟢 Completed: CLI Job Types Regression Tests Spec - Created specification plan `2027-06-05-CLI-Job-Types-Regression-Tests.md` for implementing structural verification tests for job specification interfaces.
+[v0.46.35] ✅ Completed: CLI Job Types Regression Tests - Implemented unit tests for job specification interfaces in packages/cli/src/types/__tests__/job.test.ts.

--- a/packages/cli/src/types/__tests__/job.test.ts
+++ b/packages/cli/src/types/__tests__/job.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import type { RenderJobChunk, RenderJobMetadata, JobSpec } from '../job';
+
+describe('Job Types Structural Tests', () => {
+  it('should construct a valid RenderJobChunk', () => {
+    const chunk: RenderJobChunk = {
+      id: 1,
+      startFrame: 0,
+      frameCount: 60,
+      outputFile: 'output.mp4',
+      command: 'helios render --chunk'
+    };
+
+    expect(chunk).toBeDefined();
+    expect(chunk.id).toBeTypeOf('number');
+    expect(chunk.startFrame).toBeTypeOf('number');
+    expect(chunk.frameCount).toBeTypeOf('number');
+    expect(chunk.outputFile).toBeTypeOf('string');
+    expect(chunk.command).toBeTypeOf('string');
+  });
+
+  it('should construct a valid RenderJobMetadata', () => {
+    const metadata: RenderJobMetadata = {
+      totalFrames: 120,
+      fps: 30,
+      width: 1920,
+      height: 1080,
+      duration: 4
+    };
+
+    expect(metadata).toBeDefined();
+    expect(metadata.totalFrames).toBeTypeOf('number');
+    expect(metadata.fps).toBeTypeOf('number');
+    expect(metadata.width).toBeTypeOf('number');
+    expect(metadata.height).toBeTypeOf('number');
+    expect(metadata.duration).toBeTypeOf('number');
+  });
+
+  it('should construct a valid JobSpec', () => {
+    const spec: JobSpec = {
+      metadata: {
+        totalFrames: 120,
+        fps: 30,
+        width: 1920,
+        height: 1080,
+        duration: 4
+      },
+      chunks: [
+        {
+          id: 1,
+          startFrame: 0,
+          frameCount: 60,
+          outputFile: 'output1.mp4',
+          command: 'helios render --chunk 1'
+        }
+      ],
+      mergeCommand: 'helios merge'
+    };
+
+    expect(spec).toBeDefined();
+    expect(spec.metadata).toBeTypeOf('object');
+    expect(spec.chunks).toBeInstanceOf(Array);
+    expect(spec.mergeCommand).toBeTypeOf('string');
+  });
+});


### PR DESCRIPTION
Implemented regression tests for CLI Job Types (RenderJobChunk, RenderJobMetadata, JobSpec) to enforce structural constraints, satisfying `2027-06-05-CLI-Job-Types-Regression-Tests.md`. Tested successfully via Vitest. Documented in CLI.md and PROGRESS.md. Version bumped to `0.46.35`.

---
*PR created automatically by Jules for task [2752075871426109012](https://jules.google.com/task/2752075871426109012) started by @BintzGavin*