### PR TITLE
✨ RENDERER: Document PERF-603 outcome (discarded)

### DIFF
--- a/.sys/plans/PERF-603-cork-ffmpeg-stdin.md
+++ b/.sys/plans/PERF-603-cork-ffmpeg-stdin.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-603
 slug: cork-ffmpeg-stdin
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-27
 completed: ""
-result: ""
+result: "discard"
 ---
 
 # PERF-603: Native IPC Batching via Writable.cork()

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -71,6 +71,10 @@ Last updated by: PERF-592
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-603**: Batch FFmpeg stdin writes via Writable.cork()
+  - **What I tried**: Used node Writable.cork() to batch frames.
+  - **WHY it didn't work**: The median render time regressed to ~1.360s compared to baseline ~1.267s. Native node stream batching via cork/uncork added overhead or interfered with Playwright/FFmpeg IPC pipe draining pacing.
+  - **Plan ID**: PERF-603
 - **PERF-602**: Eager Base64 Buffer Decoding in Capture Hot Loop
   - **What I tried**: Eagerly decoded Base64 strings to Buffers in CaptureLoop's runWorker to bypass Node.js Writable stream type checks and reduce V8 string GC pressure.
   - **WHY it didn't work**: The median render time regressed to ~1.454s compared to baseline ~1.267s. The CPU overhead and blocking nature of `Buffer.from(string, 'base64')` on the main thread inside the hot loop outweighed the benefits of bypassing stream coercion, starving the event loop and delaying IPC writes.

--- a/packages/renderer/.sys/perf-results-PERF-603.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-603.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.360	300	220.59	490.0	discard	Batch FFmpeg stdin via Writable.cork()


### PR DESCRIPTION
💡 **What**: Tried using Node's Writable stream `cork()` and `uncork()` to batch writes to FFmpeg stdin natively in the CaptureLoop hot loop.
🎯 **Why**: To reduce the number of IPC write boundary crossings when transmitting raw frames from memory to FFmpeg.
📊 **Impact**: The median render time regressed to ~1.360s compared to the established baseline of 1.267s. Native node stream batching via cork/uncork added overhead or interfered with Playwright/FFmpeg IPC pipe draining pacing.
🔬 **Verification**: Benchmarked 3 times, validated with FFprobe, and test suite passed natively.

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.360	300	220.59	490.0	discard	Batch FFmpeg stdin via Writable.cork()
```
📎 **Plan**: `/.sys/plans/PERF-603-cork-ffmpeg-stdin.md`

---
*PR created automatically by Jules for task [16472922328909730189](https://jules.google.com/task/16472922328909730189) started by @BintzGavin*