### PR TITLE
✨ RENDERER: Bypass time calculation in CaptureLoop single worker fast path

### DIFF
--- a/.sys/plans/PERF-775-bypass-target-time-variable-single-worker.md
+++ b/.sys/plans/PERF-775-bypass-target-time-variable-single-worker.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-775
 slug: bypass-target-time-variable-single-worker
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-15
-completed: ""
-result: ""
+completed: "2026-06-15"
+result: "discard"
 ---
 
 # PERF-775: Bypass time calculation in CaptureLoop single worker fast path
@@ -74,3 +74,9 @@ Run `npm run test -w packages/renderer` to ensure test pipeline isn't impacted.
 
 ## Correctness Check
 Run the DOM render benchmark script (`cd packages/renderer && npx tsx scripts/benchmark-perf.ts`) to ensure it produces valid outputs without regressions.
+
+## Results Summary
+- **Best render time**: ~2.337s (vs baseline ~2.304s)
+- **Improvement**: 0%
+- **Kept experiments**: none
+- **Discarded experiments**: Bypass time calculation in CaptureLoop single worker fast path

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1225,3 +1225,8 @@ Last updated by: PERF-764
 
 ## Open Questions
 - [Monomorphic Capture Loop (PERF-771)] Will completely unrolling the ternary branch (`hasProcessFn ? ... : ...`) to duplicate the `for` and `while` loops inside `CaptureLoop.ts` improve the hot path speed by making it fully monomorphic?
+
+- **PERF-775**: Bypass time calculation in CaptureLoop single worker fast path
+  - **What I tried**: Initialized `time` and `compositionTimeInSeconds` once before the loop and simply add the step values on each iteration.
+  - **WHY it worked/didn't work**: The median render time in the fast path slightly regressed to ~2.474s (vs baseline median ~2.337s). Pre-calculating increments seems to interfere with V8's optimization, perhaps by decoupling the time calculations from the loop index that TurboFan expects. Discarded.
+  - **Plan ID**: PERF-775

--- a/packages/renderer/.sys/perf-results-PERF-775.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-775.tsv
@@ -1,0 +1,7 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.295	150	12.07	62.9	keep	baseline
+2	2.337	150	12.07	62.9	keep	baseline
+3	2.304	150	12.07	62.9	keep	baseline
+4	2.781	150	53.9	63.1	discard	pre-calculate time step
+5	2.474	150	60.6	63.1	discard	pre-calculate time step
+6	2.487	150	60.3	63.1	discard	pre-calculate time step


### PR DESCRIPTION
The PERF-775 experiment to bypass dynamic floating-point multiplication overhead for time calculation in the CaptureLoop single worker fast path by using cumulative addition (time += timeStep) was executed. It was found to regress the median render time to ~2.474s (vs ~2.337s baseline) because pre-calculating increments seemed to interfere with V8's loop optimization.

The experiment was discarded. The codebase was restored to its previous state. The findings were recorded in the TSV file, journal file, and the plan markdown file.

---
*PR created automatically by Jules for task [6344691814188659604](https://jules.google.com/task/6344691814188659604) started by @BintzGavin*