### PR TITLE
✨ RENDERER: Eager Update of currentTime in CdpTimeDriver

### DIFF
--- a/.sys/perf-results-PERF-601.tsv
+++ b/.sys/perf-results-PERF-601.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.207	150	67.96	70.0	discard	Eager Update of currentTime in CdpTimeDriver
+2	1.584	150	94.71	70.1	discard	Eager Update of currentTime in CdpTimeDriver
+3	1.505	150	99.64	69.9	discard	Eager Update of currentTime in CdpTimeDriver

--- a/.sys/plans/PERF-601-eager-current-time-update.md
+++ b/.sys/plans/PERF-601-eager-current-time-update.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-601
 slug: eager-current-time-update
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-05-27
 completed: ""
 result: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -71,6 +71,10 @@ Last updated by: PERF-592
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-601**: Eager Update of currentTime in CdpTimeDriver
+  - **What I tried**: Eliminated trailing .then() in runSetTime and eagerly updated this.currentTime.
+  - **Why it didn't work**: The performance improvement was negligible or negative, possibly due to other V8 optimizations or negligible overhead of the closure.
+  - **Plan ID**: PERF-601
 - Map based string cache in CdpTimeDriver (PERF-599) - Slower than baseline (1.728s vs 1.267s). Overhead of checking and setting map values might be worse than simple V8 string concatenation for small strings.
 - **PERF-591**: Merged .catch into .then in hot loops.
   - **What I tried**: Merged .catch() into .then(onFulfilled, onRejected) in CaptureLoop and DomStrategy.


### PR DESCRIPTION
💡 **What**: The experiment PERF-601 to eagerly update `currentTime` and eliminate the trailing `.then()` in `CdpTimeDriver.ts` was discarded due to negative results.
🎯 **Why**: To reduce V8 microtask overhead and Promise allocation on every frame iteration.
📊 **Impact**: The median render time worsened to ~1.584s from the baseline of ~1.267s.
🔬 **Verification**: Code modifications compiled without error, benchmark executed 3 times to get the median, tests skipped for discarded code, discarded code changes reverted.
📎 **Plan**: `/.sys/plans/PERF-601-eager-current-time-update.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.207	150	67.96	70.0	discard	Eager Update of currentTime in CdpTimeDriver
2	1.584	150	94.71	70.1	discard	Eager Update of currentTime in CdpTimeDriver
3	1.505	150	99.64	69.9	discard	Eager Update of currentTime in CdpTimeDriver
```

---
*PR created automatically by Jules for task [11938606938003134826](https://jules.google.com/task/11938606938003134826) started by @BintzGavin*