### PR TITLE
Discard PERF-594: Inline writerWaiterResolve Wakeup

### DIFF
--- a/.sys/plans/PERF-594-inline-writerwaiter-wakeup.md
+++ b/.sys/plans/PERF-594-inline-writerwaiter-wakeup.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-594
 slug: inline-writerwaiter-wakeup
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "jules"
 created: 2024-05-26
-completed: ""
-result: ""
+completed: "2024-05-26"
+result: "discard"
 ---
 
 # PERF-594: Inline `writerWaiterResolve` Wakeup into Promise Chain in CaptureLoop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -471,3 +471,8 @@ Last updated by: PERF-592
   - **What I tried**: Pre-calculated and cached boundingBox in prepare(), removing the IPC wait from capture().
   - **WHY it didn't work**: The median render time regressed to ~6.714s vs baseline ~6.684s.
   - **Plan ID**: PERF-593
+
+- **PERF-594**: Inline `writerWaiterResolve` Wakeup into Promise Chain in CaptureLoop
+  - **What I tried**: Modified the `timePromise` chain in `CaptureLoop.ts` to check and execute `writerWaiterResolve` directly within the `.then()` and `.catch()` fulfillment handlers instead of awaiting the generator resumption.
+  - **WHY it didn't work**: The median render time regressed slightly to ~10.417s compared to the baseline of ~10.347s. Resolving the waiter inside the callback did not outweigh the overhead of checking `writerWaiterResolve && nextFrameToWrite === i` conditionally inside both the `.then` and `.catch` closures. V8 seems to optimize the generator `await` resumption more efficiently than the repeated closure state checks.
+  - **Outcome**: discard


### PR DESCRIPTION
Evaluated PERF-594 to inline the writerWaiterResolve wakeup into the timePromise `.then` and `.catch` chains in `CaptureLoop.ts` to skip waiting for the `await timePromise` generator to resume. 
The change resulted in a slight performance regression (median ~10.417s vs baseline ~10.347s), demonstrating that V8 evaluates the single external `await` generator resumption faster than it can process repeated conditional checks (`if (writerWaiterResolve && nextFrameToWrite === i)`) across multiple closures. 
The application source code changes were reverted, and the documentation in `RENDERER-EXPERIMENTS.md` and `.sys/plans/PERF-594-inline-writerwaiter-wakeup.md` was correctly updated to log the failed experiment.

---
*PR created automatically by Jules for task [10063249471816068860](https://jules.google.com/task/10063249471816068860) started by @BintzGavin*