### PR TITLE
✨ PLAYER: Document missing attributes

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -26,6 +26,7 @@ Observed attributes:
 - `loop`: Boolean attribute to enable looping playback.
 - `autoplay`: Boolean attribute for auto-playback.
 - `muted`: Boolean attribute to start the player muted.
+- `playsinline`: Indicates that the video is to be played "inline", within the element's playback area.
 - `poster`: Image URL displayed before playback starts.
 - `preload`: Strategy for preloading (none, metadata, auto).
 - `canvas-selector`: CSS selector for the primary canvas inside the iframe (default: `canvas`).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -691,3 +691,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### STUDIO v0.121.23
 - ✅ Completed: CompositionsPanel Test Coverage - Implemented comprehensive unit tests for `CompositionsPanel` component, increasing its coverage to 100%.
+
+### PLAYER v0.77.47
+- ✅ Completed: Document Missing Attributes - Updated README.md to document the missing `muted` and `playsinline` attributes.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,5 @@
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
-**Version**: 0.77.46
+**Version**: 0.77.47
 [v0.77.46] ✅ Completed: Discovered that `2027-02-16-PLAYER-Add-onaudiometering-handler.md` is an IMPOSSIBLE: DUPLICATION plan. The `onaudiometering` property is already fully implemented. Documented as impossible and discarded. Also added 'audiometering' to the event handlers test in `index.test.ts`.
 [v0.77.44] ✅ Completed: Document Missing Events - Deleted lingering plan file as the README already contained the required documentation updates.
 [v0.77.43] ✅ Completed: Document Event Handlers - Updated README.md to include standard event handler properties to match the actual implementation in packages/player/src/index.ts.
@@ -244,3 +244,4 @@
 [v0.77.39] ✅ Completed: Document Seeking Events - Updated README to document existing seeking and seeked events to match the actual implementation in packages/player/src/index.ts.
 [v0.77.40] ✅ Completed: Document Missing Events - Updated README.md to include documentation for error and audiometering events.
 [v0.77.45] ✅ Completed: Add onaudiometering event handler to HeliosPlayer class and documentation.
+[v0.77.47] ✅ Completed: Document Missing Attributes - Updated README.md to document the missing `muted` and `playsinline` attributes.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -69,6 +69,8 @@ The player will automatically attempt to access `window.helios` on the iframe's 
 | `sandbox` | Security flags for the iframe. | `allow-scripts allow-same-origin` |
 | `export-width` | Target width for client-side export. | - |
 | `export-height` | Target height for client-side export. | - |
+| `muted` | Automatically mute the player's audio upon loading. | `false` |
+| `playsinline` | Indicates that the video is to be played "inline", that is within the element's playback area. | `false` |
 | `export-bitrate` | Target bitrate for client-side export (bps). | - |
 | `export-filename` | Filename for client-side export (without extension). | `video` |
 | `export-caption-mode` | Strategy for caption export: `burn-in` or `file`. | `burn-in` |


### PR DESCRIPTION
💡 What: Documented missing `muted` and `playsinline` attributes in the `<helios-player>` README.md table.
🎯 Why: To fix the parity gap where existing observed attributes were not properly documented for developers.
📊 Impact: Improved developer experience and clearer API documentation.
🔬 Verification: Ran `npm run build -w packages/player` and `npm test -w packages/player` successfully. Verified `README.md` correctly shows the new attributes in the Attributes table. Reference plan `.sys/plans/2027-02-16-PLAYER-Document-Missing-Attributes.md`.

---
*PR created automatically by Jules for task [1449231793661903507](https://jules.google.com/task/1449231793661903507) started by @BintzGavin*