### PR TITLE
📋 RENDERER: [PERF-652] Flatten capture await

### DIFF
--- a/.sys/plans/PERF-652-flatten-capture-await.md
+++ b/.sys/plans/PERF-652-flatten-capture-await.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-652
 slug: flatten-capture-await
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-02
-completed: ""
-result: ""
+completed: "2024-06-02"
+result: "discard"
 ---
 
 # PERF-652: Bypass DOM Strategy Async Generator and Promise Return
@@ -69,3 +69,7 @@ None.
 
 ## Correctness Check
 Run the DOM render benchmark `npx tsx packages/renderer/scripts/benchmark-perf.ts` and verify output integrity. Run `npx tsx packages/renderer/tests/run-all.ts` to ensure no regressions.
+
+## Results Summary
+- **Best render time**: 2.286s
+- **Status**: discard

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -106,6 +106,10 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-652**: Flatten capture await
+  - **What I tried**: Changed the ternary await in CaptureLoop.ts to sequential awaits.
+  - **Why it didn't work**: Time was ~2.286s, not an improvement over the 2.261s baseline. The additional control flow logic (if) and sequential await unwrapping negated any gains from bypassing the .then() closure allocation in the hot loop.
+  - **Plan ID**: PERF-652
 
 - **PERF-654**: Inline defaultSyncMedia into runSetTime
   - **What I tried**: Attempted to eliminate function call overhead in the hot loop by replacing `this.defaultSyncMedia()` call with its implementation directly inside `runSetTime`.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -144,3 +144,4 @@ PERF-641	2.202	150	68.11	63.1	keep	removed redundant sync media string assignmen
 643	2.882	150	52.05	63.2	discard	inline-current-time (median of 6 runs: 3.110, 3.089, 2.860, 3.196, 2.757, 2.882)
 5	2.568	150	58.41	63.7	discard	PERF-646 fast path sync media check in CdpTimeDriver
 6	2.931	150	51.18	62.5	discard	PERF-649 optimize await chain in CaptureLoop
+PERF-652	2.286	150	65.61	62.7	discard	flatten capture await


### PR DESCRIPTION
📋 RENDERER: [PERF-652] Flatten capture await

💡 What: Changed the ternary await in CaptureLoop.ts to sequential awaits.
🎯 Why: Attempted to bypass closure and microtask allocation overhead in the runWorker hot loop.
📊 Impact: The median render time increased to ~2.286s, regressing from the ~2.261s baseline. The additional control flow logic (if statement) and sequential await unwrapping negated any gains from bypassing the `.then()` closure allocation.
🔬 Verification: Ran the dom benchmark 5 times. Code was reverted per prompt instructions because the experiment failed to improve performance. Only documentation tracking files were updated.
📎 Plan: .sys/plans/PERF-652-flatten-capture-await.md

```tsv
PERF-652	2.286	150	65.61	62.7	discard	flatten capture await
```

---
*PR created automatically by Jules for task [11742302659689062901](https://jules.google.com/task/11742302659689062901) started by @BintzGavin*