### PR TITLE
✨ RENDERER: discard PERF-728 inline setTime and pre-select sync media

### DIFF
--- a/.sys/plans/PERF-728-inline-set-time-and-pre-select-sync-media.md
+++ b/.sys/plans/PERF-728-inline-set-time-and-pre-select-sync-media.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-728
 slug: inline-set-time-and-pre-select-sync-media
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-05-28
-completed: ""
-result: ""
+completed: "2024-05-28"
+result: "discarded"
 ---
 # PERF-728: Inline setTime and Pre-select Media Sync Strategy
 

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -167,6 +167,7 @@ Last updated by: PERF-725
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- PERF-728: Inlining `runSetTime` into `setTime` and pre-selecting `syncMediaFn` closures. **Why**: The overhead of pre-selecting and calling closures was not significantly better than a single if-check inside a default sync function, and removing the `runSetTime` indirection layer yielded negligible improvements within the noise margin (baseline ~2.878s vs experiment ~2.862s).
 - **PERF-727**: Preallocate CDP evaluate payloads in CdpTimeDriver
   - **What I tried**: Moved payload allocation to handleExecutionContextCreated to simplify the defaultSyncMedia branch.
   - **Impact**: Median render time was ~2.907s (baseline 2.325s). It regressed performance, possibly due to memory locality issues or array resizing overhead when pushing incrementally compared to bulk setting.

--- a/packages/renderer/.sys/perf-results-PERF-728.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-728.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.862	150	52.41	60.0	discard	inline setTime and pre-select sync media closures


### PR DESCRIPTION
💡 **What**: Executed and discarded PERF-728, which attempted to inline `runSetTime` into `setTime` and pre-select the `syncMediaFn` closure in `CdpTimeDriver.ts`.
🎯 **Why**: To test if we could eliminate the overhead of a wrapper function and a static branch inside the `setTime` hot loop.
📊 **Impact**: The results yielded negligible changes within the noise margin (baseline ~2.878s vs experiment ~2.862s).
🔬 **Verification**: Ran `packages/renderer/scripts/benchmark-perf.ts`. Tests confirmed compilation works correctly.
📎 **Plan**: `/.sys/plans/PERF-728-inline-set-time-and-pre-select-sync-media.md`

Results Summary:
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.862	150	52.41	60.0	discard	inline setTime and pre-select sync media closures
```

---
*PR created automatically by Jules for task [12733980465674089663](https://jules.google.com/task/12733980465674089663) started by @BintzGavin*