### PR TITLE
✨ RENDERER: Bypass capture Promise await experiment (discarded)

### DIFF
--- a/.sys/plans/PERF-579-bypass-capture-await.md
+++ b/.sys/plans/PERF-579-bypass-capture-await.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-579
 slug: bypass-capture-await
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-10-30
-completed: ""
-result: ""
+completed: 2026-05-25
+result: failed
 ---
 
 # PERF-579: Bypass `capture` Promise Await in Worker Run Loop
@@ -72,3 +72,8 @@ Run `npm run test -w packages/renderer -- --run` to ensure changes don't break C
 
 ## Correctness Check
 Run `npm run test -w packages/renderer -- --run` and execute the benchmark.
+## Results Summary
+- **Best render time**: 1.361s (vs baseline 1.349s)
+- **Improvement**: -0.89%
+- **Kept experiments**: None
+- **Discarded experiments**: Bypass capture Promise await

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -405,3 +405,4 @@ Last updated by: PERF-573
   - **What I tried**: Removed `.catch(this.handleVirtualTimeBudgetError)` from the `virtualTimePromiseExecutor` in `CdpTimeDriver.ts` to bypass a Promise allocation on every frame iteration.
   - **Why it didn't work**: It caused a performance regression (median ~1.517s vs baseline ~1.427s). Removing the trailing error handler might have altered how V8 handles the Promise chain closure lifecycle in the hot loop, negatively impacting optimizations despite avoiding the explicit Promise allocation.
   - **Outcome**: discard
+- PERF-579: Bypass `capture` Promise Await. Inlining `currentTime` assignment and returning the promise directly in `runSetTime` (avoiding `.then`) yielded a slight performance regression (1.361s vs 1.349s). The V8 engine seems to optimize the local closure effectively.

--- a/packages/renderer/.sys/perf-results-PERF-579.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-579.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.349	150	111.19	42.3	keep	baseline
+2	1.361	150	110.24	44.7	discard	bypass capture await


### PR DESCRIPTION
✨ RENDERER: Bypass capture Promise await experiment (discarded)

💡 **What**: Executed PERF-579 to bypass `capture` Promise await in `CdpTimeDriver.ts`. Inlined `currentTime` assignment and returned the promise directly in `runSetTime` (avoiding `.then`).
🎯 **Why**: Attempted to reduce V8 generator allocations and microtask ticks per frame in the virtual time hot loop.
📊 **Impact**: Caused a slight performance regression (median ~1.361s vs baseline ~1.349s). The experiment was discarded and the code was fully reverted to the baseline.
🔬 **Verification**: Code built, 4-gate verification process run, median render time was worse.
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-579-bypass-capture-await.md`.

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.349	150	111.19	42.3	keep	baseline
2	1.361	150	110.24	44.7	discard	bypass capture await

---
*PR created automatically by Jules for task [12694375488592987092](https://jules.google.com/task/12694375488592987092) started by @BintzGavin*