### PR TITLE
✨ CLI: Command Coverage Tests V8

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -772,3 +772,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### PLAYER v0.77.58
 - ✅ Completed: Discovered that `2027-02-18-PLAYER-Implement-Missing-Media-Properties.md` is an IMPOSSIBLE: DUPLICATION plan. The missing standard properties and methods (`disableRemotePlayback`, `mediaGroup`, `sinkId`, `setSinkId`) are already fully implemented in `packages/player/src/index.ts`. Documented as impossible and discarded.
+
+### CLI v0.46.48
+- ✅ Completed: CLI Command Coverage Tests V8 - Implemented test coverage for missing branches in job.ts.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,4 +1,4 @@
-**Version**: 0.46.47
+**Version**: 0.46.48
 
 [v0.46.44] ✅ Completed: CLI Registry Types Regression Tests - Logged the duplicated plan as impossible since registry types regression tests are already fully implemented.
 [v0.46.41] ✅ Completed: CLI Docker Adapter Regression Tests - Logged the duplicated plan as impossible since docker-adapter template tests are already fully implemented.
@@ -178,3 +178,4 @@ The Helios CLI is the primary user interface for component registry, project sca
 [v0.46.49] 🟢 Completed: CLI Utils Coverage Tests Spec - Created specification plan 2027-06-05-CLI-Utils-Coverage-Tests.md for covering missing branches in CLI utils.
 [v0.46.47] ✅ Completed: CLI Utils Coverage Tests - Added unit tests to utils to achieve 100% coverage.
 [v0.46.50] 🟢 Completed: CLI Command Coverage Tests Spec V8 - Created specification plan 2027-06-05-CLI-Command-Coverage-Tests-V8.md for covering missing branches in job adapter flags.
+[v0.46.48] ✅ Completed: CLI Command Coverage Tests V8 - Implemented test coverage for missing branches in job.ts.

--- a/packages/cli/src/commands/__tests__/job.test.ts
+++ b/packages/cli/src/commands/__tests__/job.test.ts
@@ -244,6 +244,16 @@ describe('job command', () => {
       expect(DockerAdapter).toHaveBeenCalledWith(expect.objectContaining({ image: 'img' }));
     });
 
+    it('should pass docker args correctly', async () => {
+      await program.parseAsync([
+        'node', 'test', 'job', 'run', 'job.json',
+        '--adapter', 'docker',
+        '--docker-image', 'img',
+        '--docker-args', 'a,b'
+      ]);
+      expect(DockerAdapter).toHaveBeenCalledWith(expect.objectContaining({ dockerArgs: ['a', 'b'] }));
+    });
+
     it('should instantiate DenoDeployAdapter when deno is specified', async () => {
       await program.parseAsync([
         'node', 'test', 'job', 'run', 'job.json',
@@ -283,6 +293,20 @@ describe('job command', () => {
         apiToken: 'tok',
         serverType: 'type',
         image: 'img'
+      }));
+    });
+
+    it('should pass hetzner ssh key id correctly', async () => {
+      await program.parseAsync([
+        'node', 'test', 'job', 'run', 'job.json',
+        '--adapter', 'hetzner',
+        '--hetzner-api-token', 'tok',
+        '--hetzner-server-type', 'type',
+        '--hetzner-image', 'img',
+        '--hetzner-ssh-key-id', '123'
+      ]);
+      expect(HetznerCloudAdapter).toHaveBeenCalledWith(expect.objectContaining({
+        sshKeyId: 123
       }));
     });
   });

--- a/packages/cli/src/commands/__tests__/render.test.ts
+++ b/packages/cli/src/commands/__tests__/render.test.ts
@@ -127,10 +127,13 @@ describe('render command', () => {
 
   it('should generate mergeCommand with mixOptions when using --emit-job', async () => {
     vi.mocked(RenderOrchestrator.plan).mockReturnValueOnce({
-      chunks: [{ id: '1', startFrame: 0, frameCount: 10, outputFile: 'out.mp4', options: {} }],
+      chunks: [{ id: 1, startFrame: 0, frameCount: 10, outputFile: 'out.mp4', options: {} as any }],
       concatManifest: ['out.mp4'],
-      mixOptions: { videoCodec: 'libx264', audioCodec: 'aac', crf: 23 },
-      totalFrames: 10
+      mixOptions: { videoCodec: 'libx264', audioCodec: 'aac', crf: 23 } as any,
+      totalFrames: 10,
+      concatOutputFile: 'out_concat.mp4',
+      finalOutputFile: 'out_final.mp4',
+      cleanupFiles: []
     });
 
     await program.parseAsync(['node', 'test', 'render', 'http://example.com/comp.html', '--emit-job', 'job.json', '--video-codec', 'libx264', '--audio-codec', 'aac', '--quality', '23']);
@@ -138,7 +141,7 @@ describe('render command', () => {
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls.find(call => typeof call[0] === 'string' && call[0].endsWith('job.json'));
     expect(writeCall).toBeDefined();
     if (writeCall) {
-      const writtenJobStr = writeCall[1];
+      const writtenJobStr = writeCall[1] as string;
       const job = JSON.parse(writtenJobStr);
       expect(job.mergeCommand).toContain('--video-codec libx264');
       expect(job.mergeCommand).toContain('--audio-codec aac');

--- a/packages/cli/src/commands/__tests__/studio.test.ts
+++ b/packages/cli/src/commands/__tests__/studio.test.ts
@@ -178,8 +178,8 @@ describe('studio command', () => {
     await program.parseAsync(['node', 'test', 'studio']);
 
     // we mock consoleLogMock in beforeEach
-    const logCalls = consoleLogMock.mock.calls.map(args => args[0]);
-    expect(logCalls.some(arg => typeof arg === 'string' && arg.includes('Skills Root:'))).toBe(false);
+    const logCalls = consoleLogMock.mock.calls.map((args: any[]) => args[0]);
+    expect(logCalls.some((arg: any) => typeof arg === 'string' && arg.includes('Skills Root:'))).toBe(false);
   });
 
   it('should use default components directory if config.directories.components is missing', async () => {


### PR DESCRIPTION
Added test cases for `--docker-args` and `--hetzner-ssh-key-id` parsing in the job command to reach 100% test coverage. Also fixed existing TypeScript build errors in `render.test.ts` and `studio.test.ts` that were uncovered while verifying the CLI codebase. Updated the CLI status and progress logs to indicate completion.

---
*PR created automatically by Jules for task [10615844034035168212](https://jules.google.com/task/10615844034035168212) started by @BintzGavin*