### PR TITLE
✨ RENDERER: Discard PERF-605 Omit write callback

### DIFF
--- a/.sys/plans/PERF-605-omit-write-callback.md
+++ b/.sys/plans/PERF-605-omit-write-callback.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-605
 slug: omit-write-callback
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-28
-completed: ""
-result: ""
+completed: 2024-05-28
+result: "discard"
 ---
 
 # PERF-605: Omit write callback in FFmpeg stdin writes
@@ -58,14 +58,10 @@ to:
 **What to change**:
 Instruct the executor to explore the `spawn()` function and locate the `this.process.stdin.on('error', ...)` handler block. When the error is not `EPIPE`, the handler should be updated to invoke `this.emitError(err)` to replace the removed logic from `handleWriteError`.
 
-## Variations
-No variations planned. The primary approach is straightforward and directly targets the Node.js Writable stream optimization path.
-
-## Canvas Smoke Test
-Run `npx tsx packages/renderer/scripts/benchmark-perf.ts` to ensure Canvas mode still renders cleanly without stream write errors.
-
-## Correctness Check
-Run the `npm run test -w packages/renderer` to verify output correctly retains all frames and avoids truncation, ensuring error handling logic is not broken.
-
-## Prior Art
-Builds on findings from PERF-597 and PERF-603 regarding FFmpeg stdin write overhead and stream optimization techniques.
+## Results Summary
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.346	150	111.42	69.9	discard	omit write callback
+2	1.327	150	113.06	70.1	discard	omit write callback
+3	1.341	150	111.89	70.1	discard	omit write callback
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -71,6 +71,11 @@ Last updated by: PERF-592
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-605**: Omit write callback in FFmpeg stdin writes
+  - **What I tried**: Removed the `handleWriteError` callback from `this.ffmpegManager.stdin.write()` calls in `CaptureLoop.ts` to bypass Node.js Writable stream internal tracking allocations, and centralized error handling via the `error` event in `FFmpegManager.ts`.
+  - **WHY it didn't work**: The median render time regressed to ~1.341s compared to the baseline of ~1.267s. Although omitting the callback avoids allocating a `WriteReq` object, Node.js might use a less optimized or more complex internal queuing path for fully asynchronous, fire-and-forget writes compared to synchronous, tracked writes, leading to increased overhead in this specific high-frequency IPC write loop.
+  - **Plan ID**: PERF-605
+
 - **PERF-603**: Batch FFmpeg stdin writes via Writable.cork()
   - **What I tried**: Used node Writable.cork() to batch frames.
   - **WHY it didn't work**: The median render time regressed to ~1.360s compared to baseline ~1.267s. Native node stream batching via cork/uncork added overhead or interfered with Playwright/FFmpeg IPC pipe draining pacing.
@@ -200,6 +205,11 @@ Last updated by: PERF-592
 - Plan ID: PERF-518
 
 ## What Doesn't Work (and Why)
+- **PERF-605**: Omit write callback in FFmpeg stdin writes
+  - **What I tried**: Removed the `handleWriteError` callback from `this.ffmpegManager.stdin.write()` calls in `CaptureLoop.ts` to bypass Node.js Writable stream internal tracking allocations, and centralized error handling via the `error` event in `FFmpegManager.ts`.
+  - **WHY it didn't work**: The median render time regressed to ~1.341s compared to the baseline of ~1.267s. Although omitting the callback avoids allocating a `WriteReq` object, Node.js might use a less optimized or more complex internal queuing path for fully asynchronous, fire-and-forget writes compared to synchronous, tracked writes, leading to increased overhead in this specific high-frequency IPC write loop.
+  - **Plan ID**: PERF-605
+
 - **PERF-585**: Eliminate Progress Modulo
   - **What I tried**: Eliminated the per-frame modulo operator in the `CaptureLoop.ts` hot loop.
   - **Why it didn't work**: The overhead of tracking an additional numeric state variable and reassigning it offset the micro-savings from avoiding the modulo operator in V8, leading to a performance regression (median ~1.663s vs baseline ~1.550s).
