### PR TITLE
📋 RENDERER: Simplify Sync Media Branching

### DIFF
--- a/.sys/plans/PERF-734-simplify-sync-media-branching.md
+++ b/.sys/plans/PERF-734-simplify-sync-media-branching.md
@@ -1,0 +1,85 @@
+---
+id: PERF-734
+slug: simplify-sync-media-branching
+status: unclaimed
+claimed_by: ""
+created: 2024-06-11
+completed: ""
+result: ""
+---
+
+# PERF-734: Simplify Sync Media Branching in `CdpTimeDriver`
+
+## Focus Area
+`defaultSyncMedia` hot loop in `CdpTimeDriver.ts`. We want to eliminate redundant checks and branches.
+
+## Background Research
+Currently, `defaultSyncMedia` looks like this:
+```typescript
+  private defaultSyncMedia() {
+    const frames = this.cachedFrames;
+    if (frames.length === 1) {
+      this.client!.send('Runtime.evaluate', this.singleFrameSyncMediaParams);
+    } else {
+        if (this.executionContextIds.length > 0) {
+          for (let i = 0; i < this.executionContextIds.length; i++) {
+            this.client!.send('Runtime.evaluate', this.multiFrameSyncMediaParams[i]);
+          }
+        } else {
+          this.client!.send('Runtime.evaluate', this.singleFrameSyncMediaParams);
+        }
+    }
+  }
+```
+If we look closely, `singleFrameSyncMediaParams` is used when `frames.length === 1` OR `executionContextIds.length === 0`.
+We can simplify this to:
+```typescript
+  private defaultSyncMedia() {
+    if (this.executionContextIds.length > 0) {
+      for (let i = 0; i < this.executionContextIds.length; i++) {
+        this.client!.send('Runtime.evaluate', this.multiFrameSyncMediaParams[i]);
+      }
+    } else {
+      this.client!.send('Runtime.evaluate', this.singleFrameSyncMediaParams);
+    }
+  }
+```
+If `frames.length > 1` but `executionContextIds` hasn't been populated yet, it will fall back to `singleFrameSyncMediaParams`. This behaves functionally identical but removes the `this.cachedFrames` array lookup and the outer `if (frames.length === 1)` branch completely. We can also remove `this.cachedFrames` entirely as it's no longer used.
+
+## Benchmark Configuration
+- **Composition URL**: Any standard DOM benchmark composition
+- **Render Settings**: Same as baseline
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~2.32s
+- **Bottleneck analysis**: Micro-optimizing branching in the hot loop.
+
+## Implementation Spec
+
+### Step 1: Simplify `defaultSyncMedia` and remove `cachedFrames`
+**File**: `packages/renderer/src/drivers/CdpTimeDriver.ts`
+**What to change**:
+1. Remove `private cachedFrames` property from the class.
+2. In `prepare()`, remove `this.cachedFrames = page.frames();`.
+3. Simplify `defaultSyncMedia` to:
+```typescript
+  private defaultSyncMedia() {
+    if (this.executionContextIds.length > 0) {
+      for (let i = 0; i < this.executionContextIds.length; i++) {
+        this.client!.send('Runtime.evaluate', this.multiFrameSyncMediaParams[i]);
+      }
+    } else {
+      this.client!.send('Runtime.evaluate', this.singleFrameSyncMediaParams);
+    }
+  }
+```
+
+**Why**: Eliminating the `cachedFrames` property lookup and the outer branching reduces V8 runtime checks and byte code size in the hot path.
+
+**Risk**: Very low, logic is equivalent.
+
+## Correctness Check
+Run `npm run test -w packages/renderer` to ensure media sync logic still functions correctly.

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -9,7 +9,6 @@ export class CdpTimeDriver implements TimeDriver {
   private client: CDPSession | null = null;
   private currentTime: number = 0;
   private timeout: number;
-  private cachedFrames: import('playwright').Frame[] = [];
   private setVirtualTimePolicyParams: any = { policy: 'advance', budget: 0 };
   private executionContextIds: number[] = [];
   private cachedPromises: Promise<any>[] = [];
@@ -21,17 +20,12 @@ export class CdpTimeDriver implements TimeDriver {
   private syncMediaFn: () => void = () => {};
 
   private defaultSyncMedia() {
-    const frames = this.cachedFrames;
-    if (frames.length === 1) {
-      this.client!.send('Runtime.evaluate', this.singleFrameSyncMediaParams);
+    if (this.executionContextIds.length > 0) {
+      for (let i = 0; i < this.executionContextIds.length; i++) {
+        this.client!.send('Runtime.evaluate', this.multiFrameSyncMediaParams[i]);
+      }
     } else {
-        if (this.executionContextIds.length > 0) {
-          for (let i = 0; i < this.executionContextIds.length; i++) {
-            this.client!.send('Runtime.evaluate', this.multiFrameSyncMediaParams[i]);
-          }
-        } else {
-          this.client!.send('Runtime.evaluate', this.singleFrameSyncMediaParams);
-        }
+      this.client!.send('Runtime.evaluate', this.singleFrameSyncMediaParams);
     }
   }
 
@@ -143,8 +137,6 @@ export class CdpTimeDriver implements TimeDriver {
       }
       await Promise.all(initPromises);
     }
-
-    this.cachedFrames = page.frames();
 
     const noopCatch = () => {};
 


### PR DESCRIPTION
📋 RENDERER: Simplify Sync Media Branching

💡 What: Removed `cachedFrames` and simplified `defaultSyncMedia` branching in `CdpTimeDriver.ts`.
🎯 Why: To eliminate redundant array length checks and branch condition evaluations inside the hot frame capture loop, reducing V8 execution overhead per frame.
🔬 Approach: Removed `cachedFrames` entirely since its only purpose was a length check inside the hot loop that can be equivalently satisfied by checking if any `executionContextIds` are registered.
📎 Plan: `.sys/plans/PERF-734-simplify-sync-media-branching.md`

---
*PR created automatically by Jules for task [1799685799220872486](https://jules.google.com/task/1799685799220872486) started by @BintzGavin*