### PR TITLE
✨ RENDERER: Execute PERF-755: Pre-Evaluate hasMedia in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-755-eager-cdp-evaluate.md
+++ b/.sys/plans/PERF-755-eager-cdp-evaluate.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-755
 slug: runtime-evaluate-has-media
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor"
 created: 2024-06-13
 completed: ""
-result: ""
+result: "failed"
 ---
 
 # PERF-755: Pre-Evaluate Runtime.evaluate for hasMedia in CdpTimeDriver

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -202,6 +202,11 @@ Last updated by: PERF-752
   - **Plan ID**: PERF-740
 
 ## What Doesn't Work (and Why)
+- **PERF-755**: Pre-Evaluate Runtime.evaluate for hasMedia in CdpTimeDriver
+  - **What I did**: Replaced two separate `Runtime.evaluate` CDP calls during initialization with a single `page.evaluate()` call to extract both the media presence flag and execute stability checks.
+  - **Impact**: It yielded a performance regression (median ~2.543s vs ~2.36s baseline). Playwright's `page.evaluate` overhead (serialization, internal routing) during the critical path seems slower than making raw `Runtime.evaluate` calls via CDP directly, despite reducing the number of IPC calls. Experiment discarded.
+  - **Plan ID**: PERF-755
+
 - **PERF-739**: Eager CDP Session Initialization in DomStrategy
   - **What I tried**: Moved CDP session setup and HeadlessExperimental.enable to the top of DomStrategy.prepare()
   - **WHY it didn't work**: The median render time regressed to ~28.646s (from the baseline of ~27.41s). Eagerly enabling CDP might have caused Playwright's page evaluation for preload scripts to compete with early internal CDP processing overhead, delaying startup.


### PR DESCRIPTION
Attempted to execute plan PERF-755 by combining two separate `Runtime.evaluate` CDP calls into a single Playwright `page.evaluate()` call during the DOM rendering setup phase in `CdpTimeDriver.ts`.

After benchmarking, this caused a performance regression (median render time jumped from ~2.36s baseline to ~2.543s). Despite reducing IPC calls, Playwright's serialization and context switching overhead proved slower than the raw CDP interactions in the critical path. 

The negative code changes were reverted. The plan `.sys/plans/PERF-755-eager-cdp-evaluate.md` was updated to reflect completion and failure, and the shared journal `docs/status/RENDERER-EXPERIMENTS.md` was documented with the findings.

---
*PR created automatically by Jules for task [1612925880190721728](https://jules.google.com/task/1612925880190721728) started by @BintzGavin*