### PR TITLE
📋 RENDERER: Optimize JPEG Quality

### DIFF
--- a/.sys/plans/PERF-675-optimize-jpeg-quality.md
+++ b/.sys/plans/PERF-675-optimize-jpeg-quality.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-675
 slug: optimize-jpeg-quality
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-06-04
-completed: ""
-result: ""
+completed: 2026-06-04
+result: no-improvement
 ---
 
 # PERF-675: Optimize JPEG Quality
@@ -36,3 +36,9 @@ Slightly lowering the quality (e.g., from 90 to 80 or 85) might hit a sweet spot
 
 ## Correctness Check
 Run the visual benchmark `npx tsx scripts/benchmark-perf.ts --mode=dom` and observe the output `.mp4` file to ensure acceptable visual quality without gross compression artifacts.
+
+## Results Summary
+- **Best render time**: 2.465s (vs baseline ~2.534s median)
+- **Improvement**: 0% (inconclusive / no statistically significant improvement)
+- **Kept experiments**: []
+- **Discarded experiments**: [quality 80]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -827,3 +827,7 @@ Last updated by: PERF-592
   - **What I tried**: Attempted to eliminate per-frame allocations by removing Node.js `stdin.write` error callbacks and pre-binding the `captureNext` closure inside `CaptureLoop.ts`.
   - **WHY it didn't work**: The median render time did not improve (~2.522s vs baseline ~2.502s). The difference is within the noise margin. V8 already optimally handles local block-scoped closure allocations for promises, and Node's event loop overhead for the omitted stream callbacks was negligible.
   - **Plan ID**: PERF-672
+- **PERF-675**: Optimize JPEG Quality
+  - **What I tried**: Lowered `intermediateImageQuality` in `DomStrategy.ts` from 90 to 80 to reduce the CDP payload size and IPC processing overhead.
+  - **WHY it didn't work**: The median render time did not improve noticeably (~2.54s for quality 80 vs ~2.53s baseline). The potential savings in Node.js Base64 decoding and IPC transfer were either negligible or offset by differences in Chromium's internal image encoding times, meaning that 90 quality performs effectively the same as 80 in this environment.
+  - **Plan ID**: PERF-675

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -161,3 +161,10 @@ PERF-652	2.286	150	65.61	62.7	discard	flatten capture await
 7	2.830	150	53.00	62.8	discard	eliminate frameReadyRing
 1	2.805	150	53.48	62.8	keep	baseline (median of 3)
 2	2.522	150	59.47	62.6	discard	eliminate CaptureLoop per-frame allocations (PERF-672)
+259	2.549	150	58.85	62.9	discard	quality 80
+260	2.574	150	58.26	62.9	discard	quality 80
+261	2.543	150	58.99	62.7	discard	quality 80
+262	2.575	150	58.24	62.9	discard	quality 80
+263	2.465	150	60.86	62.8	discard	quality 80
+264	2.502	150	59.94	62.8	discard	quality 80
+265	2.468	150	60.77	62.9	discard	quality 80


### PR DESCRIPTION
💡 **What**: Executed the `PERF-675` experiment by lowering `intermediateImageQuality` in `DomStrategy.ts` from 90 to 80. The modification was ultimately discarded, and the relevant administrative files (`.sys/plans/PERF-675-optimize-jpeg-quality.md`, `docs/status/RENDERER-EXPERIMENTS.md`, and `packages/renderer/.sys/perf-results.tsv`) were updated with the results.
🎯 **Why**: To test if lowering intermediate image quality reduces CDP payload size and node IPC/JSON decoding overhead.
📊 **Impact**: The median render time did not improve noticeably (~2.54s for quality 80 vs ~2.53s baseline). The potential savings in Node.js Base64 decoding and IPC transfer were either negligible or offset by differences in Chromium's internal image encoding times, so the change was discarded.
🔬 **Verification**: Code changes were discarded via `git restore`. No functional or performance changes were merged. 
📎 **Plan**: `/.sys/plans/PERF-675-optimize-jpeg-quality.md`

---
*PR created automatically by Jules for task [8021224032390557781](https://jules.google.com/task/8021224032390557781) started by @BintzGavin*