### PR TITLE
✨ PLAYER: Implement Missing Media Properties

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -19,6 +19,8 @@ Custom extensions:
 - `audiometering` events report stereo RMS and Peak audio levels.
 
 ## Section C: Attributes
+- `disableremoteplayback`: Reflected boolean attribute.
+- `mediagroup`: Reflected string attribute.
 Observed attributes:
 - `src`: The URL of the content to load into the iframe.
 - `interactive`: Enable direct interaction with the composition.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,5 @@
 [v0.77.53] ✅ Completed: Identified missing HTMLMediaElement events (`abort`, `emptied`, `progress`) in `<helios-player>`. Created plan `.sys/plans/2027-02-15-PLAYER-Add-Missing-Events.md` to implement them.
-**Version**: 0.77.53
+**Version**: 0.77.54
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
 [v0.77.52] ✅ Completed: Fix API Parity Events - Implemented synthetic dispatches for missing media events (suspend, stalled, waiting) to improve HTMLMediaElement API parity.
 [0.77.49] ✅ Completed: Document Missing Event Handlers - Documented onplaying, onwaiting, onsuspend, and onstalled properties and events.
@@ -256,3 +256,4 @@
 [v0.77.51] ✅ Completed: Discovered that 2027-02-17-PLAYER-Document-Missing-Media-Properties.md is an IMPOSSIBLE: DUPLICATION plan. The missing properties are already fully documented in the README. Documented as impossible and discarded.
 
 [v0.77.52] ✅ Completed: Document Event Handlers - Implemented missing media event handlers (onabort, onemptied, onprogress) to improve API parity with HTMLMediaElement and updated documentation.
+[v0.77.54] ✅ Completed: Implement Missing Media Properties - Added `disableRemotePlayback`, `mediaGroup`, `sinkId`, and `setSinkId` to `HeliosPlayer` to complete API parity.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -136,6 +136,8 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 
 ### Methods
 
+- `setSinkId(sinkId: string): Promise<void>` - Sets the audio sink id.
+
 - `play(): Promise<void>` - Starts playback.
 - `getSchema(): Promise<HeliosSchema | undefined>` - Retrieves the input properties schema from the composition.
 - `pause(): void` - Pauses playback.
@@ -151,6 +153,9 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `stopAudioMetering(): void` - Stops audio metering calculation.
 
 ### Properties
+- `disableRemotePlayback` (boolean): Reflected disableremoteplayback attribute.
+- `mediaGroup` (string): Reflected mediagroup attribute.
+- `sinkId` (string, read-only): Returns the current audio sink id.
 
 - `src` (string): URL of the composition page to load in the iframe.
 - `autoplay` (boolean): Reflected autoplay attribute.

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -47,6 +47,38 @@ describe('HeliosPlayer API Parity', () => {
     expect(player.hasAttribute('autoplay')).toBe(false);
   });
 
+    it('should reflect disableremoteplayback attribute as boolean property', () => {
+    expect(player.disableRemotePlayback).toBe(false);
+
+    player.setAttribute('disableremoteplayback', '');
+    expect(player.disableRemotePlayback).toBe(true);
+
+    player.removeAttribute('disableremoteplayback');
+    expect(player.disableRemotePlayback).toBe(false);
+
+    player.disableRemotePlayback = true;
+    expect(player.hasAttribute('disableremoteplayback')).toBe(true);
+
+    player.disableRemotePlayback = false;
+    expect(player.hasAttribute('disableremoteplayback')).toBe(false);
+  });
+
+  it('should reflect mediagroup attribute as string property', () => {
+    expect(player.mediaGroup).toBe('');
+
+    player.setAttribute('mediagroup', 'test-group');
+    expect(player.mediaGroup).toBe('test-group');
+
+    player.mediaGroup = 'other-group';
+    expect(player.getAttribute('mediagroup')).toBe('other-group');
+  });
+
+  it('should support sinkId and setSinkId', async () => {
+    expect(player.sinkId).toBe('');
+    await player.setSinkId('test-sink');
+    expect(player.sinkId).toBe('test-sink');
+  });
+
   it('should reflect loop attribute as boolean property', () => {
     expect(player.loop).toBe(false);
 

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1272,6 +1272,30 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     }
   }
 
+  public get disableRemotePlayback(): boolean {
+    return this.hasAttribute("disableremoteplayback");
+  }
+  public set disableRemotePlayback(val: boolean) {
+    if (val) this.setAttribute("disableremoteplayback", "");
+    else this.removeAttribute("disableremoteplayback");
+  }
+
+  public get mediaGroup(): string {
+    return this.getAttribute("mediagroup") || "";
+  }
+  public set mediaGroup(val: string) {
+    this.setAttribute("mediagroup", val);
+  }
+
+  private _sinkId: string = "";
+  public get sinkId(): string {
+    return this._sinkId;
+  }
+  public async setSinkId(sinkId: string): Promise<void> {
+    this._sinkId = sinkId;
+    return Promise.resolve();
+  }
+
   public get seeking(): boolean {
     // Return internal scrubbing state as seeking
     return this.isScrubbing || this._isSeeking;


### PR DESCRIPTION
Added `disableRemotePlayback`, `mediaGroup`, `sinkId` properties and `setSinkId` method to `HeliosPlayer` to improve compatibility and API parity with standard HTMLMediaElements.

---
*PR created automatically by Jules for task [6526795519511861474](https://jules.google.com/task/6526795519511861474) started by @BintzGavin*