### PR TITLE
✨ PLAYER: Document Missing Media Properties

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -21,6 +21,8 @@ Custom extensions:
 ## Section C: Attributes
 Observed attributes:
 - `src`: The URL of the content to load into the iframe.
+- `interactive`: Enable direct interaction with the composition.
+- `sandbox`: Security flags for the iframe.
 - `width`, `height`: Dimensions of the player.
 - `controls`: Boolean attribute to toggle the UI overlay.
 - `loop`: Boolean attribute to enable looping playback.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,4 +1,7 @@
 #
+### PLAYER v0.77.50
+- ✅ Completed: Document Missing Media Properties - Added src, autoplay, loop, controls, poster, preload, sandbox, and interactive to README.md
+
 ### PLAYER v0.77.49
 - ✅ Completed: Document Missing Event Handlers - Documented onplaying, onwaiting, onsuspend, and onstalled properties and events.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,5 @@
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
-**Version**: 0.77.49
+**Version**: 0.77.50
 [0.77.49] ✅ Completed: Document Missing Event Handlers - Documented onplaying, onwaiting, onsuspend, and onstalled properties and events.
 [v0.77.46] ✅ Completed: Discovered that `2027-02-16-PLAYER-Add-onaudiometering-handler.md` is an IMPOSSIBLE: DUPLICATION plan. The `onaudiometering` property is already fully implemented. Documented as impossible and discarded. Also added 'audiometering' to the event handlers test in `index.test.ts`.
 [v0.77.44] ✅ Completed: Document Missing Events - Deleted lingering plan file as the README already contained the required documentation updates.
@@ -25,6 +25,7 @@
 
 [v0.77.18] ✅ Completed: Fix Duplicate README Entry - Removed duplicate getSchema entry from README.md.
 ## Status Log
+[v0.77.50] ✅ Completed: Document Missing Media Properties - Added src, autoplay, loop, controls, poster, preload, sandbox, and interactive to README.md
 [v0.77.49] ✅ Completed: Discovered undocumented event handler properties and events (playing, waiting, suspend, stalled) in implementation missing from README. Created plan `.sys/plans/v0.77.49-PLAYER-Document-Missing-Event-Handlers.md` to document them.
 [v0.77.17] ✅ Completed: Improve Index Coverage - Expanded unit tests for HTMLMediaElement properties and events.
 [v0.77.14] ✅ Completed: Document getSchema API Parity - Added missing getSchema method to README documentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7979,7 +7979,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7989,7 +7989,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -152,6 +152,14 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 
 ### Properties
 
+- `src` (string): URL of the composition page to load in the iframe.
+- `autoplay` (boolean): Reflected autoplay attribute.
+- `loop` (boolean): Reflected loop attribute.
+- `controls` (boolean): Reflected controls attribute.
+- `poster` (string): Reflected poster attribute.
+- `preload` (string): Reflected preload attribute.
+- `sandbox` (string): Reflected sandbox attribute.
+- `interactive` (boolean): Reflected interactive attribute.
 - `textTracks` (TextTrackList, read-only): The text tracks associated with the media element.
 - `audioTracks` (AudioTrackList, read-only): The audio tracks associated with the media element.
 - `videoTracks` (VideoTrackList, read-only): The video tracks associated with the media element.


### PR DESCRIPTION
Documents missing media properties (`src`, `autoplay`, `loop`, `controls`, `poster`, `preload`, `sandbox`, `interactive`) in `packages/player/README.md`. Also updates relevant status files and contexts to reflect the completion of the `.sys/plans/2027-02-17-PLAYER-Document-Missing-Media-Properties.md` plan.

---
*PR created automatically by Jules for task [8401327556141504703](https://jules.google.com/task/8401327556141504703) started by @BintzGavin*