### PR TITLE
✨ RENDERER: PERF-687 Promise.withResolvers experiment

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -115,6 +115,11 @@ Last updated by: PERF-678
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-687**: Use Promise.withResolvers in CdpTimeDriver
+  - **What I tried**: Attempted to use `Promise.withResolvers<void>()` instead of allocating a new Promise and an anonymous executor closure `new Promise<void>((resolve, reject) => { ... })` on every frame in `CdpTimeDriver.ts`.
+  - **WHY it didn't work**: The median render time was ~2.976s compared to the baseline median of ~3.054s. The results are within the noise margin (baseline fluctuated from 2.969s to 3.489s). While `Promise.withResolvers()` is a cleaner abstraction to avoid creating the closure block, it did not significantly alter the JIT execution profile or reduce garbage collection overhead in a way that measurably decreased total execution time, likely because V8 heavily optimizes inline closure construction for promises.
+  - **Plan ID**: PERF-687
+
 - **PERF-688**: Pipeline Overlap in Single Worker
   - **What I tried**: Deferred `await capturePromise` until after `await previousWritePromise` in the `CaptureLoop.ts` single-worker fast path to overlap Chromium capture with FFmpeg stream draining.
   - **WHY it didn't work**: The median render time regressed to ~2.187s compared to the single-worker fast path baseline of ~2.18s (or was indistinguishable from noise). Node's event loop overhead and microtask queuing behavior when suppressing the promise rejection inline is either equal to or slightly higher than waiting sequentially. V8's internal optimization might prefer strict await sequences over detached promise chaining here.

--- a/packages/renderer/.sys/perf-results-PERF-687.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-687.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.976	150	50.40	64.5	discard	PERF-687 Use Promise.withResolvers
+2	2.901	150	51.71	63.7	discard	PERF-687 Use Promise.withResolvers
+3	3.296	150	45.51	63.8	discard	PERF-687 Use Promise.withResolvers

--- a/packages/renderer/.sys/plans/PERF-687-promise-with-resolvers.md
+++ b/packages/renderer/.sys/plans/PERF-687-promise-with-resolvers.md
@@ -1,0 +1,28 @@
+---
+status: complete
+claimed_by: "executor-session"
+---
+
+# PERF-687: Use Promise.withResolvers in CdpTimeDriver
+
+**Intent**: In `CdpTimeDriver.ts`, we currently allocate a new Promise and an anonymous executor closure on every single frame:
+```typescript
+    const promise = new Promise<void>((resolve, reject) => {
+      this.cdpResolve = resolve;
+      this.cdpReject = reject;
+    });
+```
+Node.js 22 supports `Promise.withResolvers()`, which allows us to create a Promise and extract its `resolve` and `reject` functions without allocating an executor closure. By using `Promise.withResolvers()`, we can eliminate the anonymous closure allocation and function execution overhead on every iteration of the `setTime` hot loop.
+
+## The Benchmark Harness
+
+Standard 3-run median, check `render_time_s`.
+status: complete
+completed: 2024-05-18
+result: no-improvement
+
+## Results Summary
+- **Best render time**: 2.901s (vs baseline ~3.054s)
+- **Improvement**: 0% (Within noise margin)
+- **Kept experiments**: None
+- **Discarded experiments**: Use Promise.withResolvers in CdpTimeDriver


### PR DESCRIPTION
💡 **What**: Executed PERF-687 to test `Promise.withResolvers()` instead of `new Promise<void>((resolve, reject) => { ... })` in `CdpTimeDriver.ts`. Outcome: Discarded.
🎯 **Why**: To attempt to avoid anonymous closure allocation overhead in the `setTime` hot loop.
📊 **Impact**: No measurable improvement beyond the noise margin. Median ~2.976s compared to baseline ~3.054s.
🔬 **Verification**: Code was restored to original state. Output tsv and RENDERER-EXPERIMENTS.md updated.
📎 **Plan**: `packages/renderer/.sys/plans/PERF-687-promise-with-resolvers.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.976	150	50.40	64.5	discard	PERF-687 Use Promise.withResolvers
2	2.901	150	51.71	63.7	discard	PERF-687 Use Promise.withResolvers
3	3.296	150	45.51	63.8	discard	PERF-687 Use Promise.withResolvers
```

---
*PR created automatically by Jules for task [8966684687901430745](https://jules.google.com/task/8966684687901430745) started by @BintzGavin*