### PR TITLE
✨ RENDERER: Discard PERF-673 (Switch Default Intermediate Image Format to JPEG Quality 1)

### DIFF
--- a/.sys/plans/PERF-673-switch-jpeg-quality.md
+++ b/.sys/plans/PERF-673-switch-jpeg-quality.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-673
 slug: switch-jpeg-quality
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-05
-completed: ""
-result: ""
+completed: "2024-06-05"
+result: "no-improvement"
 ---
 
 # PERF-673: Switch Default Intermediate Image Format to JPEG
@@ -69,3 +69,9 @@ In `prepare()` function where the fallback parameters are evaluated:
 
 ## Correctness Check
 Run the DOM render benchmark `cd packages/renderer && npx tsx scripts/benchmark-perf.ts` and verify output integrity. Run `npm test -w packages/renderer` to ensure no regressions. Play the resulting `dom-benchmark.mp4` to ensure it is visually legible (even if highly compressed).
+
+## Results Summary
+- **Best render time**: 2.880s (vs baseline 2.447s)
+- **Improvement**: -17.6%
+- **Kept experiments**: []
+- **Discarded experiments**: [Change Default JPEG Quality to 1 in DomStrategy.ts]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -110,6 +110,11 @@ Last updated by: PERF-662
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-673**: Switch Default Intermediate Image Format to JPEG Quality 1
+  - **What I did**: Changed default fallback JPEG quality from 90 to 1 for intermediate frames when `hasAlpha` is false in `DomStrategy.ts`.
+  - **WHY it didn't work**: The median render time was ~2.880s, which is slower than the baseline best of ~2.447s. The Chromium encoding time improvements for a 600x600 image with quality 1 were negligible over quality 90 in the headless environment, and did not overcome natural variance, while slightly regressing performance compared to a highly optimized baseline.
+  - **Plan ID**: PERF-673
+
 - **PERF-676**: Bypass redundant virtual time policy budget allocation in CdpTimeDriver.
   - **What I tried**: Wrapped `this.setVirtualTimePolicyParams.budget = budget` in a conditional check.
   - **WHY it didn't work**: The median render time was ~2.722s, which did not improve upon the baseline best of ~2.447s. V8 is likely already highly optimized for property reassignment or inline caching.

--- a/packages/renderer/.sys/perf-results-PERF-673.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-673.tsv
@@ -1,0 +1,5 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	3.528	150	42.51	62.8	keep	quality 1
+2	2.573	150	58.30	62.8	keep	quality 1
+3	3.085	150	48.62	62.8	keep	quality 1
+4	2.676	150	56.04	62.8	keep	quality 1


### PR DESCRIPTION
💡 What: Evaluated changing the default fallback JPEG quality from 90 to 1 for intermediate frames when `hasAlpha` is false in `DomStrategy.ts`. The experiment was discarded because it did not improve performance.
🎯 Why: To test if reducing JPEG quality significantly reduces Chromium encoding latency and Playwright IPC overhead.
📊 Impact: The median render time was ~2.880s, which is slower than the baseline best of ~2.447s. The savings did not overcome natural variance and slightly regressed performance compared to the highly optimized baseline.
🔬 Verification: Benchmarked 4 times using the standard DOM composition, and tests timed out (expected in this environment). Code changes were fully reverted.
📎 Plan: `.sys/plans/PERF-673-switch-jpeg-quality.md`

Results summary:
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	3.528	150	42.51	62.8	keep	quality 1
2	2.573	150	58.30	62.8	keep	quality 1
3	3.085	150	48.62	62.8	keep	quality 1
4	2.676	150	56.04	62.8	keep	quality 1

---
*PR created automatically by Jules for task [9844791112287800864](https://jules.google.com/task/9844791112287800864) started by @BintzGavin*