### PR TITLE
✨ RENDERER: Evaluate omitting catch closure in CdpTimeDriver (PERF-704)

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -215,6 +215,7 @@ Last updated by: PERF-726
   - **Plan ID**: PERF-740
 
 ## What Doesn't Work (and Why)
+- **PERF-704 (Omit .catch(noopCatch) in defaultSyncMedia)**: The code targeted by this plan (`defaultSyncMedia` in `CdpTimeDriver.ts`) no longer contains `.catch(noopCatch)` in the latest codebase. It appears the optimization has already been made or the closure was removed by a previous architectural change. Marked as failed/impossible due to duplication.
 - **What:** Configure FFmpeg to use multi-threaded decoding for `image2pipe` PNG streams via `-c:v png -threads 0`.
   **Why it didn't work:** The median render time (2.436s) was slower than the baseline (2.351s - 2.359s). The multithreading introduces CPU context-switching overhead and pipeline synchronization cost for PNG decompression, which actually hurts performance compared to sequential single-threaded decoding in a fast pipe context.
   **Plan ID:** PERF-761

--- a/packages/renderer/.sys/perf-results-PERF-704.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-704.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	crash	PERF-704: Optimization already present in codebase

--- a/packages/renderer/.sys/plans/PERF-704-omit-catch-noopCatch.md
+++ b/packages/renderer/.sys/plans/PERF-704-omit-catch-noopCatch.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-704
 slug: omit-catch-noopcatch-sync-media
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-08
-completed: ""
-result: ""
+completed: "2026-06-16"
+result: failed
 ---
 # PERF-704: Omit .catch(noopCatch) in defaultSyncMedia
 
@@ -48,3 +48,9 @@ Verify that the output video (`packages/renderer/output/dom-benchmark.mp4`) stil
 
 ## Prior Art
 - Eliminating `.catch` handlers on ephemeral CDP calls has been proven to reduce promise allocation overhead in tight loops.
+
+## Results Summary
+- **Best render time**: N/A
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [PERF-704: Code targeted by plan already matches the desired state (no `.catch(noopCatch)` present in `defaultSyncMedia`).]


### PR DESCRIPTION
✨ RENDERER: Evaluate omitting catch closure in CdpTimeDriver (PERF-704)

💡 What: Evaluated removing .catch(noopCatch) from defaultSyncMedia
🎯 Why: To reduce V8 microtask closure allocation overhead in the hot loop
📊 Impact: N/A - The code targeted by this plan had already been rewritten or removed by a previous architectural change. Marked as failed/impossible.
🔬 Verification: Checked codebase, confirmed target .catch() did not exist in the referenced scope. Tests not run for codebase unmodified.
📎 Plan: /.sys/plans/PERF-704-omit-catch-noopCatch.md

Results Summary:
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	PERF-704: Optimization already present in codebase

---
*PR created automatically by Jules for task [17641262483798451315](https://jules.google.com/task/17641262483798451315) started by @BintzGavin*