### PR TITLE
✨ RENDERER: PERF-688 Pipeline Overlap

### DIFF
--- a/.sys/plans/PERF-688-pipeline-overlap-single-worker.md
+++ b/.sys/plans/PERF-688-pipeline-overlap-single-worker.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-688
 slug: pipeline-overlap-single-worker
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "agent"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2026-06-06"
+result: "discarded"
 ---
 
 # PERF-688: Pipeline Capture and FFmpeg Drain in Single Worker Fast Path

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -115,6 +115,11 @@ Last updated by: PERF-678
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-688**: Pipeline Overlap in Single Worker
+  - **What I tried**: Deferred `await capturePromise` until after `await previousWritePromise` in the `CaptureLoop.ts` single-worker fast path to overlap Chromium capture with FFmpeg stream draining.
+  - **WHY it didn't work**: The median render time regressed to ~2.187s compared to the single-worker fast path baseline of ~2.18s (or was indistinguishable from noise). Node's event loop overhead and microtask queuing behavior when suppressing the promise rejection inline is either equal to or slightly higher than waiting sequentially. V8's internal optimization might prefer strict await sequences over detached promise chaining here.
+  - **Plan ID**: PERF-688
+
 - **PERF-678 (Retry)**: Eliminate workerPromises Array.map
   - **What I tried**: Attempted to use a pre-allocated array and for loop instead of Array.map in CaptureLoop.ts.
   - **WHY it didn't work**: The median render time was 2.662s vs baseline 2.758s, no significant improvement. V8 optimally handles array mapping for small arrays, and this allocation happens once before the hot loop.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -185,3 +185,6 @@ run	2.293	150	60.0	60.0	discard	PERF-685: prebind capture closure
 2004	2.453	150	61.15	500.0	discard	inline writer waiter executor
 run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 1	2.173	150	69.04	63.9	discard	PERF-686 prebind this closures
+1	2.958	150	50.72	63.7	discard	PERF-688 overlap pipeline
+2	2.143	150	70.01	63.0	discard	PERF-688 overlap pipeline
+3	2.187	150	68.57	63.1	discard	PERF-688 overlap pipeline


### PR DESCRIPTION
Evaluated deferring the `await capturePromise` until after `await previousWritePromise` in `CaptureLoop.ts` to parallelize Chromium capture and FFmpeg drain. Discarded the experiment due to regression (~2.187s vs baseline single-worker ~2.180s). 

Results Summary:
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.958	150	50.72	63.7	discard	PERF-688 overlap pipeline
2	2.143	150	70.01	63.0	discard	PERF-688 overlap pipeline
3	2.187	150	68.57	63.1	discard	PERF-688 overlap pipeline
```

---
*PR created automatically by Jules for task [4169145651092841681](https://jules.google.com/task/4169145651092841681) started by @BintzGavin*