### PR TITLE
✨ RENDERER: Discard PERF-586 optimize writerWaiter Promise Allocation

### DIFF
--- a/.sys/plans/PERF-586-optimize-writer-waiter.md
+++ b/.sys/plans/PERF-586-optimize-writer-waiter.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-586
 slug: optimize-writer-waiter
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-11-01
-completed: ""
-result: ""
+completed: 2026-05-25
+result: discard
 ---
 
 # PERF-586: Optimize writerWaiter Promise Allocation in CaptureLoop
@@ -67,3 +67,7 @@ Execute the renderer benchmark to verify that no frames are dropped, the video o
 
 ## Canvas Smoke Test
 Run `npm run test -w packages/renderer -- --run` to ensure changes don't break Canvas compilation.
+
+## Results Summary
+- **Best render time**: 1.491s (vs baseline 1.449s)
+- **Status**: discard

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -430,3 +430,7 @@ Last updated by: PERF-573
   - **Why it didn't work**: It caused a performance regression (median ~1.517s vs baseline ~1.427s). Removing the trailing error handler might have altered how V8 handles the Promise chain closure lifecycle in the hot loop, negatively impacting optimizations despite avoiding the explicit Promise allocation.
   - **Outcome**: discard
 - PERF-579: Bypass `capture` Promise Await. Inlining `currentTime` assignment and returning the promise directly in `runSetTime` (avoiding `.then`) yielded a slight performance regression (1.361s vs 1.349s). The V8 engine seems to optimize the local closure effectively.
+- **PERF-586**: Optimize writerWaiter Promise Allocation
+  - **What I tried**: Replaced closure-based writerWaiterExecutor with a deferred writerWaiterPromise.
+  - **WHY it didn't work**: The median render time was ~1.491s compared to baseline ~1.449s. Avoiding the small Promise allocation overhead did not compensate for the overhead of the added branch conditions (`if (!writerWaiterPromise)`) and closure nullification in the hot loop.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-586.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-586.tsv
@@ -1,0 +1,6 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.281	150	65.76	41.0	discard	optimize writerWaiter Promise Allocation
+2	1.490	150	100.67	40.7	discard	optimize writerWaiter Promise Allocation
+3	1.478	150	101.49	41.1	discard	optimize writerWaiter Promise Allocation
+4	1.491	150	100.60	40.5	discard	optimize writerWaiter Promise Allocation
+5	1.514	150	99.08	40.5	discard	optimize writerWaiter Promise Allocation


### PR DESCRIPTION
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.281	150	65.76	41.0	discard	optimize writerWaiter Promise Allocation
2	1.490	150	100.67	40.7	discard	optimize writerWaiter Promise Allocation
3	1.478	150	101.49	41.1	discard	optimize writerWaiter Promise Allocation
4	1.491	150	100.60	40.5	discard	optimize writerWaiter Promise Allocation
5	1.514	150	99.08	40.5	discard	optimize writerWaiter Promise Allocation

---
*PR created automatically by Jules for task [6332187632463217309](https://jules.google.com/task/6332187632463217309) started by @BintzGavin*