### PR TITLE
✨ RENDERER: Evaluate PERF-582 inlining setTime promise

### DIFF
--- a/.sys/plans/PERF-582-inline-setTime-promise.md
+++ b/.sys/plans/PERF-582-inline-setTime-promise.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-582
 slug: inline-setTime-promise
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-25
-completed: ""
-result: ""
+completed: "2024-05-25"
+result: "discard"
 ---
 
 # PERF-582: Eliminate `.then()` Chain in CdpTimeDriver `runSetTime`
@@ -75,3 +75,10 @@ Run `npm run test -w packages/renderer -- --run` and execute the benchmark.
 
 ## Prior Art
 Builds on PERF-580, which eliminated the `async`/`await` generator state machines in these exact functions. This takes it a step further by eliminating the closures and trailing `.then()`/.`catch()` Promise chaining.
+
+## Results Summary
+| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
+|-----|---------------|--------|---------------|-------------|--------|-------------|
+| 1   | 1.639         | 150    | 91.52         | 42.3        | discard | inlining setTime promise |
+| 2   | 1.791         | 150    | 83.76         | 42.1        | discard | inlining setTime promise |
+| 3   | 1.788         | 150    | 83.89         | 42.2        | discard | inlining setTime promise |

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -56,6 +56,8 @@ Last updated by: PERF-580
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **Inlining `CdpTimeDriver.ts` `setTime` promise via class property (PERF-582)**: Tried to eliminate the trailing `.then()` closure in `runSetTime` by storing `targetTime` as a class property and updating `currentTime` directly in the `handleVirtualTimeBudgetExpired` event handler. Caused a performance regression (median ~1.788s vs baseline ~1.427s). This implies that retaining closure locality within the Promise execution chain is actually more efficient for V8 optimization compared to repeatedly accessing and mutating instance properties.
+- **Inlining `CdpTimeDriver.ts` `setTime` promise via class property (PERF-582)**: Tried to eliminate the trailing `.then()` closure in `runSetTime` by storing `targetTime` as a class property and updating `currentTime` directly in the `handleVirtualTimeBudgetExpired` event handler. Caused a performance regression (median ~1.788s vs baseline ~1.427s). This implies that retaining closure locality within the Promise execution chain is actually more efficient for V8 optimization compared to repeatedly accessing and mutating instance properties.
 - [FAILED] Skipping base64 payload serialization on identical frames via dirty tracking (PERF-572) - Flawed heuristic misses CSS animations, scrolling, Canvas/WebGL updates, etc.
 - **PERF-507: Eliminate defaultStabilityCheck method and inline logic**
   - **What I tried**: Attempted to inline `defaultStabilityCheck` directly into `runSetTime` in `CdpTimeDriver.ts`.
@@ -159,6 +161,7 @@ Last updated by: PERF-580
 - Plan ID: PERF-518
 
 ## What Doesn't Work (and Why)
+- **Inlining `CdpTimeDriver.ts` `setTime` promise via class property (PERF-582)**: Tried to eliminate the trailing `.then()` closure in `runSetTime` by storing `targetTime` as a class property and updating `currentTime` directly in the `handleVirtualTimeBudgetExpired` event handler. Caused a performance regression (median ~1.788s vs baseline ~1.427s). This implies that retaining closure locality within the Promise execution chain is actually more efficient for V8 optimization compared to repeatedly accessing and mutating instance properties.
 - **PERF-507: Eliminate defaultStabilityCheck method and inline logic**
   - **What I tried**: Attempted to inline `defaultStabilityCheck` directly into `runSetTime` in `CdpTimeDriver.ts`.
   - **WHY it didn't work**: The `defaultStabilityCheck` method had already been eliminated in previous iterations (likely PERF-506) and the `Runtime.evaluate` call was already inlined. This experiment was discarded as a duplicate with no code changes.
