### PR TITLE
📋 RENDERER: [Outcome of PERF-659 inline try-catch optimization]

### DIFF
--- a/.sys/plans/PERF-659-inline-try-catch-domstrategy.md
+++ b/.sys/plans/PERF-659-inline-try-catch-domstrategy.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-659
 slug: inline-try-catch-domstrategy
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-03
-completed: ""
-result: ""
+completed: 2026-06-03
+result: "discard"
 ---
 
 # PERF-659: Inline try-catch inside DomStrategy capture to reduce per-frame scope allocation
@@ -66,3 +66,9 @@ Run the DOM render benchmark script (`npx tsx packages/renderer/scripts/benchmar
 ## Prior Art
 - PERF-544 tried to remove try-catch but used inline closures (`.catch(() => ...)`), causing performance regression due to closure allocations.
 - PERF-656 and others showed the importance of pre-binding callbacks in hot loops.
+
+## Results Summary
+- **Best render time**: ~2.587s (vs local baseline ~2.565s)
+- **Improvement**: -0.8% (worse)
+- **Kept experiments**: None
+- **Discarded experiments**: Inline try-catch inside DomStrategy capture (restored)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -106,6 +106,11 @@ Last updated by: PERF-614
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-659**: Inline try-catch inside DomStrategy capture to reduce per-frame scope allocation
+  - **What I tried**: Added a prebound catch handler and rewrote the `capture` method in `DomStrategy.ts` to use `.catch(this.beginFrameErrorHandler)` on the CDP promise instead of setting up a `try...catch` scope on every frame.
+  - **WHY it didn't work**: The median render time was ~2.587s compared to the local baseline of ~2.565s. The overhead of setting up a block scope for `try...catch` on every loop iteration is extremely small in V8, and replacing it with a chained promise `.catch()` introduces slightly more microtask scheduling/promise resolution overhead, resulting in no gain and a minor regression. This confirms findings from earlier similar experiments (like PERF-623).
+  - **Plan ID**: PERF-659
+
 - **PERF-458**: Bypass Runtime.evaluate in CdpTimeDriver When No Media Exists
   - **What I tried**: Conditionally assigned a `syncMediaFn` closure during initialization instead of checking `if (this.hasMedia)` on every frame inside the `runSetTime` hot loop in `CdpTimeDriver.ts`.
   - **WHY it didn't work**: The median render time was ~3.045s vs the baseline of ~2.595s (up to ~3.236s). By substituting a simple boolean branch with a closure invocation, we likely defeated V8's fast-path optimization for the branch, resulting in added closure resolution overhead that outweighed any gains from avoiding the `if` check.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -152,3 +152,4 @@ PERF-652	2.286	150	65.61	62.7	discard	flatten capture await
 474	2.896	150	51.80	63.7	discard	PERF-474 recursive .then chain
 474	2.443	150	61.40	63.6	discard	PERF-474 recursive .then chain
 474	2.565	150	58.49	63.5	discard	PERF-474 recursive .then chain
+659	2.587	150	57.98	63.1	discard	PERF-659 inline try-catch inside DomStrategy capture to reduce per-frame scope allocation


### PR DESCRIPTION
💡 What: Evaluated replacing `try...catch` with a pre-bound `.catch()` in DomStrategy.ts `capture()`. The change was discarded as it regressed performance.
🎯 Why: To test if avoiding block-scope allocation per-frame in the hot loop would improve throughput.
📊 Impact: Regressed median render time by -0.8% (2.587s vs 2.565s baseline).
🔬 Verification: 4-gate verification (Build, tests, FFprobe, Benchmark consistency). Code reverted.

659	2.587	150	57.98	63.1	discard	PERF-659 inline try-catch inside DomStrategy capture to reduce per-frame scope allocation

---
*PR created automatically by Jules for task [15088883689774587767](https://jules.google.com/task/15088883689774587767) started by @BintzGavin*