### PR TITLE
✨ RENDERER: Remove drainPromise await in multi-worker path

### DIFF
--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -370,11 +370,7 @@ export class CaptureLoop {
 
 
             if (stdin?.writable) {
-                    const canWriteMore = stdin.write(buffer as any);
-
-                    if (!canWriteMore && stdin.writableLength >= 16777216) {
-                    await this.drainPromise;
-                }
+                    stdin.write(buffer as any);
             } else {
                 console.warn('FFmpeg stdin is not writable. Skipping write.');
             }


### PR DESCRIPTION
Removed `await this.drainPromise` block in the multi-worker path of CaptureLoop.ts.
To decouple the writer thread from FFmpeg's consumption speed.
Removed the drainPromise await within the writer loop for multi-worker pipeline, taking advantage of pipeline depth bounds for backpressure instead.

---
*PR created automatically by Jules for task [5410291391022310481](https://jules.google.com/task/5410291391022310481) started by @BintzGavin*