### PR TITLE
✨ RENDERER: Evaluate Eager CDP Session Initialization (PERF-739)

### DIFF
--- a/.sys/plans/PERF-739-eager-cdp-session-in-dom-strategy.md
+++ b/.sys/plans/PERF-739-eager-cdp-session-in-dom-strategy.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-739
 slug: eager-cdp-session-in-dom-strategy
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-12
-completed: ""
-result: ""
+completed: "2024-06-12"
+result: "discarded"
 ---
 
 # PERF-739: Eager CDP Session Initialization in DomStrategy
@@ -49,3 +49,9 @@ We can eagerly initialize `this.cdpSession` at the very beginning of `prepare()`
 
 ## Correctness Check
 Run the canvas and dom smoke tests to ensure startup still works correctly.
+
+## Results Summary
+- **Best render time**: 28.646s (vs baseline 27.410s)
+- **Improvement**: Regressed
+- **Kept experiments**: None
+- **Discarded experiments**: [PERF-739]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -182,6 +182,11 @@ Last updated by: PERF-740
   - **Plan ID**: PERF-740
 
 ## What Doesn't Work (and Why)
+- **PERF-739**: Eager CDP Session Initialization in DomStrategy
+  - **What I tried**: Moved CDP session setup and HeadlessExperimental.enable to the top of DomStrategy.prepare()
+  - **WHY it didn't work**: The median render time regressed to ~28.646s (from the baseline of ~27.41s). Eagerly enabling CDP might have caused Playwright's page evaluation for preload scripts to compete with early internal CDP processing overhead, delaying startup.
+  - **Plan ID**: PERF-739
+
 - Replace Runtime.evaluate with Runtime.callFunctionOn in CdpTimeDriver syncMedia (PERF-741)
   - WHY: V8 optimization for evaluation vs callFunctionOn was negligible or slower than the baseline in the hot loop. The median time skyrocketed to ~25.1s, indicating a severe regression, likely due to execution context ID handling issues or closure capture problems.
 - **PERF-735**: Omit reject parameter in CdpTimeDriver.setTime promise

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -224,3 +224,4 @@ run	2.662	150	56.35	63.8	discard	PERF-678 Eliminate Array.map in workerPromises
 223	25.139	600	23.87	60.8	discard	replace evaluate with callFunctionOn in syncMedia
 742	30.719	600	19.53	60.0	keep	baseline (PERF-742)
 742	28.717	600	20.89	60.0	keep	eliminate promise allocation in setTime
+run	28.646	600	20.95	60.0	discard	PERF-739 Eager CDP Session Initialization in DomStrategy


### PR DESCRIPTION
📋 RENDERER: Evaluate Eager CDP Session Initialization (PERF-739)

💡 What: Evaluated moving the CDP session initialization and HeadlessExperimental.enable to the very beginning of the DomStrategy.prepare() method to see if it speeds up early phase DOM rendering startup overhead.
🎯 Why: In DomStrategy.prepare(), this.cdpSession is set up after several asynchronous evaluations (like preloading scripts and scanning for tracks). Eagerly initializing might reduce mid-setup context switching and late-stage CDP binding overhead.
📊 Impact: The median render time regressed to ~28.646s (compared to baseline ~27.410s). Playwright's page evaluation for preload scripts might compete with early internal CDP processing overhead, delaying startup. Experiment discarded and code restored.
🔬 Verification: Built with tsc and benchmarked in the isolated runtime. Code changes explicitly reverted. Tracking files updated.
📎 Plan: .sys/plans/PERF-739-eager-cdp-session-in-dom-strategy.md

Results Summary
```
run	28.646	600	20.95	60.0	discard	PERF-739 Eager CDP Session Initialization in DomStrategy
```

---
*PR created automatically by Jules for task [11818720402054148841](https://jules.google.com/task/11818720402054148841) started by @BintzGavin*