### PR TITLE
📋 RENDERER: PERF-735: Omit reject parameter in CdpTimeDriver.setTime promise

### DIFF
--- a/.sys/plans/PERF-735-omit-reject-cdp-promise.md
+++ b/.sys/plans/PERF-735-omit-reject-cdp-promise.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-735
 slug: omit-reject-cdp-promise
-status: unclaimed
+status: complete
+completed: 2024-06-12
+result: discarded
 claimed_by: ""
 created: 2024-06-12
-completed: ""
-result: ""
 ---
 
 # PERF-735: Omit reject parameter in CdpTimeDriver.setTime promise
@@ -58,3 +58,9 @@ Run the `dom` benchmark (`cd packages/renderer && npx tsx scripts/benchmark-perf
 ## Prior Art
 - PERF-711 tried removing `cdpReject` tracking entirely, which caused a regression. We are not removing the tracking or the property itself, we are specifically omitting the `reject` parameter from the inline promise executor to optimize V8's closure handling, based on micro-benchmark results.
 - PERF-725 and PERF-729 focused on removing promise chaining and function wrappers in the hot loop.
+
+## Results Summary
+- **Best render time**: 2.660s (vs baseline 2.321s)
+- **Improvement**: -14% (Regression)
+- **Kept experiments**: None
+- **Discarded experiments**: Omit reject parameter in CdpTimeDriver.setTime promise

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: ~2.48s (median of PERF-737)
 Last updated by: PERF-725
 
 ## What Works
+
 - **PERF-737**: Replace Promise.all with sequential awaits in SeekTimeDriver
   - **What I did**: Removed Promise.all and tracking array for multi-frame evaluation in SeekTimeDriver.
   - **Impact**: Improved median render time to ~2.48s.
@@ -176,6 +177,11 @@ Last updated by: PERF-725
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- **PERF-735**: Omit reject parameter in CdpTimeDriver.setTime promise
+  - **What I tried**: Omitted the reject parameter from the inline promise executor in the CdpTimeDriver.setTime hot loop to reduce V8 closure allocation overhead.
+  - **WHY it didn't work**: The median render time regressed to ~2.66s compared to the baseline of ~2.321s (or the current best of ~2.48s). V8 is already highly optimized for handling standard two-argument promise executors.
+  - **Plan ID**: PERF-735
+
 - **PERF-736**: Eliminate native .bind() for processCaptureResult in CaptureLoop
   - **What I tried**: Replaced native `.bind()` with a standard closure `(res) => strategy.processCaptureResult!(res)` during the hot loop setup phase.
   - **WHY it didn't work**: Yielded a performance regression (median ~2.759s vs baseline ~2.317s). This indicates that the V8 JIT handles the native bound function object better than the allocation or execution overhead of a standard wrapper closure on every iteration in this specific context.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -219,3 +219,4 @@ run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 
 1	2.759	150	54.36	62.9	discard	Eliminate native .bind() for processCaptureResult in CaptureLoop
 1	2.48	150	60.48	0	keep	Replace Promise.all with sequential awaits in SeekTimeDriver.setTime
+2	2.660	150	56.54	62.8	discard	PERF-735 omit reject parameter


### PR DESCRIPTION
💡 **What**: Evaluated omitting the `reject` parameter in the inline promise executor inside `CdpTimeDriver.setTime` to reduce V8 closure allocation overhead. The outcome was a regression, so the change was discarded.
🎯 **Why**: The `setTime` method allocates an inline promise executor on every single frame, causing V8 closure overhead. The idea was to drop from ~160ms to ~143ms per 1M iterations in synthetic tests by optimizing single-argument promise executors.
📊 **Impact**: The baseline rendering time was `2.321s`. The median benchmark run for the change took `2.66s`, which corresponds to a regression.
🔬 **Verification**: The `packages/renderer` package was successfully built. Benchmarks were run using `npx tsx scripts/benchmark-perf.ts` capturing 150 frames. Due to the regression, the code change was reverted via `git restore`. Results were logged into `.sys/perf-results.tsv`.
📎 **Plan**: `/.sys/plans/PERF-735-omit-reject-cdp-promise.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 2 | 2.660 | 150 | 56.54 | 62.8 | discard | PERF-735 omit reject parameter |

---
*PR created automatically by Jules for task [9952427386214380635](https://jules.google.com/task/9952427386214380635) started by @BintzGavin*