### PR TITLE
✨ RENDERER: Discard PERF-754 Page.startScreencast push model

### DIFF
--- a/.sys/plans/PERF-754-cdp-screencast-push-model.md
+++ b/.sys/plans/PERF-754-cdp-screencast-push-model.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-754
 slug: cdp-screencast-push-model
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-13
-completed: ""
-result: ""
+completed: 2024-06-13
+result: failed
 ---
 
 # PERF-754: Test `Page.startScreencast` Push-Based Capture
@@ -50,3 +50,9 @@ Run the DOM render benchmark `cd packages/renderer && npx tsx scripts/benchmark-
 
 ## Prior Art
 - PERF-381 previously attempted this but was discarded. The current setup might allow it to work or at least give us new insight.
+
+## Results Summary
+- **Best render time**: 0.000s (Crash) (vs baseline 11.684s)
+- **Improvement**: N/A
+- **Kept experiments**: []
+- **Discarded experiments**: [Push-based model using Page.startScreencast]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1156,3 +1156,8 @@ Last updated by: PERF-698
   - **What I tried**: Hoist Runtime.enable out of CdpTimeDriver and into DomStrategy to avoid competition with frame evaluation.
   - **WHY it didn't work**: The median render time regressed slightly to ~28.229s vs baseline ~27.882s. Enabling the Runtime earlier in DomStrategy after initial script evaluation does not speed up the process. Likely, moving it earlier clusters too many CDP commands early on, or Playwright internals compete with the event processing, reducing performance compared to conditional lazy enabling.
   - **Plan ID**: PERF-751
+
+## What Doesn't Work (and Why)
+- **`Page.startScreencast` push-based capture (PERF-754)**
+  - Tried switching from `HeadlessExperimental.beginFrame` to `Page.startScreencast`.
+  - **WHY it didn't work**: `Page.startScreencast` ONLY emits `screencastFrame` events when the page has visual damage (changes). In a deterministic frame-by-frame renderer where we advance virtual time, if a frame has no visual changes or if the engine drops frames because it's too fast, we get no frame emitted, causing a deadlock when awaiting frames for the encoding pipeline.

--- a/packages/renderer/.sys/perf-results-PERF-754.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-754.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	11.684	150	12.84	62.5	keep	baseline
+2	0.000	0	0.00	0.0	crash	Push-based model using Page.startScreencast deadlocks because it only emits frames on visual changes, violating the frame-by-frame deterministic time advance


### PR DESCRIPTION
✨ RENDERER: Discard PERF-754 Page.startScreencast push model

- 💡 What: Attempted to use Page.startScreencast as a push model to capture frames instead of pulling with HeadlessExperimental.beginFrame.
- 🎯 Why: To test if push-based capture pipelines better with encoding and reduces render time.
- 📊 Impact: N/A (Crash/Deadlock). Median render time 0.000s vs 11.684s baseline.
- 🔬 Verification: Code crashed in verification and deadlocked because screencast only emits frames on visual changes, breaking frame-by-frame rendering constraints when virtual time advances without UI updates.
- 📎 Plan: .sys/plans/PERF-754-cdp-screencast-push-model.md

## Results Summary
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	11.684	150	12.84	62.5	keep	baseline
2	0.000	0	0.00	0.0	crash	Push-based model using Page.startScreencast deadlocks because it only emits frames on visual changes, violating the frame-by-frame deterministic time advance

---
*PR created automatically by Jules for task [11215679268048749590](https://jules.google.com/task/11215679268048749590) started by @BintzGavin*