### PR TITLE
✨ RENDERER: [PERF-593] Cache targetElement boundingBox in DomStrategy prepare

### DIFF
--- a/.sys/plans/PERF-593-cache-bounding-box.md
+++ b/.sys/plans/PERF-593-cache-bounding-box.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-593
 slug: cache-bounding-box
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-05-26
-completed: ""
-result: ""
+completed: "2026-05-26"
+result: "failed"
 ---
 
 # PERF-593: Cache targetElement boundingBox in DomStrategy prepare
@@ -101,3 +101,8 @@ with just:
 ```
 **Why**: Avoids `boundingBox()` Playwright IPC call and its `.then()` chain on every frame in the hot loop.
 **Risk**: If the target element moves or resizes during the render, the output will be incorrectly cropped. However, target elements for screen recording are typically fixed-size containers. The performance gain vastly outweighs edge cases.
+
+## Results Summary
+- **Best render time**: 6.714s (vs baseline 6.684s)
+- **Kept experiments**: None
+- **Discarded experiments**: PERF-593

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -467,3 +467,7 @@ Last updated by: PERF-592
   - **What I did**: Removed `typeof window.__helios_sync_media==='function'` check from the expression string assignments in the `defaultSyncMedia` method in `CdpTimeDriver.ts`.
   - **Impact**: Improved median render time to ~1.374.
 - **PERF-593**: Could caching `targetElementHandle.boundingBox()` in `prepare()` instead of calling it on every frame in `capture()` avoid unnecessary IPC and Promise allocations, speeding up the hot loop?
+- **PERF-593**: Cache targetElement boundingBox in DomStrategy prepare
+  - **What I tried**: Pre-calculated and cached boundingBox in prepare(), removing the IPC wait from capture().
+  - **WHY it didn't work**: The median render time regressed to ~6.714s vs baseline ~6.684s.
+  - **Plan ID**: PERF-593

--- a/packages/renderer/.sys/perf-results-PERF-593.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-593.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	6.714	300	44.6828	45.0	discard	Cache targetElement boundingBox in DomStrategy prepare


### PR DESCRIPTION
💡 **What**: Executed and discarded PERF-593. Pre-calculated and cached boundingBox in prepare(), removing the IPC wait and Promise allocation from capture().
🎯 **Why**: Attempted to avoid IPC overhead and Promise allocation for targetElement.boundingBox() on every frame.
📊 **Impact**: The median render time regressed to ~6.714s compared to the baseline ~6.684s in the microVM CPU-only environment. The experiment was discarded.
🔬 **Verification**: Ran `benchmark-perf.ts` 3 times and measured the median render time.
📎 **Plan**: Reference the plan file `/.sys/plans/PERF-593-cache-bounding-box.md`.

Results:
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	6.714	300	44.6828	45.0	discard	Cache targetElement boundingBox in DomStrategy prepare

---
*PR created automatically by Jules for task [14814993021291375529](https://jules.google.com/task/14814993021291375529) started by @BintzGavin*