### PR TITLE
📋 RENDERER: Discard PERF-613 as duplicate of PERF-511

### DIFF
--- a/.sys/plans/PERF-613-merge-domstrategy-promises.md
+++ b/.sys/plans/PERF-613-merge-domstrategy-promises.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-613
 slug: merge-domstrategy-promises
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-29
-completed: ""
-result: ""
+completed: "2024-05-29"
+result: "discard (duplicate)"
 ---
 
 # PERF-613: Merge Promise Catch Handlers in DomStrategy

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -86,6 +86,11 @@ Last updated by: PERF-612
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-613**: Merge Promise Catch Handlers in DomStrategy
+  - **What I tried**: Attempted to rewrite `.then(onFulfilled).catch(onRejected)` to `.then(onFulfilled, onRejected)` in the `DomStrategy.ts` hot loop.
+  - **WHY it didn't work**: The experiment was discarded as an IMPOSSIBLE/duplicate plan. The target code was already optimized to natively use `async/await` and an inline `try/catch` sequence in `PERF-511`, meaning the `then/catch` promise chain target no longer exists.
+  - **Plan ID**: PERF-613
+
 - **PERF-611**: Pre-allocate Capture Handlers
   - **What I tried**: Pre-allocated fulfillment and rejection handlers in runWorker.
   - **Why it didn't work**: No significant improvement. Overhead of accessing array elements is equal to or greater than closure allocation, or within noise. Median was 1.455s.


### PR DESCRIPTION
Evaluated and discarded PERF-613 as an IMPOSSIBLE/duplicate plan. The target code in `DomStrategy.ts` was previously optimized to use native `async/await` and inline `try/catch` (via PERF-511), rendering the `.then().catch()` promise chain optimization moot. Updated the plan metadata and documented the finding in the `RENDERER-EXPERIMENTS.md` journal.

---
*PR created automatically by Jules for task [12440994944234056526](https://jules.google.com/task/12440994944234056526) started by @BintzGavin*