### PR TITLE
✨ RENDERER: Preallocate CDP evaluate payloads

### DIFF
--- a/.sys/plans/PERF-727-preallocate-cdp-evaluate-payloads.md
+++ b/.sys/plans/PERF-727-preallocate-cdp-evaluate-payloads.md
@@ -1,10 +1,10 @@
 ---
 id: PERF-727
 slug: preallocate-cdp-evaluate-payloads
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-03-01
-completed: ""
+completed: "2026-06-10"
 result: ""
 ---
 # PERF-727: Preallocate CDP evaluate payloads in CdpTimeDriver Multi-Frame Sync Media
@@ -76,3 +76,9 @@ Instead of checking and creating new objects in `defaultSyncMedia`, we can updat
 
 ## Correctness Check
 Run tests in `packages/renderer` and ensure tests pass, specifically checking that DOM captures still render multi-frame videos properly.
+
+## Results Summary
+- **Best render time**: 2.907s (vs baseline 2.325s)
+- **Improvement**: -25.03%
+- **Kept experiments**: None
+- **Discarded experiments**: Preallocate CDP payloads

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -162,6 +162,11 @@ Last updated by: PERF-726
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-727**: Preallocate CDP evaluate payloads in CdpTimeDriver
+  - **What I tried**: Moved payload allocation to handleExecutionContextCreated to simplify the defaultSyncMedia branch.
+  - **Impact**: Median render time was ~2.907s (baseline 2.325s). It regressed performance, possibly due to memory locality issues or array resizing overhead when pushing incrementally compared to bulk setting.
+  - **Plan ID**: PERF-727
+
 - **PERF-726:** Eliminate Optional Branching in processCaptureResult
   - Tried to make `processCaptureResult` mandatory on `RenderStrategy` and implemented an identity function in `CanvasStrategy`, removing the optional truthiness check in `CaptureLoop.ts`.
   - **WHY it didn't work:** Moving the identity function onto the `RenderStrategy` interface and invoking it unconditionally per frame introduced slightly more overhead than the native JavaScript truthiness check (`strategy.processCaptureResult ? ...`). V8 is already extremely efficient at checking properties, and invoking a function with object context is marginally slower.

--- a/packages/renderer/.sys/perf-results-PERF-727.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-727.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1					discard	preallocate-cdp-evaluate-payloads
+2					discard	preallocate-cdp-evaluate-payloads
+3					discard	preallocate-cdp-evaluate-payloads
+1	3.488	150	43.00	63.7	discard	preallocate-cdp-evaluate-payloads
+2	2.907	150	51.60	63.8	discard	preallocate-cdp-evaluate-payloads
+3	2.692	150	55.73	63.2	discard	preallocate-cdp-evaluate-payloads

--- a/packages/renderer/scripts/benchmark-perf.ts
+++ b/packages/renderer/scripts/benchmark-perf.ts
@@ -1,6 +1,10 @@
-import { Renderer } from '../src/index';
+import { Renderer } from '../src/index.js';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 async function main() {
   const renderer = new Renderer({
@@ -12,10 +16,7 @@ async function main() {
     intermediateImageFormat: 'png'
   });
 
-  const compositionPath = path.resolve(
-    process.cwd(),
-    '../../examples/dom-benchmark/composition.html'
-  );
+  const compositionPath = path.resolve(__dirname, '../../../examples/dom-benchmark/composition.html');
   const compositionUrl = `file://${compositionPath}`;
   const outputPath = path.resolve(process.cwd(), 'output/dom-benchmark.mp4');
   await fs.mkdir(path.dirname(outputPath), { recursive: true });


### PR DESCRIPTION
💡 What: Moved payload allocation to handleExecutionContextCreated to simplify the defaultSyncMedia branch.
🎯 Why: Conditional checks and object allocation overhead during sync media.
📊 Impact: Median render time regressed from ~2.325s to ~2.907s, possibly due to memory locality issues or array resizing overhead when pushing incrementally compared to bulk setting.
🔬 Verification: Ran the test suite (npm test) and evaluated benchmark logic via Node scripts comparing results. Experiment was discarded and code reverted.
📎 Plan: PERF-727

TSV Results:
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	3.488	150	43.00	63.7	discard	preallocate-cdp-evaluate-payloads
2	2.907	150	51.60	63.8	discard	preallocate-cdp-evaluate-payloads
3	2.692	150	55.73	63.2	discard	preallocate-cdp-evaluate-payloads
```

---
*PR created automatically by Jules for task [6682400856166044783](https://jules.google.com/task/6682400856166044783) started by @BintzGavin*