### PR TITLE
📋 RENDERER: [PERF-664] Inline writer waiter resolve

### DIFF
--- a/.sys/plans/PERF-664-inline-writer-waiter-resolve.md
+++ b/.sys/plans/PERF-664-inline-writer-waiter-resolve.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-664
 slug: inline-writer-waiter-resolve
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor"
 created: 2024-06-03
-completed: ""
-result: ""
+completed: 2024-06-03
+result: "no-improvement"
 ---
 
 # PERF-664: Inline Writer Waiter Resolve Call to Bypass Null Reassignment

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -798,3 +798,8 @@ Last updated by: PERF-592
   - **What I did**: Inlined the `virtualTimePromiseExecutor` logic directly into the `runSetTime` method within `CdpTimeDriver.ts`. This moved the CDP client `send` call outside the promise constructor and utilized a localized inline executor.
   - **Impact**: Improved median render time to ~2.447s (from baseline ~2.525s), avoiding the overhead of invoking a pre-bound class method callback on every frame.
   - **Plan ID**: PERF-662
+
+- **PERF-664**: Inline `writerWaiterResolve` in CaptureLoop
+  - **What I tried**: Attempted to remove the local `res` variable allocation in `CaptureLoop.ts` (`checkState` and `runWorker`) by directly invoking `writerWaiterResolve()` before setting it to null.
+  - **WHY it didn't work**: The median render time was ~2.444s, which did not improve upon the baseline best of ~2.447s. The difference is within the noise margin. V8 already optimally handles local block-scoped variables and garbage-collecting them inside such conditions.
+  - **Plan ID**: PERF-664


### PR DESCRIPTION
💡 What: Attempted to remove local `res` variable allocation in `CaptureLoop.ts` (`checkState` and `runWorker`) by directly invoking `writerWaiterResolve()` before setting it to null.
🎯 Why: To reduce V8 scope variable allocations in the hot loop.
📊 Impact: Negligible. The median render time was ~2.444s, which did not improve upon the baseline best of ~2.447s. The difference is within the noise margin. V8 already optimally handles local block-scoped variables and garbage-collecting them inside such conditions.
🔬 Verification: Ran `benchmark-perf.ts` 3 times. Passed all TypeScript and Core validations. Code reverted.
📎 Plan: `/.sys/plans/PERF-664-inline-writer-waiter-resolve.md`

Results Summary:
```
664	2.913	150	51.49	62.8	discard	inline-writer-waiter-resolve
664	2.444	150	61.37	62.8	discard	inline-writer-waiter-resolve
664	2.336	150	64.21	62.9	discard	inline-writer-waiter-resolve
```

---
*PR created automatically by Jules for task [7236899960680541653](https://jules.google.com/task/7236899960680541653) started by @BintzGavin*