@@ -201,6 +204,7 @@ Last updated by: PERF-580
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **Inlining `CdpTimeDriver.ts` `setTime` promise via class property (PERF-582)**: Tried to eliminate the trailing `.then()` closure in `runSetTime` by storing `targetTime` as a class property and updating `currentTime` directly in the `handleVirtualTimeBudgetExpired` event handler. Caused a performance regression (median ~1.788s vs baseline ~1.427s). This implies that retaining closure locality within the Promise execution chain is actually more efficient for V8 optimization compared to repeatedly accessing and mutating instance properties.
 - **PERF-507: Eliminate defaultStabilityCheck method and inline logic**
   - **What I tried**: Attempted to inline `defaultStabilityCheck` directly into `runSetTime` in `CdpTimeDriver.ts`.
   - **WHY it didn't work**: The `defaultStabilityCheck` method had already been eliminated in previous iterations (likely PERF-506) and the `Runtime.evaluate` call was already inlined. This experiment was discarded as a duplicate with no code changes.
@@ -277,6 +281,7 @@ Last updated by: PERF-580
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **Inlining `CdpTimeDriver.ts` `setTime` promise via class property (PERF-582)**: Tried to eliminate the trailing `.then()` closure in `runSetTime` by storing `targetTime` as a class property and updating `currentTime` directly in the `handleVirtualTimeBudgetExpired` event handler. Caused a performance regression (median ~1.788s vs baseline ~1.427s). This implies that retaining closure locality within the Promise execution chain is actually more efficient for V8 optimization compared to repeatedly accessing and mutating instance properties.
 - **PERF-507: Eliminate defaultStabilityCheck method and inline logic**
   - **What I tried**: Attempted to inline `defaultStabilityCheck` directly into `runSetTime` in `CdpTimeDriver.ts`.
   - **WHY it didn't work**: The `defaultStabilityCheck` method had already been eliminated in previous iterations (likely PERF-506) and the `Runtime.evaluate` call was already inlined. This experiment was discarded as a duplicate with no code changes.
@@ -320,6 +325,7 @@ Last updated by: PERF-580
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **Inlining `CdpTimeDriver.ts` `setTime` promise via class property (PERF-582)**: Tried to eliminate the trailing `.then()` closure in `runSetTime` by storing `targetTime` as a class property and updating `currentTime` directly in the `handleVirtualTimeBudgetExpired` event handler. Caused a performance regression (median ~1.788s vs baseline ~1.427s). This implies that retaining closure locality within the Promise execution chain is actually more efficient for V8 optimization compared to repeatedly accessing and mutating instance properties.
 - **PERF-507: Eliminate defaultStabilityCheck method and inline logic**
   - **What I tried**: Attempted to inline `defaultStabilityCheck` directly into `runSetTime` in `CdpTimeDriver.ts`.
   - **WHY it didn't work**: The `defaultStabilityCheck` method had already been eliminated in previous iterations (likely PERF-506) and the `Runtime.evaluate` call was already inlined. This experiment was discarded as a duplicate with no code changes.

--- a/packages/renderer/.sys/perf-results-PERF-582.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-582.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.639	150	91.52	42.3	discard	inlining setTime promise
+2	1.791	150	83.76	42.1	discard	inlining setTime promise
+3	1.788	150	83.89	42.2	discard	inlining setTime promise


### PR DESCRIPTION
💡 **What**: Executed PERF-582 experiment to eliminate `.then()` closure in `runSetTime`.
🎯 **Why**: To reduce V8 garbage collection and microtask overhead in the capture hot loop.
📊 **Impact**: Regression. Median render time increased from ~1.427s to ~1.788s (-25% slower). Retaining closure locality appears more efficient for V8 optimization than repeatedly accessing/mutating instance properties in this hot path.
🔬 **Verification**: 3x benchmark runs, outputs verified.
📎 **Plan**: PERF-582 (`/.sys/plans/PERF-582-inline-setTime-promise.md`)

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|-----|---------------|--------|---------------|-------------|--------|-------------|
| 1   | 1.639         | 150    | 91.52         | 42.3        | discard | inlining setTime promise |
| 2   | 1.791         | 150    | 83.76         | 42.1        | discard | inlining setTime promise |
| 3   | 1.788         | 150    | 83.89         | 42.2        | discard | inlining setTime promise |

---
*PR created automatically by Jules for task [11448868581879558517](https://jules.google.com/task/11448868581879558517) started by @BintzGavin*