### PR TITLE
📋 PLAYER: Document Seeking Events API Parity Gap

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -48,3 +48,6 @@
 ## v0.77.31 - Accurate Verification of Documented API
 **Learning:** During planning to update `README.md` for undocumented API members (`audioTracks`, `videoTracks`, `setPlaybackRange`, etc.), I found that some of these were actually either already documented or they belonged to the controller interface rather than the public web component API.
 **Action:** Always carefully check the target documentation file (`README.md`) using strict grep patterns to ensure the gap actually exists, and verify if the member belongs to the public API or internal interfaces before adding it to the plan.
+## v0.77.32 - Undocumented Seeking Events
+**Learning:** Found that `seeking` and `seeked` events are being dispatched by the player but were not documented in the README.md events list.
+**Action:** Created a plan to document the missing events to maintain API parity visibility.

--- a/.sys/plans/v0.77.33-PLAYER-Document-Seeking-Events.md
+++ b/.sys/plans/v0.77.33-PLAYER-Document-Seeking-Events.md
@@ -1,0 +1,20 @@
+#### 1. Context & Goal
+- **Objective**: Document the `seeking` and `seeked` events in the `README.md` to match the actual implementation in `packages/player/src/index.ts`.
+- **Trigger**: I reviewed `packages/player/src/index.ts` and confirmed that `seeking` and `seeked` events are dispatched, but they are missing from the `Events` list in `packages/player/README.md`.
+
+#### 2. File Inventory
+- **Modify**: `packages/player/README.md`
+- **Read-Only**: `packages/player/src/index.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Documentation update to maintain API parity visibility.
+- **Pseudo-Code**:
+  - Add `- \`seeking\`: Fired when a seek operation starts.` to the Events section.
+  - Add `- \`seeked\`: Fired when a seek operation completes.` to the Events section.
+- **Public API Changes**: None (documentation only).
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `grep -A 20 "## Events" packages/player/README.md`
+- **Success Criteria**: The `seeking` and `seeked` events appear in the `Events` section of the README.
+- **Edge Cases**: None.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -235,3 +235,4 @@
 [v0.77.30] ✅ Completed: Discovered undocumented API properties and events in README.md. Created plan `.sys/plans/2026-12-30-PLAYER-README-API-Update.md` to document `audioTracks`, `videoTracks`, `enterpictureinpicture`, and `leavepictureinpicture`.
 [v0.77.31] ✅ Completed: Discovered undocumented API properties, methods and events in README.md. Created plan `.sys/plans/2026-12-30-PLAYER-README-API-Update.md` to document `enterpictureinpicture`, `leavepictureinpicture`, `captureStream`, `startAudioMetering`, and `stopAudioMetering`.
 [v0.77.32] ✅ Completed: Document API Parity Gap - Updated README to document existing methods (captureStream, startAudioMetering, stopAudioMetering) and events (enterpictureinpicture, leavepictureinpicture).
+[v0.77.33] ✅ Completed: Discovered undocumented seeking events in README.md. Created plan `.sys/plans/v0.77.33-PLAYER-Document-Seeking-Events.md` to document `seeking` and `seeked` events.


### PR DESCRIPTION
Created a plan file to address missing API parity documentation for the `seeking` and `seeked` events in the `<helios-player>` Web Component.
The plan (`.sys/plans/v0.77.33-PLAYER-Document-Seeking-Events.md`) outlines how to update the `README.md` to properly document these events which are already dispatched by the component logic.
Updated tracker files appropriately as the Planner agent.

---
*PR created automatically by Jules for task [5255540589549952890](https://jules.google.com/task/5255540589549952890) started by @BintzGavin*