### PR TITLE
✨ RENDERER: Native stream buffering in single-worker fast path

### DIFF
--- a/.sys/plans/PERF-689-native-stream-buffering-single-worker.md
+++ b/.sys/plans/PERF-689-native-stream-buffering-single-worker.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-689
 slug: native-stream-buffering-single-worker
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-06
 completed: ""
 result: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,10 @@ Current best: ~2.115s (median of PERF-699, best ~2.00s)
 Last updated by: PERF-699
 
 ## What Works
+- **PERF-689**: Native Stream Buffering in Single Worker Fast Path
+  - **What I tried**: Modified the drain condition in `CaptureLoop.ts` for the single worker path to only block on FFmpeg drain when `stdin.writableLength >= 16777216`.
+  - **Impact**: Improved median render time to ~2.054s (baseline ~2.128s). By allowing Node to buffer multiple frames instead of waiting for a pipe drain on every frame, we achieved pipeline overlap between Chromium rendering and FFmpeg encoding natively.
+  - **Plan ID**: PERF-689
 - **PERF-457**: Skip Media Sync via Closure Assignment
   - **What I tried**: Assigned syncMediaFn to avoid boolean branch in hot loop.
   - **Impact**: 2.31s render time (baseline 2.498s). Status: keep.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -202,3 +202,4 @@ run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 198	2.435	150	61.60	63.6	discard	PERF-714 Promise.withResolvers
 202	2.779	150	53.97	63.5	discard	eliminate-empty-try-catch
 203	3.212	150	46.70	63.6	discard	PERF-716: Omit default CDP evaluate params in syncMedia
+1	2.054	150	73.02	63.5	keep	native stream buffering in CaptureLoop single worker

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -122,7 +122,7 @@ export class CaptureLoop {
                         canWriteMore = stdin.write(buffer);
                     }
 
-                    if (!canWriteMore) {
+                    if (!canWriteMore && stdin.writableLength >= 16777216) {
                         previousWritePromise = new Promise<void>(this.drainPromiseExecutor);
                     }
                 } else {
@@ -306,7 +306,7 @@ export class CaptureLoop {
                     canWriteMore = stdin.write(buffer);
                 }
 
-                if (!canWriteMore) {
+                if (!canWriteMore && stdin.writableLength >= 16777216) {
                     previousWritePromise = new Promise<void>(this.drainPromiseExecutor);
                 }
             } else {


### PR DESCRIPTION
Implemented PERF-689 to optimize stream writing in the single-worker fast path. By using native Node.js stream buffering up to 16MB before waiting for an FFmpeg drain, Chromium rendering and FFmpeg encoding can overlap effectively. This reduced median render time from ~2.128s to ~2.054s. All verification gates and testing steps were completed.

---
*PR created automatically by Jules for task [15238440392363903405](https://jules.google.com/task/15238440392363903405) started by @BintzGavin*