### PR TITLE
✨ RENDERER: Discard PERF-581 prebind capture promises experiment

### DIFF
--- a/.sys/plans/PERF-581-prebind-capture-promises.md
+++ b/.sys/plans/PERF-581-prebind-capture-promises.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-581
 slug: prebind-capture-promises
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-25
-completed: ""
-result: ""
+completed: "2024-05-25"
+result: "discarded"
 ---
 
 # PERF-581: Prebind Promises and Eliminate Closures in Capture Hot Loop
@@ -103,3 +103,9 @@ Run `npm run test -w packages/renderer -- --run` and execute the benchmark.
 
 ## Prior Art
 Builds on PERF-580, which eliminated the `async`/`await` generator state machines in these exact functions. This takes it a step further by eliminating the closures and trailing `.then()`/.`catch()` Promise chaining.
+
+## Results Summary
+- **Best render time**: 1.477s (median 1.516s)
+- **Improvement**: Regressed compared to baseline (~1.427s)
+- **Kept experiments**: None
+- **Discarded experiments**: Prebind CDP capture handlers and eliminate closures in `DomStrategy.ts` and `CdpTimeDriver.ts`. Reason: Indirect function execution contexts slightly slowed down Promise resolution compared to V8's highly optimized inline closures.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -391,3 +391,7 @@ Last updated by: PERF-573
 - **PERF-580**: Bypass `capture` Promise Await and Inline CDP Session Send
   - **What I did**: Removed `async`/`await` from `capture` in `DomStrategy.ts` and `runSetTime` in `CdpTimeDriver.ts`, returning the CDP Promise chain directly instead.
   - **Impact**: Reduced V8 generator allocations and microtask ticks per frame. Median render time improved to ~1.427s.
+- **PERF-581**: Prebind Promises and Eliminate Closures in Capture Hot Loop
+  - **What I tried**: Attempted to pre-bind CDP success and error handlers as class properties in `DomStrategy.ts` and manually update the driver state to bypass closures and short promise chains in `CdpTimeDriver.ts`.
+  - **WHY it didn't work**: The median render time regressed to ~1.516s compared to the baseline of ~1.427s. Replacing inline closures with bound instance properties likely created indirect execution contexts for V8, slowing down the fast-path resolution of the promise chain slightly more than the garbage collection overhead saved.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-581.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-581.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.516	150	98.97	42.2	discard	PERF-581: prebind capture promises
+2	1.477	150	101.54	42.2	discard	PERF-581: prebind capture promises
+3	1.521	150	98.60	42.1	discard	PERF-581: prebind capture promises


### PR DESCRIPTION
💡 What: Evaluated prebinding CDP success/error handlers as class properties in DomStrategy.ts and manually managing state in CdpTimeDriver.ts to eliminate closures.
🎯 Why: To reduce V8 garbage collection pressure and eliminate microtask ticks from inline closures in the capture hot path.
📊 Impact: Median render time regressed to ~1.516s compared to baseline ~1.427s. The experiment was discarded and source code changes reverted.
🔬 Verification: Compilation, Benchmark (median 1.516s).
📎 Plan: PERF-581

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.516	150	98.97	42.2	discard	PERF-581: prebind capture promises
2	1.477	150	101.54	42.2	discard	PERF-581: prebind capture promises
3	1.521	150	98.60	42.1	discard	PERF-581: prebind capture promises
```

---
*PR created automatically by Jules for task [2457998013997764788](https://jules.google.com/task/2457998013997764788) started by @BintzGavin*