### PR TITLE
✨ RENDERER: Optimize FFmpeg Stdin Pipe by Removing Thread Queue

### DIFF
--- a/.sys/plans/PERF-698-remove-thread-queue-size.md
+++ b/.sys/plans/PERF-698-remove-thread-queue-size.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-698
 slug: remove-thread-queue-size
-status: unclaimed
-claimed_by: ""
+status: completed
+claimed_by: "Jules"
 created: 2024-06-11
-completed: ""
-result: ""
+completed: "2024-06-11"
+result: "keep"
 ---
 
 # PERF-698: Optimize FFmpeg Stdin Pipe by Removing Thread Queue
@@ -37,7 +37,7 @@ By adding `-thread_queue_size 512`, we force FFmpeg to spawn an additional threa
 - **Minimum runs**: 3 per experiment, report median
 
 ## Baseline
-- **Current estimated render time**: ~2.347s
+- **Current estimated render time**: ~2.7s
 - **Bottleneck analysis**: IPC latency and thread synchronization overhead in the FFmpeg child process, compounded by Node.js stream overhead.
 
 ## Implementation Spec

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -696,8 +696,8 @@ Last updated by: PERF-692
   - **Outcome**: discard
 
 ## Performance Trajectory
-Current best: 2.347s (baseline was 2.471s, -5.0%)
-Last updated by: PERF-693
+Current best: ~2.624s (baseline was ~2.710s, -3%)
+Last updated by: PERF-698
 
 ## What Works
 - **PERF-637**: Optimize Writer Waiter Check in CaptureLoop Hot Loop
@@ -933,6 +933,7 @@ Last updated by: PERF-693
   - **Plan ID**: PERF-686
 
 ## What Works
+- PERF-698: Removed `-thread_queue_size 512` from `DomStrategy.ts` FFmpeg arguments. By relying on native Unix pipe backpressure instead of an internal FFmpeg thread queue, the median render time improved to ~2.624s (from ~2.710s baseline).
 - PERF-693: Omit `this.handleWriteError` callbacks to `stdin.write` in the `CaptureLoop.ts` single-worker fast path to avoid Node.js stream internal state machine tracking overhead. This reduced median render time to ~2.347s (from ~2.471s baseline).
 - **PERF-694**: Bypass capture await check in single-worker hot loop
   - **What I tried**: Unrolled the first iteration of the loop in `CaptureLoop.ts` to skip evaluating the `setTimeResult ? await ... : await` ternary condition on every frame.

--- a/packages/renderer/.sys/perf-results-PERF-698.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-698.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.710	150	55.36	64.3	keep	baseline
+2	3.335	150	44.98	63.6	keep	baseline
+3	2.669	150	56.21	63.6	keep	baseline
+4	3.014	150	49.77	63.5	keep	removed thread_queue_size
+5	2.599	150	57.72	63.4	keep	removed thread_queue_size
+6	2.624	150	57.17	64.3	keep	removed thread_queue_size

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -203,7 +203,6 @@ export class DomStrategy implements RenderStrategy {
       '-f', inputFormat,
       ...(format === 'webp' ? ['-vcodec', 'webp'] : []),
       '-framerate', `${options.fps}`,
-      '-thread_queue_size', '512',
       '-i', '-',
     ];
 


### PR DESCRIPTION
Removed `-thread_queue_size 512` argument from FFmpeg pipe input to allow native Unix backpressure, slightly reducing render time.

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.710	150	55.36	64.3	keep	baseline
2	3.335	150	44.98	63.6	keep	baseline
3	2.669	150	56.21	63.6	keep	baseline
4	3.014	150	49.77	63.5	keep	removed thread_queue_size
5	2.599	150	57.72	63.4	keep	removed thread_queue_size
6	2.624	150	57.17	64.3	keep	removed thread_queue_size
```

---
*PR created automatically by Jules for task [13687500473151661528](https://jules.google.com/task/13687500473151661528) started by @BintzGavin*