### PR TITLE
✨ RENDERER: Run PERF-626 bypass capture async/await experiment

### DIFF
--- a/.sys/plans/PERF-626-bypass-capture-async-await.md
+++ b/.sys/plans/PERF-626-bypass-capture-async-await.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-626
 slug: bypass-capture-async-await
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-30
-completed: ""
-result: ""
+completed: "2024-05-30"
+result: "no-improvement"
 ---
 
 # PERF-626: Bypass `async/await` in DomStrategy capture
@@ -62,3 +62,9 @@ However, if we pre-bind the success and error handlers as class methods, we can 
 
 ## Correctness Check
 Run the `npx tsx packages/renderer/scripts/benchmark-perf.ts` script to test performance and verify correct output. Ensure the video renders successfully and doesn't crash.
+
+## Results Summary
+- **Best render time**: 2.221s (vs baseline 2.233s)
+- **Improvement**: 0% (noise)
+- **Kept experiments**:
+- **Discarded experiments**: PERF-626

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -632,3 +632,8 @@ Last updated by: PERF-592
   - **Plan ID**: PERF-623
 
 - PERF-627 (discard): Attempted to consolidate capture branching in DomStrategy's hot loop by pre-computing activeBeginFrameParams to eliminate conditional evaluations on every frame and improve V8 inlining. The median render time regressed from the ~1.317s baseline to ~2.127s. This is likely because the added memory lookup and setup for `activeBeginFrameParams` negated the minor savings from avoiding the branch, or potentially defeated other V8 optimizations related to constant parameters.
+
+- **PERF-626**: Bypass `async/await` in DomStrategy capture
+  - **What I tried**: Added pre-bound success and error handler methods to `DomStrategy` and removed `async/await` from `capture()`, returning the Promise chain directly instead.
+  - **WHY it didn't work**: The median render time was ~2.221s, compared to the baseline of ~2.233s. The difference is within noise margins and the change slightly adds more complexity without providing meaningful improvement. V8 appears highly optimized for inline `async/await` and `try/catch`.
+  - **Plan ID**: PERF-626

--- a/packages/renderer/.sys/perf-results-PERF-626.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-626.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.233	150	67.16	63.4	keep	baseline
+2	2.221	150	67.54	63.1	discard	bypass-capture-async-await


### PR DESCRIPTION
✨ RENDERER: Run PERF-626 bypass capture async/await experiment

💡 **What**: Executed PERF-626 to test bypassing `async/await` in `DomStrategy.capture()` using pre-bound Promise handlers. The experiment yielded no measurable performance improvement (0% difference vs baseline). The code changes were discarded/reverted, and the documentation updated to reflect the outcome.
🎯 **Why**: To reduce V8 generator allocations and microtask ticks per frame in the DOM rendering capture hot loop.
📊 **Impact**: Baseline ~2.233s. Experiment ~2.221s. Difference is within noise.
🔬 **Verification**: Codebase integrity verified via `verify-cdp-determinism.ts`. Plan structure verified via `verify-orchestrator-plan.ts`.
📎 **Plan**: .sys/plans/PERF-626-bypass-capture-async-await.md

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.233	150	67.16	63.4	keep	baseline
2	2.221	150	67.54	63.1	discard	bypass-capture-async-await
```

---
*PR created automatically by Jules for task [9547985093693023891](https://jules.google.com/task/9547985093693023891) started by @BintzGavin*