@@ -247,6 +257,11 @@ Last updated by: PERF-592
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-605**: Omit write callback in FFmpeg stdin writes
+  - **What I tried**: Removed the `handleWriteError` callback from `this.ffmpegManager.stdin.write()` calls in `CaptureLoop.ts` to bypass Node.js Writable stream internal tracking allocations, and centralized error handling via the `error` event in `FFmpegManager.ts`.
+  - **WHY it didn't work**: The median render time regressed to ~1.341s compared to the baseline of ~1.267s. Although omitting the callback avoids allocating a `WriteReq` object, Node.js might use a less optimized or more complex internal queuing path for fully asynchronous, fire-and-forget writes compared to synchronous, tracked writes, leading to increased overhead in this specific high-frequency IPC write loop.
+  - **Plan ID**: PERF-605
+
 - **PERF-585**: Eliminate Progress Modulo
   - **What I tried**: Eliminated the per-frame modulo operator in the `CaptureLoop.ts` hot loop.
   - **Why it didn't work**: The overhead of tracking an additional numeric state variable and reassigning it offset the micro-savings from avoiding the modulo operator in V8, leading to a performance regression (median ~1.663s vs baseline ~1.550s).
@@ -328,6 +343,11 @@ Last updated by: PERF-592
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-605**: Omit write callback in FFmpeg stdin writes
+  - **What I tried**: Removed the `handleWriteError` callback from `this.ffmpegManager.stdin.write()` calls in `CaptureLoop.ts` to bypass Node.js Writable stream internal tracking allocations, and centralized error handling via the `error` event in `FFmpegManager.ts`.
+  - **WHY it didn't work**: The median render time regressed to ~1.341s compared to the baseline of ~1.267s. Although omitting the callback avoids allocating a `WriteReq` object, Node.js might use a less optimized or more complex internal queuing path for fully asynchronous, fire-and-forget writes compared to synchronous, tracked writes, leading to increased overhead in this specific high-frequency IPC write loop.
+  - **Plan ID**: PERF-605
+
 - **PERF-585**: Eliminate Progress Modulo
   - **What I tried**: Eliminated the per-frame modulo operator in the `CaptureLoop.ts` hot loop.
   - **Why it didn't work**: The overhead of tracking an additional numeric state variable and reassigning it offset the micro-savings from avoiding the modulo operator in V8, leading to a performance regression (median ~1.663s vs baseline ~1.550s).
@@ -376,6 +396,11 @@ Last updated by: PERF-592
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-605**: Omit write callback in FFmpeg stdin writes
+  - **What I tried**: Removed the `handleWriteError` callback from `this.ffmpegManager.stdin.write()` calls in `CaptureLoop.ts` to bypass Node.js Writable stream internal tracking allocations, and centralized error handling via the `error` event in `FFmpegManager.ts`.
+  - **WHY it didn't work**: The median render time regressed to ~1.341s compared to the baseline of ~1.267s. Although omitting the callback avoids allocating a `WriteReq` object, Node.js might use a less optimized or more complex internal queuing path for fully asynchronous, fire-and-forget writes compared to synchronous, tracked writes, leading to increased overhead in this specific high-frequency IPC write loop.
+  - **Plan ID**: PERF-605
+
 - **PERF-585**: Eliminate Progress Modulo
   - **What I tried**: Eliminated the per-frame modulo operator in the `CaptureLoop.ts` hot loop.
   - **Why it didn't work**: The overhead of tracking an additional numeric state variable and reassigning it offset the micro-savings from avoiding the modulo operator in V8, leading to a performance regression (median ~1.663s vs baseline ~1.550s).

--- a/packages/renderer/.sys/perf-results-PERF-605.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-605.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.346	150	111.42	69.9	discard	omit write callback
+2	1.327	150	113.06	70.1	discard	omit write callback
+3	1.341	150	111.89	70.1	discard	omit write callback


### PR DESCRIPTION
💡 **What**: Removed the `handleWriteError` callback from `this.ffmpegManager.stdin.write()` calls in `CaptureLoop.ts` to bypass Node.js Writable stream internal tracking allocations, and centralized error handling via the `error` event in `FFmpegManager.ts`.
🎯 **Why**: To bypass Node.js Writable stream internal tracking allocations (e.g., `WriteReq`) and reduce V8 garbage collection pressure and main-thread overhead during high-frequency IPC writes to FFmpeg.
📊 **Impact**: The median render time regressed to ~1.341s compared to the baseline of ~1.267s. Although omitting the callback avoids allocating a `WriteReq` object, Node.js might use a less optimized or more complex internal queuing path for fully asynchronous, fire-and-forget writes compared to synchronous, tracked writes, leading to increased overhead in this specific high-frequency IPC write loop.
🔬 **Verification**: Benchmarked against dom-benchmark. Code changes reverted.
📎 **Plan**: PERF-605

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.346	150	111.42	69.9	discard	omit write callback
2	1.327	150	113.06	70.1	discard	omit write callback
3	1.341	150	111.89	70.1	discard	omit write callback
```

---
*PR created automatically by Jules for task [17192733199434086836](https://jules.google.com/task/17192733199434086836) started by @BintzGavin*