### PR TITLE
📋 RENDERER: Batch FFmpeg stdin writes

### DIFF
--- a/.sys/plans/PERF-597-batch-ffmpeg-stdin-writes.md
+++ b/.sys/plans/PERF-597-batch-ffmpeg-stdin-writes.md
@@ -1,0 +1,44 @@
+---
+id: PERF-597
+slug: batch-ffmpeg-stdin-writes
+status: unclaimed
+claimed_by: ""
+created: 2024-05-26
+completed: ""
+result: ""
+---
+
+# PERF-597: Batch FFmpeg stdin writes in CaptureLoop
+
+## Focus Area
+DOM Rendering Pipeline - Output Write Phase (`packages/renderer/src/core/CaptureLoop.ts`).
+
+## Background Research
+Currently, the CaptureLoop orchestration flushes each completed frame buffer into the FFmpeg `stdin` pipe individually as soon as it becomes available (`this.ffmpegManager.stdin.write(buffer)`). Node.js stream writes to a spawned child process involve IPC boundary crossings. For a high-fps composition (e.g., 60fps), writing 60 distinct chunks per second incurs measurable overhead from frequent stream flushing and context switching. By conceptually coalescing multiple frame buffers (e.g., concatenating Base64 strings or accumulating Buffers) before writing to the FFmpeg pipe, we can theoretically reduce IPC chatter and improve throughput.
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark composition (`examples/dom-benchmark`)
+- **Render Settings**: 600x600, 30fps, 5s duration, ultrafast preset
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~1.374s (from RENDERER-EXPERIMENTS.md current best)
+- **Bottleneck analysis**: IPC overhead from frequent, small stream writes between Node.js and the FFmpeg child process.
+
+## Implementation Spec
+
+### Step 1: Accumulate frame chunks in `CaptureLoop.ts`
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+1. Introduce a batching accumulation strategy near the sequential write block that uses `this.ffmpegManager.stdin.write(buffer)`.
+2. Instead of writing every frame immediately, store incoming frames in a local array/buffer string.
+3. Once the accumulated batch reaches a target size (e.g., 8 frames) or the render reaches completion (e.g. `nextFrameToWrite === this.totalFrames - 1`), coalesce the frames (e.g., `Buffer.concat` for buffers or `+=` for strings).
+4. Perform a single `this.ffmpegManager.stdin.write(coalescedData)` call and clear the accumulator.
+
+**Why**: Consolidating IPC pipe writes to a child process is a standard systems optimization to reduce kernel context switches.
+**Risk**: Accumulating memory could momentarily increase V8 garbage collection pressure, especially with `Buffer.concat()`. If the string operations overhead exceeds the IPC savings, the change will cause a regression.
+
+## Correctness Check
+Run the `npx tsx packages/renderer/scripts/benchmark-perf.ts` script to test performance, followed by `npm run test -w packages/renderer` to verify output correctly retains all frames and avoids truncation.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -476,3 +476,4 @@ Last updated by: PERF-592
   - **What I tried**: Modified the `timePromise` chain in `CaptureLoop.ts` to check and execute `writerWaiterResolve` directly within the `.then()` and `.catch()` fulfillment handlers instead of awaiting the generator resumption.
   - **WHY it didn't work**: The median render time regressed slightly to ~10.417s compared to the baseline of ~10.347s. Resolving the waiter inside the callback did not outweigh the overhead of checking `writerWaiterResolve && nextFrameToWrite === i` conditionally inside both the `.then` and `.catch` closures. V8 seems to optimize the generator `await` resumption more efficiently than the repeated closure state checks.
   - **Outcome**: discard
+- Would batching frame buffers via Buffer.concat() before writing to FFmpeg stdin reduce IPC overhead? (PERF-597)


### PR DESCRIPTION
Created PERF-597 experiment plan to test batching FFmpeg stdin writes and updated the RENDERER-EXPERIMENTS.md journal.

---
*PR created automatically by Jules for task [3310565870237361766](https://jules.google.com/task/3310565870237361766) started by @BintzGavin*