### PR TITLE
📋 RENDERER: Discard PERF-666 eliminate frameReadyRing in CaptureLoop

### DIFF
--- a/commit_desc.txt
+++ b/commit_desc.txt
@@ -1,21 +1,14 @@
-💡 **What**: The experiment run and its outcome
-Tried rewriting \`.then(onFulfilled).catch(onRejected)\` to \`.then(onFulfilled, onRejected)\` in \`DomStrategy.ts\` hot loop. It was discarded.
+💡 **What**: The PERF-666 experiment run and its outcome, discarding the removal of `frameReadyRing` in `CaptureLoop.ts`.
+🎯 **Why**: Attempted to reduce memory footprint and CPU overhead by consolidating state tracking into the primary `frameBufferRing` with null checks, avoiding maintaining parallel arrays.
+📊 **Impact**: Discarded. The median render time regressed to ~2.830s vs the baseline of ~2.447s.
+🔬 **Verification**:
+- Benchmarks executed 3 times to gather median.
+- Output validated (duration 5s, 150 frames, x264).
+- Tests passed.
+📎 **Plan**: `packages/renderer/.sys/plans/PERF-666-eliminate-framereadyring.md`
 
-🎯 **Why**: The performance bottleneck targeted
-Microtask and Promise allocation overhead in the `capture` hot loop.
-
-📊 **Impact**: Before/after render times and percentage improvement
-The median render time did not improve significantly over the baseline (median ~1.375s vs baseline ~1.374s). The minor promise allocation savings were offset by potential V8 deoptimization from altering the promise structure, just as observed previously in PERF-591. The experiment was discarded as inconclusive noise.
-
-🔬 **Verification**: What was tested (4-gate verification, benchmark results)
-Passed compilation, all tests, and output verification. Benchmark results showed a slight regression.
-
-run | render_time_s | frames | fps_effective | peak_mem_mb | status  | description
-1   | 1.382         | 150    | 108.50        | 70.1        | discard | PERF-608: merge promise catch in DomStrategy
-2   | 1.375         | 150    | 109.08        | 70.7        | discard | PERF-608: merge promise catch in DomStrategy
-3   | 1.391         | 150    | 107.85        | 70.0        | discard | PERF-608: merge promise catch in DomStrategy
-4   | 1.368         | 150    | 109.68        | 70.0        | discard | PERF-608: merge promise catch in DomStrategy
-5   | 1.390         | 150    | 107.91        | 70.1        | discard | PERF-608: merge promise catch in DomStrategy
-
-📎 **Plan**: Reference the plan file
-/.sys/plans/PERF-608-merge-domstrategy-promise-chain.md
+| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
+|---|---|---|---|---|---|---|
+| 1 | 2.904 | 150 | 51.65 | 62.8 | discard | eliminate frameReadyRing |
+| 2 | 2.814 | 150 | 53.30 | 63.0 | discard | eliminate frameReadyRing |
+| 3 | 2.830 | 150 | 53.00 | 62.8 | discard | eliminate frameReadyRing |

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -809,3 +809,5 @@ Last updated by: PERF-592
   - **WHY it didn't work**: The median render time was ~2.650s, which is within the noise margin of the baseline ~2.550s. The operations happen outside the hot loop and therefore do not noticeably impact the median render time, only slightly shifting the absolute startup initialization which is hidden by variance in benchmark runs.
   - **Plan ID**: PERF-669
 - Would avoiding `Array.map` array allocation overhead for `workerPromises` in `CaptureLoop.ts` improve startup latency? (PERF-667)
+
+- **PERF-666 (Discarded):** Eliminated `frameReadyRing` in `CaptureLoop.ts` by using `null` checks on `frameBufferRing` to track readiness. Yielded a performance regression (median ~2.830s vs baseline ~2.447s). This indicates that using parallel fixed-type Uint8Arrays for state tracking is faster in V8 than checking for null/object references in a mixed-type array, likely due to monomorphic optimizations on typed arrays versus polymorphism checks in the `Array<Buffer | string | null>`.

--- a/packages/renderer/.sys/perf-results-PERF-666.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-666.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.904	150	51.65	62.8	discard	eliminate frameReadyRing
+2	2.814	150	53.30	63.0	discard	eliminate frameReadyRing
+3	2.830	150	53.00	62.8	discard	eliminate frameReadyRing

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -158,3 +158,4 @@ PERF-652	2.286	150	65.61	62.7	discard	flatten capture await
 7	2.699	150	55.57	62.9	keep	prebind capture promises
 8	2.538	150	59.09	63.0	keep	prebind capture promises
 6	2.705	150	55.45	62.8	discard	remove redundant null assignment frameBufferRing
+7	2.830	150	53.00	62.8	discard	eliminate frameReadyRing

--- a/packages/renderer/.sys/plans/PERF-666-eliminate-framereadyring.md
+++ b/packages/renderer/.sys/plans/PERF-666-eliminate-framereadyring.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-666
 slug: eliminate-framereadyring
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-06-04
-completed: ""
-result: ""
+completed: "2026-06-04"
+result: "discarded"
 ---
 # PERF-666: Eliminate frameReadyRing in CaptureLoop
 
@@ -63,3 +63,13 @@ Verify output video opens and contains 150 frames.
 
 ## Prior Art
 PERF-622 successfully eliminated `frameErrorRing`, showing that consolidating parallel tracking arrays in the hot loop yields measurable performance improvements in V8.
+
+
+## Results Summary
+| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
+|---|---|---|---|---|---|---|
+| 1 | 2.904 | 150 | 51.65 | 62.8 | discard | eliminate frameReadyRing |
+| 2 | 2.814 | 150 | 53.30 | 63.0 | discard | eliminate frameReadyRing |
+| 3 | 2.830 | 150 | 53.00 | 62.8 | discard | eliminate frameReadyRing |
+
+**Outcome:** Discarded. Using parallel fixed-type Uint8Arrays for state tracking is faster in V8 than checking for null/object references in a mixed-type array.


### PR DESCRIPTION
💡 **What**: The PERF-666 experiment run and its outcome, discarding the removal of `frameReadyRing` in `CaptureLoop.ts`.
🎯 **Why**: Attempted to reduce memory footprint and CPU overhead by consolidating state tracking into the primary `frameBufferRing` with null checks, avoiding maintaining parallel arrays.
📊 **Impact**: Discarded. The median render time regressed to ~2.830s vs the baseline of ~2.447s.
🔬 **Verification**:
- Benchmarks executed 3 times to gather median.
- Output validated (duration 5s, 150 frames, x264).
- Tests passed.
📎 **Plan**: `packages/renderer/.sys/plans/PERF-666-eliminate-framereadyring.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 2.904 | 150 | 51.65 | 62.8 | discard | eliminate frameReadyRing |
| 2 | 2.814 | 150 | 53.30 | 63.0 | discard | eliminate frameReadyRing |
| 3 | 2.830 | 150 | 53.00 | 62.8 | discard | eliminate frameReadyRing |

---
*PR created automatically by Jules for task [12243978550219320269](https://jules.google.com/task/12243978550219320269) started by @BintzGavin*