### PR TITLE
📋 RENDERER: PERF-745 Eliminate processCaptureResult Branching and Inline Closure

### DIFF
--- a/.sys/plans/PERF-745-eliminate-processfn-closure.md
+++ b/.sys/plans/PERF-745-eliminate-processfn-closure.md
@@ -1,0 +1,47 @@
+---
+id: PERF-745
+slug: eliminate-processfn-closure
+status: unclaimed
+claimed_by: ""
+created: 2024-06-12
+completed: ""
+result: ""
+---
+
+# PERF-745: Eliminate processCaptureResult Branching and Inline Closure
+
+## Focus Area
+`CaptureLoop.ts` fast path and `RenderStrategy` interface.
+
+## Background Research
+Currently, `CaptureLoop` executes this line before entering the hot loop to accommodate optional synchronous post-processing of the capture frame:
+```typescript
+const processFn = strategy.processCaptureResult ? strategy.processCaptureResult.bind(strategy) : (res: any) => res;
+```
+This is because `processCaptureResult` is optional on `RenderStrategy`. In PERF-726, an experiment was tried to make it mandatory by defining a no-op identity function `(res: any) => res` in `CanvasStrategy`. However, it was found that the overhead of calling an object method unconditionally (`strategy.processCaptureResult(res)`) per frame was higher than truthiness check `if (strategy.processCaptureResult)`.
+But currently, the code is using `.bind(strategy)` to create an external bound closure `processFn` and invoking it per frame. As discovered in PERF-736, native `.bind()` closures are generally slower than simple inline function calls or method invocation.
+
+We can completely eliminate the closure allocation `processFn` from `CaptureLoop` by instead checking `strategy.processCaptureResult` directly inside the loop but caching the boolean condition BEFORE the loop. A boolean evaluation in V8 is far faster than invoking an intermediate closure.
+
+## Benchmark Configuration
+- **Composition URL**: `http://localhost:3000/tests/benchmarks/dom-benchmark`
+- **Render Settings**: 1920x1080, 60fps, 10 seconds, `libx264` codec
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Bottleneck analysis**: Evaluating an intermediate bound closure or anonymous closure for frame processing on every iteration adds overhead.
+
+## Implementation Spec
+
+### Step 1: Replace `processFn` with cached boolean
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+1. Remove `const processFn = strategy.processCaptureResult ? strategy.processCaptureResult.bind(strategy) : (res: any) => res;` in both single-worker and multi-worker loops.
+2. Add a boolean flag before the loop:
+`const hasProcessFn = !!strategy.processCaptureResult;`
+3. Inside the loop, change `const buffer = processFn(rawResult);` to:
+`const buffer = hasProcessFn ? strategy.processCaptureResult!(rawResult) : rawResult;`
+
+**Why**: Replaces an intermediate closure invocation with a fast boolean branch and direct object method invocation, saving closure allocation and indirection overhead.


### PR DESCRIPTION
I have drafted a detailed execution plan for PERF-745 to optimize `CaptureLoop.ts` by removing the closure allocation for `processFn` and instead using a cached boolean to execute `strategy.processCaptureResult(rawResult)` directly. The markdown plan has been verified and committed, making it ready for an executor session to claim.

---
*PR created automatically by Jules for task [1309003223160790419](https://jules.google.com/task/1309003223160790419) started by @BintzGavin*