### PR TITLE
📋 RENDERER: Discard PERF-778 (Inline capture write)

### DIFF
--- a/.sys/plans/PERF-778-inline-capture-write.md
+++ b/.sys/plans/PERF-778-inline-capture-write.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-778
 slug: inline-capture-write
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-16
-completed: ""
-result: ""
+completed: "2024-06-16"
+result: "failed"
 ---
 # PERF-778: Inline strategy.capture() into stdin.write()
 
@@ -88,3 +88,9 @@ Verify that the output MP4 compiles successfully without truncation and visual o
 
 ## Prior Art
 - PERF-777 (Bypass stream writable getter)
+
+## Results Summary
+- **Best render time**: 2.636s (vs baseline ~2.3s)
+- **Improvement**: Regressed
+- **Kept experiments**:
+- **Discarded experiments**: Inline strategy.capture() into stdin.write()

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1251,3 +1251,7 @@ Last updated by: PERF-764
   - **What I tried**: Bypassed `stdin?.writable` stream state getter evaluation in `CaptureLoop.ts` single-worker fast path.
   - **WHY it worked/didn't work**: The median render time in the fast path regressed slightly to ~2.311s (vs baseline median ~2.281s). Replacing the nullable property access with a strict stream variable likely didn't offset the fact that `stdin.write` and `drainPromise` await still carry overhead. The experiment yielded no improvement and increased noise. Discarded.
   - **Plan ID**: PERF-777
+- **Inline `strategy.capture()` into `stdin.write()`**
+  - **What I tried**: Removed intermediate buffer allocation in the `CaptureLoop.ts` fast path by directly passing the result to `stdin.write()`.
+  - **WHY it worked/didn't work**: The median render time in the fast path regressed to ~2.636s (vs baseline median ~2.3s). The AST simplification likely negatively affected TurboFan optimization, leading to slower execution despite fewer local scope allocations. Discarded.
+  - **Plan ID**: PERF-778

--- a/packages/renderer/.sys/perf-results-PERF-778.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-778.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.640	150	56.81	63.0	discard	inline capture write
+2	2.679	150	55.99	63.1	discard	inline capture write
+3	2.636	150	56.90	62.9	discard	inline capture write


### PR DESCRIPTION
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.640	150	56.81	63.0	discard	inline capture write
2	2.679	150	55.99	63.1	discard	inline capture write
3	2.636	150	56.90	62.9	discard	inline capture write

---
*PR created automatically by Jules for task [3113054178169161651](https://jules.google.com/task/3113054178169161651) started by @BintzGavin*