### PR TITLE
✨ RENDERER: [PERF-742] Eliminate Promise Allocation in CdpTimeDriver setTime

### DIFF
--- a/.sys/plans/PERF-742-eliminate-promise-allocation-in-cdp-time-driver.md
+++ b/.sys/plans/PERF-742-eliminate-promise-allocation-in-cdp-time-driver.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-742
 slug: eliminate-promise-allocation-in-cdp-time-driver
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-06-11
-completed: ""
-result: ""
+completed: "2026-06-11"
+result: "improved"
 ---
 # PERF-742: Reusable Thenable for CDP Virtual Time in CdpTimeDriver
 
@@ -84,3 +84,10 @@ None.
 
 ## Correctness Check
 Ensure the DOM frames still render sequentially and correctly without hanging.
+
+
+## Results Summary
+- **Best render time**: 28.717s (vs baseline 30.719s)
+- **Improvement**: ~6.5%
+- **Kept experiments**: [PERF-742-eliminate-promise-allocation-in-cdp-time-driver]
+- **Discarded experiments**: []

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1109,3 +1109,7 @@ Last updated by: PERF-698
   - **What I did**: Replaced dynamic string concatenation and `Runtime.evaluate` with preallocated payloads and `Runtime.callFunctionOn` using `executionContextId`.
   - **Impact**: Kept code logic simpler and reduced string GC pressure. Performance check skipped due to environment limits, functionally verified.
   - **Plan ID**: PERF-738
+- **PERF-742**: Eliminate Promise Allocation in CdpTimeDriver setTime
+  - **What I did**: Replaced the per-frame \`new Promise\` and executor closure allocation with a single instance of a \`ReusableThenable\` class that duck-types as a Promise, allowing `await` to still work properly.
+  - **Impact**: Improved median render time to ~28.717s (from baseline ~30.719s in the isolated environment), avoiding closure allocation and tracking overhead per frame in the core headless rendering loop.
+  - **Plan ID**: PERF-742

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -222,3 +222,5 @@ run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 2	2.660	150	56.54	62.8	discard	PERF-735 omit reject parameter
 3	1.815	150	82.64	37.0	keep	Inline media promise creation in SeekTimeDriver
 223	25.139	600	23.87	60.8	discard	replace evaluate with callFunctionOn in syncMedia
+742	30.719	600	19.53	60.0	keep	baseline (PERF-742)
+742	28.717	600	20.89	60.0	keep	eliminate promise allocation in setTime

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -5,15 +5,43 @@ import { FIND_ALL_MEDIA_FUNCTION, SYNC_MEDIA_FUNCTION, PARSE_MEDIA_ATTRIBUTES_FU
 
 const RESOLVED_PROMISE = Promise.resolve();
 
+class ReusableThenable {
+  public resolveCb: (() => void) | null = null;
+  public rejectCb: ((err: Error) => void) | null = null;
+
+  then(resolve: () => void, reject: (err: Error) => void) {
+    this.resolveCb = resolve;
+    this.rejectCb = reject;
+  }
+
+  resolve() {
+    if (this.resolveCb) {
+      const cb = this.resolveCb;
+      this.resolveCb = null;
+      this.rejectCb = null;
+      cb();
+    }
+  }
+
+  reject(err: Error) {
+    if (this.rejectCb) {
+      const cb = this.rejectCb;
+      this.resolveCb = null;
+      this.rejectCb = null;
+      cb(err);
+    }
+  }
+}
+
 export class CdpTimeDriver implements TimeDriver {
+  private timePromise = new ReusableThenable();
   private client: CDPSession | null = null;
   private currentTime: number = 0;
   private timeout: number;
   private setVirtualTimePolicyParams: any = { policy: 'advance', budget: 0 };
   private executionContextIds: number[] = [];
   private cachedPromises: Promise<any>[] = [];
-  private cdpResolve: (() => void) | null = null;
-  private cdpReject: ((err: Error) => void) | null = null;
+
   private singleFrameSyncMediaParams: any = { expression: "window.__helios_sync_media();", awaitPromise: false, returnByValue: false };
   private multiFrameSyncMediaParams: any[] = [];
   private hasMedia: boolean = true;
@@ -34,11 +62,7 @@ export class CdpTimeDriver implements TimeDriver {
   };
 
   private handleVirtualTimeBudgetExpired = () => {
-    if (this.cdpResolve) {
-      this.cdpResolve();
-      this.cdpResolve = null;
-      this.cdpReject = null;
-    }
+    this.timePromise.resolve();
   };
 
 
@@ -193,11 +217,7 @@ export class CdpTimeDriver implements TimeDriver {
     // This triggers the browser event loop and requestAnimationFrame
     this.setVirtualTimePolicyParams.budget = delta * 1000;
     this.currentTime = timeInSeconds;
-    const promise = new Promise<void>((resolve, reject) => {
-      this.cdpResolve = resolve;
-      this.cdpReject = reject;
-    });
     this.client!.send('Emulation.setVirtualTimePolicy', this.setVirtualTimePolicyParams);
-    return promise;
+    return this.timePromise as any as Promise<void>;
   }
 }


### PR DESCRIPTION
✨ RENDERER: [PERF-742] Eliminate Promise Allocation in CdpTimeDriver setTime

💡 What: Replaced the per-frame `new Promise` and executor closure allocation with a single instance of a `ReusableThenable` class that duck-types as a Promise, allowing `await` to still work properly.
🎯 Why: To avoid closure allocation and garbage collection tracking overhead per frame in the core headless rendering loop.
📊 Impact: Improved median render time to ~28.717s (from baseline ~30.719s in the isolated environment), yielding a ~6.5% improvement.
🔬 Verification: Ran the benchmark via `npm run build` and `npx tsx packages/renderer/tests/fixtures/benchmark.ts dom`. Tested successfully against the Canvas smoke test.
📎 Plan: `/.sys/plans/PERF-742-eliminate-promise-allocation-in-cdp-time-driver.md`

| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 742 | 30.719 | 600 | 19.53 | 60.0 | keep | baseline (PERF-742) |
| 742 | 28.717 | 600 | 20.89 | 60.0 | keep | eliminate promise allocation in setTime |

---
*PR created automatically by Jules for task [1417630504374886453](https://jules.google.com/task/1417630504374886453) started by @BintzGavin*