### PR TITLE
✨ RENDERER: Bypass Stream Writable Getter in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-777-bypass-stream-writable-getter.md
+++ b/.sys/plans/PERF-777-bypass-stream-writable-getter.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-777
 slug: bypass-stream-writable-getter
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-06-15
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1245,3 +1245,8 @@ Last updated by: PERF-764
   - **What I did**: Inlined the media sync boolean check (`if (this.hasMedia)`), removing the empty closure invocation (`this.syncMediaFn()`) per frame on the fast path.
   - **Impact**: Fast-path execution optimization for single worker loops.
   - **Plan ID**: PERF-776
+
+- **PERF-777**: Bypass Stream Writable Getter in CaptureLoop
+  - **What I tried**: Bypassed `stdin?.writable` stream state getter evaluation in `CaptureLoop.ts` single-worker fast path.
+  - **WHY it worked/didn't work**: The median render time in the fast path regressed slightly to ~2.311s (vs baseline median ~2.281s). Replacing the nullable property access with a strict stream variable likely didn't offset the fact that `stdin.write` and `drainPromise` await still carry overhead. The experiment yielded no improvement and increased noise. Discarded.
+  - **Plan ID**: PERF-777

--- a/packages/renderer/.sys/perf-results-PERF-777.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-777.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.830	150	53.01	62.9	discard	bypass stream writable getter
+2	2.311	150	64.91	63.0	discard	bypass stream writable getter
+3	2.205	150	68.04	63.1	discard	bypass stream writable getter


### PR DESCRIPTION
💡 **What**: Evaluated removing per-frame stream getter checks
🎯 **Why**: To reduce CPU instruction overhead
📊 **Impact**: Baseline ~2.281s vs. experimental ~2.311s (discarded)
🔬 **Verification**: Compilation, Tests, and Benchmark Consistency
🔗 **Plan**: PERF-777

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.830	150	53.01	62.9	discard	bypass stream writable getter
2	2.311	150	64.91	63.0	discard	bypass stream writable getter
3	2.205	150	68.04	63.1	discard	bypass stream writable getter
```

---
*PR created automatically by Jules for task [17718876434243303626](https://jules.google.com/task/17718876434243303626) started by @BintzGavin*