### PR TITLE
✨ RENDERER: Discard PERF-644 Bitmask frameReadyRing

### DIFF
--- a/.sys/plans/PERF-644-bitmask-frame-ready-ring.md
+++ b/.sys/plans/PERF-644-bitmask-frame-ready-ring.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-644
 slug: bitmask-frame-ready-ring
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-01
-completed: ""
-result: ""
+completed: "2024-06-01"
+result: "discard"
 ---
 
 # PERF-644: Bitmask Optimization for `frameReadyRing` in CaptureLoop
@@ -61,3 +61,8 @@ Run the DOM benchmark and ensure the video renders successfully without hanging 
 
 ## Prior Art
 - **PERF-622**: Replaced `frameErrorRing` array with a single scalar `fatalError` which improved performance by 6%. Scalar/primitive replacement of short arrays is a proven optimization in this loop.
+## Results Summary
+- **Best render time**: ~2.395s (vs baseline ~2.239s)
+- **Improvement**: 0% (Regression)
+- **Kept experiments**: None
+- **Discarded experiments**: Bitmask frameReadyRing

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -97,6 +97,11 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-644**: Bitmask frameReadyRing
+  - **What I tried**: Replaced the `frameReadyRing` Uint8Array in `CaptureLoop.ts` with a single integer `frameReadyMask` bitmask to optimize read/write overhead in the hot loop.
+  - **WHY it didn't work**: It yielded slightly worse performance (~2.395s vs ~2.239s baseline) because V8 bitwise operations did not outperform direct array writes and lookups on a small, statically sized Uint8Array.
+  - **Plan ID**: PERF-644
+
 - **PERF-644**: Bitmask Optimization for frameReadyRing in CaptureLoop
   - **What I tried**: Replaced the Uint8Array frameReadyRing in CaptureLoop.ts with a scalar bitmask to eliminate bounds checking and memory allocation in the hot loop.
   - **WHY it didn't work**: The median render time was ~2.246s, which is slightly slower than the local baseline of ~2.223s. The bitwise mask operations and bitshifts in V8 do not seem to outperform simple direct array writes and lookups on a small statically sized Uint8Array.

--- a/packages/renderer/.sys/perf-results-PERF-644.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-644.tsv
@@ -1,0 +1,1 @@
+1	2.395	150	62.63	63.3	discard	bitmask frame ready ring


### PR DESCRIPTION
✨ RENDERER: Discard PERF-644 Bitmask frameReadyRing

💡 **What**: The experiment run and its outcome (Discarded)
🎯 **Why**: Attempted to optimize the `CaptureLoop.ts` hot loop by replacing the `frameReadyRing` `Uint8Array` with a bitmask `frameReadyMask`.
📊 **Impact**: The median render time degraded to ~2.395s compared to a baseline of ~2.239s. V8 bitwise operations and bitshifts do not seem to outperform direct array writes and lookups on a small statically sized Uint8Array.
🔬 **Verification**: Ran benchmarks (median of 3 runs). The output video properties matched expected parameters. The experiment code changes were correctly reverted upon failure.
📎 **Plan**: PERF-644-bitmask-frame-ready-ring.md

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 2.395 | 150 | 62.63 | 63.3 | discard | bitmask frame ready ring |

---
*PR created automatically by Jules for task [3713488256236342867](https://jules.google.com/task/3713488256236342867) started by @BintzGavin*