### PR TITLE
✨ PLAYER: Add onaudiometering event handler

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -50,6 +50,7 @@ Properties:
 - `paused: boolean`
 - `ended: boolean`
 - `error: MediaError | null`
+- `onaudiometering: ((event: Event) => void) | null`
 - `readyState: number`
 - `networkState: number`
 - `srcObject: MediaStream | MediaSource | Blob | null`

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -679,3 +679,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### STUDIO v0.121.21
 - ✅ Completed: Timeline Drag & Drop - Verified that the timeline drag drop logic is already fully implemented (IMPOSSIBLE: DUPLICATION).
+
+### PLAYER v0.77.45
+- ✅ Completed: Add onaudiometering event handler to HeliosPlayer class and documentation.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,5 @@
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
-**Version**: 0.77.44
+**Version**: 0.77.45
 [v0.77.44] ✅ Completed: Document Missing Events - Deleted lingering plan file as the README already contained the required documentation updates.
 [v0.77.43] ✅ Completed: Document Event Handlers - Updated README.md to include standard event handler properties to match the actual implementation in packages/player/src/index.ts.
 [v0.77.42] ✅ Completed: Discovered that v0.77.40-PLAYER-Document-Missing-Events.md is an IMPOSSIBLE plan because the events `error` and `audiometering` are already documented in `packages/player/README.md`. Documented as duplicate and discarded.
@@ -242,3 +242,4 @@
 [v0.77.33] ✅ Completed: Discovered undocumented seeking events in README.md. Created plan `.sys/plans/v0.77.33-PLAYER-Document-Seeking-Events.md` to document `seeking` and `seeked` events.
 [v0.77.39] ✅ Completed: Document Seeking Events - Updated README to document existing seeking and seeked events to match the actual implementation in packages/player/src/index.ts.
 [v0.77.40] ✅ Completed: Document Missing Events - Updated README.md to include documentation for error and audiometering events.
+[v0.77.45] ✅ Completed: Add onaudiometering event handler to HeliosPlayer class and documentation.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -218,6 +218,7 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `onerror` (function | null): Event handler for the `error` event.
 - `onenterpictureinpicture` (function | null): Event handler for the `enterpictureinpicture` event.
 - `onleavepictureinpicture` (function | null): Event handler for the `leavepictureinpicture` event.
+- `onaudiometering` (function | null): Event handler for the `audiometering` event.
 
 ## Events
 

--- a/packages/player/src/event_handlers.test.ts
+++ b/packages/player/src/event_handlers.test.ts
@@ -52,7 +52,8 @@ describe('HeliosPlayer Event Handlers', () => {
       'pause', 'ended', 'timeupdate', 'volumechange', 'ratechange',
       'durationchange', 'seeking', 'seeked', 'resize', 'loadstart',
       'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough',
-      'error', 'enterpictureinpicture', 'leavepictureinpicture'
+      'error', 'enterpictureinpicture', 'leavepictureinpicture',
+      'audiometering'
     ];
 
     events.forEach(eventName => {

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1094,6 +1094,14 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     if (handler) this.addEventListener('leavepictureinpicture', handler);
   }
 
+  private _onaudiometering: ((event: Event) => void) | null = null;
+  public get onaudiometering() { return this._onaudiometering; }
+  public set onaudiometering(handler: ((event: Event) => void) | null) {
+    if (this._onaudiometering) this.removeEventListener('audiometering', this._onaudiometering);
+    this._onaudiometering = handler;
+    if (handler) this.addEventListener('audiometering', handler);
+  }
+
   // --- Standard Media API ---
 
   public canPlayType(type: string): CanPlayTypeResult {


### PR DESCRIPTION
💡 What: Added the `onaudiometering` property to the `HeliosPlayer` component and updated documentation and tests.
🎯 Why: To complete API parity as the player was dispatching `audiometering` events but lacked the corresponding handler property.
📊 Impact: Developers can now use the `player.onaudiometering = ...` standard syntax to listen for audio metering changes.
🔬 Verification: Verified locally by running `npm test -w packages/player` and checking that the properties setter/getters are tested successfully.

---
*PR created automatically by Jules for task [1012892348102882197](https://jules.google.com/task/1012892348102882197) started by @BintzGavin*