### PR TITLE
📋 RENDERER: [PERF-665] Remove redundant null assignments

### DIFF
--- a/.sys/plans/PERF-665-remove-redundant-null-assignment.md
+++ b/.sys/plans/PERF-665-remove-redundant-null-assignment.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-665
 slug: remove-redundant-null-assignment
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-03
-completed: ""
-result: ""
+completed: 2024-06-03
+result: no-improvement
 ---
 
 # PERF-665: Remove explicit null assignments from local variables in CaptureLoop to reduce bytecode
@@ -97,3 +97,9 @@ None.
 
 ## Correctness Check
 Run the DOM render benchmark script (`npx tsx packages/renderer/scripts/benchmark-perf.ts`) to ensure it produces valid outputs without regressions.
+
+## Results Summary
+- **Best render time**: 2.705s (vs baseline ~2.755s, but overall current best is 2.447s)
+- **Improvement**: ~1.8% vs local baseline, but regressed vs overall best.
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-665]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -110,6 +110,10 @@ Last updated by: PERF-662
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-665**: Remove redundant null assignment in CaptureLoop
+  - **What I tried**: Removed `frameBufferRing[ringIndex] = null;` before assigning a task to a worker in `CaptureLoop.ts`.
+  - **WHY it didn't work**: The overhead of setting a local array element to null is virtually nonexistent in V8 due to efficient memory layouts. It yielded no measurable performance improvement and failed to beat the current best time of 2.447s (median of modified runs was ~2.705s).
+  - **Plan ID**: PERF-665
 - **PERF-659**: Inline try-catch inside DomStrategy capture to reduce per-frame scope allocation
   - **What I tried**: Added a prebound catch handler and rewrote the `capture` method in `DomStrategy.ts` to use `.catch(this.beginFrameErrorHandler)` on the CDP promise instead of setting up a `try...catch` scope on every frame.
   - **WHY it didn't work**: The median render time was ~2.587s compared to the local baseline of ~2.565s. The overhead of setting up a block scope for `try...catch` on every loop iteration is extremely small in V8, and replacing it with a chained promise `.catch()` introduces slightly more microtask scheduling/promise resolution overhead, resulting in no gain and a minor regression. This confirms findings from earlier similar experiments (like PERF-623).

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -157,3 +157,4 @@ PERF-652	2.286	150	65.61	62.7	discard	flatten capture await
 6	2.677	150	56.04	63.1	keep	prebind capture promises
 7	2.699	150	55.57	62.9	keep	prebind capture promises
 8	2.538	150	59.09	63.0	keep	prebind capture promises
+6	2.705	150	55.45	62.8	discard	remove redundant null assignment frameBufferRing


### PR DESCRIPTION
Discard PERF-665: Remove redundant null assignment in CaptureLoop

💡 What: Evaluated removing `frameBufferRing[ringIndex] = null` before task assignment. It yielded no measurable performance improvement (median ~2.705s) and failed to beat the baseline 2.447s.
🎯 Why: Attempted to reduce bytecode and redundant array property assignment overhead in V8 hot path.
📊 Impact: No improvement. Reverted the codebase changes and documented the findings.

Result from `perf-results.tsv`:
6	2.705	150	55.45	62.8	discard	remove redundant null assignment frameBufferRing

---
*PR created automatically by Jules for task [9112288935575154090](https://jules.google.com/task/9112288935575154090) started by @BintzGavin*