### PR TITLE
✨ RENDERER: Discard .catch() elimination due to regression

### DIFF
--- a/.sys/plans/PERF-583-bypass-promise-catch-allocation.md
+++ b/.sys/plans/PERF-583-bypass-promise-catch-allocation.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-583
 slug: bypass-promise-catch-allocation
-status: unclaimed
-claimed_by: ""
+status: completed
+claimed_by: "executor-session"
 created: 2024-05-25
-completed: ""
-result: ""
+completed: 2024-05-25
+result: failed
 ---
 
 # PERF-583: Eliminate `.catch()` Promise Chaining in CdpTimeDriver Executor
@@ -62,3 +62,9 @@ Run `npm run test -w packages/renderer -- --run` and execute the benchmark.
 
 ## Prior Art
 Builds on PERF-580, which eliminated the `async`/`await` generator state machines. This removes the final trailing `.catch()` Promise chain allocation.
+
+## Results Summary
+- **Best render time**: 1.517s (vs baseline 1.427s)
+- **Improvement**: Regressed
+- **Kept experiments**: none
+- **Discarded experiments**: PERF-583

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -401,3 +401,7 @@ Last updated by: PERF-573
   - **What I tried**: Attempted to pre-bind CDP success and error handlers as class properties in `DomStrategy.ts` and manually update the driver state to bypass closures and short promise chains in `CdpTimeDriver.ts`.
   - **WHY it didn't work**: The median render time regressed to ~1.516s compared to the baseline of ~1.427s. Replacing inline closures with bound instance properties likely created indirect execution contexts for V8, slowing down the fast-path resolution of the promise chain slightly more than the garbage collection overhead saved.
   - **Outcome**: discard
+- **PERF-583**: Eliminate `.catch()` Promise Chaining in CdpTimeDriver Executor
+  - **What I tried**: Removed `.catch(this.handleVirtualTimeBudgetError)` from the `virtualTimePromiseExecutor` in `CdpTimeDriver.ts` to bypass a Promise allocation on every frame iteration.
+  - **Why it didn't work**: It caused a performance regression (median ~1.517s vs baseline ~1.427s). Removing the trailing error handler might have altered how V8 handles the Promise chain closure lifecycle in the hot loop, negatively impacting optimizations despite avoiding the explicit Promise allocation.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-583.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-583.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.537	150	97.59	42.2	discard	PERF-583: Eliminate .catch() Promise Chaining in CdpTimeDriver (Run 1)
+2	1.481	150	101.26	42.3	discard	PERF-583: Eliminate .catch() Promise Chaining in CdpTimeDriver (Run 2)
+3	1.517	150	98.88	42.2	discard	PERF-583: Eliminate .catch() Promise Chaining in CdpTimeDriver (Run 3)


### PR DESCRIPTION
💡 **What**: The experiment removed `.catch()` from the virtualTimePromiseExecutor in `CdpTimeDriver.ts`. It was discarded due to a performance regression and the code was fully reverted.
🎯 **Why**: Attempted to bypass a V8 promise allocation per frame iteration.
📊 **Impact**: Regressed median render time from baseline ~1.427s to ~1.517s.
🔬 **Verification**: Code built successfully, test suite passed natively, and benchmark was measured 3 times before being reverted.
📎 **Plan**: PERF-583 (.sys/plans/PERF-583-bypass-promise-catch-allocation.md)

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.537	150	97.59	42.2	discard	PERF-583: Eliminate .catch() Promise Chaining in CdpTimeDriver (Run 1)
2	1.481	150	101.26	42.3	discard	PERF-583: Eliminate .catch() Promise Chaining in CdpTimeDriver (Run 2)
3	1.517	150	98.88	42.2	discard	PERF-583: Eliminate .catch() Promise Chaining in CdpTimeDriver (Run 3)
```

---
*PR created automatically by Jules for task [17928477971828819601](https://jules.google.com/task/17928477971828819601) started by @BintzGavin*