### PR TITLE
✨ RENDERER: Infinite Node.js Stream Buffering (No Drain Await)

### DIFF
--- a/.sys/plans/PERF-781-infinite-node-buffering.md
+++ b/.sys/plans/PERF-781-infinite-node-buffering.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-781
 slug: infinite-node-buffering
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-06-16
 completed: ""
-result: ""
+result: "failed"
 ---
 
 # PERF-781: Infinite Node.js Stream Buffering (No Drain Await)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -215,6 +215,11 @@ Last updated by: PERF-726
   - **Plan ID**: PERF-740
 
 ## What Doesn't Work (and Why)
+- **PERF-781**: Infinite Node.js Stream Buffering (No Drain Await)
+  - **What I tried**: Removed the `await this.drainPromise` in the FFmpeg stdin writing block in the single-worker fast path to decouple Chromium frame generation from FFmpeg processing.
+  - **WHY it didn't work**: The median render time in the fast path regressed to ~2.96s (vs baseline median ~2.069s). While it theoretically avoids event loop stalls from `drainPromise`, removing the backpressure causes memory pressure and seems to disrupt V8's optimization of the hot loop, likely due to uncontrolled stream buffer expansion or garbage collection.
+  - **Plan ID**: PERF-781
+
 - **PERF-704 (Omit .catch(noopCatch) in defaultSyncMedia)**: The code targeted by this plan (`defaultSyncMedia` in `CdpTimeDriver.ts`) no longer contains `.catch(noopCatch)` in the latest codebase. It appears the optimization has already been made or the closure was removed by a previous architectural change. Marked as failed/impossible due to duplication.
 - **What:** Configure FFmpeg to use multi-threaded decoding for `image2pipe` PNG streams via `-c:v png -threads 0`.
   **Why it didn't work:** The median render time (2.436s) was slower than the baseline (2.351s - 2.359s). The multithreading introduces CPU context-switching overhead and pipeline synchronization cost for PNG decompression, which actually hurts performance compared to sequential single-threaded decoding in a fast pipe context.


### PR DESCRIPTION
Completed the PERF-781 infinite node buffering experiment. The experiment was to remove the `drainPromise` await when writing to FFmpeg in the single worker path. It resulted in a performance regression (~2.96s vs ~2.069s), therefore the code was reverted. Documentation in `RENDERER-EXPERIMENTS.md` and the `.sys/plans` status have been updated to reflect the failed outcome.

---
*PR created automatically by Jules for task [12270574764046050236](https://jules.google.com/task/12270574764046050236) started by @BintzGavin*