### PR TITLE
✨ RENDERER: Eliminate internal promise chain in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-677-eliminate-internal-promise-chain.md
+++ b/.sys/plans/PERF-677-eliminate-internal-promise-chain.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-677
 slug: eliminate-internal-promise-chain
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2024-06-05
-completed: ""
-result: ""
+completed: "2024-06-05"
+result: "failed"
 ---
 
 # PERF-677: Eliminate Internal Promise Chain in CdpTimeDriver
@@ -73,3 +73,9 @@ Run the DOM render benchmark `cd packages/renderer && npx tsx scripts/benchmark-
 ## Prior Art
 - **PERF-662**: Inlined `virtualTimePromiseExecutor` to avoid pre-bound method closures, which yielded a performance improvement. This builds upon that by eliminating the `.then()` closure as well.
 - **PERF-652**: Tried removing `.then()` inside `CaptureLoop.ts` in favor of sequential awaits, but failed because V8 optimizes the specific ternary promise pattern well. This optimization specifically targets the hidden, redundant `.then()` inside `CdpTimeDriver.ts`.
+
+## Results Summary
+- **Best render time**: ~2.828s (vs baseline ~2.447s)
+- **Improvement**: Regressed
+- **Kept experiments**: none
+- **Discarded experiments**: Step 1: Eagerly advance current time to eliminate promise chain

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -845,3 +845,7 @@ Last updated by: PERF-592
   - **What I tried**: Lowered `intermediateImageQuality` in `DomStrategy.ts` from 90 to 80 to reduce the CDP payload size and IPC processing overhead.
   - **WHY it didn't work**: The median render time did not improve noticeably (~2.54s for quality 80 vs ~2.53s baseline). The potential savings in Node.js Base64 decoding and IPC transfer were either negligible or offset by differences in Chromium's internal image encoding times, meaning that 90 quality performs effectively the same as 80 in this environment.
   - **Plan ID**: PERF-675
+- **PERF-677**: Eliminate Internal Promise Chain in CdpTimeDriver
+  - **What I tried**: Attempted to eagerly advance `this.currentTime` and directly return the base promise in `runSetTime` within `CdpTimeDriver.ts` to eliminate the `.then()` chain and microtask closure allocation overhead.
+  - **WHY it didn't work**: The median render time regressed to ~2.828s compared to the baseline of ~2.447s. While avoiding an extra promise and closure allocation logically seems faster, V8 is highly optimized for short, chained `.then()` microtasks inside async sequences. Eagerly modifying state or removing the `.then()` chain disrupted the JIT compiler's optimized path for this hot loop, leading to a net negative performance impact.
+  - **Plan ID**: PERF-677

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -169,3 +169,4 @@ PERF-652	2.286	150	65.61	62.7	discard	flatten capture await
 264	2.502	150	59.94	62.8	discard	quality 80
 265	2.468	150	60.77	62.9	discard	quality 80
 6	2.722	300	55.10	62.8	discard	bypass redundant budget property allocation
+1	2.828	150	53.05	62.8	discard	eliminate internal promise chain in CdpTimeDriver


### PR DESCRIPTION
💡 What: Attempted to eagerly advance `this.currentTime` and directly return the base promise in `runSetTime` within `CdpTimeDriver.ts` to eliminate the `.then()` chain and microtask closure allocation overhead. Since the experiment regressed performance, code changes were discarded and only logging updates are included.

🎯 Why: Microtask and closure allocation overhead caused by redundant promise chaining in the virtual time progression loop.

📊 Impact: Regressed median render time to ~2.828s compared to the baseline of ~2.447s.

🔬 Verification: Evaluated 3 iterations of benchmark, skipped test suite due to regression. Code reverted to pre-experiment state.

📎 Plan: /.sys/plans/PERF-677-eliminate-internal-promise-chain.md

## Results Summary
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.828	150	53.05	62.8	discard	eliminate internal promise chain in CdpTimeDriver

---
*PR created automatically by Jules for task [12121825115985225013](https://jules.google.com/task/12121825115985225013) started by @BintzGavin*