### PR TITLE
✨ PLAYER: Document Event Handlers

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,4 +1,8 @@
-### PLAYER v0.77.42
+#
+### PLAYER v0.77.43
+- ✅ Completed: Document Event Handlers - Updated README.md to include standard event handler properties to match the actual implementation in packages/player/src/index.ts.
+
+## PLAYER v0.77.42
 - ✅ Completed: Discovered that v0.77.40-PLAYER-Document-Missing-Events.md is an IMPOSSIBLE plan because the events `error` and `audiometering` are already documented in `packages/player/README.md`. Documented as duplicate and discarded.
 
 ### PLAYER v0.77.39

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,6 @@
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
-**Version**: 0.77.42
+**Version**: 0.77.43
+[v0.77.43] ✅ Completed: Document Event Handlers - Updated README.md to include standard event handler properties to match the actual implementation in packages/player/src/index.ts.
 [v0.77.42] ✅ Completed: Discovered that v0.77.40-PLAYER-Document-Missing-Events.md is an IMPOSSIBLE plan because the events `error` and `audiometering` are already documented in `packages/player/README.md`. Documented as duplicate and discarded.
 [v0.77.38] ✅ Completed: Expand Index Coverage - Added unit tests for disconnectedCallback in packages/player/src/index.ts.
 [v0.77.37] ✅ Completed: Improve index.ts test coverage - Added tests for diagnose API and retryConnection.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -197,6 +197,28 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `mediaArtwork` (string): Reflected media-artwork attribute.
 
 
+
+### Event Handlers
+
+- `onplay` (function | null): Event handler for the `play` event.
+- `onpause` (function | null): Event handler for the `pause` event.
+- `onended` (function | null): Event handler for the `ended` event.
+- `ontimeupdate` (function | null): Event handler for the `timeupdate` event.
+- `onvolumechange` (function | null): Event handler for the `volumechange` event.
+- `onratechange` (function | null): Event handler for the `ratechange` event.
+- `ondurationchange` (function | null): Event handler for the `durationchange` event.
+- `onseeking` (function | null): Event handler for the `seeking` event.
+- `onseeked` (function | null): Event handler for the `seeked` event.
+- `onresize` (function | null): Event handler for the `resize` event.
+- `onloadstart` (function | null): Event handler for the `loadstart` event.
+- `onloadedmetadata` (function | null): Event handler for the `loadedmetadata` event.
+- `onloadeddata` (function | null): Event handler for the `loadeddata` event.
+- `oncanplay` (function | null): Event handler for the `canplay` event.
+- `oncanplaythrough` (function | null): Event handler for the `canplaythrough` event.
+- `onerror` (function | null): Event handler for the `error` event.
+- `onenterpictureinpicture` (function | null): Event handler for the `enterpictureinpicture` event.
+- `onleavepictureinpicture` (function | null): Event handler for the `leavepictureinpicture` event.
+
 ## Events
 
 The element dispatches the following custom events:


### PR DESCRIPTION
Documented missing standard event handler properties such as `onplay`, `onpause`, `onended`, etc., in the PLAYER domain's `README.md` to achieve API documentation parity with the actual codebase implementation. Added a new `### Event Handlers` section under the Standard Media API. Updated status and progress documentation to reflect the completed change.

---
*PR created automatically by Jules for task [6231351375669445966](https://jules.google.com/task/6231351375669445966) started by @BintzGavin*