### PR TITLE
✨ RENDERER: Discard eliminate processCaptureResult branching in DomStrategy

### DIFF
--- a/.sys/plans/PERF-757-eliminate-process-capture-result-branching.md
+++ b/.sys/plans/PERF-757-eliminate-process-capture-result-branching.md
@@ -1,8 +1,10 @@
 ---
 id: PERF-757
 slug: eliminate-process-capture-result-branching
-status: unclaimed
-claimed_by: ""
+status: complete
+completed: "2024-06-13"
+result: "discarded"
+claimed_by: "executor-session"
 created: 2024-06-13
 completed: ""
 result: ""
@@ -129,3 +131,9 @@ Run canvas benchmark or `npm run build -w packages/renderer`.
 
 ## Correctness Check
 Run the DOM render benchmark script (`npx tsx scripts/benchmark-perf.ts`) to ensure it produces valid outputs without regressions.
+
+## Results Summary
+- **Best render time**: 2.513s (vs baseline 2.441s)
+- **Improvement**: -2.9% (Regression)
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-757]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1198,3 +1198,6 @@ Last updated by: PERF-764
   - **What I tried**: Caching the exact base64 string reference returned from `DomStrategy.processCaptureResult` along with its decoded Buffer, to bypass `Buffer.from(..., 'base64')` if the new frame is identical to the previous frame in `CaptureLoop.ts`.
   - **WHY it didn't work**: The median render time in the fast path regressed to ~2.527s (vs baseline median ~2.523s). This proves that the overhead of introducing additional state tracking (two local variables per context) and checking the conditional `buffer === lastBase64Str` string reference is greater than letting V8 quickly handle base64 decodes using its highly optimized built-ins, especially in a benchmark where frames change frequently.
   - **Plan ID**: PERF-760
+
+## What Doesn't Work (and Why)
+- Inlining `processCaptureResult` into `DomStrategy.capture()` via `.then(this.processCaptureResultBound)` (PERF-757): Regressed median render time to ~2.513s (vs ~2.441s baseline). Returning a chained Promise via `.then()` incurred more microtask allocation overhead than explicitly evaluating the ternary condition (`hasProcessFn ? ...`) which V8 inline caches efficiently.

--- a/packages/renderer/.sys/perf-results-PERF-757.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-757.tsv
@@ -1,0 +1,2 @@
+discard	baseline is ~2.41s, removing processCaptureResult regressed to ~2.51s due to Promise  closure overhead being worse than the ternary branch.
+discard	baseline is ~2.41s, removing processCaptureResult regressed to ~2.51s due to Promise .then closure overhead being worse than the ternary branch.


### PR DESCRIPTION
💡 What: Discarded experiment PERF-757 (eliminate processCaptureResult branching) and recorded results.
🎯 Why: To eliminate the per-frame conditional check (hasProcessFn) and overhead inside CaptureLoop's hot loop.
📊 Impact: Regressed median render time to ~2.513s (vs ~2.441s baseline) due to Promise microtask allocation overhead.
🔬 Verification: Benchmark was run.
🔗 Plan: .sys/plans/PERF-757-eliminate-process-capture-result-branching.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.513	150	59.70	62.9	discard	baseline is ~2.41s, removing processCaptureResult regressed to ~2.51s due to Promise .then() closure overhead being worse than the ternary branch.

---
*PR created automatically by Jules for task [4333278943354846855](https://jules.google.com/task/4333278943354846855) started by @BintzGavin*