### PR TITLE
📋 RENDERER: Discard PERF-594

### DIFF
--- a/.sys/plans/PERF-594-inline-writerwaiter-wakeup.md
+++ b/.sys/plans/PERF-594-inline-writerwaiter-wakeup.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-594
 slug: inline-writerwaiter-wakeup
-status: claimed
+status: complete
 claimed_by: "jules"
 created: 2024-05-26
 completed: "2024-05-26"
@@ -98,3 +98,9 @@ With:
 
 ## Correctness Check
 Run the `npx tsx packages/renderer/tests/fixtures/benchmark.ts` script to test performance, followed by `npm run test -w packages/renderer -- --run` to verify correctness and ensure no race conditions are introduced in the ring buffer.
+
+## Results Summary
+- **Best render time**: 2.846s (vs baseline ~2.727s)
+- **Improvement**: ~-4.3% (worse)
+- **Kept experiments**: none
+- **Discarded experiments**: [PERF-594: Inline writerWaiterResolve Wakeup into Promise Chain in CaptureLoop]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -93,6 +93,11 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-594**: Inline `writerWaiterResolve` Wakeup into Promise Chain in CaptureLoop
+  - **What I tried**: Modified the `captureResult` try/catch block in `CaptureLoop.ts` to check and execute `writerWaiterResolve` immediately after setting `frameReadyRing` to 1, instead of awaiting the generator resumption of the whole block.
+  - **WHY it didn't work**: The median render time regressed to ~2.955s compared to the baseline of ~2.785s. Resolving the waiter inside the microtask did not outweigh the overhead of checking `writerWaiterResolve && nextFrameToWrite === i` conditionally inside both the `try` and `else` blocks. V8 seems to optimize the generator `await` resumption more efficiently than the repeated closure state checks.
+  - **Outcome**: discard
+
 - **PERF-632**: Consolidate `CaptureLoop` Worker Wait Logic
   - **What I tried**: Replaced `workerBlockedExecutors` array and multiple Promise closures with a single `workerBlockedPromises` array containing a deferred promise pattern to reduce V8 allocation overhead in the `CaptureLoop` multi-worker wait block.
   - **WHY it didn't work**: The median render time was ~2.620s, which is slower than the historical best of ~2.160s (and roughly the same as the current local baseline of ~2.664s). The minor savings from avoiding `new Promise` on every block was negated by the overhead of allocating the deferred object wrapper and the added logic to resolve it. V8's optimization of simple promise allocations in closures within hot async generators is likely more efficient than maintaining custom deferred objects in this hot loop.

--- a/packages/renderer/.sys/perf-results-PERF-594.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-594.tsv
@@ -1,0 +1,8 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	3.614	150	41.51	63.2	keep	baseline
+2	2.785	150	53.85	63.2	keep	baseline
+3	2.791	150	53.74	63.2	keep	baseline
+4	2.727	150	55.01	63.3	keep	baseline
+5	2.955	150	50.76	63.2	discard	PERF-594: Inline writerWaiterResolve Wakeup into Promise Chain in CaptureLoop
+6	2.846	150	52.70	63.1	discard	PERF-594: Inline writerWaiterResolve Wakeup into Promise Chain in CaptureLoop
+7	2.994	150	50.10	63.1	discard	PERF-594: Inline writerWaiterResolve Wakeup into Promise Chain in CaptureLoop


### PR DESCRIPTION
Discarded PERF-594 inline writerWaiterResolve due to performance regression.

---
*PR created automatically by Jules for task [11539419016333372773](https://jules.google.com/task/11539419016333372773) started by @BintzGavin*