### PR TITLE
✨ RENDERER: Overlap Time Progression with FFmpeg Drain (Retry)

### DIFF
--- a/.sys/plans/PERF-779-overlap-time-and-drain-retry.md
+++ b/.sys/plans/PERF-779-overlap-time-and-drain-retry.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-779
 slug: overlap-time-and-drain-retry
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-16
-completed: ""
-result: ""
+completed: "2024-06-16"
+result: "failed"
 ---
 # PERF-779: Overlap Time Progression with FFmpeg Drain (Retry)
 
@@ -52,7 +52,7 @@ This effectively revives the concept from PERF-717, which showed a performance r
 - **Minimum runs**: 3 per experiment, report median
 
 ## Baseline
-- **Current estimated render time**: ~12.994s (latest benchmark run)
+- **Current estimated render time**: ~2.069s (latest benchmark run)
 - **Bottleneck analysis**: The node thread is blocking on IPC pipe IO (`drainPromise`), completely pausing Chromium rendering, creating a sequential pipeline stall.
 
 ## Implementation Spec
@@ -82,3 +82,9 @@ None.
 
 ## Correctness Check
 Run `npx tsx scripts/benchmark-perf.ts` and verify output.
+
+## Results Summary
+- **Best render time**: ~2.580s (vs baseline ~2.069s)
+- **Improvement**: Regressed
+- **Kept experiments**:
+- **Discarded experiments**: Overlap Time Progression with FFmpeg Drain (Retry)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1255,3 +1255,8 @@ Last updated by: PERF-764
   - **What I tried**: Removed intermediate buffer allocation in the `CaptureLoop.ts` fast path by directly passing the result to `stdin.write()`.
   - **WHY it worked/didn't work**: The median render time in the fast path regressed to ~2.636s (vs baseline median ~2.3s). The AST simplification likely negatively affected TurboFan optimization, leading to slower execution despite fewer local scope allocations. Discarded.
   - **Plan ID**: PERF-778
+
+- **PERF-779**: Overlap Time Progression with FFmpeg Drain (Retry)
+  - **What I tried**: Hoisted `await this.drainPromise` in the single-worker path to occur *after* the `timeDriver.setTime()` call for the subsequent frame, attempting to overlap the Node.js block waiting for FFmpeg with the Chromium execution of the next frame.
+  - **Impact**: The median render time regressed to ~2.68s (from a highly optimized baseline of ~2.069s). It appears that holding the promise and awaiting it later interferes with the deeply optimized V8 fast-path monomorphism achieved in earlier experiments, outweighing the minor theoretical IPC overlap benefit.
+  - **Plan ID**: PERF-779


### PR DESCRIPTION
Implemented PERF-779, tested it, found it regressed, and reverted the code while committing the documentation.

---
*PR created automatically by Jules for task [17430197313077508261](https://jules.google.com/task/17430197313077508261) started by @BintzGavin*