### PR TITLE
✨ RENDERER: Discard PERF-643 inline currentTime in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-643-inline-current-time.md
+++ b/.sys/plans/PERF-643-inline-current-time.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-643
 slug: inline-current-time
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-05-31
-completed: ""
-result: ""
+completed: "2024-05-31"
+result: failed
 ---
 
 # PERF-643: Inline `currentTime` update into `handleVirtualTimeBudgetExpired`
@@ -76,3 +76,9 @@ Run a basic canvas render.
 
 ## Correctness Check
 Run `npx tsx packages/renderer/tests/verify-cdp-media-sync-timing.ts` to ensure time advances correctly.
+
+## Results Summary
+- **Best render time**: 2.882s (vs baseline 2.780s)
+- **Improvement**: -3.6%
+- **Kept experiments**: []
+- **Discarded experiments**: [Inline `currentTime` update into `handleVirtualTimeBudgetExpired`]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -687,3 +687,8 @@ Last updated by: PERF-592
   - **What I tried**: Attempted to eliminate the `.then()` chain in `runSetTime` by eagerly assigning `this.currentTime = timeInSeconds` right before sending the `Emulation.setVirtualTimePolicy` CDP command and directly returning the new Promise, aiming to bypass V8 microtask closure allocation overhead per frame.
   - **WHY it didn't work**: The median render time did not improve and remained around ~2.492s (baseline ~2.499s). V8 is likely already highly efficient at optimizing local closure execution and short `.then()` microtasks inside generator await loops. The overhead saved by avoiding `.then()` was negligible and absorbed by the noise floor of Playwright IPC.
   - **Plan ID**: PERF-642
+
+- **PERF-643**: Inline `currentTime` update into `handleVirtualTimeBudgetExpired`
+  - **What I tried**: Added a `nextTimeInSeconds` variable to `CdpTimeDriver.ts` to eagerly store the time and updated `this.currentTime` directly in the `handleVirtualTimeBudgetExpired` CDP event handler, bypassing the `.then()` promise closure allocation in `runSetTime`.
+  - **WHY it didn't work**: The median render time regressed slightly to ~2.882s compared to the baseline median of ~2.780s. Despite eliminating the promise closure allocation in the hot loop, V8 is highly optimized for short `.then()` microtasks inside async chains. By shifting state mutation into the CDP callback context, we might have disrupted the JIT compiler's optimization of the async/await hot loop sequence, resulting in a net negative performance impact.
+  - **Plan ID**: PERF-643

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -141,3 +141,4 @@ PERF-408	49.135	600	12.21	43.1	keep	Cache Media Elements in CdpTimeDriver to avo
 3	2.490	150	60.25	63.2	keep	PERF-629: Consolidate HeadlessExperimental.beginFrame CDP Call in DomStrategy
 1	0.000	0	0.00	0.0	discard	bypass lastFrameData assignment (breaks frame fallback)
 PERF-641	2.202	150	68.11	63.1	keep	removed redundant sync media string assignment
+643	2.882	150	52.05	63.2	discard	inline-current-time (median of 6 runs: 3.110, 3.089, 2.860, 3.196, 2.757, 2.882)


### PR DESCRIPTION
💡 **What**: Executed and discarded PERF-643 experiment attempting to inline the `currentTime` assignment into `handleVirtualTimeBudgetExpired` in `CdpTimeDriver.ts`. Code changes were fully reverted as the experiment failed.
🎯 **Why**: The goal was to remove the `.then(() => { this.currentTime = timeInSeconds; })` closure allocation in the `runSetTime` hot loop to reduce microtask GC pressure per frame.
📊 **Impact**: The median render time regressed slightly to ~2.882s compared to the baseline median of ~2.780s. The overhead saved by avoiding `.then()` was negligible and absorbed by the noise floor of Playwright IPC, while shifting state mutation into the CDP callback likely disrupted V8 async/await optimizations.
🔬 **Verification**: Compilation passed (`npm run build`). Determinism verification passed (`verify-cdp-determinism.ts`). Benchmark measured across 6 runs.
📎 **Plan**: `/.sys/plans/PERF-643-inline-current-time.md`

---
*PR created automatically by Jules for task [4207532210877888635](https://jules.google.com/task/4207532210877888635) started by @BintzGavin*