### PR TITLE
📋 RENDERER: PERF-714 Promise.withResolvers

### DIFF
--- a/.sys/plans/PERF-714-promise-with-resolvers.md
+++ b/.sys/plans/PERF-714-promise-with-resolvers.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-714
 slug: promise-with-resolvers
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-09
 completed: ""
 result: ""
@@ -57,3 +57,9 @@ Replace it with:
 
 ## Correctness Check
 Run the `renderer` package tests to ensure DOM strategies function as expected.
+
+## Results Summary
+- **Best render time**: 2.435s (vs baseline ~2.408s)
+- **Improvement**: -1.12%
+- **Kept experiments**: None
+- **Discarded experiments**: Use Promise.withResolvers in CdpTimeDriver

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -133,6 +133,11 @@ Last updated by: PERF-699
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-714**: Promise.withResolvers in CdpTimeDriver
+  - **What I tried**: Replaced the inline promise executor with Promise.withResolvers.
+  - **WHY it didn't work**: The median render time did not improve (~2.435s vs baseline ~2.408s). The optimization likely has negligible impact here since Node supports inline executors efficiently. And we have to create object wrapping for promise/resolve/reject with withResolvers.
+  - **Plan ID**: PERF-714
+
 - **PERF-690**: Bypass timeStep multiplication in fast path
   - **What I tried**: Used accumulating variables instead of loop multiplication.
   - **WHY it didn't work**: Yielded no measurable performance improvement beyond the noise margin (~2.520s vs current ~2.530s baseline, well off the historical ~2.115s best). V8 handles the simple loop multiplication well enough.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -199,3 +199,4 @@ run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 197	2.453	150	61.15	63.3	discard	PERF-713: Simplify empty try-catches in CdpTimeDriver
 
 198	2.520	150	59.52	63.4	discard	PERF-690: Bypass timeStep multiplication
+198	2.435	150	61.60	63.6	discard	PERF-714 Promise.withResolvers


### PR DESCRIPTION
Implemented and evaluated PERF-714 which tested replacing the inline promise executor in `CdpTimeDriver.ts` with `Promise.withResolvers()`.

🎯 **Why**: To test if allocating fewer closures by avoiding the inline executor function reduces Node context switching and GC overhead on every frame iteration.
💡 **What**: Replaced inline `new Promise((resolve, reject) => ...)` with `const { promise, resolve, reject } = Promise.withResolvers()`.
📊 **Impact**: The median render time did not improve (~2.435s vs baseline ~2.408s). V8 optimally handles local block-scoped closure allocations for promises, and object destructuring/wrapping from `withResolvers` offset any gains.
🔬 **Verification**: Code built successfully. Ran standard benchmark multiple times. Discarded the modification and documented in `RENDERER-EXPERIMENTS.md` and `.sys/plans/PERF-714-promise-with-resolvers.md`. Appended run results to `perf-results.tsv`.
📎 **Plan**: `/.sys/plans/PERF-714-promise-with-resolvers.md`

---
*PR created automatically by Jules for task [11220279174031114711](https://jules.google.com/task/11220279174031114711) started by @BintzGavin*