### PR TITLE
✨ RENDERER: Evaluate Array.map overhead in CaptureLoop for PERF-678

### DIFF
--- a/.sys/plans/PERF-678-eliminate-run-worker-promise-allocation.md
+++ b/.sys/plans/PERF-678-eliminate-run-worker-promise-allocation.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-678
 slug: eliminate-run-worker-promise-allocation
-status: unclaimed
-claimed_by: ""
+status: complete
+result: discard
+claimed_by: "executor-session"
 created: 2025-06-05
-completed: ""
-result: ""
+completed: 2026-06-06
 ---
 # PERF-678: Eliminate `workerPromises` Array Mapping in `CaptureLoop`
 
@@ -58,3 +58,9 @@ Run `npm run test` or check the output video of the DOM benchmark.
 
 ## Prior Art
 - PERF-667 (in journal open questions): "Would avoiding `Array.map` array allocation overhead for `workerPromises` in `CaptureLoop.ts` improve startup latency?"
+
+## Results Summary
+- **Best render time**: 2.662s
+- **Improvement**: 0%
+- **Kept experiments**: none
+- **Discarded experiments**: [PERF-678]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -115,6 +115,11 @@ Last updated by: PERF-678
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-678 (Retry)**: Eliminate workerPromises Array.map
+  - **What I tried**: Attempted to use a pre-allocated array and for loop instead of Array.map in CaptureLoop.ts.
+  - **WHY it didn't work**: The median render time was 2.662s vs baseline 2.758s, no significant improvement. V8 optimally handles array mapping for small arrays, and this allocation happens once before the hot loop.
+  - **Plan ID**: PERF-678
+
 - **PERF-684**: Separate setTime Await from Strategy Capture
   - **What I tried**: Replaced chained `.then()` with sequential `await` in CaptureLoop.ts.
   - **WHY**: Removing the chained closure allocations actually caused a regression or negligible improvement (median 2.487s vs baseline 2.127s), as V8 optimizes inline `.then()` very well for short microtasks.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -183,3 +183,4 @@ run	2.534	150	34.65	63.8	discard	PERF-680 Inline writerWaiterExecutor
 181	2.487	150	60.31	63.6	discard	Separate setTime Await from Strategy Capture
 run	2.293	150	60.0	60.0	discard	PERF-685: prebind capture closure
 2004	2.453	150	61.15	500.0	discard	inline writer waiter executor
+run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises


### PR DESCRIPTION
## Description
Evaluated the overhead of `Array.map` on `workerPromises` allocation inside the hot loop `CaptureLoop.ts` (`packages/renderer`) as defined in `.sys/plans/PERF-678-eliminate-run-worker-promise-allocation.md`. 

The change replaced `this.pool.map` with a statically allocated fixed array size and `for` loop to test V8's closure optimization.

## Results
- Baseline median render time: ~2.758s
- Experiment median render time: ~2.662s
The experiment showed a negligible improvement that falls within standard variance limits, especially considering it operates on an array size of 1 only once during startup before the main `CaptureLoop` executes. 

Per the RENDERER experimentation protocol, the change was discarded to avoid unnecessary code churn, and `packages/renderer/src/core/CaptureLoop.ts` was fully restored to its pre-experiment state.

## Artifacts Updated
- `.sys/plans/PERF-678-eliminate-run-worker-promise-allocation.md` updated and marked complete.
- `docs/status/RENDERER-EXPERIMENTS.md` appended with details about why the approach was discarded.
- `packages/renderer/.sys/perf-results.tsv` appended with experiment output telemetry.

---
*PR created automatically by Jules for task [8692018499449901158](https://jules.google.com/task/8692018499449901158) started by @BintzGavin*