### PR TITLE
📋 RENDERER: Restore native await sequence in runWorker hot loop

### DIFF
--- a/.sys/plans/PERF-604-restore-await-sequence.md
+++ b/.sys/plans/PERF-604-restore-await-sequence.md
@@ -1,0 +1,39 @@
+---
+id: PERF-604
+slug: restore-await-sequence
+status: complete
+claimed_by: "jules"
+created: 2026-05-28
+completed: 2026-05-28
+result: "discard (median: 1.590s)"
+---
+
+# PERF-604: Restore await sequence in runWorker for modern V8
+
+## Focus Area
+DOM Rendering Pipeline - Output writing and worker loops in `packages/renderer/src/core/CaptureLoop.ts`.
+
+## Background Research
+A previous experiment (PERF-584) replaced explicit `await` statements wrapped in a `try/catch` with a `.then().catch()` promise chain wrapped in a single `await` inside the `runWorker` hot loop. It achieved a speedup at the time. However, modern V8 heavily optimizes native `await` and `try/catch` inside `async` generators, whereas `.then()` chains unavoidably allocate closure environments for their handlers (e.g., `() => strategy.capture(page, time)`), which creates short-lived objects on the heap during every frame iteration, increasing garbage collection pressure.
+By converting this back to a linear `await` sequence wrapped in `try/catch`, we can eliminate all per-frame closure allocations in this hot path, allowing V8 to use its highly optimized `async` state machine without accumulating garbage.
+
+## Benchmark Configuration
+- **Composition URL**: Standard benchmark composition (`examples/dom-benchmark`)
+- **Render Settings**: 600x600, 30fps, 5s duration, ultrafast preset
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~1.267s
+- **Bottleneck analysis**: Allocation of `.then()` closures on every frame inside the `runWorker` asynchronous loop, causing V8 garbage collection overhead.
+
+## Implementation Spec
+
+### Step 1: Replace `.then()` chain with native `await` sequence
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the `runWorker` method, replace the `timePromise` chain with a `try/catch` using native `await`s.
+
+## Correctness Check
+Run the `npx tsx packages/renderer/tests/run-all.ts` to verify output correctly retains all frames and avoids truncation.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -501,3 +501,7 @@ Last updated by: PERF-592
   - **What I tried**: Accumulated frames in memory (unified Buffer[]) and wrote them in batches (size 8) to FFmpeg stdin to reduce IPC overhead.
   - **WHY it didn't work**: The median render time regressed to ~1.442s compared to baseline ~1.413s. The memory pressure from Buffer allocations/concatenation and GC pauses likely outweighed the savings from reducing the IPC calls.
   - **Plan ID**: PERF-597
+- **PERF-604**: Restore `await` sequence in `runWorker`
+  - **What I tried**: Replaced `.then()` chain with native `await`s wrapped in `try/catch` to avoid closure allocations.
+  - **WHY it didn't work**: The median render time was ~1.590s compared to baseline ~1.267s. V8 optimization of closures inside async generators is highly efficient, and the native `try/catch` overhead still outweighs the closure allocation cost.
+  - **Plan ID**: PERF-604


### PR DESCRIPTION
💡 **What**: The experiment evaluated restoring native `await` and `try/catch` blocks instead of `.then().catch()` chains in `CaptureLoop.ts`'s `runWorker` hot loop.
🎯 **Why**: To reduce V8 garbage collection pressure by avoiding closure allocations per frame iteration.
🔬 **Approach**: Replace the promise chain with a native `await` sequence wrapped in a `try/catch`.
📎 **Plan**: `/.sys/plans/PERF-604-restore-await-sequence.md`

The experiment was discarded as it caused a performance regression (median ~1.590s vs baseline ~1.267s). The code changes have been reverted, and only the tracking documentation and plan file are included in this commit.

---
*PR created automatically by Jules for task [5803684121170601164](https://jules.google.com/task/5803684121170601164) started by @BintzGavin*