### PR TITLE
✨ RENDERER: Evaluate raw CDP Screencast vs HeadlessExperimental.beginFrame

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -370,3 +370,7 @@ Last updated by: PERF-573
   - **What I tried**: Modified `BrowserPool.ts` concurrency calculation from `Math.max(1, (os.cpus().length || 4) - 1)` to `Math.max(1, (os.cpus().length || 4))` to match the number of workers exactly to the number of logical cores.
   - **WHY it didn't work**: The median render time did not improve and remained roughly the same as the baseline (~1.529s vs baseline ~1.541s). There was no significant throughput improvement, indicating that leaving one core free (the baseline) is sufficient and matching exactly the number of cores does not alleviate the Playwright CDP IPC wait time bottleneck. Therefore, the experiment was discarded as inconclusive noise.
   - **Outcome**: discard
+- **PERF-512**: Test raw CDP Screencast vs HeadlessExperimental.beginFrame
+  - **What I tried**: Removed `--enable-begin-frame-control` and `--run-all-compositor-stages-before-draw` from `BrowserPool.ts` and replaced `HeadlessExperimental.beginFrame` with `Page.startScreencast` using a small fallback timeout for damage-less frames in `DomStrategy.ts`.
+  - **WHY it didn't work**: The median render time regressed to ~1.664s compared to the baseline of ~1.515s. Without the deterministic explicit synchronization provided by `beginFrame` and Chromium's external compositor control, falling back to timeouts for static frames and relying purely on screencast frame emission overhead is slower and less efficient than directly advancing and reading frames in lockstep.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -114,3 +114,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	2.158	150	69.49	42.3	discard	already implemented in baseline (PERF-488)
 1	2.158	150	69.49	42.3	discard	already implemented in baseline (PERF-491)
 2026-05-18	1.476	150	101.62	44.0	keep	Pre-check freeWorkersHead in CaptureLoop orchestrator
+1	1.664	150	90.12	45.6	discard	PERF-512 Test raw CDP Screencast vs HeadlessExperimental.beginFrame

--- a/packages/renderer/.sys/plans/PERF-512-test-raw-cdp-screencast-no-external-compositor.md
+++ b/packages/renderer/.sys/plans/PERF-512-test-raw-cdp-screencast-no-external-compositor.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-512
 slug: test-raw-cdp-screencast-no-external-compositor
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-15
-completed: ""
-result: ""
+completed: 2024-05-24
+result: "no-improvement"
 ---
 
 # PERF-512: Test Raw CDP Screencast without External Compositor Control
@@ -41,3 +41,9 @@ Previous attempts to use `Page.startScreencast` failed because Chromium's extern
 
 ## Correctness Check
 Verify DOM output is still correct, specifically that animations and transitions remain smooth and accurately timed without external compositor control.
+
+## Results Summary
+- **Best render time**: 1.664s (vs baseline 1.515s)
+- **Improvement**: -9.8% (regression)
+- **Kept experiments**: []
+- **Discarded experiments**: [Test raw CDP Screencast vs HeadlessExperimental.beginFrame]


### PR DESCRIPTION
✨ RENDERER: Evaluate raw CDP Screencast vs HeadlessExperimental.beginFrame

💡 What: Evaluated replacing HeadlessExperimental.beginFrame with Page.startScreencast and removing external compositor control flags.
🎯 Why: To test if falling back to screencast timeouts for static frames could bypass IPC overhead of beginFrame.
📊 Impact: Regression. Render time increased to ~1.664s compared to the ~1.515s baseline.
🔬 Verification: Ran the benchmark script and correctly discarded the code changes while documenting the regression in RENDERER-EXPERIMENTS.md and perf-results.tsv.
📎 Plan: Reference the plan file /.sys/plans/PERF-512-test-raw-cdp-screencast-no-external-compositor.md

Results:
1	1.664	150	90.12	45.6	discard	PERF-512 Test raw CDP Screencast vs HeadlessExperimental.beginFrame

---
*PR created automatically by Jules for task [11842865255758707004](https://jules.google.com/task/11842865255758707004) started by @BintzGavin*