### PR TITLE
✨ RENDERER: [Discard] Optimize HeadlessExperimental.beginFrame calls in DomStrategy

### DIFF
--- a/.sys/plans/PERF-623-optimize-dom-strategy-begin-frame.md
+++ b/.sys/plans/PERF-623-optimize-dom-strategy-begin-frame.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-623
 slug: optimize-dom-strategy-begin-frame
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-30
-completed: ""
-result: ""
+completed: "2026-05-30"
+result: failed
 ---
 
 # PERF-623: Optimize HeadlessExperimental.beginFrame calls in DomStrategy
@@ -128,3 +128,9 @@ Run `npx tsx packages/renderer/tests/verify-orchestrator-plan.ts` to ensure basi
 
 ## Correctness Check
 Verify output via `npx tsx packages/renderer/scripts/benchmark-perf.ts`.
+
+## Results Summary
+- **Best render time**: 2.632s (vs baseline ~1.317s)
+- **Improvement**: Regressed by ~100%
+- **Kept experiments**: []
+- **Discarded experiments**: [Step 1, Step 2, Step 3]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -619,3 +619,9 @@ Last updated by: PERF-592
   - **What I did**: Replaced the `frameErrorRing` array with a single global `fatalError` variable in `CaptureLoop.ts` to reduce array write bounds checking inside the V8 hot loop.
   - **Impact**: Improved median render time by ~6% (median ~2.16s compared to baseline ~2.296s).
   - **Plan ID**: PERF-622
+
+## What Doesn't Work (and Why)
+- **PERF-623**: Optimize HeadlessExperimental.beginFrame calls in DomStrategy
+  - **What I tried**: Removing the `async/await` and `try/catch` wrapping around `this.cdpSession!.send('HeadlessExperimental.beginFrame', ...)` and directly returning the promise chain to avoid microtask allocations in V8.
+  - **Why it didn't work**: It severely regressed performance from ~1.317s down to ~2.685s. This suggests that the V8 engine has highly optimized fast-paths for inline `try/catch` and `async/await` around promises, whereas manual Promise chaining `.then()` introduces significantly more closure allocations and overhead in this specific hot loop.
+  - **Plan ID**: PERF-623

--- a/packages/renderer/.sys/perf-results-PERF-623.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-623.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.685	150	55.87	63.1	discard	optimize-dom-strategy-begin-frame
+2	2.694	150	55.67	63.0	discard	optimize-dom-strategy-begin-frame
+3	2.632	150	57.00	63.0	discard	optimize-dom-strategy-begin-frame


### PR DESCRIPTION
✨ RENDERER: [Discard] Optimize HeadlessExperimental.beginFrame calls in DomStrategy

💡 **What**: Discarded replacing async/await and try/catch in DomStrategy with direct Promise chains
🎯 **Why**: Avoid V8 microtask overhead
📊 **Impact**: Regressed median time to ~2.632s from ~1.317s baseline (-100%)
🔬 **Verification**: Rendered examples/dom-benchmark/output/example-build/composition.html
📎 **Plan**: PERF-623

### Benchmark Results
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.685	150	55.87	63.1	discard	optimize-dom-strategy-begin-frame
2	2.694	150	55.67	63.0	discard	optimize-dom-strategy-begin-frame
3	2.632	150	57.00	63.0	discard	optimize-dom-strategy-begin-frame
```

---
*PR created automatically by Jules for task [1710313882696765021](https://jules.google.com/task/1710313882696765021) started by @BintzGavin*