### PR TITLE
✨ RENDERER: Discard PERF-576 exact match browserpool concurrency

### DIFF
--- a/.sys/plans/PERF-576-browser-pool-concurrency-three.md
+++ b/.sys/plans/PERF-576-browser-pool-concurrency-three.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-576
 slug: browser-pool-concurrency-three
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2024-05-24"
+result: "no-improvement"
 ---
 
 # PERF-576: Test Exact Core Match Concurrency for DOM Strategy
@@ -51,3 +51,9 @@ Run `npm run test -w packages/renderer -- --run`
 
 ## Correctness Check
 Run the DOM render benchmark script (`npx tsx scripts/benchmark-perf.ts`) to measure performance and ensure valid output video generation.
+
+## Results Summary
+- **Best render time**: 1.529s (vs baseline 1.541s)
+- **Improvement**: 0.7% (noise)
+- **Kept experiments**: []
+- **Discarded experiments**: [BrowserPool Concurrency Exact Match]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -366,3 +366,7 @@ Last updated by: PERF-573
   - **WHY it didn't work**: The optimization is already natively implemented in the baseline codebase.
   - **Outcome**: discard (already implemented)
 - Pre-check freeWorkersHead in CaptureLoop orchestrator: ~2% faster (PERF-575)
+- **PERF-576**: BrowserPool Concurrency Exact Match
+  - **What I tried**: Modified `BrowserPool.ts` concurrency calculation from `Math.max(1, (os.cpus().length || 4) - 1)` to `Math.max(1, (os.cpus().length || 4))` to match the number of workers exactly to the number of logical cores.
+  - **WHY it didn't work**: The median render time did not improve and remained roughly the same as the baseline (~1.529s vs baseline ~1.541s). There was no significant throughput improvement, indicating that leaving one core free (the baseline) is sufficient and matching exactly the number of cores does not alleviate the Playwright CDP IPC wait time bottleneck. Therefore, the experiment was discarded as inconclusive noise.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-576.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-576.tsv
@@ -1,0 +1,3 @@
+run\trender_time_s\tframes\tfps_effective\tpeak_mem_mb\tstatus\tdescription
+1\t1.541\t150\t97.32\t42.3\tkeep\tbaseline
+2\t1.529\t150\t98.12\t44.8\tdiscard\tMath.max(1, (os.cpus().length || 4))


### PR DESCRIPTION
Evaluated exact core match concurrency for `BrowserPool` by changing the calculation from `Math.max(1, (os.cpus().length || 4) - 1)` to `Math.max(1, (os.cpus().length || 4))`. The optimization was discarded because the median render time improvement was negligible and well within the margin of noise (1.529s vs 1.541s baseline), indicating that leaving a core free avoids context-switching without decreasing CDP IPC throughput.

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.541	150	97.32	42.3	keep	baseline
2	1.529	150	98.12	44.8	discard	Math.max(1, (os.cpus().length || 4))
```

---
*PR created automatically by Jules for task [1676199583691241708](https://jules.google.com/task/1676199583691241708) started by @BintzGavin*