### PR TITLE
📋 RENDERER: Pre-bind currentTime Update Handler in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-656-prebind-currenttime-update.md
+++ b/.sys/plans/PERF-656-prebind-currenttime-update.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-656
 slug: prebind-currenttime-update
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-06-02
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -106,6 +106,11 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-656**: Prebind currentTime Update Handler
+  - **What I did**: Created a private bound method and private property to avoid closure allocations in CdpTimeDriver virtual time await chain.
+  - **Why it didn't work**: The median render time was ~2.463s (baseline ~2.48s). V8 seems to already optimize away the overhead of inline anonymous closures in this hot loop, so replacing it with a pre-bound function provides no measurable gain.
+  - **Plan ID**: PERF-656
+
 - **PERF-652**: Flatten capture await
   - **What I tried**: Changed the ternary await in CaptureLoop.ts to sequential awaits.
   - **Why it didn't work**: Time was ~2.286s, not an improvement over the 2.261s baseline. The additional control flow logic (if) and sequential await unwrapping negated any gains from bypassing the .then() closure allocation in the hot loop.

--- a/packages/renderer/.sys/perf-results-PERF-656.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-656.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.482	150	60.43	63.2	discard	PERF-656: Pre-bind currentTime Update Handler
+2	2.463	150	60.89	63.0	discard	PERF-656: Pre-bind currentTime Update Handler
+3	2.370	150	63.29	63.0	discard	PERF-656: Pre-bind currentTime Update Handler


### PR DESCRIPTION
💡 What: Pre-bound the `.then` closure allocation in the virtual time execution in `CdpTimeDriver.ts`.
🎯 Why: PERF-656: We allocated an anonymous closure on every frame. By creating a predefined method, we eliminate allocation.
📊 Impact:
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.482	150	60.43	63.2	discard	PERF-656: Pre-bind currentTime Update Handler
2	2.463	150	60.89	63.0	discard	PERF-656: Pre-bind currentTime Update Handler
3	2.370	150	63.29	63.0	discard	PERF-656: Pre-bind currentTime Update Handler
Discarded. The median render time was ~2.463s (baseline ~2.48s). V8 seems to already optimize away the overhead of inline anonymous closures in this hot loop, so replacing it with a pre-bound function provides no measurable gain.
🔬 Verification: 4-gate verification passed, benchmark results logged.
📎 Plan: .sys/plans/PERF-656-prebind-currenttime-update.md

---
*PR created automatically by Jules for task [3811474817471007168](https://jules.google.com/task/3811474817471007168) started by @BintzGavin*