### PR TITLE
✨ RENDERER: Discarded prebind dom strategy begin frame handler inline closure

### DIFF
--- a/.sys/plans/PERF-710-prebind-domstrategy-begin-frame-handler.md
+++ b/.sys/plans/PERF-710-prebind-domstrategy-begin-frame-handler.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-710
 slug: prebind-domstrategy-begin-frame-handler
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-27
 completed: ""
-result: ""
+result: "Discarded, regression to 2.739s"
 ---
 
 # PERF-710: Prebind `handleBeginFrameResult` logic and simplify `.then` in DomStrategy

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -133,6 +133,9 @@ Last updated by: PERF-699
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- Reverted prebound `handleBeginFrameResult` in `DomStrategy.capture()` to an inline closure. PERF-710.
+  - **WHY it didn't work:** It regressed performance (median ~2.739s vs baseline ~2.115s). While V8 does highly optimize inline closures, the original issue wasn't the closure dispatch but V8's optimization limits around `async/await` and object property lookups inside hot loops that pre-bound fields resolved. Going back to an inline arrow function meant more allocations per frame.
+
 - **PERF-709**: Prebind virtualTimePromiseExecutor in CdpTimeDriver
   - **What I tried**: Attempted to extract the inline anonymous closure `(resolve, reject) => { ... }` for `new Promise<void>` into a prebound class property `virtualTimePromiseExecutor` to avoid allocating a closure on every frame.
   - **WHY it didn't work**: Yielded a performance regression (median ~2.559s vs baseline ~2.115s). While V8 performs inline closure allocation, creating a static reference to the bound closure adds additional property-lookup overhead in the hot loop, which seems to disrupt V8's optimization of the async/await promise execution sequence. We are discarding this change.

--- a/packages/renderer/.sys/perf-results-PERF-710.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-710.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.739	150	54.76	64.4	discard	inline beginFrame handler
+2	2.739	150	54.76	63.4	discard	inline beginFrame handler
+3	2.735	150	54.84	63.5	discard	inline beginFrame handler


### PR DESCRIPTION
💡 **What:**
Reverted the prebound `handleBeginFrameResult` instance property inside `DomStrategy.capture()` to an inline anonymous closure `result => (this.lastFrameData = result.screenshotData || this.lastFrameData)!;`.

🎯 **Why:**
PERF-704 showed that extracting the inline closure into an instance field regressed performance but was kept for simplicity. This experiment (PERF-710) sought to revert that and verify if the inline anonymous closure regained the baseline performance (~2.115s) by avoiding object property lookups in V8's optimization of the hot path.

📊 **Impact:**
The experiment yielded a significant regression, with a median render time of ~2.739s compared to the ~2.115s baseline. It demonstrated that in the current heavily optimized asynchronous hot path, allocating a new inline closure function on every frame incurred more overhead than simply resolving the instance property lookup for a pre-bound field.

🔬 **Verification:**
- **Compilation:** Passed (`npm run build`)
- **Benchmark Consistency:** Failed - 3 runs yielded median 2.739s, meaning it is a regression from the 2.115s baseline.

📎 **Plan:** `/.sys/plans/PERF-710-prebind-domstrategy-begin-frame-handler.md`

### Results Summary
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.739	150	54.76	64.4	discard	inline beginFrame handler
2	2.739	150	54.77	63.4	discard	inline beginFrame handler
3	2.735	150	54.84	63.5	discard	inline beginFrame handler

---
*PR created automatically by Jules for task [1707939150974696668](https://jules.google.com/task/1707939150974696668) started by @BintzGavin*