### PR TITLE
📋 RENDERER: Eliminate Async/Await Overhead in DomStrategy.capture()

### DIFF
--- a/.sys/plans/PERF-681-eliminate-async-await-domstrategy-capture.md
+++ b/.sys/plans/PERF-681-eliminate-async-await-domstrategy-capture.md
@@ -1,0 +1,80 @@
+---
+id: PERF-681
+slug: eliminate-async-await-domstrategy-capture
+status: unclaimed
+claimed_by: ""
+created: 2024-11-20
+completed: ""
+result: ""
+---
+
+# PERF-681: Eliminate Async/Await Overhead in DomStrategy.capture()
+
+## Focus Area
+`packages/renderer/src/strategies/DomStrategy.ts`, specifically the `capture` method, which is the hot path for DOM rendering.
+
+## Background Research
+Currently, the `capture` method in `DomStrategy.ts` is an `async` function that `await`s the CDP `HeadlessExperimental.beginFrame` command. Inside the hot loop of `CaptureLoop.ts`, this generator and microtask scheduling overhead is incurred on every frame.
+In `PERF-132`, an attempt was made to eliminate this overhead by manually returning the `Promise` chain, but the attempt was inconclusive (0% improvement), leaving the codebase with an `async` generator. Since V8 engines have heavily optimized direct Promise chaining versus async/await state machines in hot loops, we should implement a clean pre-bound direct promise return strategy, similar to the pre-bound property strategy explored in `PERF-172` (though not present in the current branch code).
+
+## Benchmark Configuration
+- **Composition URL**: `output/example-build/examples/simple-animation/composition.html` (or standard DOM benchmark)
+- **Render Settings**: 1280x720, 30fps, 5 seconds
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~2.447s (based on recent bests)
+- **Bottleneck analysis**: IPC latency and promise generator allocation overhead in the `DomStrategy.capture` hot loop. By stripping `async`/`await` and returning the `.then()` chain directly, we reduce V8 context switching per frame.
+
+## Implementation Spec
+
+### Step 1: Pre-bind the Result Handler
+**File**: `packages/renderer/src/strategies/DomStrategy.ts`
+**What to change**:
+Add a pre-bound instance property to handle the CDP response, avoiding inline closure allocation on every frame:
+
+```typescript
+  private handleCaptureResult = (result: any): Buffer | string => {
+    const data = result.screenshotData;
+    if (data) {
+      this.lastFrameData = data;
+      return data;
+    }
+    return this.lastFrameData!;
+  };
+
+  private handleCaptureError = (e: any): Buffer | string => {
+    return this.lastFrameData!;
+  };
+```
+
+### Step 2: Refactor `capture` to return Promises directly
+**File**: `packages/renderer/src/strategies/DomStrategy.ts`
+**What to change**:
+Remove the `async` keyword and the `try/catch` block from the `capture` method. Return the promise chain directly:
+
+```typescript
+  capture(page: Page, frameTime: number): Promise<Buffer | string> {
+    return this.cdpSession!.send('HeadlessExperimental.beginFrame', this.beginFrameParams)
+      .then(this.handleCaptureResult)
+      .catch(this.handleCaptureError);
+  }
+```
+
+**Why**: By returning the promise directly and using pre-bound prototype/instance methods for `.then` and `.catch`, we eliminate the `async` generator state machine overhead and inline closure allocation per frame.
+**Risk**: Very low. The behavior is logically identical, only the V8 execution mechanics change.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Not applicable (this only affects DOM Strategy).
+
+## Correctness Check
+Run the renderer benchmark script `npx tsx packages/renderer/tests/fixtures/benchmark.ts` to verify DOM rendering succeeds and outputs valid frames.
+
+## Prior Art
+- PERF-132 (Inconclusive prior attempt to manually return promises)
+- PERF-172 (Eliminate Closure Allocation via pre-bound handlers)


### PR DESCRIPTION
Drafted PERF-681 execution plan to eliminate the async/await overhead inside the hot loop of `DomStrategy.capture()`.

---
*PR created automatically by Jules for task [17119006297786346602](https://jules.google.com/task/17119006297786346602) started by @BintzGavin*