### PR TITLE
✨ RENDERER: Discard PERF-627 (consolidate capture branching)

### DIFF
--- a/.sys/plans/PERF-627-consolidate-capture-branching.md
+++ b/.sys/plans/PERF-627-consolidate-capture-branching.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-627
 slug: consolidate-capture-branching
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2027-06-06
 completed: ""
-result: ""
+result: "discard"
 ---
 
 # PERF-627: Consolidate Capture Branching in DomStrategy

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -630,3 +630,5 @@ Last updated by: PERF-592
   - **What I tried**: Removing the `async/await` and `try/catch` wrapping around `this.cdpSession!.send('HeadlessExperimental.beginFrame', ...)` and directly returning the promise chain to avoid microtask allocations in V8.
   - **Why it didn't work**: It severely regressed performance from ~1.317s down to ~2.685s. This suggests that the V8 engine has highly optimized fast-paths for inline `try/catch` and `async/await` around promises, whereas manual Promise chaining `.then()` introduces significantly more closure allocations and overhead in this specific hot loop.
   - **Plan ID**: PERF-623
+
+- PERF-627 (discard): Attempted to consolidate capture branching in DomStrategy's hot loop by pre-computing activeBeginFrameParams to eliminate conditional evaluations on every frame and improve V8 inlining. The median render time regressed from the ~1.317s baseline to ~2.127s. This is likely because the added memory lookup and setup for `activeBeginFrameParams` negated the minor savings from avoiding the branch, or potentially defeated other V8 optimizations related to constant parameters.

--- a/packages/renderer/.sys/perf-results-PERF-627.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-627.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	11.880	150	12.63	63.0	discard	consolidate capture branching (initial slow run)
+2	2.498	150	60.05	63.3	discard	consolidate capture branching
+3	2.057	150	72.93	63.1	discard	consolidate capture branching
+4	2.241	150	66.95	63.1	discard	consolidate capture branching
+5	2.102	150	71.34	63.0	discard	consolidate capture branching
+6	2.127	150	70.53	63.2	discard	consolidate capture branching


### PR DESCRIPTION
Evaluated an experiment to consolidate `beginFrame` parameters in `DomStrategy.ts` to avoid conditional branching on every frame. The experiment caused a significant regression (from ~1.317s to ~2.127s) and was discarded.

Results:
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	11.880	150	12.63	63.0	discard	consolidate capture branching (initial slow run)
2	2.498	150	60.05	63.3	discard	consolidate capture branching
3	2.057	150	72.93	63.1	discard	consolidate capture branching
4	2.241	150	66.95	63.1	discard	consolidate capture branching
5	2.102	150	71.34	63.0	discard	consolidate capture branching
6	2.127	150	70.53	63.2	discard	consolidate capture branching

---
*PR created automatically by Jules for task [4187286978932169399](https://jules.google.com/task/4187286978932169399) started by @BintzGavin*