### PR TITLE
✨ CLI: Log Registry Types Regression Tests Plan as Duplicate

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -662,3 +662,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 - ✅ Completed: Document Missing Events - Updated README.md to include documentation for error and audiometering events.
 ### STUDIO v0.121.18
 - ❌ Blocked: Waiting for a new, valid plan in /.sys/plans/ as existing plans are already implemented or obsolete.
+
+### CLI v0.46.38
+- ✅ Completed: CLI Registry Types Regression Tests - Logged the duplicated plan as impossible since registry types regression tests are already fully implemented (IMPOSSIBLE: DUPLICATION).

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,5 +1,6 @@
-**Version**: 0.46.37
+**Version**: 0.46.38
 
+[v0.46.38] ✅ Completed: CLI Registry Types Regression Tests - Logged the duplicated plan as impossible since registry types regression tests are already fully implemented.
 [v0.46.34] ✅ Completed: CLI Registry Types Regression Tests - Implemented structural verification tests for registry interfaces.
 [v0.46.33] ✅ Completed: CLI Job Regression Tests Missing Mock - Added missing mock setup for @helios-project/infrastructure to fix import resolution errors
 [v0.46.32] ✅ Completed: CLI Docker Adapter Regression Tests - Implemented unit tests for the docker-adapter cloud template.


### PR DESCRIPTION
The implementation plan `2027-06-05-CLI-Registry-Types-Regression-Tests.md` requested the creation of unit tests for type definition structural verification in `packages/cli/src/registry/__tests__/types.test.ts`. 

During exploration, it was discovered via `docs/status/CLI.md` that these exact structural verification tests for registry interfaces had already been fully implemented in version `v0.46.34`. 

Following standard protocols for duplicate tasks, no redundant code changes were made. Instead, the task was documented as `IMPOSSIBLE: DUPLICATION` in `docs/status/CLI.md` and `docs/PROGRESS.md`, and the CLI version was incremented to `v0.46.38` to accurately reflect the completed domain review cycle. All existing tests pass.

---
*PR created automatically by Jules for task [5059698763902853791](https://jules.google.com/task/5059698763902853791) started by @BintzGavin*