### PR TITLE
📋 RENDERER: Inline Worker Promise Chain in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-588-inline-worker-promise-chain.md
+++ b/.sys/plans/PERF-588-inline-worker-promise-chain.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-588
 slug: inline-worker-promise-chain
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2026-10-31
-completed: ""
-result: ""
+completed: 2026-10-31
+result: discard
 ---
 
 # PERF-588: Inline Worker Promise Chain in CaptureLoop
@@ -17,13 +17,15 @@ DOM Rendering Pipeline - Hot loop in `packages/renderer/src/core/CaptureLoop.ts`
 In `CaptureLoop.ts`, the multi-worker ACTOR MODEL spins up independent asynchronous tasks inside `runWorker` that orchestrate frame capture. Currently, the inner loop executes:
 ```typescript
             try {
-                await timeDriver.setTime(page, compositionTimeInSeconds);
-                const buffer = await strategy.capture(page, time);
+                const buffer = setTimeResult
+                    ? await setTimeResult.then(() => strategy.capture(page, time))
+                    : await strategy.capture(page, time);
                 frameBufferRing[ringIndex] = buffer;
                 frameReadyRing[ringIndex] = 1;
             } catch (e) {
-                frameErrorRing[ringIndex] = e;
-                frameReadyRing[ringIndex] = 1;
+                fatalError = e;
+                aborted = true;
+                checkState();
             }
 ```
 This requires multiple `await` resumptions inside the generator and specifically wraps them in a `try/catch` block. Research has demonstrated that V8's generator state machine allocates more execution context overhead for `try/catch` blocks inside hot asynchronous loops.
@@ -37,7 +39,7 @@ By chaining the calls using `.then()` and `.catch()` behind a single `await`, we
 - **Minimum runs**: 3 per experiment, report median
 
 ## Baseline
-- **Current estimated render time**: ~1.298s
+- **Current estimated render time**: ~2.261s
 - **Bottleneck analysis**: V8 generator state machine transitions (`try/catch` and multiple `await`s) in the core inner loop of `CaptureLoop.ts`.
 
 ## Implementation Spec
@@ -47,27 +49,32 @@ By chaining the calls using `.then()` and `.catch()` behind a single `await`, we
 **What to change**:
 Inside the `runWorker` function, replace the `try/catch` block:
 ```typescript
+            const setTimeResult = timeDriver.setTime(page, compositionTimeInSeconds);
             try {
-                await timeDriver.setTime(page, compositionTimeInSeconds);
-                const buffer = await strategy.capture(page, time);
+                const buffer = setTimeResult
+                    ? await setTimeResult.then(() => strategy.capture(page, time))
+                    : await strategy.capture(page, time);
                 frameBufferRing[ringIndex] = buffer;
                 frameReadyRing[ringIndex] = 1;
             } catch (e) {
-                frameErrorRing[ringIndex] = e;
-                frameReadyRing[ringIndex] = 1;
+                fatalError = e;
+                aborted = true;
+                checkState();
             }
 ```
 with the following single `await` expression:
 ```typescript
-            await Promise.resolve(timeDriver.setTime(page, compositionTimeInSeconds))
+            const setTimeResult = timeDriver.setTime(page, compositionTimeInSeconds);
+            await Promise.resolve(setTimeResult)
                 .then(() => strategy.capture(page, time))
                 .then((buffer) => {
                     frameBufferRing[ringIndex] = buffer;
                     frameReadyRing[ringIndex] = 1;
                 })
                 .catch((e) => {
-                    frameErrorRing[ringIndex] = e;
-                    frameReadyRing[ringIndex] = 1;
+                    fatalError = e;
+                    aborted = true;
+                    checkState();
                 });
 ```
 **Why**: Consolidating to a single `await` and utilizing `.then()` and `.catch()` eliminates the explicit `try/catch` block from the generator context. Wrapping in `Promise.resolve()` ensures it cleanly chains regardless of whether `setTime` returns `Promise<void>` or `void` synchronously.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -106,6 +106,10 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-588**: Inline Worker Promise Chain in CaptureLoop
+  - **What I tried**: Replaced try/catch block with a single Promise chain.
+  - **Why it didn't work**: Caused a performance regression (slower, median ~2.503s vs baseline ~2.261s) because shifting generator suspension into a structured promise chain negated the performance benefits of bypassing the try/catch overhead, adding variable allocation latency.
+  - **Plan ID**: PERF-588
 - **PERF-656**: Pre-bind currentTime Update Handler in CdpTimeDriver.ts
   - **What I tried**: Added `nextTimeInSeconds` and `updateCurrentTime` properties to `CdpTimeDriver` and updated `runSetTime` to use these instead of an anonymous closure for the promise resolution.
   - **Why it didn't work**: It caused a performance regression (median ~2.543s vs baseline ~2.261s). This indicates that shifting the state mutation into a pre-bound handler rather than an inline anonymous closure slightly disrupted V8's optimization of the async/await hot loop sequence or introduced additional scope resolution overhead.

--- a/packages/renderer/.sys/perf-results-PERF-588.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-588.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	3.069	150	48.88	63.1	discard	Inline worker promise chain
+2	2.503	150	59.93	63.1	discard	Inline worker promise chain
+3	2.501	150	59.97	63.3	discard	Inline worker promise chain


### PR DESCRIPTION
Experiment PERF-588: discarded. Median time: 2.503s vs baseline 2.261s.

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	3.069	150	48.88	63.1	discard	Inline worker promise chain
2	2.503	150	59.93	63.1	discard	Inline worker promise chain
3	2.501	150	59.97	63.3	discard	Inline worker promise chain

---
*PR created automatically by Jules for task [18163621935889242485](https://jules.google.com/task/18163621935889242485) started by @BintzGavin*