### PR TITLE
✨ RENDERER: Discard duplicate PERF-598

### DIFF
--- a/.sys/plans/PERF-598-cache-sync-media-expression.md
+++ b/.sys/plans/PERF-598-cache-sync-media-expression.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-598
 slug: cache-sync-media-expression
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-27
-completed: ""
-result: ""
+completed: "2024-05-29"
+result: "failed"
 ---
 
 # PERF-598: Cache sync media CDP expression in CdpTimeDriver
@@ -49,3 +49,9 @@ Since the set of `timeInSeconds` is extremely small and deterministic, the Map w
 
 ## Correctness Check
 Run the `npx tsx packages/renderer/scripts/benchmark-perf.ts` script to test performance, followed by `npm run test -w packages/renderer` to verify correctness and ensure media synchronization continues to work properly.
+
+## Results Summary
+- **Best render time**: 0.000s (vs baseline 1.317s)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-598]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -89,6 +89,10 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-598**: Cache sync media CDP expression in CdpTimeDriver
+  - **What I tried**: Planned to cache the dynamically generated sync media expression.
+  - **WHY it didn't work**: The experiment was discarded as an IMPOSSIBLE/duplicate plan because the code was already natively optimized to use a static string (`"window.__helios_sync_media();"`) in PERF-612, eliminating the dynamic concatenation altogether.
+  - **Plan ID**: PERF-598
 - **PERF-615**: Flatten CaptureLoop Promise Chain into Native Await
   - **What I tried**: Flattened the setTimeResult promise chain into a native await block in CaptureLoop.ts runWorker.
   - **WHY it didn't work**: The median render time difference (~2.392s vs baseline ~2.478s) was too small to be conclusive and falls within variance noise. The native `try/catch` block execution overhead negates any minor savings from avoiding `.then()` closure allocations in the V8 engine, similar to past experiments (PERF-604).
@@ -259,6 +263,10 @@ Last updated by: PERF-614
 - Plan ID: PERF-518
 
 ## What Doesn't Work (and Why)
+- **PERF-598**: Cache sync media CDP expression in CdpTimeDriver
+  - **What I tried**: Planned to cache the dynamically generated sync media expression.
+  - **WHY it didn't work**: The experiment was discarded as an IMPOSSIBLE/duplicate plan because the code was already natively optimized to use a static string (`"window.__helios_sync_media();"`) in PERF-612, eliminating the dynamic concatenation altogether.
+  - **Plan ID**: PERF-598
 - **PERF-605**: Omit write callback in FFmpeg stdin writes
   - **What I tried**: Removed the `handleWriteError` callback from `this.ffmpegManager.stdin.write()` calls in `CaptureLoop.ts` to bypass Node.js Writable stream internal tracking allocations, and centralized error handling via the `error` event in `FFmpegManager.ts`.
   - **WHY it didn't work**: The median render time regressed to ~1.341s compared to the baseline of ~1.267s. Although omitting the callback avoids allocating a `WriteReq` object, Node.js might use a less optimized or more complex internal queuing path for fully asynchronous, fire-and-forget writes compared to synchronous, tracked writes, leading to increased overhead in this specific high-frequency IPC write loop.
@@ -311,6 +319,10 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-598**: Cache sync media CDP expression in CdpTimeDriver
+  - **What I tried**: Planned to cache the dynamically generated sync media expression.
+  - **WHY it didn't work**: The experiment was discarded as an IMPOSSIBLE/duplicate plan because the code was already natively optimized to use a static string (`"window.__helios_sync_media();"`) in PERF-612, eliminating the dynamic concatenation altogether.
+  - **Plan ID**: PERF-598
 - **PERF-605**: Omit write callback in FFmpeg stdin writes
   - **What I tried**: Removed the `handleWriteError` callback from `this.ffmpegManager.stdin.write()` calls in `CaptureLoop.ts` to bypass Node.js Writable stream internal tracking allocations, and centralized error handling via the `error` event in `FFmpegManager.ts`.
   - **WHY it didn't work**: The median render time regressed to ~1.341s compared to the baseline of ~1.267s. Although omitting the callback avoids allocating a `WriteReq` object, Node.js might use a less optimized or more complex internal queuing path for fully asynchronous, fire-and-forget writes compared to synchronous, tracked writes, leading to increased overhead in this specific high-frequency IPC write loop.
@@ -397,6 +409,10 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-598**: Cache sync media CDP expression in CdpTimeDriver
+  - **What I tried**: Planned to cache the dynamically generated sync media expression.
+  - **WHY it didn't work**: The experiment was discarded as an IMPOSSIBLE/duplicate plan because the code was already natively optimized to use a static string (`"window.__helios_sync_media();"`) in PERF-612, eliminating the dynamic concatenation altogether.
+  - **Plan ID**: PERF-598
 - **PERF-605**: Omit write callback in FFmpeg stdin writes
   - **What I tried**: Removed the `handleWriteError` callback from `this.ffmpegManager.stdin.write()` calls in `CaptureLoop.ts` to bypass Node.js Writable stream internal tracking allocations, and centralized error handling via the `error` event in `FFmpegManager.ts`.
   - **WHY it didn't work**: The median render time regressed to ~1.341s compared to the baseline of ~1.267s. Although omitting the callback avoids allocating a `WriteReq` object, Node.js might use a less optimized or more complex internal queuing path for fully asynchronous, fire-and-forget writes compared to synchronous, tracked writes, leading to increased overhead in this specific high-frequency IPC write loop.
@@ -450,6 +466,10 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-598**: Cache sync media CDP expression in CdpTimeDriver
+  - **What I tried**: Planned to cache the dynamically generated sync media expression.
+  - **WHY it didn't work**: The experiment was discarded as an IMPOSSIBLE/duplicate plan because the code was already natively optimized to use a static string (`"window.__helios_sync_media();"`) in PERF-612, eliminating the dynamic concatenation altogether.
+  - **Plan ID**: PERF-598
 - **PERF-607**: Merge Promise Catch Handlers in runWorker (Part 2)
   - **What I tried**: Attempted to merge the `.catch()` block into the preceding `.then()` in `CaptureLoop.ts`.
   - **WHY it didn't work**: The change is already implemented natively in the file (from a previous PERF execution). The `.catch` block no longer exists in `CaptureLoop.ts` around line 187-196, it has already been converted to `.then(onFulfilled, onRejected)`.

--- a/packages/renderer/.sys/perf-results-PERF-598.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-598.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	IMPOSSIBLE/duplicate: CdpTimeDriver expression is already a static string via PERF-612


### PR DESCRIPTION
💡 What: Discarded PERF-598 as duplicate.
🎯 Why: CdpTimeDriver already uses static string since PERF-612.
📊 Impact: 0% (Duplicate)
🔬 Verification: Orchestrator plan check passed.
📎 Plan: PERF-598

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	IMPOSSIBLE/duplicate: CdpTimeDriver expression is already a static string via PERF-612

---
*PR created automatically by Jules for task [10127136161376837949](https://jules.google.com/task/10127136161376837949) started by @BintzGavin*