### PR TITLE
📋 PLAYER: Document Missing Attributes

### DIFF
--- a/.sys/plans/2027-02-16-PLAYER-Document-Missing-Attributes.md
+++ b/.sys/plans/2027-02-16-PLAYER-Document-Missing-Attributes.md
@@ -1,0 +1,24 @@
+#### 1. Context & Goal
+- **Objective**: Update `packages/player/README.md` to document the missing `muted` and `playsinline` attributes for the `<helios-player>` Web Component.
+- **Trigger**: An audit of `observedAttributes` in `packages/player/src/index.ts` versus the Attributes table in `README.md` revealed that `muted` and `playsinline` are actively supported by the component but remain completely undocumented.
+- **Impact**: Provides developers with complete and accurate documentation of the Web Component's attributes, ensuring parity between implementation and documentation, and improving the developer experience.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**: `packages/player/README.md` (Add `muted` and `playsinline` to the `## Attributes` table)
+- **Read-Only**: `packages/player/src/index.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Pure documentation update directly mapping existing `src/index.ts` observed attributes to the markdown specification table.
+- **Pseudo-Code**:
+  - In `packages/player/README.md`, under the `## Attributes` table, append the missing entries:
+    - `| \`muted\` | Automatically mute the player's audio upon loading. | \`false\` |`
+    - `| \`playsinline\` | Indicates that the video is to be played "inline", that is within the element's playback area. | \`false\` |`
+  - Ensure the new table rows match the existing Markdown table formatting correctly.
+- **Public API Changes**: No code changes; this is purely documentation parity.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `cat packages/player/README.md | grep -iE "\|\s*\`muted\`\s*\||\|\s*\`playsinline\`\s*\|"`
+- **Success Criteria**: Both `muted` and `playsinline` exist in the table format within the README output.
+- **Edge Cases**: Ensure the formatting (e.g., markdown tables) remains syntactically valid and does not break the table rendering.


### PR DESCRIPTION
Created spec .sys/plans/2027-02-16-PLAYER-Document-Missing-Attributes.md to document the 'muted' and 'playsinline' attributes that are supported in the component implementation but missing from the README.

---
*PR created automatically by Jules for task [13452501039932868898](https://jules.google.com/task/13452501039932868898) started by @BintzGavin*