### PR TITLE
✨ RENDERER: Discard PERF-474 recursive .then chain

### DIFF
--- a/.sys/plans/PERF-474-optimize-runworker-promise-chain.md
+++ b/.sys/plans/PERF-474-optimize-runworker-promise-chain.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-474
 slug: optimize-runworker-promise-chain
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-18
-completed: ""
-result: ""
+completed: "2024-06-02"
+result: "discard"
 ---
 
 # PERF-474: Optimize runWorker Loop by Removing Async Await
@@ -47,3 +47,9 @@ Check if `timeDriver.setTime` or `strategy.capture` actually return Promises at 
 
 ## Verification Check
 Run `npm test -w @helios-project/renderer` to ensure test suites pass, validating logical equivalence. Run the benchmark script to compare performance. Ensure that the test suite runs correctly by checking for regressions in DOM rendering output.
+
+## Results Summary
+- **Best render time**: 2.565s (vs baseline 2.395s)
+- **Improvement**: -7%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-474]

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -146,3 +146,9 @@ PERF-641	2.202	150	68.11	63.1	keep	removed redundant sync media string assignmen
 6	2.931	150	51.18	62.5	discard	PERF-649 optimize await chain in CaptureLoop
 PERF-652	2.286	150	65.61	62.7	discard	flatten capture await
 20	3.045	150	49.26	63.2	discard	PERF-458: Bypass Runtime.evaluate in CdpTimeDriver When No Media Exists
+474	2.375	150	63.16	63.7	keep	PERF-474 baseline
+474	2.395	150	62.64	63.0	keep	PERF-474 baseline
+474	2.519	150	59.55	63.0	keep	PERF-474 baseline
+474	2.896	150	51.80	63.7	discard	PERF-474 recursive .then chain
+474	2.443	150	61.40	63.6	discard	PERF-474 recursive .then chain
+474	2.565	150	58.49	63.5	discard	PERF-474 recursive .then chain

--- a/packages/renderer/docs/status/RENDERER-EXPERIMENTS.md
+++ b/packages/renderer/docs/status/RENDERER-EXPERIMENTS.md
@@ -13,3 +13,4 @@ Last updated by: PERF-508
 
 ## Open Questions
 - [PERF-306] Attempted to disable renderer backgrounding (`--disable-renderer-backgrounding`, `--disable-backgrounding-occluded-windows`) to improve multi-worker actor model performance. DISCARDED. Resulted in significantly slower performance (42.335s vs ~32.1s baseline). Disabling backgrounding heuristics in the multi-process microVM environment appears to cause resource contention or CPU starvation rather than improving throughput.
+- [PERF-474] Attempted to replace the async/await `runWorker` loop in `CaptureLoop.ts` with direct recursive Promise `.then()` chaining. DISCARDED because it resulted in a slower median render time (~2.565s vs baseline ~2.395s). The overhead from allocating many closure contexts for the `.then()` handlers outweighed any savings from bypassing the V8 async generator state machine.


### PR DESCRIPTION
💡 What: Attempted to replace the `async`/`await` `runWorker` loop in `CaptureLoop.ts` with direct recursive Promise `.then()` chaining.
🎯 Why: To eliminate the overhead of V8 async state machine allocation and micro-stalls within the hot worker execution path.
📊 Impact: DISCARDED. Median render time regressed from ~2.395s (baseline) to ~2.565s (-7% improvement).
🔬 Verification: Ran the dom-benchmark script (`npx tsx scripts/benchmark-perf.ts`) 3 times before and after the change. Output tested with ffmpeg to ensure duration and frames are valid.
📎 Plan: `.sys/plans/PERF-474-optimize-runworker-promise-chain.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 474 | 2.375 | 150 | 63.16 | 63.7 | keep | PERF-474 baseline |
| 474 | 2.395 | 150 | 62.64 | 63.0 | keep | PERF-474 baseline |
| 474 | 2.519 | 150 | 59.55 | 63.0 | keep | PERF-474 baseline |
| 474 | 2.896 | 150 | 51.80 | 63.7 | discard | PERF-474 recursive .then chain |
| 474 | 2.443 | 150 | 61.40 | 63.6 | discard | PERF-474 recursive .then chain |
| 474 | 2.565 | 150 | 58.49 | 63.5 | discard | PERF-474 recursive .then chain |

---
*PR created automatically by Jules for task [2340893652392298132](https://jules.google.com/task/2340893652392298132) started by @BintzGavin*