### PR TITLE
✨ RENDERER: Eliminate frameReadyRing in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-628-eliminate-frame-ready-ring.md
+++ b/.sys/plans/PERF-628-eliminate-frame-ready-ring.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-628
 slug: eliminate-frame-ready-ring
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-01
-completed: ""
-result: ""
+completed: "2024-06-01"
+result: "failed"
 ---
 
 # PERF-628: Eliminate `frameReadyRing` in CaptureLoop
@@ -50,3 +50,9 @@ Currently, `CaptureLoop.ts` synchronizes the workers and the FFmpeg writer loop 
 ## Correctness Check
 - Verify the pipeline completes without stalling (no infinite writer waits).
 - Run `npx tsx packages/renderer/scripts/benchmark-perf.ts` to confirm rendering outputs the expected frame count.
+
+## Results Summary
+- **Best render time**: 2.874s (vs baseline 1.317s)
+- **Improvement**: Regressed
+- **Kept experiments**: None
+- **Discarded experiments**: PERF-628

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -93,6 +93,10 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-628**: Eliminate `frameReadyRing` array in CaptureLoop.ts
+  - **What I tried**: Removed the `frameReadyRing` TypedArray to reduce synchronous operations and array lookups. Replaced its readiness flag entirely by checking `frameBufferRing[ringIndex] === null`.
+  - **Why it didn't work**: It caused a massive performance regression (~2.874s vs baseline ~1.317s). V8 is likely heavily optimized for `Uint8Array` read/writes over checking for `null` in a polymorphic array (`Buffer | string | null`). The type-checked read overhead inside the writer loop negated the savings of removing the assignment flags.
+  - **Plan ID**: PERF-628
 - Single worker fast path (PERF-624): Discarded because bypassing the multi-worker actor model entirely for the single worker case didn't significantly reduce overhead, rendering mostly stayed within noise constraints and regressed slightly in medians.
 - **PERF-621**: Disable V8 Idle Tasks and Background GC
   - **What I did**: Added `--disable-v8-idle-tasks` and `--disable-background-gc` to `DEFAULT_BROWSER_ARGS` in `BrowserPool.ts`.

--- a/packages/renderer/.sys/perf-results-PERF-628.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-628.tsv
@@ -1,0 +1,1 @@
+1	2.874	150	52.20	63.0	discard	Eliminate frameReadyRing - Regressed performance (2.874s vs 1.317s baseline)


### PR DESCRIPTION
💡 **What**: Removed the `frameReadyRing` array in CaptureLoop.ts to use `frameBufferRing` for readiness checks instead.
🎯 **Why**: To reduce array allocation and fast-path index lookups in the V8 hot path loop.
📊 **Impact**: Massive performance regression (~2.874s vs baseline ~1.317s).
🔬 **Verification**: Benchmarked on dom-benchmark. Code reverted and failure documented.
📎 **Plan**: Reference the plan file (/.sys/plans/PERF-628-eliminate-frame-ready-ring.md)

1	2.874	150	52.20	63.0	discard	Eliminate frameReadyRing - Regressed performance (2.874s vs 1.317s baseline)

---
*PR created automatically by Jules for task [14617257008775915257](https://jules.google.com/task/14617257008775915257) started by @BintzGavin*