### PR TITLE
✨ RENDERER: Bypass Promise Wrapper in CaptureLoop Capture Logic

### DIFF
--- a/.sys/plans/PERF-695-bypass-capture-await.md
+++ b/.sys/plans/PERF-695-bypass-capture-await.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-695
 slug: bypass-capture-await
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-09
-completed: ""
-result: ""
+completed: 2026-06-07
+result: discarded
 ---
 
 # PERF-695: Bypass Promise Wrapper in CaptureLoop Capture Logic
@@ -94,3 +94,15 @@ Run `npm run build -w packages/renderer` to ensure no syntax errors.
 
 ## Correctness Check
 Run the DOM benchmark (`cd packages/renderer && npx tsx scripts/benchmark-perf.ts`) and ensure output videos render correctly.
+
+## Impossibility Explanation
+This experiment was discarded because it resulted in a performance regression. The median render time was ~2.854s, compared to the baseline of ~2.347s. Eagerly wrapping the potentially undefined result in a native `Promise.resolve()` and adding a `.then()` chain allocated more closures and microtasks on every frame than simply relying on V8's optimization of the explicit branch and native await.
+
+## Results Summary
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.854	150	52.56	63.7	discard	eager promise chain capture
+2	2.953	150	50.80	63.5	discard	eager promise chain capture
+3	2.617	150	57.32	63.6	discard	eager promise chain capture
+
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -125,6 +125,10 @@ Last updated by: PERF-692
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-695**: Bypass Promise Wrapper in CaptureLoop Capture Logic
+  - **What I tried**: Replaced the ternary promise check inside the hot loop in `CaptureLoop.ts` with an eagerly chained promise using `await Promise.resolve(setTimeResult).then(...)`.
+  - **WHY it didn't work**: Yielded a performance regression (median ~2.854s vs baseline ~2.347s). Eagerly wrapping the potentially undefined result in a native `Promise.resolve()` and adding a `.then()` chain allocated more closures and microtasks on every frame than simply relying on V8's optimization of the explicit branch and native await.
+  - **Plan ID**: PERF-695
 - **PERF-676**: Conditionally Update Virtual Time Budget
   - **What I tried**: Attempted to conditionally assign `this.setVirtualTimePolicyParams.budget = budget` in `CdpTimeDriver.ts` only if the budget value changed from the previous frame.
   - **WHY it didn't work**: The median render time regressed to ~2.46s (baseline best ~2.347s). Adding the conditional check and branch logic overhead outweighs the cost of blindly writing the budget property in the V8 hot loop, as V8 is highly optimized for consecutive property writes to the same object shape via inline caching.

--- a/packages/renderer/.sys/perf-results-PERF-695.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-695.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.854	150	52.56	63.7	discard	eager promise chain capture
+2	2.953	150	50.80	63.5	discard	eager promise chain capture
+3	2.617	150	57.32	63.6	discard	eager promise chain capture


### PR DESCRIPTION
Ran and documented the PERF-695 experiment, attempting to bypass the promise wrapper in `CaptureLoop.ts`. The experiment yielded a performance regression, so the source code changes were correctly reverted, and only the generated metadata files (TSV, plan update, and journal update) are included in this PR.

---
*PR created automatically by Jules for task [14752677985042355526](https://jules.google.com/task/14752677985042355526) started by @BintzGavin*