### PR TITLE
📋 CLI: Command Coverage Spec V8

### DIFF
--- a/.sys/plans/2027-06-05-CLI-Command-Coverage-Tests-V8.md
+++ b/.sys/plans/2027-06-05-CLI-Command-Coverage-Tests-V8.md
@@ -1,0 +1,25 @@
+# CLI Command Coverage Tests V8 Spec
+
+## 1. Context & Goal
+- **Objective**: Improve regression test coverage for `packages/cli/src/commands/job.ts` to 100%.
+- **Trigger**: `vitest run --coverage` reveals uncovered branch lines for `--docker-args` and `--hetzner-ssh-key-id` parsing.
+- **Impact**: Full branch coverage for CLI commands ensures adapter configuration edge-cases work properly.
+
+## 2. File Inventory
+- **Create**: None
+- **Modify**: `packages/cli/src/commands/__tests__/job.test.ts`
+- **Read-Only**: `packages/cli/src/commands/job.ts`
+
+## 3. Implementation Spec
+- **Architecture**:
+  - Add specific mock implementations and execute the `job run` command with the precise missing flags: `--docker-args` (to hit line 175) and `--hetzner-ssh-key-id` (to hit line 210).
+- **Pseudo-Code**:
+  - In `job.test.ts` add a test case: `it('should pass docker args correctly')` with `['run', 'job.json', '--adapter', 'docker', '--docker-image', 'x', '--docker-args', 'a,b']`
+  - In `job.test.ts` add a test case: `it('should pass hetzner ssh key id correctly')` with `['run', 'job.json', '--adapter', 'hetzner', '--hetzner-api-token', 't', '--hetzner-server-type', 's', '--hetzner-image', 'i', '--hetzner-ssh-key-id', '123']`
+- **Public API Changes**: None
+- **Dependencies**: None
+
+## 4. Test Plan
+- **Verification**: Run `cd packages/cli && npx vitest run --coverage src/commands/__tests__/job.test.ts`
+- **Success Criteria**: Coverage report shows 100% Branch coverage for `job.ts` with no missing lines.
+- **Edge Cases**: None.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -177,3 +177,4 @@ The Helios CLI is the primary user interface for component registry, project sca
 [v0.46.47] 🟢 Completed: CLI Registry Client Coverage Tests Spec - Created specification plan 2027-06-05-CLI-Registry-Client-Coverage-Tests.md for covering missing branches in RegistryClient.
 [v0.46.49] 🟢 Completed: CLI Utils Coverage Tests Spec - Created specification plan 2027-06-05-CLI-Utils-Coverage-Tests.md for covering missing branches in CLI utils.
 [v0.46.47] ✅ Completed: CLI Utils Coverage Tests - Added unit tests to utils to achieve 100% coverage.
+[v0.46.50] 🟢 Completed: CLI Command Coverage Tests Spec V8 - Created specification plan 2027-06-05-CLI-Command-Coverage-Tests-V8.md for covering missing branches in job adapter flags.


### PR DESCRIPTION
Generated an execution plan to cover missing test branches in `packages/cli/src/commands/job.ts` for parsing `--docker-args` and `--hetzner-ssh-key-id` flags. Documented learnings about missing CLI flag optional edge cases.

---
*PR created automatically by Jules for task [16193401295375013156](https://jules.google.com/task/16193401295375013156) started by @BintzGavin*