### PR TITLE
✨ RENDERER: Discarded pre-allocate Capture Handlers in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-611-preallocate-capture-handlers.md
+++ b/.sys/plans/PERF-611-preallocate-capture-handlers.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-611
 slug: preallocate-capture-handlers
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-28
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -80,6 +80,9 @@ Last updated by: PERF-610
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-611**: Pre-allocate Capture Handlers
+  - **What I tried**: Pre-allocated fulfillment and rejection handlers in runWorker.
+  - **Why it didn't work**: No significant improvement. Overhead of accessing array elements is equal to or greater than closure allocation, or within noise. Median was 1.455s.
 
 - **PERF-608**: Merge Promise Catch Handlers in DomStrategy
   - **What I tried**: Rewrote `.then(onFulfilled).catch(onRejected)` to `.then(onFulfilled, onRejected)` in `DomStrategy.ts` hot loop.

--- a/packages/renderer/.sys/perf-results-PERF-611.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-611.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	1.449	150	103.53	70.0	discard	Pre-allocate capture handlers
+2	1.455	150	103.08	70.1	discard	Pre-allocate capture handlers
+3	1.472	150	101.91	70.2	discard	Pre-allocate capture handlers


### PR DESCRIPTION
💡 What: Pre-allocate fulfillment and rejection handlers in CaptureLoop.ts runWorker hot loop.
🎯 Why: Reduce V8 heap garbage collection pressure caused by closure allocation per frame iteration.
📊 Impact: Discarded. Median render time regressed to ~1.455s (vs 1.404s baseline). The overhead of accessing array elements is equal to or greater than closure allocation, or within noise.
🔬 Verification: Ran benchmark 3x.
📎 Plan: PERF-611

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	1.449	150	103.53	70.0	discard	Pre-allocate capture handlers
2	1.455	150	103.08	70.1	discard	Pre-allocate capture handlers
3	1.472	150	101.91	70.2	discard	Pre-allocate capture handlers
```

---
*PR created automatically by Jules for task [7958310805053452697](https://jules.google.com/task/7958310805053452697) started by @BintzGavin*