### PR TITLE
✨ RENDERER: Discard PERF-768 experiment

### DIFF
--- a/.sys/plans/PERF-768-eliminate-sync-media-cdp-call.md
+++ b/.sys/plans/PERF-768-eliminate-sync-media-cdp-call.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-768
 slug: eliminate-sync-media-cdp-call
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-14
-completed: ""
-result: ""
+completed: 2024-06-14
+result: discard
 ---
 
 # PERF-768: Eliminate per-frame CDP call by hoisting media sync to `requestAnimationFrame`
@@ -67,3 +67,9 @@ Add this immediately after the `window.__helios_wait_until_stable` definition.
 
 ## Correctness Check
 Run the `npm run test -w packages/renderer` tests to ensure DOM rendering behavior remains correct and videos stay in sync.
+
+## Results Summary
+- **Best render time**: 2.188s (vs baseline 2.150s)
+- **Improvement**: 0%
+- **Kept experiments**:
+- **Discarded experiments**: Eliminate per-frame CDP call by hoisting media sync to `requestAnimationFrame`

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1217,3 +1217,8 @@ Last updated by: PERF-764
   - **What I tried**: Applied the `ReusableThenable` pattern from `PERF-746` to the stream drain backpressure handling in `CaptureLoop.ts` by replacing `new Promise<void>(this.drainPromiseExecutor)` allocations with a shared `drainPromise`.
   - **WHY it worked**: V8 heap allocation pressure during FFmpeg stdin backpressure events is eliminated by reusing the same duck-typed `ReusableThenable` instance, further reducing garbage collection overhead and keeping the fast-path clean.
   - **Plan ID**: PERF-747
+
+- **PERF-768**: Eliminate per-frame CDP call by hoisting media sync to requestAnimationFrame
+  - **What I tried**: Hoisted the `window.__helios_sync_media()` call into a persistent `requestAnimationFrame` loop in the initialization script of `CdpTimeDriver.ts`, entirely eliminating the `this.client!.send('Runtime.evaluate')` IPC call from the Node.js hot loop per frame.
+  - **WHY it didn't work**: The median render time in the fast path slightly regressed to ~2.195s (vs baseline median ~2.178s). This suggests that letting the browser run its own internal `requestAnimationFrame` loop on every virtual frame tick adds more processing overhead inside Chromium than sending a lightweight asynchronous, un-awaited CDP message from Node.js.
+  - **Plan ID**: PERF-768

--- a/packages/renderer/.sys/perf-results-PERF-768.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-768.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.257	150	66.47	63.0	keep	baseline
+2	2.150	150	69.75	63.7	keep	baseline
+3	2.178	150	68.87	62.9	keep	baseline
+4	2.207	150	67.98	62.9	discard	hoist rAF loop
+5	2.195	150	68.34	62.8	discard	hoist rAF loop
+6	2.188	150	68.56	62.9	discard	hoist rAF loop


### PR DESCRIPTION
💡 What: Hoisted the requestAnimationFrame loop in CdpTimeDriver.ts to eliminate per-frame CDP calls.
🎯 Why: Attempting to optimize DOM capture by replacing Node.js to Chrome IPC overhead with a native browser animation loop for media sync.
📊 Impact: Regressed median render time slightly to ~2.195s vs baseline ~2.178s. Discarded because internal Chromium overhead of running a requestAnimationFrame loop exceeds the lightweight CDP message cost.
🔬 Verification: Evaluated median render times across multiple test runs. Restored all code files.
🔗 Plan: .sys/plans/PERF-768-eliminate-sync-media-cdp-call.md

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.257	150	66.47	63.0	keep	baseline
2	2.150	150	69.75	63.7	keep	baseline
3	2.178	150	68.87	62.9	keep	baseline
4	2.207	150	67.98	62.9	discard	hoist rAF loop
5	2.195	150	68.34	62.8	discard	hoist rAF loop
6	2.188	150	68.56	62.9	discard	hoist rAF loop
```

---
*PR created automatically by Jules for task [5793586040083233507](https://jules.google.com/task/5793586040083233507) started by @BintzGavin*