### PR TITLE
✨ RENDERER: Evaluate conditional Runtime.enable for performance

### DIFF
--- a/.sys/plans/PERF-707-disable-runtime-enable.md
+++ b/.sys/plans/PERF-707-disable-runtime-enable.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-707
 slug: disable-runtime-enable
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-18
 completed: ""
@@ -100,3 +100,15 @@ Run the standard canvas benchmark (`packages/renderer/scripts/benchmark-perf.ts`
 
 ## Correctness Check
 Run the `dom-benchmark.mp4` output check. Ensure the video renders properly with the expected number of frames and the animation looks visually identical.
+
+## Results
+
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	12.037	150	12.46	63.4	discard	initial warm up, conditionally enable Runtime.enable
+2	2.495	150	60.12	63.6	discard	conditionally enable Runtime.enable
+3	2.120	150	70.75	63.4	discard	conditionally enable Runtime.enable
+4	2.137	150	70.19	63.5	discard	conditionally enable Runtime.enable
+```
+
+**Outcome**: DISCARDED. The median render time did not improve over the baseline. The overhead of the Runtime domain events is negligible for DOM animations compared to other rendering costs, and conditional initialization adds complexity without benefit.

--- a/commit-details.txt
+++ b/commit-details.txt
@@ -1,0 +1,14 @@
+💡 **What**: Conditionally enabled `Runtime.enable` in `CdpTimeDriver.ts` only when media elements are present.
+🎯 **Why**: To reduce CDP overhead and avoid tracking executionContextCreated events during DOM compositions that have no media elements.
+📊 **Impact**: Median render time ~2.13s (baseline ~2.115s). The change is within the noise margin and provides no measurable improvement. The experiment is DISCARDED.
+🔬 **Verification**: Code built, ran benchmark 4 times.
+📎 **Plan**: `.sys/plans/PERF-707-disable-runtime-enable.md`
+
+**Results Summary:**
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	12.037	150	12.46	63.4	discard	initial warm up, conditionally enable Runtime.enable
+2	2.495	150	60.12	63.6	discard	conditionally enable Runtime.enable
+3	2.120	150	70.75	63.4	discard	conditionally enable Runtime.enable
+4	2.137	150	70.19	63.5	discard	conditionally enable Runtime.enable
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -128,6 +128,7 @@ Last updated by: PERF-699
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- Conditionally calling `Runtime.enable` based on `this.hasMedia` in `CdpTimeDriver.ts`. **Why it didn't work:** It yielded no measurable performance improvement (median ~2.13s vs baseline ~2.115s). The overhead of tracking `executionContextCreated` events via the Runtime domain during DOM compositions is negligible compared to other bottlenecks. We discard this to avoid complicating the initialization logic. (PERF-707)
 - **PERF-700**: Strict undefined checks for previousWritePromise
   - **What I tried**: Used strict `!== undefined` checks instead of truthiness evaluation for `previousWritePromise` in the hot loop inside `CaptureLoop.ts`.
   - **WHY it didn't work**: The median render time regressed to ~2.696s (baseline best ~2.347s). JavaScript truthiness checking `if (previousWritePromise)` is highly optimized in V8 for object/undefined checks, and replacing it with an explicit strict equality check may have subtly altered the inline caching profile or bytecode generation, resulting in slightly more overhead per frame.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -191,3 +191,7 @@ run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 50	2.166	150	70.79	63.5	keep	PERF-701: Optimize Promise Closure in DomStrategy.capture()
 51	2.236	150	67.08	63.6	discard	PERF-702: Optimize CDP Send Parameters in SeekTimeDriver.ts
 52	2.327	150	67.89	63.8	keep	PERF-704: Eliminate per-frame closures
+193	12.037	150	12.46	63.4	discard	initial warm up, conditionally enable Runtime.enable
+194	2.495	150	60.12	63.6	discard	conditionally enable Runtime.enable
+195	2.12	150	70.75	63.4	discard	conditionally enable Runtime.enable
+196	2.137	150	70.19	63.5	discard	conditionally enable Runtime.enable


### PR DESCRIPTION
💡 **What**: Conditionally enabled `Runtime.enable` in `CdpTimeDriver.ts` only when media elements are present.
🎯 **Why**: To reduce CDP overhead and avoid tracking executionContextCreated events during DOM compositions that have no media elements.
📊 **Impact**: Median render time ~2.13s (baseline ~2.115s). The change is within the noise margin and provides no measurable improvement. The experiment is DISCARDED.
🔬 **Verification**: Code built, ran benchmark 4 times.
📎 **Plan**: `.sys/plans/PERF-707-disable-runtime-enable.md`

**Results Summary:**
```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	12.037	150	12.46	63.4	discard	initial warm up, conditionally enable Runtime.enable
2	2.495	150	60.12	63.6	discard	conditionally enable Runtime.enable
3	2.120	150	70.75	63.4	discard	conditionally enable Runtime.enable
4	2.137	150	70.19	63.5	discard	conditionally enable Runtime.enable
```

---
*PR created automatically by Jules for task [2560501933965074624](https://jules.google.com/task/2560501933965074624) started by @BintzGavin*