### PR TITLE
✨ RENDERER: Evaluate PERF-758 processCaptureResult branching

### DIFF
--- a/.sys/perf-results-PERF-758.tsv
+++ b/.sys/perf-results-PERF-758.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.412	150	62.20	63.1	keep	baseline
+2	2.401	150	62.48	63.0	keep	baseline
+3	2.417	150	62.07	63.0	keep	baseline
+4	3.829	150	39.17	63.1	discard	inline process capture result
+5	2.441	150	61.46	62.9	discard	inline process capture result
+6	2.551	150	58.80	62.9	discard	inline process capture result

--- a/.sys/plans/PERF-758-eliminate-process-capture-result-branching.md
+++ b/.sys/plans/PERF-758-eliminate-process-capture-result-branching.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-758
 slug: eliminate-process-capture-result-branching
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-06-13
-completed: ""
-result: ""
+completed: "2026-06-13"
+result: "discarded"
 ---
 
 # PERF-758: Eliminate branch logic around processCaptureResult in DomStrategy
@@ -99,3 +99,15 @@ Run canvas benchmark or `npm run build -w packages/renderer`.
 
 ## Correctness Check
 Run the DOM render benchmark script (`cd packages/renderer && npx tsx scripts/benchmark-perf.ts`) to ensure it produces valid outputs without regressions.
+
+
+## Results Summary
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.412	150	62.20	63.1	keep	baseline
+2	2.401	150	62.48	63.0	keep	baseline
+3	2.417	150	62.07	63.0	keep	baseline
+4	3.829	150	39.17	63.1	discard	inline process capture result
+5	2.441	150	61.46	62.9	discard	inline process capture result
+6	2.551	150	58.80	62.9	discard	inline process capture result
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1172,3 +1172,7 @@ Last updated by: PERF-698
   - **What I tried**: Caching the decoded Buffer in CaptureLoop and reusing it if the CDP frame output string is identical to the previous frame's string.
   - **WHY it didn't work**: The median render time in single worker fast path (~2.673s) did not meaningfully improve over the baseline (~2.716s). V8 seems to optimize the Base64 decode overhead well enough natively, and identical frames don't happen frequently enough in typical UI scenarios to make the caching overhead worthwhile on the fast path.
   - **Plan ID**: PERF-756
+- **PERF-758**: Eliminate processCaptureResult Branching
+  - **What I tried**: Removed `processCaptureResult` from `RenderStrategy` and `DomStrategy`, pre-binding the processing closure directly to the `beginFrame` promise resolution in `DomStrategy.capture()`, eliminating the ternary branch in `CaptureLoop.ts`.
+  - **WHY it didn't work**: The median render time regressed to ~2.551s (from ~2.412s baseline). Pushing the logic inside `DomStrategy` forced returning a chained Promise via `.then()`, resulting in additional anonymous closure and microtask allocation per frame, which proved to be slower than explicitly evaluating the ternary inside `CaptureLoop`. V8 inline caches the boolean condition `hasProcessFn` faster than Promise resolution chaining.
+  - **Plan ID**: PERF-758


### PR DESCRIPTION
Evaluated the PERF-758 experiment to inline the `processCaptureResult` logic into `DomStrategy.capture()` via a bound closure, eliminating the `hasProcessFn` condition from the `CaptureLoop` hot path. The experiment regressed median render times from ~2.412s baseline to ~2.551s because chaining a Promise with `.then()` incurs greater microtask and closure allocation overhead than simply allowing V8 to evaluate the cached ternary expression inside the loop. The code changes were reverted, and the plan was recorded as discarded in `docs/status/RENDERER-EXPERIMENTS.md`.

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.412	150	62.20	63.1	keep	baseline
2	2.401	150	62.48	63.0	keep	baseline
3	2.417	150	62.07	63.0	keep	baseline
4	3.829	150	39.17	63.1	discard	inline process capture result
5	2.441	150	61.46	62.9	discard	inline process capture result
6	2.551	150	58.80	62.9	discard	inline process capture result
```

---
*PR created automatically by Jules for task [722654975851149945](https://jules.google.com/task/722654975851149945) started by @BintzGavin*