### PR TITLE
✨ RENDERER: Discard PERF-617 Flatten CdpTimeDriver Promise Chain

### DIFF
--- a/.sys/plans/PERF-617-flatten-cdptimedriver-await.md
+++ b/.sys/plans/PERF-617-flatten-cdptimedriver-await.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-617
 slug: flatten-cdptimedriver-await
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-29
 completed: ""
-result: ""
+result: "discard"
 ---
 
 # PERF-617: Flatten CdpTimeDriver Promise Chain into Native Await
@@ -80,3 +80,9 @@ Run the tests, specifically `npx tsx packages/renderer/tests/verify-cdp-determin
 ## Prior Art
 - **PERF-511**: Inlined Begin Frame Await (`.then` to `await`), which significantly improved performance.
 - **PERF-614**: Eliminated Capture Result Promise Allocation, moving to inline `try/catch`. This experiment naturally extends this paradigm to `CdpTimeDriver`.
+
+## Results Summary
+- **Best render time**: 2.079s (vs baseline 1.317s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [flatten cdptimedriver await]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -89,6 +89,11 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-617**: Flatten CdpTimeDriver Promise Chain into Native Await
+  - **What I tried**: Made runSetTime async and replaced .then() with await.
+  - **WHY it didn't work**: The median render time regressed to ~2.079s compared to baseline ~1.317s.
+  - **Outcome**: discard
+
 - **PERF-616**: Monomorphic Capture Worker Paths
   - **What I tried**: Split runWorker into monomorphic runAsyncWorker and runSyncWorker to eliminate dynamic instanceof Promise checks.
   - **WHY it didn't work**: The median render time regressed to ~2.204s vs baseline ~1.317s. V8 optimization inside async generators and closures seems to perform better or at least equally well with the dynamic type check in this context compared to splitting the logic into multiple closure functions and checking options outside the loop. The regression is quite large, potentially because V8 optimizes the unified runWorker better with monomorphic inline caches under the hood, or because there is an additional closure overhead.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -136,3 +136,6 @@ run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
 2	2.650	150	56.60	63.8	keep	PERF-508: Optimize Playwright Concurrency
 3	2.658	150	56.42	63.2	keep	PERF-508: Optimize Playwright Concurrency
 4	2.573	150	58.30	63.1	keep	PERF-508: Optimize Playwright Concurrency
+1	2.110	150	71.09	63.0	discard	PERF-617: flatten cdptimedriver await
+2	2.079	150	72.15	63.8	discard	PERF-617: flatten cdptimedriver await
+3	2.072	150	72.39	63.2	discard	PERF-617: flatten cdptimedriver await


### PR DESCRIPTION
## What
Executed and discarded PERF-617: Flatten CdpTimeDriver Promise Chain into Native Await.

## Why
The goal was to test if replacing the `.then()` chain with a native `await` would reduce closure allocation overhead and speed up the virtual time advancement in the CDP Time Driver.

## Impact
The median render time regressed to ~2.079s compared to a measured baseline of ~1.317s. V8 optimization of closures inside async generators is highly efficient, and the native try/catch overhead still outweighs the closure allocation cost.

## Verification
- Code changes discarded via git checkout.
- `perf-results.tsv` and `RENDERER-EXPERIMENTS.md` updated with discard log.
- `verify-cdp-determinism.ts` runs passed locally.

---
*PR created automatically by Jules for task [14194918246947395296](https://jules.google.com/task/14194918246947395296) started by @BintzGavin*