### PR TITLE
✨ RENDERER: Discard FFmpeg multi-threaded PNG decoding

### DIFF
--- a/.sys/plans/PERF-761-optimize-ffmpeg-input-pipe.md
+++ b/.sys/plans/PERF-761-optimize-ffmpeg-input-pipe.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-761
 slug: optimize-ffmpeg-input-pipe
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-06-13
-completed: ""
-result: ""
+completed: "2026-06-13"
+result: "discard"
 ---
 
 # PERF-761: Optimize FFmpeg Image2Pipe Threads
@@ -68,3 +68,10 @@ Run canvas benchmark or `npm run build -w packages/renderer`.
 
 ## Correctness Check
 Run the DOM render benchmark script (`cd packages/renderer && npx tsx scripts/benchmark-perf.ts`) to ensure it produces valid outputs without regressions.
+
+## Results Summary
+| run | render_time_s | frames | fps_effective | peak_mem_mb | status | description |
+|-----|---------------|--------|---------------|-------------|--------|-------------|
+| 1   | 2.314         | 150    | 64.83         | 63.1        | discard| FFmpeg PNG multithreading via -threads 0 |
+| 2   | 2.455         | 150    | 61.09         | 63.0        | discard| FFmpeg PNG multithreading via -threads 0 |
+| 3   | 2.436         | 150    | 61.58         | 62.9        | discard| FFmpeg PNG multithreading via -threads 0 |

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -210,6 +210,9 @@ Last updated by: PERF-726
   - **Plan ID**: PERF-740
 
 ## What Doesn't Work (and Why)
+- **What:** Configure FFmpeg to use multi-threaded decoding for `image2pipe` PNG streams via `-c:v png -threads 0`.
+  **Why it didn't work:** The median render time (2.436s) was slower than the baseline (2.351s - 2.359s). The multithreading introduces CPU context-switching overhead and pipeline synchronization cost for PNG decompression, which actually hurts performance compared to sequential single-threaded decoding in a fast pipe context.
+  **Plan ID:** PERF-761
 - **PERF-755**: Pre-Evaluate Runtime.evaluate for hasMedia in CdpTimeDriver
   - **What I did**: Replaced two separate `Runtime.evaluate` CDP calls during initialization with a single `page.evaluate()` call to extract both the media presence flag and execute stability checks.
   - **Impact**: It yielded a performance regression (median ~2.543s vs ~2.36s baseline). Playwright's `page.evaluate` overhead (serialization, internal routing) during the critical path seems slower than making raw `Runtime.evaluate` calls via CDP directly, despite reducing the number of IPC calls. Experiment discarded.

--- a/packages/renderer/.sys/perf-results-PERF-761.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-761.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.314	150	64.83	63.1	discard	FFmpeg PNG multithreading via -threads 0
+2	2.455	150	61.09	63.0	discard	FFmpeg PNG multithreading via -threads 0
+3	2.436	150	61.58	62.9	discard	FFmpeg PNG multithreading via -threads 0

--- a/update-journal.cjs
+++ b/update-journal.cjs
@@ -1,4 +1,0 @@
-const fs = require('fs');
-let content = fs.readFileSync('docs/status/RENDERER-EXPERIMENTS.md', 'utf8');
-const entry = `\n- **PERF-751**: Hoist Runtime.enable to DomStrategy.prepare()\n  - **What I tried**: Hoist Runtime.enable out of CdpTimeDriver and into DomStrategy to avoid competition with frame evaluation.\n  - **WHY it didn't work**: The median render time regressed slightly to ~28.229s vs baseline ~27.882s. Enabling the Runtime earlier in DomStrategy after initial script evaluation does not speed up the process. Likely, moving it earlier clusters too many CDP commands early on, or Playwright internals compete with the event processing, reducing performance compared to conditional lazy enabling.\n  - **Plan ID**: PERF-751\n`;
-fs.appendFileSync('docs/status/RENDERER-EXPERIMENTS.md', entry);


### PR DESCRIPTION
Completed PERF-761. Experiment was discarded due to performance regression. Code reverted, results tracked in .sys/plans/ and docs/status/RENDERER-EXPERIMENTS.md.

---
*PR created automatically by Jules for task [7972536971557860840](https://jules.google.com/task/7972536971557860840) started by @BintzGavin*