### PR TITLE
📋 PLAYER: Document Event Handlers

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -55,3 +55,6 @@
 ## [v0.77.40] - Undocumented Events
 **Learning:** The `error` and `audiometering` events were being fired by `<helios-player>` but were missing from the `README.md` events list.
 **Action:** Created a plan to document these missing events to maintain strict API parity visibility.
+## [v0.77.41] - Documenting Event Handlers
+**Learning**: The standard event handler properties (`onplay`, `onpause`, etc.) were implemented for API parity but never explicitly documented in the README, leading to a vision gap.
+**Action**: Always verify that newly implemented API surfaces are immediately documented in the project's README to maintain synchronization between implementation and vision.

--- a/.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md
+++ b/.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md
@@ -1,0 +1,23 @@
+#### 1. Context & Goal
+- **Objective**: Document the missing HTMLMediaElement standard event handler properties (`onplay`, `onpause`, `onended`, etc.) in `packages/player/README.md`.
+- **Trigger**: Vision gap identified between the actual implementation (which includes `_onplay`, `_onpause`, etc., with public getters/setters) and the README (which lacks documentation for them).
+- **Impact**: Provides developers with clear documentation on how to use standard event handler properties with the `<helios-player>` Web Component, improving API parity documentation and AX/DX.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**: `packages/player/README.md` (Add a new `### Event Handlers` section under `## Standard Media API`).
+- **Read-Only**: `packages/player/src/index.ts` (Verify exact list of implemented event handlers).
+
+#### 3. Implementation Spec
+- **Architecture**: Update Markdown documentation.
+- **Pseudo-Code**:
+  - Locate `### Properties` section within `## Standard Media API` in `packages/player/README.md`.
+  - Add a new `### Event Handlers` section immediately after it (or before `## Events`).
+  - List the implemented event handler properties based on `packages/player/src/index.ts`: `onplay`, `onpause`, `onended`, `ontimeupdate`, `onvolumechange`, `onratechange`, `ondurationchange`, `onseeking`, `onseeked`, `onresize`, `onloadstart`, `onloadedmetadata`, `onloadeddata`, `oncanplay`, `oncanplaythrough`, `onerror`, `onenterpictureinpicture`, `onleavepictureinpicture`.
+- **Public API Changes**: None (documentation only).
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `grep -A 20 "### Event Handlers" packages/player/README.md`
+- **Success Criteria**: The README includes the new section listing all standard event handler properties.
+- **Edge Cases**: Ensure no existing sections or Markdown formatting are broken.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,5 @@
-**Version**: 0.77.40
+[v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
+**Version**: 0.77.41
 [v0.77.38] ✅ Completed: Expand Index Coverage - Added unit tests for disconnectedCallback in packages/player/src/index.ts.
 [v0.77.37] ✅ Completed: Improve index.ts test coverage - Added tests for diagnose API and retryConnection.
 [v0.77.36] ✅ Completed: Discovered that 2026-06-21-PLAYER-Smart-Controls.md is an IMPOSSIBLE: DUPLICATION plan. The smart controls for CC and PiP are already fully implemented. Documented as duplicate and discarded.


### PR DESCRIPTION
Created an execution plan to document the missing standard HTMLMediaElement event handler properties (`onplay`, `onpause`, `onended`, etc.) in the `<helios-player>` README.md to ensure strict API parity and close the vision gap.

---
*PR created automatically by Jules for task [17382411426960025570](https://jules.google.com/task/17382411426960025570) started by @BintzGavin*