### PR TITLE
✨ RENDERER: Document PERF-686 experiment for prebinding CaptureLoop closures

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -899,3 +899,7 @@ Last updated by: PERF-592
   - **What I tried**: Removed the pre-bound writerWaiterExecutor function and inlined the promise executor in the writer wait loop inside CaptureLoop.ts.
   - **WHY it didn't work**: The median render time regressed compared to the baseline. V8's optimization of the await loop sequence likely prefers the statically allocated promise executor reference, as allocating a new closure inline every iteration incurred greater allocation overhead than context-switching to the pre-bound closure.
   - **Plan ID**: PERF-679
+- **PERF-686**: Prebind stdin closures and eliminate `this` references
+  - **What I tried**: Stored `this.handleWriteError` and `this.drainPromiseExecutor` in local variables in `CaptureLoop.ts` to bypass property resolution in the hot loop.
+  - **WHY it didn't work**: The median render time regressed slightly to ~2.173s (baseline best ~2.127s). V8 is already incredibly optimized for `this` property access due to hidden classes (inline caching). By breaking `this.handleWriteError` and passing it as a local variable, we may have modified how V8 executes the context of those callbacks, or added unnecessary local variables causing slight overhead. The JIT optimizations prefer standard method context passing.
+  - **Plan ID**: PERF-686

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -184,3 +184,4 @@ run	2.534	150	34.65	63.8	discard	PERF-680 Inline writerWaiterExecutor
 run	2.293	150	60.0	60.0	discard	PERF-685: prebind capture closure
 2004	2.453	150	61.15	500.0	discard	inline writer waiter executor
 run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
+1	2.173	150	69.04	63.9	discard	PERF-686 prebind this closures

--- a/packages/renderer/.sys/plans/PERF-686-prebind-this-closures.md
+++ b/packages/renderer/.sys/plans/PERF-686-prebind-this-closures.md
@@ -1,0 +1,13 @@
+---
+status: complete
+---
+# PERF-686: Prebind stdin closures and eliminate this references
+
+**Intent**: V8 performance degrades slightly when doing property accesses like `this.handleWriteError` and `this.drainPromiseExecutor` on every loop iteration, especially when combined with a branch like `if (typeof buffer === 'string')`.
+By storing `this.handleWriteError` and `this.drainPromiseExecutor` in local variables before the hot loop, we bypass the property resolution (`this.`) on every frame loop.
+
+## Results
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.173	150	69.04	63.9	discard	PERF-686 prebind this closures
+```


### PR DESCRIPTION
💡 **What**: Executed and documented PERF-686 experiment to prebind `this` closures to local variables in CaptureLoop.ts. The experiment was discarded because it caused a regression.
🎯 **Why**: To test if bypassing `this` property resolution overhead inside the tight writer loops would improve performance.
📊 **Impact**: Median render time regressed to ~2.173s (from baseline best of ~2.127s). V8 inline caching already heavily optimizes property access, and the local closure mapping resulted in worse JIT compilation outcomes.
🔬 **Verification**: Code built and executed using the dom-benchmark. Code changes were reverted upon identifying the regression, keeping only the documentation/telemetry updates.
📎 **Plan**: `packages/renderer/.sys/plans/PERF-686-prebind-this-closures.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.173	150	69.04	63.9	discard	PERF-686 prebind this closures
```

---
*PR created automatically by Jules for task [7354633925808191484](https://jules.google.com/task/7354633925808191484) started by @BintzGavin*