### PR TITLE
✨ RENDERER: Bypass timeStep multiplication in fast path

### DIFF
--- a/.sys/plans/PERF-690-bypass-time-step-multiplication.md
+++ b/.sys/plans/PERF-690-bypass-time-step-multiplication.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-690
 slug: bypass-time-step-multiplication
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-07
-completed: ""
-result: ""
+completed: "2026-06-08"
+result: "failed"
 ---
 
 # PERF-690: Bypass timeStep Multiplication in Fast Path
@@ -92,3 +92,9 @@ Run the DOM benchmark (`npx tsx scripts/benchmark-perf.ts`) and ensure output vi
 ## Prior Art
 - PERF-683: Introduced the single-worker fast path.
 - General V8 optimization knowledge: simple addition is computationally cheaper than loop-dependent multiplication.
+
+## Results Summary
+- **Best render time**: ~2.520s (vs baseline ~2.530s)
+- **Improvement**: ~0.4% (Within noise margin)
+- **Kept experiments**: None
+- **Discarded experiments**: Bypass timeStep multiplication

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -133,6 +133,11 @@ Last updated by: PERF-699
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-690**: Bypass timeStep multiplication in fast path
+  - **What I tried**: Used accumulating variables instead of loop multiplication.
+  - **WHY it didn't work**: Yielded no measurable performance improvement beyond the noise margin (~2.520s vs current ~2.530s baseline, well off the historical ~2.115s best). V8 handles the simple loop multiplication well enough.
+  - **Plan ID**: PERF-690
+
 
 - **PERF-713**: Simplify Empty Try-Catch Overhead in CdpTimeDriver
   - **What I tried**: Attempted to simplify the `hasMedia` and `waitUntilStable` try-catch blocks utilizing a `noopCatch` and replaced the empty closure in `.catch(() => {})` for `Runtime.enable` with `noopCatch` in `CdpTimeDriver.ts`.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -197,3 +197,5 @@ run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 
 196	2.638	150	56.86	63.5	discard	PERF-711: Clean up unused cdpReject
 197	2.453	150	61.15	63.3	discard	PERF-713: Simplify empty try-catches in CdpTimeDriver
+
+198	2.520	150	59.52	63.4	discard	PERF-690: Bypass timeStep multiplication


### PR DESCRIPTION
💡 **What**: Executed and discarded PERF-690: Bypass timeStep multiplication in fast path.
🎯 **Why**: Attempted to use accumulating variables instead of loop multiplication inside the single-worker hot loop in `CaptureLoop.ts` to reduce overhead.
📊 **Impact**: The experiment yielded no measurable performance improvement beyond the noise margin (~2.520s vs current ~2.530s baseline, well off the historical ~2.115s best). V8 handles the simple loop multiplication well enough. The code changes were reverted.
🔬 **Verification**: Code compilation and test suites passed.
📎 **Plan**: `/.sys/plans/PERF-690-bypass-time-step-multiplication.md`

```tsv
198	2.520	150	59.52	63.4	discard	PERF-690: Bypass timeStep multiplication
```

---
*PR created automatically by Jules for task [3312900708625996035](https://jules.google.com/task/3312900708625996035) started by @BintzGavin*