### PR TITLE
✨ RENDERER: Discard PERF-667 avoid map allocation

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -854,3 +854,8 @@ Last updated by: PERF-592
   - **What I tried**: Attempted to eagerly advance `this.currentTime` and directly return the base promise in `runSetTime` within `CdpTimeDriver.ts` to eliminate the `.then()` chain and microtask closure allocation overhead.
   - **WHY it didn't work**: The median render time regressed to ~2.828s compared to the baseline of ~2.447s. While avoiding an extra promise and closure allocation logically seems faster, V8 is highly optimized for short, chained `.then()` microtasks inside async sequences. Eagerly modifying state or removing the `.then()` chain disrupted the JIT compiler's optimized path for this hot loop, leading to a net negative performance impact.
   - **Plan ID**: PERF-677
+
+- **PERF-667**: Avoid `Array.map` Allocation in CaptureLoop
+  - **What I tried**: Attempted to avoid the allocation and iterator overhead of `Array.map` when creating `workerPromises` in `CaptureLoop.ts` by using a pre-allocated array and a standard `for` loop.
+  - **WHY it didn't work**: The median render time did not improve and remained around ~1.988s, which is not measurably better than the baseline. In fact, standard `.map` calls are highly optimized by V8's JIT compiler. The perceived overhead of a small map allocation in the startup sequence is trivial and easily absorbed by the baseline variance.
+  - **Plan ID**: PERF-667

--- a/packages/renderer/.sys/perf-results-PERF-667.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-667.tsv
@@ -1,0 +1,6 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.248	150	66.72	0.0	discard	avoid map allocation in capture loop
+2	2.106	150	71.22	0.0	discard	avoid map allocation in capture loop
+3	1.988	150	75.45	0.0	discard	avoid map allocation in capture loop
+4	1.986	150	75.52	0.0	discard	avoid map allocation in capture loop
+5	1.968	150	76.21	0.0	discard	avoid map allocation in capture loop

--- a/packages/renderer/.sys/plans/PERF-667-avoid-map-allocation-captureloop.md
+++ b/packages/renderer/.sys/plans/PERF-667-avoid-map-allocation-captureloop.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-667
 slug: avoid-map-allocation-captureloop
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-06-04
-completed: ""
-result: ""
+completed: "2024-06-05"
+result: "discarded"
 ---
 # PERF-667: Avoid Array.map Allocation in CaptureLoop
 
@@ -52,3 +52,14 @@ Verify output video opens and contains 150 frames.
 
 ## Prior Art
 Optimizations like PERF-650 have shown that reducing array operations and variables in `CaptureLoop.ts` can yield minor improvements.
+
+## Results Summary
+
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.248	150	66.72	0.0	discard	avoid map allocation in capture loop
+2	2.106	150	71.22	0.0	discard	avoid map allocation in capture loop
+3	1.988	150	75.45	0.0	discard	avoid map allocation in capture loop
+4	1.986	150	75.52	0.0	discard	avoid map allocation in capture loop
+5	1.968	150	76.21	0.0	discard	avoid map allocation in capture loop
+```


### PR DESCRIPTION
💡 **What**: Tested avoiding `Array.map` allocation in `CaptureLoop.ts` by using a pre-allocated array and a standard `for` loop. The experiment was discarded because it didn't improve performance.
🎯 **Why**: To see if removing a minor mapping allocation in the startup sequence could reduce render latency overhead.
📊 **Impact**: Median render time remained at ~1.988s, indicating V8 handles standard `.map` calls optimally without measurable overhead in this context.
🔬 **Verification**: 4-gate verification process, including building, rendering benchmarks and confirming output.
📎 **Plan**: `packages/renderer/.sys/plans/PERF-667-avoid-map-allocation-captureloop.md`

### Results Summary
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.248	150	66.72	0.0	discard	avoid map allocation in capture loop
2	2.106	150	71.22	0.0	discard	avoid map allocation in capture loop
3	1.988	150	75.45	0.0	discard	avoid map allocation in capture loop
4	1.986	150	75.52	0.0	discard	avoid map allocation in capture loop
5	1.968	150	76.21	0.0	discard	avoid map allocation in capture loop
```

---
*PR created automatically by Jules for task [9708643747287207457](https://jules.google.com/task/9708643747287207457) started by @BintzGavin*