### PR TITLE
📋 RENDERER: [PERF-510] Mark plan as impossible

### DIFF
--- a/packages/renderer/.sys/plans/PERF-510-inline-stability-check-await.md
+++ b/packages/renderer/.sys/plans/PERF-510-inline-stability-check-await.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-510
 slug: inline-stability-check-await
-status: unclaimed
+status: impossible
 claimed_by: ""
 created: 2024-05-15
-completed: ""
-result: ""
+completed: 2026-06-01
+result: impossible
 ---
 
 # PERF-510: Inline Stability Check Await
@@ -68,3 +68,6 @@ Modify `defaultStabilityCheck` to return the promise without `.then()`, and upda
 ```
 **Why**: Avoids creating a secondary Promise object via `.then()` and an anonymous closure per frame.
 **Risk**: None.
+
+## Impossibility Explanation
+Upon reviewing `packages/renderer/src/drivers/CdpTimeDriver.ts`, this optimization has already been fully implemented by `PERF-520`. That experiment entirely removed `defaultStabilityCheck` and `evaluateStabilityParams`, inlining the `await` directly into `runSetTime()`. Therefore, this experiment's target code no longer exists and the optimization is structurally obsolete.


### PR DESCRIPTION
The `PERF-510` optimization (inlining the stability check promise and awaiting it in `runSetTime`) was actually fully completed in `PERF-520`, which entirely eliminated `defaultStabilityCheck` and `evaluateStabilityParams` from `CdpTimeDriver.ts`. Thus, this experiment plan is structurally obsolete and impossible to execute on the current codebase.

I updated the plan frontmatter to mark it as impossible and appended an impossibility explanation. 
I also completed pre-commit steps ensuring codebase tests (`verify-cdp-determinism`) still pass normally.

---
*PR created automatically by Jules for task [10478212377305783161](https://jules.google.com/task/10478212377305783161) started by @BintzGavin*