### PR TITLE
📋 CLI: Job/Render/Merge Tests Missing Mock Spec

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -223,3 +223,6 @@ Critical learnings only. This is not a log—only add entries for insights that 
 ## [v0.46.34] - Identify Uncovered Job Types
 **Learning:** The fallback action from [v0.46.33] for the registry types regression tests was completed. Searching for uncovered areas in a stable domain requires thoroughly checking tests against source files. `packages/cli/src/types/job.ts` currently lacks test coverage (using static types in assertions) while defining the core shape of the render job specification.
 **Action:** When falling back to regression testing under the NOTHING TO DO PROTOCOL, target TypeScript type files (like types.ts) that enforce structural constraints when command, templates, registry and utils coverage is 100%. Created plan `2027-06-05-CLI-Job-Types-Regression-Tests.md`.
+## [v0.46.36] - Document missing mock plan creation
+**Learning:** The fallback action from [v0.46.29] for the job, render, and merge test failure was to write a new plan. I created 2027-06-05-CLI-Job-Render-Merge-Regression-Tests-Missing-Mock.md.
+**Action:** Wrote plan to fix missing vi.mock calls.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -144,4 +144,5 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] [v0.46.20] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/
 - [x] [v0.46.21] CLI Unblocked: Generated plan /.sys/plans/2027-06-05-CLI-Registry-Manifest-Regression-Tests.md
 - [x] [v0.46.22] CLI Unblocked: Generated plan /.sys/plans/2027-06-05-CLI-Templates-Regression-Tests.md
-- [ ] [v0.46.29] CLI Unblocked: Generated strictly new plan /.sys/plans/2027-06-05-CLI-Cloud-Templates-Regression-Tests-V2.md
+- [x] [v0.46.29] CLI Unblocked: Generated strictly new plan /.sys/plans/2027-06-05-CLI-Cloud-Templates-Regression-Tests-V2.md
+- [ ] [v0.46.36] CLI Unblocked: Generated strictly new plan /.sys/plans/2027-06-05-CLI-Job-Render-Merge-Regression-Tests-Missing-Mock.md

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -145,8 +145,9 @@ The Helios CLI is the primary user interface for component registry, project sca
 [v0.46.22] 🟢 Completed: CLI Templates Regression Tests Spec - Created specification plan `2027-06-05-CLI-Templates-Regression-Tests.md` for implementing regression tests for all file generation templates in `packages/cli/src/templates`.
 
 [v0.46.24] ✅ Completed: CLI Templates Regression Tests - Implemented unit tests for file generation templates in packages/cli/src/templates.
-- [ ] [v0.46.27] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/
+- [x] [v0.46.27] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/
 [v0.46.31] ✅ Completed: CLI Index Regression Tests - Implemented unit tests for the main CLI entry point in packages/cli/src/__tests__/index.test.ts.
 [v0.46.33] 🟢 Completed: CLI Registry Types Regression Tests Spec - Created specification plan `2027-06-05-CLI-Registry-Types-Regression-Tests.md` for implementing structural verification tests for registry interfaces.
 [v0.46.34] 🟢 Completed: CLI Job Types Regression Tests Spec - Created specification plan `2027-06-05-CLI-Job-Types-Regression-Tests.md` for implementing structural verification tests for job specification interfaces.
 [v0.46.35] ✅ Completed: CLI Job Types Regression Tests - Implemented unit tests for job specification interfaces in packages/cli/src/types/__tests__/job.test.ts.
+[v0.46.36] 🟢 Completed: CLI Job/Render/Merge Tests Missing Mock Spec - Created specification plan `2027-06-05-CLI-Job-Render-Merge-Regression-Tests-Missing-Mock.md` for fixing vitest mock resolution errors.


### PR DESCRIPTION
Created specification plan `.sys/plans/2027-06-05-CLI-Job-Render-Merge-Regression-Tests-Missing-Mock.md` for fixing vitest mock resolution errors.
Updated `docs/status/CLI.md`, `docs/BACKLOG.md` and `.jules/CLI.md`.

---
*PR created automatically by Jules for task [9251686498482648343](https://jules.google.com/task/9251686498482648343) started by @BintzGavin*