### PR TITLE
📋 PLAYER: Document Missing Event Handlers

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -73,3 +73,6 @@
 ## [v0.77.46] - Duplicate Implementation Plan
 **Learning:** Sometimes plans are generated for features that are already fully implemented in the code.
 **Action:** Always verify code and README first, mark as 'IMPOSSIBLE: DUPLICATION', and discard the plan if the feature exists.
+## [v0.77.49] - Document Missing Event Handlers
+**Learning:** Found an undocumented event handler properties gap (playing, waiting, suspend, stalled) between the `index.ts` implementation and `README.md`.
+**Action:** Generated plan to document them in `README.md` ensuring complete API parity matching `index.ts`. Always compare actual getter/setter implementations to README properties lists.

--- a/.sys/plans/v0.77.49-PLAYER-Document-Missing-Event-Handlers.md
+++ b/.sys/plans/v0.77.49-PLAYER-Document-Missing-Event-Handlers.md
@@ -1,0 +1,31 @@
+#### 1. Context & Goal
+- **Objective**: Document the missing standard HTMLMediaElement event handlers (`onplaying`, `onwaiting`, `onsuspend`, `onstalled`) in `packages/player/README.md`.
+- **Trigger**: Vision gap identified between the actual implementation (which includes `onplaying`, `onwaiting`, `onsuspend`, and `onstalled` getters and setters in `index.ts`) and the README (which lacks documentation for them in the "Event Handlers" section).
+- **Impact**: Provides developers with complete documentation on the standard HTMLMediaElement event handlers supported by the `<helios-player>` Web Component, improving API parity documentation.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**: `packages/player/README.md` (Add missing properties to the `### Event Handlers` section).
+- **Read-Only**: `packages/player/src/index.ts` (Verify exact properties implemented).
+
+#### 3. Implementation Spec
+- **Architecture**: Update Markdown documentation to reflect existing public API surface.
+- **Pseudo-Code**:
+  - Locate `### Event Handlers` section in `packages/player/README.md`.
+  - Add the following event handler properties to the list, maintaining alphabetical or logical order (likely near `onplay`):
+    - `- \`onplaying\` (function | null): Event handler for the \`playing\` event.`
+    - `- \`onsuspend\` (function | null): Event handler for the \`suspend\` event.`
+    - `- \`onstalled\` (function | null): Event handler for the \`stalled\` event.`
+    - `- \`onwaiting\` (function | null): Event handler for the \`waiting\` event.`
+  - Under `## Events` add the corresponding events, preserving existing format:
+    - `- \`playing\`: Fired when playback is ready to start after having been paused or delayed due to lack of data.`
+    - `- \`suspend\`: Fired when media data loading has been suspended.`
+    - `- \`stalled\`: Fired when the user agent is trying to fetch media data, but data is unexpectedly not forthcoming.`
+    - `- \`waiting\`: Fired when playback has stopped because of a temporary lack of data.`
+- **Public API Changes**: None (documentation only).
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `grep -i "onplaying" packages/player/README.md`
+- **Success Criteria**: The README includes the new documented event handlers in the `### Event Handlers` list and the events in the `## Events` list.
+- **Edge Cases**: Ensure Markdown formatting is preserved.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -24,6 +24,7 @@
 
 [v0.77.18] ✅ Completed: Fix Duplicate README Entry - Removed duplicate getSchema entry from README.md.
 ## Status Log
+[v0.77.49] ✅ Completed: Discovered undocumented event handler properties and events (playing, waiting, suspend, stalled) in implementation missing from README. Created plan `.sys/plans/v0.77.49-PLAYER-Document-Missing-Event-Handlers.md` to document them.
 [v0.77.17] ✅ Completed: Improve Index Coverage - Expanded unit tests for HTMLMediaElement properties and events.
 [v0.77.14] ✅ Completed: Document getSchema API Parity - Added missing getSchema method to README documentation.
 [v0.77.13] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner to create the next implementation spec.


### PR DESCRIPTION
Created a plan to fix the vision gap where the standard HTMLMediaElement event handlers (`onplaying`, `onwaiting`, `onsuspend`, `onstalled`) implemented in the `HeliosPlayer` web component were missing from the `README.md` documentation.

---
*PR created automatically by Jules for task [8458341413778400811](https://jules.google.com/task/8458341413778400811) started by @BintzGavin*