### PR TITLE
✨ RENDERER: Discard raw CDP screencast experiment (PERF-513)

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -374,3 +374,7 @@ Last updated by: PERF-573
   - **What I tried**: Removed `--enable-begin-frame-control` and `--run-all-compositor-stages-before-draw` from `BrowserPool.ts` and replaced `HeadlessExperimental.beginFrame` with `Page.startScreencast` using a small fallback timeout for damage-less frames in `DomStrategy.ts`.
   - **WHY it didn't work**: The median render time regressed to ~1.664s compared to the baseline of ~1.515s. Without the deterministic explicit synchronization provided by `beginFrame` and Chromium's external compositor control, falling back to timeouts for static frames and relying purely on screencast frame emission overhead is slower and less efficient than directly advancing and reading frames in lockstep.
   - **Outcome**: discard
+- **PERF-513**: Test raw CDP Screencast without external compositor control
+  - **What I tried**: Removed `--enable-begin-frame-control` and `--run-all-compositor-stages-before-draw` from `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`. Replaced `HeadlessExperimental.beginFrame` with `Page.startScreencast` and a short timeout fallback in `DomStrategy.ts`.
+  - **WHY it didn't work**: The median render time regressed to ~1.801s compared to the baseline of ~1.511s. Relying on screencast frame emission with a timeout fallback for static frames is slower and less efficient than directly advancing and reading frames deterministically in lockstep using `beginFrame`.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -115,3 +115,4 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 1	2.158	150	69.49	42.3	discard	already implemented in baseline (PERF-491)
 2026-05-18	1.476	150	101.62	44.0	keep	Pre-check freeWorkersHead in CaptureLoop orchestrator
 1	1.664	150	90.12	45.6	discard	PERF-512 Test raw CDP Screencast vs HeadlessExperimental.beginFrame
+118	1.801	150	83.27	36.4	discard	PERF-513 Test raw CDP Screencast without external compositor control

--- a/packages/renderer/.sys/plans/PERF-513-test-raw-cdp-screencast-no-external-compositor.md
+++ b/packages/renderer/.sys/plans/PERF-513-test-raw-cdp-screencast-no-external-compositor.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-513
 slug: test-raw-cdp-screencast-no-external-compositor
-status: claimed
+status: complete
 claimed_by: ""
 created: 2024-05-15
 completed: "2024-05-15"
@@ -43,3 +43,10 @@ This plan aims to modify `BrowserPool.ts` to remove the conflicting arguments, a
 
 ## Correctness Check
 Verify DOM output is still correct, specifically that animations and transitions remain smooth and accurately timed without external compositor control.
+
+## Results Summary
+| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
+|---|---|---|---|---|---|---|
+| 118 | 1.801 | 150 | 83.27 | 36.4 | discard | PERF-513 Test raw CDP Screencast without external compositor control |
+
+**Outcome**: discard. The median render time regressed to ~1.801s compared to the baseline of ~1.511s. Relying on screencast frame emission with a timeout fallback for static frames is slower and less efficient than directly advancing and reading frames deterministically in lockstep using `beginFrame`.


### PR DESCRIPTION
💡 **What**: Tested removing external compositor control (`--enable-begin-frame-control` and `--run-all-compositor-stages-before-draw`) and replacing `HeadlessExperimental.beginFrame` with `Page.startScreencast` using a short fallback timeout for unchanged frames. The experiment failed and the code was reverted to the baseline.
🎯 **Why**: To see if relying purely on damage-driven `screencastFrame` events would bypass the strict synchronization latencies of `beginFrame` and Playwright IPC overheads during deterministic playback.
📊 **Impact**: The median render time regressed to ~1.801s compared to the highly optimized baseline of ~1.511s. Relying on screencast frame emission with a timeout fallback for static frames proved to be slower and far less efficient than deterministically advancing and reading frames in lockstep.
🔬 **Verification**: Code built successfully. The benchmark was run 3 times, yielding rendering times of 2.207s, 1.363s, and 1.801s. Due to the regression, code changes were fully reverted while tracking files were updated with the result.
📎 **Plan**: `packages/renderer/.sys/plans/PERF-513-test-raw-cdp-screencast-no-external-compositor.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 118 | 1.801 | 150 | 83.27 | 36.4 | discard | PERF-513 Test raw CDP Screencast without external compositor control |

---
*PR created automatically by Jules for task [611003918432049614](https://jules.google.com/task/611003918432049614) started by @BintzGavin*