### PR TITLE
📋 RENDERER: Inline writerWaiterExecutor in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-680-eliminate-pre-bound-executor.md
+++ b/.sys/plans/PERF-680-eliminate-pre-bound-executor.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-680
 slug: eliminate-pre-bound-executor
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2025-05-26
 completed: ""
-result: ""
+result: failed
 ---
 
 # PERF-680: Eliminate Pre-Bound Writer Waiter Executor
@@ -63,3 +63,9 @@ Run a basic Canvas smoke test to ensure the fallback pipeline is not broken.
 
 ## Correctness Check
 Verify that the output DOM video is fully rendered and identical in length and content.
+
+## Results Summary
+- **Best render time**: 2.375s (vs baseline ~2.127s)
+- **Improvement**: Regressed
+- **Kept experiments**: None
+- **Discarded experiments**: Inline writerWaiterExecutor in CaptureLoop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -859,3 +859,8 @@ Last updated by: PERF-592
   - **What I tried**: Attempted to avoid the allocation and iterator overhead of `Array.map` when creating `workerPromises` in `CaptureLoop.ts` by using a pre-allocated array and a standard `for` loop.
   - **WHY it didn't work**: The median render time did not improve and remained around ~1.988s, which is not measurably better than the baseline. In fact, standard `.map` calls are highly optimized by V8's JIT compiler. The perceived overhead of a small map allocation in the startup sequence is trivial and easily absorbed by the baseline variance.
   - **Plan ID**: PERF-667
+
+- **PERF-680**: Inline `writerWaiterExecutor` in `CaptureLoop`
+  - **What I tried**: Removed the pre-bound `writerWaiterExecutor` function and inlined the promise executor in the writer wait loop inside `CaptureLoop.ts`.
+  - **WHY it didn't work**: The median render time was ~2.375, regressing compared to the baseline of ~2.127s. V8's optimization of the await loop sequence likely prefers the statically allocated promise executor reference, as allocating a new closure inline every iteration incurred greater allocation overhead than context-switching to the pre-bound closure.
+  - **Plan ID**: PERF-680

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -170,3 +170,4 @@ PERF-652	2.286	150	65.61	62.7	discard	flatten capture await
 265	2.468	150	60.77	62.9	discard	quality 80
 6	2.722	300	55.10	62.8	discard	bypass redundant budget property allocation
 1	2.828	150	53.05	62.8	discard	eliminate internal promise chain in CdpTimeDriver
+1	2.375	150	63.16	63.5	discard	Inline writerWaiterExecutor in CaptureLoop


### PR DESCRIPTION
💡 **What**: Removed the pre-bound `writerWaiterExecutor` function and inlined the promise executor in the writer wait loop inside `CaptureLoop.ts`.
🎯 **Why**: To reduce allocation and context-switching overhead in the hot write loop.
📊 **Impact**: The median render time was ~2.375s, regressing compared to the baseline of ~2.127s. V8's optimization of the await loop sequence likely prefers the statically allocated promise executor reference.
🔬 **Verification**: Code built, ran 4-gate verification process, output validation passed but regression found, so code changes were reverted.
📎 **Plan**: `/.sys/plans/PERF-680-eliminate-pre-bound-executor.md`

```tsv
1	2.375	150	63.16	63.5	discard	Inline writerWaiterExecutor in CaptureLoop
```

---
*PR created automatically by Jules for task [9582497122943631189](https://jules.google.com/task/9582497122943631189) started by @BintzGavin*