### PR TITLE
✨ RENDERER: Evaluate Monomorphic Capture Worker Paths

### DIFF
--- a/.sys/plans/PERF-616-monomorphic-capture-worker.md
+++ b/.sys/plans/PERF-616-monomorphic-capture-worker.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-616
 slug: monomorphic-capture-worker
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-29
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -89,6 +89,10 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-616**: Monomorphic Capture Worker Paths
+  - **What I tried**: Split runWorker into monomorphic runAsyncWorker and runSyncWorker to eliminate dynamic instanceof Promise checks.
+  - **WHY it didn't work**: The median render time regressed to ~2.204s vs baseline ~1.317s. V8 optimization inside async generators and closures seems to perform better or at least equally well with the dynamic type check in this context compared to splitting the logic into multiple closure functions and checking options outside the loop. The regression is quite large, potentially because V8 optimizes the unified runWorker better with monomorphic inline caches under the hood, or because there is an additional closure overhead.
+  - **Plan ID**: PERF-616
 - **PERF-613**: Merge Promise Catch Handlers in DomStrategy
   - **What I tried**: Attempted to rewrite `.then(onFulfilled).catch(onRejected)` to `.then(onFulfilled, onRejected)` in the `DomStrategy.ts` hot loop.
   - **WHY it didn't work**: The experiment was discarded as an IMPOSSIBLE/duplicate plan. The target code was already optimized to natively use `async/await` and an inline `try/catch` sequence in `PERF-511`, meaning the `then/catch` promise chain target no longer exists.

--- a/packages/renderer/.sys/perf-results-PERF-616.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-616.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.343	150	64.01	62.9	discard	Monomorphic capture worker paths
+2	2.203	150	68.08	62.8	discard	Monomorphic capture worker paths
+3	2.204	150	68.07	62.8	discard	Monomorphic capture worker paths


### PR DESCRIPTION
✨ RENDERER: Evaluate Monomorphic Capture Worker Paths

💡 **What**: Experiment run to split `runWorker` into monomorphic sync and async paths.
🎯 **Why**: Reduce type checking overhead in the hot loop.
📊 **Impact**: Regressed median render time to ~2.204s from baseline ~1.317s. Discarded.
🔬 **Verification**: Checked with benchmark script.
📎 **Plan**: PERF-616

**Results Summary:**
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.343	150	64.01	62.9	discard	Monomorphic capture worker paths
2	2.203	150	68.08	62.8	discard	Monomorphic capture worker paths
3	2.204	150	68.07	62.8	discard	Monomorphic capture worker paths
```

---
*PR created automatically by Jules for task [626644527650110671](https://jules.google.com/task/626644527650110671) started by @BintzGavin*