### PR TITLE
📋 RENDERER: Remove unused cdpReject in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-711-remove-unused-cdp-reject.md
+++ b/.sys/plans/PERF-711-remove-unused-cdp-reject.md
@@ -1,0 +1,57 @@
+---
+id: PERF-711
+slug: remove-unused-cdp-reject
+status: complete
+claimed_by: "jules"
+created: 2024-06-08
+completed: "2026-06-08"
+result: "discard"
+---
+
+# PERF-711: Clean up unused cdpReject in CdpTimeDriver
+
+## Focus Area
+DOM Rendering Pipeline - Hot loop in `packages/renderer/src/drivers/CdpTimeDriver.ts`.
+
+## Background Research
+In PERF-706, we successfully removed the `.catch()` clause attached to `Emulation.setVirtualTimePolicy` inside `CdpTimeDriver.ts`. This successfully eliminated unhandled rejection closures from the hot path. However, the `cdpReject` property assignment inside the `new Promise` executor was left over and is now dead code. We continue to allocate a closure with `(resolve, reject)` and perform property assignments (`this.cdpReject = reject`) and nullifications on every frame. By removing this dead code, we slightly reduce GC pressure and property access overhead in the V8 hot loop.
+
+## Benchmark Configuration
+- **Composition URL**: `examples/dom-benchmark/composition.html`
+- **Render Settings**: 600x600, 30 FPS, 5s duration (150 frames)
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~2.115s
+
+## Implementation Spec
+
+### Step 1: Remove cdpReject
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+- Remove `private cdpReject: ((err: Error) => void) | null = null;`.
+- Remove `this.cdpReject = null;` from `handleVirtualTimeBudgetExpired`.
+- Remove `reject` parameter and `this.cdpReject = reject;` from `new Promise` inside `runSetTime`.
+
+**Why**: Eliminates unused variables and assignments, marginally reducing GC pressure on every frame.
+**Risk**: Low.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Ensure Canvas renders complete successfully without regressions.
+
+## Correctness Check
+Run the DOM render benchmark script (`cd packages/renderer && npx tsx scripts/benchmark-perf.ts`) to verify correct output without regressions.
+
+## Prior Art
+Builds directly on PERF-706.
+
+## Results Summary
+- **Best render time**: ~2.638s (vs baseline ~2.115s)
+- **Improvement**: -24.73%
+- **Kept experiments**: none
+- **Discarded experiments**: PERF-711

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -469,6 +469,11 @@ Last updated by: PERF-699
   - **How much it improved**: The median render time on the dom-benchmark improved from ~1.448s to ~1.304s (approx 10% faster) on a 150-frame microVM benchmark by bypassing unoptimized synchronization paths inside Chromium for screenshot captures.
   - **Outcome**: keep
 
+- **PERF-711**: Remove unused cdpReject in CdpTimeDriver
+  - **What I tried**: Removed unused `cdpReject` tracking in `CdpTimeDriver.ts` left over from PERF-706 to reduce GC pressure.
+  - **WHY it didn't work**: Yielded a median render time of ~2.638s vs baseline ~2.115s.
+  - **Plan ID**: PERF-711
+
 ## Open Questions
 - Inlining stability check promise resolution in CdpTimeDriver.ts
 - The bottleneck is likely in V8 runtime boundaries or Playwright CDP IPC, meaning microtask queue optimizations yield no measurable performance improvement over the baseline.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -194,3 +194,5 @@ run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 53	3.269	150	45.89	63.6	discard	PERF-707: Disable Runtime.enable
 194	2.824	150	53.12	63.4	discard	Omit .catch() in CdpTimeDriver defaultSyncMedia
 195	2.310	150	64.94	63.5	keep	PERF-457: Conditionally assign syncMediaFn
+
+196	2.638	150	56.86	63.5	discard	PERF-711: Clean up unused cdpReject


### PR DESCRIPTION
💡 What: The experiment removed the dead code cdpReject variable mapping.
🎯 Why: To marginally reduce GC pressure in the hot loop.
🔬 Approach: Modified CdpTimeDriver.ts to drop cdpReject.
📎 Plan: /.sys/plans/PERF-711-remove-unused-cdp-reject.md

---
*PR created automatically by Jules for task [16588596894426389773](https://jules.google.com/task/16588596894426389773) started by @BintzGavin*