### PR TITLE
✨ RENDERER: Eliminate Writer Waiter Executor Closure

### DIFF
--- a/.sys/plans/PERF-679-eliminate-writer-waiter-executor.md
+++ b/.sys/plans/PERF-679-eliminate-writer-waiter-executor.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-679
 slug: eliminate-writer-waiter-executor
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-06-05
-completed: ""
-result: ""
+completed: "2024-06-06"
+result: "discard"
 ---
 
 # PERF-679: Eliminate Writer Waiter Executor Closure in CaptureLoop
@@ -77,3 +77,7 @@ Run a canvas test to ensure no breaking changes in CaptureLoop structure.
 
 ## Correctness Check
 Run the DOM render benchmark `cd packages/renderer && npx tsx scripts/benchmark-perf.ts` and verify output integrity.
+
+## Results Summary
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.453	150	61.15	500.0	discard	inline writer waiter executor

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -889,3 +889,8 @@ Last updated by: PERF-592
   - **What I tried**: Prebound the capture closure before the hot loop to avoid per-frame scope allocation and garbage collection overhead.
   - **WHY it didn't work**: The median render time did not improve significantly (2.293s vs baseline 2.18s). V8 is likely optimizing the anonymous inline closure construction optimally during the JIT pass without the need to maintain an external reference wrapper that modifies a captured variable.
   - **Plan ID**: PERF-685
+
+- **PERF-679**: Eliminate Writer Waiter Executor Closure
+  - **What I tried**: Removed the pre-bound writerWaiterExecutor function and inlined the promise executor in the writer wait loop inside CaptureLoop.ts.
+  - **WHY it didn't work**: The median render time regressed compared to the baseline. V8's optimization of the await loop sequence likely prefers the statically allocated promise executor reference, as allocating a new closure inline every iteration incurred greater allocation overhead than context-switching to the pre-bound closure.
+  - **Plan ID**: PERF-679

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -182,3 +182,4 @@ run	2.534	150	34.65	63.8	discard	PERF-680 Inline writerWaiterExecutor
 
 181	2.487	150	60.31	63.6	discard	Separate setTime Await from Strategy Capture
 run	2.293	150	60.0	60.0	discard	PERF-685: prebind capture closure
+2004	2.453	150	61.15	500.0	discard	inline writer waiter executor


### PR DESCRIPTION
PERF-679: Eliminate Writer Waiter Executor Closure

This PR records the results of the performance experiment for `PERF-679`.

**What**: Tried inlining the `writerWaiterExecutor` promise in the writer wait loop inside `CaptureLoop.ts`.
**Why**: To remove closure reference overhead.
**Impact**: The median render time regressed to ~2.45s compared to the baseline of 2.18s. V8's optimization of the await loop sequence likely prefers the statically allocated promise executor reference, as allocating a new closure inline every iteration incurred greater allocation overhead than context-switching to the pre-bound closure.
**Verification**: Tested via benchmark script. Test failed, changes were reverted.
**Plan**: `/.sys/plans/PERF-679-eliminate-writer-waiter-executor.md`

## Results Summary
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.453	150	61.15	500.0	discard	inline writer waiter executor
```

---
*PR created automatically by Jules for task [7183720750092433408](https://jules.google.com/task/7183720750092433408) started by @BintzGavin*