### PR TITLE
✨ RENDERER: Eliminate processCaptureResult bind in CaptureLoop

### DIFF
--- a/.sys/plans/2026-06-10-RENDERER-eliminate-process-capture-bind.md
+++ b/.sys/plans/2026-06-10-RENDERER-eliminate-process-capture-bind.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-736
 slug: eliminate-process-capture-bind
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-06-10
-completed: ""
-result: ""
+completed: "2026-06-10"
+result: "discard"
 ---
 
 # PERF-736: Eliminate native .bind() for processCaptureResult in CaptureLoop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -172,6 +172,11 @@ Last updated by: PERF-725
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-736**: Eliminate native .bind() for processCaptureResult in CaptureLoop
+  - **What I tried**: Replaced native `.bind()` with a standard closure `(res) => strategy.processCaptureResult!(res)` during the hot loop setup phase.
+  - **WHY it didn't work**: Yielded a performance regression (median ~2.759s vs baseline ~2.317s). This indicates that the V8 JIT handles the native bound function object better than the allocation or execution overhead of a standard wrapper closure on every iteration in this specific context.
+  - **Plan ID**: PERF-736
+
 - PERF-728: Inlining `runSetTime` into `setTime` and pre-selecting `syncMediaFn` closures. **Why**: The overhead of pre-selecting and calling closures was not significantly better than a single if-check inside a default sync function, and removing the `runSetTime` indirection layer yielded negligible improvements within the noise margin (baseline ~2.878s vs experiment ~2.862s).
 - **PERF-727**: Preallocate CDP evaluate payloads in CdpTimeDriver
   - **What I tried**: Moved payload allocation to handleExecutionContextCreated to simplify the defaultSyncMedia branch.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -216,3 +216,5 @@ run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 727	24.674	600	24.44	61.8	keep	baseline (PERF-725)
 728	23.422	600	26.04	61.9	keep	modified (PERF-725)
 729	2.155	150	69.61	62.8	keep	inline setTime
+
+1	2.759	150	54.36	62.9	discard	Eliminate native .bind() for processCaptureResult in CaptureLoop


### PR DESCRIPTION
💡 What: Replaced native .bind() with a standard closure.
🎯 Why: To reduce allocation overhead in hot loop.
📊 Impact: Degraded from ~2.317s to ~2.759s. Discarded.
🔬 Verification: 4-gate verification via benchmark scripts.
📎 Plan: PERF-736

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.759	150	54.36	62.9	discard	Eliminate native .bind() for processCaptureResult in CaptureLoop
```

---
*PR created automatically by Jules for task [1216675105261841516](https://jules.google.com/task/1216675105261841516) started by @BintzGavin*