### PR TITLE
✨ RENDERER: PERF-680 Inline writerWaiterExecutor in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-680-inline-writerwaiterexecutor.md
+++ b/.sys/plans/PERF-680-inline-writerwaiterexecutor.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-680
 slug: inline-writerwaiterexecutor
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-05
 completed: ""
-result: ""
+result: "discarded"
 ---
 
 # PERF-680: Inline writerWaiterExecutor in CaptureLoop
@@ -76,3 +76,9 @@ Run the DOM benchmark and manually ensure the output video is still generated co
 - PERF-662: Inlined `virtualTimePromiseExecutor` in `CdpTimeDriver.ts` to avoid pre-bound method overhead, improving performance.
 - PERF-658: Confirmed inline anonymous closures for `updateCurrentTime` were better than pre-bound handlers.
 - PERF-632: Attempted custom deferred objects for workers which failed; native simple promises are best.
+
+## Results Summary
+- **Best render time**: 2.534s (vs baseline ~2.127s)
+- **Improvement**: Regressed
+- **Kept experiments**: None
+- **Discarded experiments**: Inline writerWaiterExecutor in CaptureLoop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -876,3 +876,8 @@ Last updated by: PERF-592
   - **What I did**: Bypassed the Actor Model ring buffer and synchronous writer loop when `concurrency = 1` by running a sequential, single loop for capturing and writing frames.
   - **Impact**: Improved stability and marginal reduction in V8 context switching for sequential DOM renders. The median render time averaged ~2.18s (with best run of 2.05s, which is slightly better than the previous baseline of ~2.127s).
   - **Plan ID**: PERF-683
+
+- **PERF-680 (Retry)**: Inline `writerWaiterExecutor` in `CaptureLoop`
+  - **What I tried**: Attempted again to remove the pre-bound `writerWaiterExecutor` function and inline the promise executor in the writer wait loop inside `CaptureLoop.ts`.
+  - **WHY it didn't work**: Regressed performance (2.534s vs baseline 2.127s). Once again confirmed that adding scope allocation overhead for an anonymous closure on every iteration of the hot loop is slower than letting V8 reference the pre-bound closure.
+  - **Plan ID**: PERF-680

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -178,3 +178,4 @@ run	27.619	600	21.72	66.9	discard	PERF-681 eliminate async await domstrategy cap
 4	2.373	150	63.21	63.4	discard	PERF-682 Transfer Ring Buffer Cleanup to Writer
 5	2.382	150	62.97	62.6	discard	PERF-682 Transfer Ring Buffer Cleanup to Writer
 PERF-683	2024-06-05	2.050
+run	2.534	150	34.65	63.8	discard	PERF-680 Inline writerWaiterExecutor


### PR DESCRIPTION
💡 What: Evaluated the experiment to inline writerWaiterExecutor in CaptureLoop.
🎯 Why: To reduce allocation and context-switching overhead in the hot write loop.
📊 Impact: See .sys/perf-results.tsv for exact results.
🔬 Verification: Built, benchmarked 3 times, tested.
📎 Plan: .sys/plans/PERF-680-inline-writerwaiterexecutor.md

---
*PR created automatically by Jules for task [1726866618088925945](https://jules.google.com/task/1726866618088925945) started by @BintzGavin*