### PR TITLE
✨ RENDERER: Bypass redundant virtual time policy budget allocation in CdpTimeDriver

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -110,6 +110,10 @@ Last updated by: PERF-662
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-676**: Bypass redundant virtual time policy budget allocation in CdpTimeDriver.
+  - **What I tried**: Wrapped `this.setVirtualTimePolicyParams.budget = budget` in a conditional check.
+  - **WHY it didn't work**: The median render time was ~2.722s, which did not improve upon the baseline best of ~2.447s. V8 is likely already highly optimized for property reassignment or inline caching.
+  - **Plan ID**: PERF-676
 - **PERF-665**: Remove redundant null assignment in CaptureLoop
   - **What I tried**: Removed `frameBufferRing[ringIndex] = null;` before assigning a task to a worker in `CaptureLoop.ts`.
   - **WHY it didn't work**: The overhead of setting a local array element to null is virtually nonexistent in V8 due to efficient memory layouts. It yielded no measurable performance improvement and failed to beat the current best time of 2.447s (median of modified runs was ~2.705s).

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -168,3 +168,4 @@ PERF-652	2.286	150	65.61	62.7	discard	flatten capture await
 263	2.465	150	60.86	62.8	discard	quality 80
 264	2.502	150	59.94	62.8	discard	quality 80
 265	2.468	150	60.77	62.9	discard	quality 80
+6	2.722	300	55.10	62.8	discard	bypass redundant budget property allocation

--- a/packages/renderer/.sys/plans/PERF-676-bypass-budget-allocation.md
+++ b/packages/renderer/.sys/plans/PERF-676-bypass-budget-allocation.md
@@ -1,0 +1,9 @@
+---
+status: complete
+---
+# Plan: PERF-676
+
+1. Read `packages/renderer/src/drivers/CdpTimeDriver.ts`.
+2. Inspect `runSetTime` method.
+3. Modify `this.setVirtualTimePolicyParams.budget = budget;` to only assign if the budget has changed.
+4. Run tests and benchmarks to evaluate.


### PR DESCRIPTION
💡 **What**: Executed PERF-676 to bypass redundant virtual time policy budget property allocations in `CdpTimeDriver.ts`. Wrapped the assignment in a conditional check to see if V8 benefits from avoiding the allocation.
🎯 **Why**: To reduce unnecessary object property assignments in the hot loop, potentially eliminating V8 overhead on every frame delta update.
📊 **Impact**: The median render time degraded to ~2.722s, compared to the baseline best of ~2.447s. Because it did not improve performance, the change was discarded and the code reverted.
🔬 **Verification**: Ran `benchmark-perf.ts` 5 times to obtain a stable median. Validated the environment and updated the journal with findings. Reverted changes correctly.
📎 **Plan**: `packages/renderer/.sys/plans/PERF-676-bypass-budget-allocation.md`

### Results Summary
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
6	2.722	300	55.10	62.8	discard	bypass redundant budget property allocation
```

---
*PR created automatically by Jules for task [16990141111107171971](https://jules.google.com/task/16990141111107171971) started by @BintzGavin*