### PR TITLE
✨ RENDERER: Increase maxPipelineDepth to 64

### DIFF
--- a/.sys/plans/PERF-484-increase-pipeline-depth.md
+++ b/.sys/plans/PERF-484-increase-pipeline-depth.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-484
 slug: increase-pipeline-depth
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-05-12
-completed: ""
-result: ""
+completed: "2026-05-26"
+result: "discarded"
 ---
 # PERF-484: Increase CaptureLoop maxPipelineDepth
 
@@ -52,3 +52,8 @@ Run a standard Canvas mode benchmark to ensure no regressions.
 
 ## Correctness Check
 Run the standard DOM benchmark to ensure FFmpeg video output remains valid and frames are not dropped.
+## Results Summary
+- **Best render time**: 1.407s (vs baseline 1.249s)
+- **Improvement**: -12.6% (Regression)
+- **Kept experiments**: []
+- **Discarded experiments**: [Increase maxPipelineDepth to 64]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -449,3 +449,7 @@ Last updated by: PERF-589
   - **What I tried**: Replaced closure-based writerWaiterExecutor with a deferred writerWaiterPromise.
   - **WHY it didn't work**: The median render time was ~1.491s compared to baseline ~1.449s. Avoiding the small Promise allocation overhead did not compensate for the overhead of the added branch conditions (`if (!writerWaiterPromise)`) and closure nullification in the hot loop.
   - **Outcome**: discard
+- **PERF-484**: Increase maxPipelineDepth
+  - **What I tried**: Increased `maxPipelineDepth` in `CaptureLoop.ts` from `poolLen * 8` to `poolLen * 64`.
+  - **WHY it didn't work**: The median render time regressed to ~1.407s compared to the baseline of ~1.249s. Increasing the pipeline depth dramatically increases the number of frames actively being buffered and captured by workers without being flushed, leading to higher V8 garbage collection pressure and potentially overwhelming the IPC queue with Playwright before FFmpeg can process them. The current balance is better tuned for this memory-constrained microVM environment.
+  - **Outcome**: discard

--- a/packages/renderer/.sys/perf-results-PERF-484.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-484.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.054	150	73.01	45.8	discard	Increase maxPipelineDepth to 64
+2	1.407	150	106.64	43.2	discard	Increase maxPipelineDepth to 64
+3	1.387	150	108.15	45.2	discard	Increase maxPipelineDepth to 64


### PR DESCRIPTION
💡 **What**: Executed the `PERF-484` experiment to increase the `CaptureLoop` ring buffer depth (`maxPipelineDepth`) from `poolLen * 8` to `poolLen * 64`.

🎯 **Why**: To reduce backpressure stalls between the DOM capture workers and the FFmpeg stdin writer by allowing the workers to run further ahead.

📊 **Impact**: The median render time regressed to ~1.407s (-12.6% vs baseline ~1.249s). The deeper pipeline likely increased V8 garbage collection pressure and overwhelmed the Playwright IPC queue before FFmpeg could flush the buffers.

🔬 **Verification**:
- Baseline render time: 1.249s
- Benchmark results (median of 3 runs): 1.407s
- The code change was discarded and successfully reverted from this branch since it resulted in a regression.
- Relevant journal entries (`RENDERER-EXPERIMENTS.md`) and logs (`.sys/perf-results-PERF-484.tsv`) have been committed.

📎 **Plan**: `/.sys/plans/PERF-484-increase-pipeline-depth.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.054	150	73.01	45.8	discard	Increase maxPipelineDepth to 64
2	1.407	150	106.64	43.2	discard	Increase maxPipelineDepth to 64
3	1.387	150	108.15	45.2	discard	Increase maxPipelineDepth to 64
```

---
*PR created automatically by Jules for task [8949804427622406257](https://jules.google.com/task/8949804427622406257) started by @BintzGavin*