### PR TITLE
✨ RENDERER: Evaluate CdpTimeDriver sync media fast path

### DIFF
--- a/.sys/plans/PERF-646-fast-path-sync-media.md
+++ b/.sys/plans/PERF-646-fast-path-sync-media.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-646
 slug: fast-path-sync-media
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-01
 completed: ""
 result: ""
@@ -63,3 +63,9 @@ Run the tests and benchmark to verify determinism and performance.
 
 ## Prior Art
 - Many optimizations (e.g. PERF-637, PERF-641) focused on stripping redundant calls and branches from the `CaptureLoop` and `CdpTimeDriver` hot loops.
+
+## Results Summary
+- **Best render time**: ~2.568s (vs baseline ~2.483s)
+- **Improvement**: 0%
+- **Kept experiments**: none
+- **Discarded experiments**: Inlined fast-path media sync

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -97,6 +97,11 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+
+- **PERF-646**: Fast path sync media check
+  - **What I tried**: Inlined the common case of single-frame media sync directly into `runSetTime` in `CdpTimeDriver.ts` to bypass the function call and branching overhead of `defaultSyncMedia`.
+  - **Why it didn't work**: Did not provide a clear performance improvement compared to the baseline variations (median of ~2.568s vs runs of 2.483s-2.649s). V8 likely already optimizes and inlines this function call efficiently, rendering the manual inline redundant.
+  - **Plan ID**: PERF-646
 - **PERF-594**: Inline `writerWaiterResolve` Wakeup into Promise Chain in CaptureLoop
   - **What I tried**: Modified the `captureResult` try/catch block in `CaptureLoop.ts` to check and execute `writerWaiterResolve` immediately after setting `frameReadyRing` to 1, instead of awaiting the generator resumption of the whole block.
   - **WHY it didn't work**: The median render time regressed to ~2.955s compared to the baseline of ~2.785s. Resolving the waiter inside the microtask did not outweigh the overhead of checking `writerWaiterResolve && nextFrameToWrite === i` conditionally inside both the `try` and `else` blocks. V8 seems to optimize the generator `await` resumption more efficiently than the repeated closure state checks.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -142,3 +142,4 @@ PERF-408	49.135	600	12.21	43.1	keep	Cache Media Elements in CdpTimeDriver to avo
 1	0.000	0	0.00	0.0	discard	bypass lastFrameData assignment (breaks frame fallback)
 PERF-641	2.202	150	68.11	63.1	keep	removed redundant sync media string assignment
 643	2.882	150	52.05	63.2	discard	inline-current-time (median of 6 runs: 3.110, 3.089, 2.860, 3.196, 2.757, 2.882)
+5	2.568	150	58.41	63.7	discard	PERF-646 fast path sync media check in CdpTimeDriver


### PR DESCRIPTION
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
5	2.568	150	58.41	63.7	discard	PERF-646 fast path sync media check in CdpTimeDriver

---
*PR created automatically by Jules for task [67881857912149775](https://jules.google.com/task/67881857912149775) started by @BintzGavin*