### PR TITLE
📋 CLI: Create CLI command coverage tests V5 spec

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -1,3 +1,6 @@
 ## [v0.46.39] - CLI Command Coverage Spec V3
 **Learning:** Initial attempts to run coverage across the entire `packages/cli` workspace via Vitest timed out consistently after 400s. Further examination of line-by-line coverage outputs required targeting specific files.
 **Action:** When gathering metrics for execution plans on testing gaps, always explicitly navigate to the package and test specific folders (e.g. `cd packages/cli && npx vitest run --coverage src/commands/__tests__`) instead of wide wildcard runs. Never hallucinate specific line numbers.
+## [v0.46.41] - CLI Command Coverage Spec V5
+**Learning:** Checking overall command coverage (`src/commands/`) highlighted additional edge cases for command prompt cancellations (`undefined` responses).
+**Action:** When gathering metrics for execution plans on testing gaps, always explicitly target line-level coverage missing points.

--- a/.sys/plans/2027-06-05-CLI-Command-Coverage-Tests-V5.md
+++ b/.sys/plans/2027-06-05-CLI-Command-Coverage-Tests-V5.md
@@ -1,0 +1,36 @@
+#### 1. Context & Goal
+- **Objective**: Implement comprehensive regression testing to cover all missing branch paths in `packages/cli/src/commands/deploy.ts`, `packages/cli/src/commands/render.ts`, and `packages/cli/src/commands/init.ts`.
+- **Trigger**: The testing command coverage for `init.ts`, `render.ts` and `deploy.ts` is incomplete, showing uncovered lines representing edge cases, configuration errors, and process terminations when users decline prompts.
+- **Impact**: Full line coverage across the main CLI command files increases stability and ensures unexpected exits or prompt rejections are handled properly without exceptions.
+
+#### 2. File Inventory
+- **Create**: []
+- **Modify**:
+  - `packages/cli/src/commands/__tests__/deploy.test.ts` (Add tests for the `undefined` response cancellation branches for all deploy subcommands)
+  - `packages/cli/src/commands/__tests__/render.test.ts` (Add tests to handle invalid missing branches like browser args)
+  - `packages/cli/src/commands/__tests__/init.test.ts` (Add tests to handle edge cases for when user hits Ctrl+C returning `undefined` for `response.framework` and `response.example` when prompted)
+- **Read-Only**:
+  - `packages/cli/src/commands/deploy.ts`
+  - `packages/cli/src/commands/render.ts`
+  - `packages/cli/src/commands/init.ts`
+
+#### 3. Implementation Spec
+- **Architecture**:
+  - Update `deploy.test.ts` by mocking `prompts` to return `{ value: undefined }` to trigger the `Operation cancelled.` console log and `process.exit(0)` branch for the various files across all deploy sub-commands (`docker`, `gcp`, `aws`, `cloudflare`, `cloudflare-sandbox`, `fly`, `azure`, `kubernetes`, `deno`).
+  - Update `render.test.ts` to cover uncovered execution block checks via specific missing parameter configurations and environment variables logic to trigger previously ignored line execution logic.
+  - Update `init.test.ts` to mock `prompts` returning undefined or `{ mode: undefined }` and `{ framework: undefined }` to cover representing the case where `response.example` is undefined, terminating execution cleanly.
+- **Pseudo-Code**:
+  ```typescript
+  // Example for deploy.test.ts
+  it('should exit when prompt returns undefined', async () => {
+     vi.mocked(prompts).mockResolvedValue({ value: undefined });
+     // Execute command and assert exit is called
+  });
+  ```
+- **Public API Changes**: None
+- **Dependencies**: None
+
+#### 4. Test Plan
+- **Verification**: Run `cd packages/cli && npx vitest run --coverage src/commands/__tests__/deploy.test.ts src/commands/__tests__/render.test.ts src/commands/__tests__/init.test.ts`
+- **Success Criteria**: Vitest outputs 100% line, branch, statement, and function coverage for `deploy.ts`, `render.ts`, and `init.ts`.
+- **Edge Cases**: Verifies undefined values for prompts gracefully exit with code `0`.


### PR DESCRIPTION
Created the `.sys/plans/2027-06-05-CLI-Command-Coverage-Tests-V5.md` spec file to capture missing coverage paths in `init.ts`, `render.ts`, and `deploy.ts`, particularly focusing on prompt cancellations and environment variable edge cases.

Key decisions:
- Mocking the `prompts` module returning undefined values for `response.value` to trigger the `Operation cancelled.` and `process.exit(0)` branches across all deploy sub-commands.
- Documented findings in `.jules/CLI.md` regarding line-level targeting required for precise test coverage evaluation.
- Ignored coverage testing artifacts by verifying them properly and deleting them via `rm -rf packages/cli/coverage/` before committing the plan logic.

---
*PR created automatically by Jules for task [7274341520711507836](https://jules.google.com/task/7274341520711507836) started by @BintzGavin*