### PR TITLE
📋 RENDERER: Bypass capture Promise Await

### DIFF
--- a/.sys/plans/PERF-580-inline-cdp-session-send.md
+++ b/.sys/plans/PERF-580-inline-cdp-session-send.md
@@ -1,0 +1,58 @@
+---
+id: PERF-580
+slug: inline-cdp-session-send
+status: unclaimed
+claimed_by: ""
+created: 2026-10-31
+completed: ""
+result: ""
+---
+
+# PERF-580: Bypass `capture` Promise Await and Inline CDP Session Send
+
+## Focus Area
+`DomStrategy.ts` and `CdpTimeDriver.ts` hot loops.
+
+## Background Research
+In the multi-worker ACTOR MODEL implementation, `runWorker` awaits `timeDriver.setTime()` and `strategy.capture()`.
+Because `strategy.capture(page, time)` ultimately calls Playwright's CDP `client.send(...)` which returns a Promise, we are currently awaiting that Promise directly within an `async` function. Every `await` in V8 introduces at least two microtask ticks and allocates a new Promise under the hood for resuming the generator context.
+By removing the `async` wrapper on `capture()` and `runSetTime()` and returning the promises directly (using `.then()` for `capture`), we eliminate the V8 generator allocations for those functions, saving promise allocation overhead per frame.
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark (Simple Animation)
+- **Render Settings**: 1920x1080, 60fps, 10s duration
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~1.436s
+- **Bottleneck analysis**: V8 generator state machine allocations (`async`/`await`) in the per-frame `capture` and `runSetTime` methods.
+
+## Implementation Spec
+
+### Step 1: Remove `async`/`await` from `DomStrategy.capture`
+**File**: `packages/renderer/src/strategies/DomStrategy.ts`
+**What to change**:
+Change the signature of `capture` to return `Promise<Buffer | string> | Buffer | string` and remove `async`.
+Update the main `HeadlessExperimental.beginFrame` code path to return the promise from `cdpSession!.send` with a `.then()` and `.catch()` chain, rather than using `await` and `try/catch`.
+Update the `targetElementHandle` block similarly to use `.then()` for `boundingBox()` and the inner CDP call.
+
+**Why**: Returning the promise directly avoids the overhead of V8 wrapping the execution in an `async` generator.
+
+### Step 2: Remove `async`/`await` from `CdpTimeDriver.runSetTime`
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+Change the signature of `runSetTime` to return `Promise<void> | void` and remove `async`.
+Replace `await new Promise<void>(this.virtualTimePromiseExecutor);` and the following `this.currentTime = timeInSeconds;` with setting `currentTime` and returning the Promise directly.
+
+**Why**: Returning the promise directly avoids the overhead of V8 wrapping the execution in an `async` generator, reducing memory allocations and microtask ticks per frame.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run `npm run test -w packages/renderer -- --run` to ensure changes don't break Canvas compilation.
+
+## Correctness Check
+Run `npm run test -w packages/renderer -- --run` and execute the benchmark.


### PR DESCRIPTION
Creates the `PERF-580` plan file to investigate bypassing the promise await in the capture hot loops by returning the promises directly.

---
*PR created automatically by Jules for task [13773741953378547349](https://jules.google.com/task/13773741953378547349) started by @BintzGavin*