### PR TITLE
📋 RENDERER: Document PERF-709 prebind promise executor

### DIFF
--- a/.sys/plans/PERF-709-prebind-promise-executor.md
+++ b/.sys/plans/PERF-709-prebind-promise-executor.md
@@ -1,0 +1,60 @@
+---
+id: PERF-709
+slug: prebind-promise-executor
+status: complete
+claimed_by: "jules"
+created: 2025-05-13
+completed: "2025-05-13"
+result: "failed"
+---
+
+# PERF-709: Optimize CdpTimeDriver virtualTimePromiseExecutor inline closure
+
+## Focus Area
+The `CdpTimeDriver.runSetTime` hot loop currently allocates a new inline closure `(resolve, reject) => { this.cdpResolve = resolve; ... }` to pass to `new Promise<void>` on every frame to pause the pipeline until Chromium's virtual time budget is consumed.
+
+## Background Research
+V8 handles inline closure optimization reasonably well, but in extremely tight synchronous single-frame loops (like DOM capture where 60+ promises are constructed per second), allocating the closure arguments and capturing the `this` context to assign the resolver variables into class properties can create unnecessary heap traffic and garbage collection pressure.
+By extracting this anonymous executor closure into a pre-bound class property, we can avoid allocating the function object repeatedly. Unlike `Promise.withResolvers()` which creates an intermediate object, passing a pre-bound static property executor directly into the `new Promise` constructor provides the lowest level of overhead for V8, reusing the same function instance across thousands of frames.
+
+## Benchmark Configuration
+- **Composition URL**: file:///app/examples/dom-benchmark/composition.html
+- **Render Settings**: 600x600, 30 FPS, 150 frames, ultrafast preset
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 4 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~2.38s - 2.53s
+- **Bottleneck analysis**: The closure allocation `(resolve, reject) => { ... }` in `CdpTimeDriver.ts` at line 213 inside `runSetTime()` is executed per frame.
+
+## Implementation Spec
+
+### Step 1: Add prebound executor property to `CdpTimeDriver`
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+Add a private property to the class:
+\`\`\`typescript
+  private virtualTimePromiseExecutor = (resolve: () => void, reject: (err: Error) => void) => {
+    this.cdpResolve = resolve;
+    this.cdpReject = reject;
+  };
+\`\`\`
+Modify `runSetTime` to use it:
+\`\`\`typescript
+<<<<<<< SEARCH
+    const promise = new Promise<void>((resolve, reject) => {
+      this.cdpResolve = resolve;
+      this.cdpReject = reject;
+    });
+=======
+    const promise = new Promise<void>(this.virtualTimePromiseExecutor);
+>>>>>>> REPLACE
+\`\`\`
+**Why**: Avoids creating a new closure context for the Promise executor function on every single frame loop iteration.
+
+## Canvas Smoke Test
+- Canvas rendering paths do not use `CdpTimeDriver` (they use `SeekTimeDriver` or raw WebCodecs), so they should not be affected, but `npm run test` will run the standard verification suite.
+
+## Correctness Check
+The resulting `dom-benchmark.mp4` must not be empty and must complete rendering without timing out.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -128,6 +128,11 @@ Last updated by: PERF-699
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-709**: Prebind virtualTimePromiseExecutor in CdpTimeDriver
+  - **What I tried**: Attempted to extract the inline anonymous closure `(resolve, reject) => { ... }` for `new Promise<void>` into a prebound class property `virtualTimePromiseExecutor` to avoid allocating a closure on every frame.
+  - **WHY it didn't work**: Yielded a performance regression (median ~2.559s vs baseline ~2.115s). While V8 performs inline closure allocation, creating a static reference to the bound closure adds additional property-lookup overhead in the hot loop, which seems to disrupt V8's optimization of the async/await promise execution sequence. We are discarding this change.
+  - **Plan ID**: PERF-709
+
 - **PERF-708**: Omit .catch() in CdpTimeDriver defaultSyncMedia
   - **What I tried**: Removed `.catch(noopCatch)` in `defaultSyncMedia` of `CdpTimeDriver.ts` to avoid per-frame promise and microtask allocation during CDP evaluate calls.
   - **WHY it didn't work**: Yielded a median render time of ~2.824s vs baseline ~2.115s. This is slower, so we are discarding it.


### PR DESCRIPTION
Tested whether extracting the `new Promise` closure in `CdpTimeDriver.runSetTime` into a prebound class property would improve performance by reducing per-frame allocation. 

The change introduced a regression, slowing down the median render time from ~2.115s to ~2.559s. V8 optimizes inline anonymous closures within async sequences better than invoking pre-bound class properties on every iteration. 

The code changes were discarded and the outcome recorded in `RENDERER-EXPERIMENTS.md`.

---
*PR created automatically by Jules for task [2256838408444908973](https://jules.google.com/task/2256838408444908973) started by @BintzGavin*