### PR TITLE
✨ PLAYER: Document Missing Event Handlers

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,4 +1,7 @@
 #
+### PLAYER v0.77.49
+- ✅ Completed: Document Missing Event Handlers - Documented onplaying, onwaiting, onsuspend, and onstalled properties and events.
+
 ### PLAYER v0.77.48
 ### PLAYER v0.77.48
 - ✅ Completed: Fix API Parity Events - Implemented missing media events (playing, waiting, suspend, stalled).

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,6 @@
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
-**Version**: 0.77.48
+**Version**: 0.77.49
+[0.77.49] ✅ Completed: Document Missing Event Handlers - Documented onplaying, onwaiting, onsuspend, and onstalled properties and events.
 [v0.77.46] ✅ Completed: Discovered that `2027-02-16-PLAYER-Add-onaudiometering-handler.md` is an IMPOSSIBLE: DUPLICATION plan. The `onaudiometering` property is already fully implemented. Documented as impossible and discarded. Also added 'audiometering' to the event handlers test in `index.test.ts`.
 [v0.77.44] ✅ Completed: Document Missing Events - Deleted lingering plan file as the README already contained the required documentation updates.
 [v0.77.43] ✅ Completed: Document Event Handlers - Updated README.md to include standard event handler properties to match the actual implementation in packages/player/src/index.ts.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -203,6 +203,7 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 ### Event Handlers
 
 - `onplay` (function | null): Event handler for the `play` event.
+- `onplaying` (function | null): Event handler for the `playing` event.
 - `onpause` (function | null): Event handler for the `pause` event.
 - `onended` (function | null): Event handler for the `ended` event.
 - `ontimeupdate` (function | null): Event handler for the `timeupdate` event.
@@ -217,6 +218,9 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `onloadeddata` (function | null): Event handler for the `loadeddata` event.
 - `oncanplay` (function | null): Event handler for the `canplay` event.
 - `oncanplaythrough` (function | null): Event handler for the `canplaythrough` event.
+- `onsuspend` (function | null): Event handler for the `suspend` event.
+- `onstalled` (function | null): Event handler for the `stalled` event.
+- `onwaiting` (function | null): Event handler for the `waiting` event.
 - `onerror` (function | null): Event handler for the `error` event.
 - `onenterpictureinpicture` (function | null): Event handler for the `enterpictureinpicture` event.
 - `onleavepictureinpicture` (function | null): Event handler for the `leavepictureinpicture` event.
@@ -228,6 +232,10 @@ The element dispatches the following custom events:
 
 - `error`: Fired when an error occurs during media loading or playback.
 - `audiometering`: Fired during playback to report stereo RMS and Peak audio levels.
+- `playing`: Fired when playback is ready to start after having been paused or delayed due to lack of data.
+- `suspend`: Fired when media data loading has been suspended.
+- `stalled`: Fired when the user agent is trying to fetch media data, but data is unexpectedly not forthcoming.
+- `waiting`: Fired when playback has stopped because of a temporary lack of data.
 - `play`: Fired when playback starts.
 - `pause`: Fired when playback is paused.
 - `seeking`: Fired when a seek operation starts.


### PR DESCRIPTION
Updated `packages/player/README.md` to include documentation for missing media event handlers (`onplaying`, `onsuspend`, `onstalled`, `onwaiting`) and their corresponding events. This matches the actual component implementation for better API parity documentation. Also incremented the status and progress logs to reflect version 0.77.49 completion.

---
*PR created automatically by Jules for task [13283669591726872158](https://jules.google.com/task/13283669591726872158) started by @BintzGavin*