### PR TITLE
✨ RENDERER: Discard PERF-726: Eliminate Optional Branching in processCaptureResult

### DIFF
--- a/.sys/plans/PERF-726-eliminate-process-capture-ternary.md
+++ b/.sys/plans/PERF-726-eliminate-process-capture-ternary.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-726
 slug: eliminate-process-capture-ternary
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2027-02-18
-completed: ""
-result: ""
+completed: "2026-06-10"
+result: "Discarded - The experiment resulted in a regression. The overhead of calling an identity function unconditionally was slightly higher than the V8 property truthiness check."
 ---
 # PERF-726: Eliminate Optional Branching in processCaptureResult
 
@@ -58,3 +58,16 @@ Run `npm run test -w packages/renderer` and ensure tests pass, specifically chec
 ## Prior Art
 - PERF-724 introduced `processCaptureResult` as optional.
 - PERF-618 avoided media sync branching by relying on a monomorphic empty function instead of a boolean check.
+
+
+## Results Summary
+
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.177	150	68.89	63.1	keep	baseline (re-run on new environment)
+2	2.174	150	69.00	63.1	keep	eliminate processCaptureResult ternary
+3	2.205	150	68.02	63.3	keep	eliminate processCaptureResult ternary
+4	2.237	150	67.07	63.0	keep	eliminate processCaptureResult ternary
+5	2.586	150	58.00	63.1	discard	test with identity CanvasStrategy.processCaptureResult (slower)
+6	2.333	150	64.31	63.3	discard	test with identity CanvasStrategy.processCaptureResult (slower)
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -162,6 +162,9 @@ Last updated by: PERF-726
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-726:** Eliminate Optional Branching in processCaptureResult
+  - Tried to make `processCaptureResult` mandatory on `RenderStrategy` and implemented an identity function in `CanvasStrategy`, removing the optional truthiness check in `CaptureLoop.ts`.
+  - **WHY it didn't work:** Moving the identity function onto the `RenderStrategy` interface and invoking it unconditionally per frame introduced slightly more overhead than the native JavaScript truthiness check (`strategy.processCaptureResult ? ...`). V8 is already extremely efficient at checking properties, and invoking a function with object context is marginally slower.
 
 - **PERF-726**: Prebind processCaptureResult in CaptureLoop
   - **What I tried**: Extracted strategy.processCaptureResult branch out of the CaptureLoop hot path.

--- a/packages/renderer/.sys/perf-results-PERF-726.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-726.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.177	150	68.89	63.1	keep	baseline (re-run on new environment)
+2	2.174	150	69.00	63.1	keep	eliminate processCaptureResult ternary
+3	2.205	150	68.02	63.3	keep	eliminate processCaptureResult ternary
+4	2.237	150	67.07	63.0	keep	eliminate processCaptureResult ternary
+5	2.586	150	58.00	63.1	discard	test with identity CanvasStrategy.processCaptureResult (slower)
+6	2.333	150	64.31	63.3	discard	test with identity CanvasStrategy.processCaptureResult (slower)


### PR DESCRIPTION
✨ RENDERER: Discard PERF-726: Eliminate Optional Branching in processCaptureResult

💡 **What**: The experiment attempted to make `processCaptureResult` mandatory on `RenderStrategy` and implemented an identity function in `CanvasStrategy`, removing the optional truthiness check in `CaptureLoop.ts`. The experiment resulted in a regression and was discarded.

🎯 **Why**: To see if removing a tiny optional branching statement would result in better V8 JIT loop execution.

📊 **Impact**: Before: ~2.177s, After: ~2.333s (regression, ~7% slower).

🔬 **Verification**: 4-gate validation test was run and benchmark output observed. Code restored.

📎 **Plan**: `/.sys/plans/PERF-726-eliminate-process-capture-ternary.md`

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.177	150	68.89	63.1	keep	baseline (re-run on new environment)
2	2.174	150	69.00	63.1	keep	eliminate processCaptureResult ternary
3	2.205	150	68.02	63.3	keep	eliminate processCaptureResult ternary
4	2.237	150	67.07	63.0	keep	eliminate processCaptureResult ternary
5	2.586	150	58.00	63.1	discard	test with identity CanvasStrategy.processCaptureResult (slower)
6	2.333	150	64.31	63.3	discard	test with identity CanvasStrategy.processCaptureResult (slower)
```

---
*PR created automatically by Jules for task [843351819242355549](https://jules.google.com/task/843351819242355549) started by @BintzGavin*