### PR TITLE
✨ RENDERER: Discard PERF-738 callFunctionOn optimization

### DIFF
--- a/.sys/plans/PERF-738-preallocate-call-function-on.md
+++ b/.sys/plans/PERF-738-preallocate-call-function-on.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-738
 slug: preallocate-call-function-on
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2024-06-12
-completed: ""
-result: ""
+completed: "2024-06-12"
+result: "discard"
 ---
 
 # PERF-738: Use `Runtime.callFunctionOn` Instead of `Runtime.evaluate` in `SeekTimeDriver`
@@ -44,3 +44,10 @@ However, CDP `Runtime.callFunctionOn` accepts `executionContextId` instead of `o
 
 ## Correctness Check
 Run the `dom` benchmark and verify output video generation completes successfully.
+
+
+## Results Summary
+- **Best render time**: 3.928s (vs baseline 3.789s)
+- **Improvement**: Regression
+- **Kept experiments**: None
+- **Discarded experiments**: Preallocate `Runtime.callFunctionOn` payloads in `SeekTimeDriver.ts` to eliminate per-frame string concatenation

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -177,6 +177,7 @@ Last updated by: PERF-725
   - **Outcome**: discard
 
 ## What Doesn't Work (and Why)
+- Tried PERF-738: using Runtime.callFunctionOn with preallocated payloads instead of Runtime.evaluate in SeekTimeDriver.ts to avoid string allocations. Why it didn't work: Resulted in a slight performance regression (median ~3.928s vs baseline ~3.789s). It seems executionContextId lookups and calling functions might be slower than Chromium's fast-path parsing of simple cached evaluation strings, or the object/array modification overhead in JS for arguments offsets the gains.
 - **PERF-735**: Omit reject parameter in CdpTimeDriver.setTime promise
   - **What I tried**: Omitted the reject parameter from the inline promise executor in the CdpTimeDriver.setTime hot loop to reduce V8 closure allocation overhead.
   - **WHY it didn't work**: The median render time regressed to ~2.66s compared to the baseline of ~2.321s (or the current best of ~2.48s). V8 is already highly optimized for handling standard two-argument promise executors.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -220,3 +220,4 @@ run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 1	2.759	150	54.36	62.9	discard	Eliminate native .bind() for processCaptureResult in CaptureLoop
 1	2.48	150	60.48	0	keep	Replace Promise.all with sequential awaits in SeekTimeDriver.setTime
 2	2.660	150	56.54	62.8	discard	PERF-735 omit reject parameter
+1	3.928	150	38.19	4.4	discard	PERF-738-preallocate-call-function-on

--- a/packages/renderer/scripts/render-dom.ts
+++ b/packages/renderer/scripts/render-dom.ts
@@ -16,7 +16,7 @@ async function main() {
   // Target the built artifact
   const compositionPath = path.resolve(
     process.cwd(),
-    '../../output/example-build/examples/dom-benchmark/composition.html'
+    './output/example-build/examples/dom-benchmark/composition.html'
   );
   const compositionUrl = `file://${compositionPath}`;
 


### PR DESCRIPTION
💡 **What**: Executed PERF-738 to test replacing `Runtime.evaluate` with `Runtime.callFunctionOn` (and preallocating payloads) in `SeekTimeDriver.ts`.
🎯 **Why**: The goal was to eliminate per-frame string concatenations and browser-side JS parsing overhead.
📊 **Impact**: The experiment resulted in a performance regression. The median render time increased to ~3.928s from the ~3.789s baseline (using DOM mode). The object reference lookups and tracking seemingly offset the fast-path gains.
🔬 **Verification**: Benchmarks executed iteratively against DOM mode using `render-dom.ts` test script (which was also fixed due to an incorrect build artifact path). Confirmed regression and appropriately restored `SeekTimeDriver.ts`.
📎 **Plan**: Reference `.sys/plans/PERF-738-preallocate-call-function-on.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 3.928 | 150 | 38.19 | 4.4 | discard | PERF-738-preallocate-call-function-on |

---
*PR created automatically by Jules for task [6061565637835385233](https://jules.google.com/task/6061565637835385233) started by @BintzGavin*