### PR TITLE
✨ RENDERER: Inline CdpTimeDriver setTime allocation

### DIFF
--- a/.sys/plans/PERF-631-inline-cdptime-settime.md
+++ b/.sys/plans/PERF-631-inline-cdptime-settime.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-631
 slug: inline-cdptime-settime
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-31
-completed: ""
-result: ""
+completed: "2024-05-31"
+result: "no-improvement"
 ---
 # PERF-631: Inline CdpTimeDriver setTime allocation
 
@@ -59,3 +59,9 @@ Run `npx tsx packages/renderer/tests/verify-cdp-determinism.ts` to verify DOM ou
 
 ## Prior Art
 - PERF-630 and PERF-612 optimizations attempted to clean up hot loop variables but missed these specific redundant allocations and function wrapper layers.
+
+## Results Summary
+- **Best render time**: 2.513s (vs baseline ~2.490s - 2.520s)
+- **Improvement**: 0% (Median ~2.638s is worse than baseline median ~2.513s. Best was ~2.513s, which is within noise)
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-631]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -93,6 +93,11 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-631**: Inline CdpTimeDriver setTime allocation
+  - **What I tried**: Inlined `runSetTime` logic into `setTime` directly in `CdpTimeDriver.ts` and removed a redundant string assignment `this.singleFrameSyncMediaParams.expression` inside `defaultSyncMedia` to bypass V8 Promise allocation overhead and property mutation in the hot loop.
+  - **WHY it didn't work**: It did not improve performance. The median render time was ~2.638s (vs baseline ~2.513s), with the best run at ~2.513s which is within the noise margin. V8 likely already inlines this effectively and the redundant string assignment overhead is negligible.
+  - **Plan ID**: PERF-631
+
 - **PERF-630**: Bypass `lastFrameData` assignment in DomStrategy capture loop
   - **What I tried**: Attempted to directly return `result.screenshotData || this.lastFrameData!` to avoid property mutation overhead.
   - **Why it didn't work**: Breaks the frame fallback mechanism, which is critical for recovering from dropped frames or CDP errors.

--- a/packages/renderer/.sys/perf-results-PERF-631.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-631.tsv
@@ -1,0 +1,3 @@
+1	4.225	150	35.50	62.7	discard	PERF-631: Inline CdpTimeDriver setTime allocation
+2	2.638	150	56.85	62.9	discard	PERF-631: Inline CdpTimeDriver setTime allocation
+3	2.513	150	59.68	62.8	discard	PERF-631: Inline CdpTimeDriver setTime allocation


### PR DESCRIPTION
💡 **What**: Tested inlining `runSetTime` logic into `setTime` and removing a redundant string assignment in `CdpTimeDriver.ts`. Code changes discarded because they didn't improve performance.
🎯 **Why**: To bypass V8 Promise allocation and property mutation overhead in the hot loop.
📊 **Impact**: No improvement. Median render time ~2.638s (baseline ~2.513s). Best run ~2.513s (within noise).
🔬 **Verification**: Benchmarked 3 times. Verified CDP determinism and Canvas fallback prior to reverting.
📎 **Plan**: `/.sys/plans/PERF-631-inline-cdptime-settime.md`

```tsv
1	4.225	150	35.50	62.7	discard	PERF-631: Inline CdpTimeDriver setTime allocation
2	2.638	150	56.85	62.9	discard	PERF-631: Inline CdpTimeDriver setTime allocation
3	2.513	150	59.68	62.8	discard	PERF-631: Inline CdpTimeDriver setTime allocation
```

---
*PR created automatically by Jules for task [4644136400793643487](https://jules.google.com/task/4644136400793643487) started by @BintzGavin*