### PR TITLE
📋 PLAYER: Add missing onaudiometering event handler spec

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -58,3 +58,14 @@
 ## [v0.77.41] - Documenting Event Handlers
 **Learning**: The standard event handler properties (`onplay`, `onpause`, etc.) were implemented for API parity but never explicitly documented in the README, leading to a vision gap.
 **Action**: Always verify that newly implemented API surfaces are immediately documented in the project's README to maintain synchronization between implementation and vision.
+## [v0.77.44] - Add Missing Plan Content
+**Learning:** When using `cat << 'EOF'` to create a file in an execution plan, the complete, explicit text/markdown content must be provided within the command. Using placeholders like `...` violates the Specificity Rule.
+**Action:** Always write out the full file content inside the `cat << 'EOF'` command when drafting a plan.
+
+## [v0.77.44] - Avoid Unverified Test Assumptions
+**Learning:** The script `packages/renderer/tests/verify-orchestrator-plan.ts` is strictly for verifying performance experiment plans (`PERF-*.md`) and is not applicable to Frontend Planner specs (`PLAYER-*.md`). Furthermore, the Planner role explicitly forbids running tests.
+**Action:** Do not include steps to run tests (e.g., `npm test` or `verify-orchestrator-plan.ts`) in the execution plan when acting as the Planner.
+
+## [v0.77.44] - Missing onaudiometering Event Handler Property
+**Learning:** The `audiometering` event was dispatched and documented, but the corresponding IDL attribute (event handler property `onaudiometering`) was missing from the `<helios-player>` implementation, creating an API parity gap with standard HTMLMediaElement patterns.
+**Action:** Created an implementation spec to add the `onaudiometering` getter and setter to complete standard media API parity.

--- a/.sys/plans/2027-02-16-PLAYER-Add-onaudiometering-handler.md
+++ b/.sys/plans/2027-02-16-PLAYER-Add-onaudiometering-handler.md
@@ -1,0 +1,26 @@
+#### 1. Context & Goal
+- **Objective**: Implement missing `onaudiometering` standard event handler property on the `<helios-player>` Web Component.
+- **Trigger**: The Vision vs Reality analysis revealed that while the `audiometering` event is documented and dispatched by the player, the corresponding `onaudiometering` IDL attribute (event handler property) is missing from the implementation and documentation, leaving an API parity gap.
+- **Impact**: Completes the standard event handler API parity by allowing developers to use the `player.onaudiometering = (e) => {}` pattern, consistent with other media events.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**:
+  - `packages/player/src/index.ts` (Add `onaudiometering` getter/setter)
+  - `packages/player/README.md` (Document `onaudiometering` under Event Handlers)
+- **Read-Only**: `packages/player/src/index.test.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Standard HTMLMediaElement IDL event handler property pattern matching existing implementations (e.g., `_onplay`, `get onplay()`, `set onplay()`).
+- **Pseudo-Code**:
+  - In `packages/player/src/index.ts`, add a private `_onaudiometering: ((event: Event) => void) | null = null;` to the `HeliosPlayer` class.
+  - Add public getter: `public get onaudiometering() { return this._onaudiometering; }`
+  - Add public setter: `public set onaudiometering(handler: ((event: Event) => void) | null)` which calls `removeEventListener` for the old handler (if exists), updates `_onaudiometering`, and calls `addEventListener` for the new handler (if not null).
+  - In `packages/player/README.md`, add `- \`onaudiometering\` (function | null): Event handler for the \`audiometering\` event.` to the `### Event Handlers` list.
+- **Public API Changes**: Adds `onaudiometering` property to the `HeliosPlayer` class.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm run build -w packages/player && npm test -w packages/player`
+- **Success Criteria**: The `HeliosPlayer` class supports getting and setting the `onaudiometering` property. Documentation accurately lists the new event handler.
+- **Edge Cases**: Unsetting the handler by assigning `null` successfully removes the underlying event listener.


### PR DESCRIPTION
Creates the implementation spec `2027-02-16-PLAYER-Add-onaudiometering-handler.md` to add the missing `onaudiometering` IDL attribute to the `<helios-player>` Web Component to resolve an API parity gap where the event is emitted but lacks a standard event handler property.

---
*PR created automatically by Jules for task [13830943372408454104](https://jules.google.com/task/13830943372408454104) started by @BintzGavin*