### PR TITLE
✨ RENDERER: Bypass virtualTimeBudget parameter assignment in CdpTimeDriver

### DIFF
--- a/.sys/plans/PERF-782-bypass-cdptime-driver-budget-assignment.md
+++ b/.sys/plans/PERF-782-bypass-cdptime-driver-budget-assignment.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-782
 slug: bypass-cdptime-driver-budget-assignment
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2026-06-16
-completed: ""
-result: ""
+completed: 2026-06-16
+result: "discard"
 ---
 
 # PERF-782: Bypass virtualTimeBudget parameter assignment in CdpTimeDriver
@@ -57,3 +57,7 @@ Run the DOM benchmark. Ensure the video isn't structurally desynced and that it 
 ## Prior Art
 - PERF-777: Bypassing stream state getter to avoid property access overhead in hot loop.
 - PERF-769: Minimizing CDP Message Payloads by caching object shapes.
+
+## Results
+- **Outcome**: discard
+- **Median Time**: 2.262s

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1270,3 +1270,8 @@ Last updated by: PERF-764
   - **What I tried**: Pre-calculated `time` and `compositionTimeInSeconds` arrays as Float64Array and indexed them in the `CaptureLoop.ts` single-worker and multi-worker loops.
   - **WHY it didn't work**: V8 natively optimizes `i * timeStep` arithmetic inside simple hot loops effectively. Attempting to use a Typed Array index read (`compTimesArray[i]`) actually incurred a performance regression compared to simply multiplying the numbers, as V8 had to perform bounds checking or memory access instead of registering simple floating-point multiplications inline.
   - **Plan ID**: PERF-780
+
+- **PERF-782**: Bypass virtualTimeBudget parameter assignment in CdpTimeDriver
+  - **What I tried**: Rounded and cached the frame time delta `budget` in `CdpTimeDriver.ts` to avoid modifying the `this.setVirtualTimePolicyParams.budget` object property for consecutive frames, aiming to reduce V8 internal object mutation overhead inside the hot path.
+  - **WHY it didn't work**: The median render time regressed to ~2.262s (from ~2.069s baseline). The arithmetic overhead of `Math.round(delta * 1000)` combined with an explicit conditional property branch negated any savings from bypassing object mutation. V8's hidden classes already optimize simple integer-like float assignments to the same property shape extremely well.
+  - **Plan ID**: PERF-782

--- a/packages/renderer/.sys/perf-results-PERF-782.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-782.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.350	150	63.82	63.1	discard	Bypass virtualTimeBudget assignment
+2	2.241	150	66.94	63.1	discard	Bypass virtualTimeBudget assignment
+3	2.262	150	66.31	62.9	discard	Bypass virtualTimeBudget assignment


### PR DESCRIPTION
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.350	150	63.82	63.1	discard	Bypass virtualTimeBudget assignment
2	2.241	150	66.94	63.1	discard	Bypass virtualTimeBudget assignment
3	2.262	150	66.31	62.9	discard	Bypass virtualTimeBudget assignment

---
*PR created automatically by Jules for task [13535365019210897595](https://jules.google.com/task/13535365019210897595) started by @BintzGavin*