### PR TITLE
✨ RENDERER: [PERF-607] Mark merge catch as already implemented

### DIFF
--- a/.sys/plans/PERF-607-merge-runworker-promise-chain-part2.md
+++ b/.sys/plans/PERF-607-merge-runworker-promise-chain-part2.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-607
 slug: merge-runworker-promise-chain-part2
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-28
-completed: ""
-result: ""
+completed: 2024-05-28
+result: failed
 ---
 
 # PERF-607: Merge Promise Catch Handlers in runWorker
@@ -38,3 +38,9 @@ In the `runWorker` promise chain around line 187-196, the executor must read the
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/run-all.ts` to verify correctness and ensure no unhandled promise rejections occur.
+
+## Results Summary
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	already implemented natively
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -414,6 +414,10 @@ Last updated by: PERF-610
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-607**: Merge Promise Catch Handlers in runWorker (Part 2)
+  - **What I tried**: Attempted to merge the `.catch()` block into the preceding `.then()` in `CaptureLoop.ts`.
+  - **WHY it didn't work**: The change is already implemented natively in the file (from a previous PERF execution). The `.catch` block no longer exists in `CaptureLoop.ts` around line 187-196, it has already been converted to `.then(onFulfilled, onRejected)`.
+  - **Plan ID**: PERF-607
 - **PERF-605**: Omit write callback in FFmpeg stdin writes
   - **What I tried**: Removed the `handleWriteError` callback from `this.ffmpegManager.stdin.write()` calls in `CaptureLoop.ts` to bypass Node.js Writable stream internal tracking allocations, and centralized error handling via the `error` event in `FFmpegManager.ts`.
   - **WHY it didn't work**: The median render time regressed to ~1.341s compared to the baseline of ~1.267s. Although omitting the callback avoids allocating a `WriteReq` object, Node.js might use a less optimized or more complex internal queuing path for fully asynchronous, fire-and-forget writes compared to synchronous, tracked writes, leading to increased overhead in this specific high-frequency IPC write loop.

--- a/packages/renderer/.sys/perf-results-PERF-607.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-607.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	already implemented natively


### PR DESCRIPTION
💡 What: Discarded PERF-607.
🎯 Why: The optimization (merging catch into then) is already natively implemented in CaptureLoop.ts (from the previous PERF-606 execution). The `.catch` block no longer exists in `CaptureLoop.ts` around line 187-196, it has already been converted to `.then(onFulfilled, onRejected)`.
📊 Impact: N/A.
🔬 Verification: Verified the code already reflects this change.
📎 Plan: PERF-607

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	already implemented natively
```

---
*PR created automatically by Jules for task [6942516558133367524](https://jules.google.com/task/6942516558133367524) started by @BintzGavin*