### PR TITLE
✨ RENDERER: Eager update of currentTime in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-619-eager-current-time-update.md
+++ b/.sys/plans/PERF-619-eager-current-time-update.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-619
 slug: eager-current-time-update
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-29
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -89,6 +89,10 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-619**: Eager update of currentTime in CdpTimeDriver
+  - **What I tried**: Eagerly updated currentTime.
+  - **WHY it didn't work**: Caused performance regression (median ~18.655s vs baseline ~1.317s).
+  - **Plan ID**: PERF-619
 - **PERF-618**: Avoid Media Sync Branching
   - **What I tried**: Used method dispatch for media sync instead of evaluating a boolean branch in the hot loop.
   - **WHY it didn't work**: The median render time regressed to ~2.725s compared to baseline ~1.317s. V8 optimization of boolean checks inside the hot loop might be highly efficient, and method dispatch overhead outweighs the cost of evaluating the branch condition.

--- a/packages/renderer/.sys/perf-results-PERF-619.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-619.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	18.655	150	8.04	500.0	discard	Eager update of currentTime in CdpTimeDriver


### PR DESCRIPTION
💡 What: Eagerly updated currentTime.
🎯 Why: Eager update of currentTime in CdpTimeDriver
📊 Impact: Caused performance regression (median ~18.655s vs baseline ~1.317s).
🔬 Verification: Ran the benchmark 1 times to check performance and checked output using ffmpeg. Also verified using tests packages/renderer/tests/verify-cdp-determinism.ts.
📎 Plan: PERF-619

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	18.655	150	8.04	500.0	discard	Eager update of currentTime in CdpTimeDriver

---
*PR created automatically by Jules for task [16780411726829451761](https://jules.google.com/task/16780411726829451761) started by @BintzGavin*