### PR TITLE
✨ RENDERER: Simplify abort check in CaptureLoop fast path

### DIFF
--- a/.sys/plans/PERF-786-simplify-abort-check.md
+++ b/.sys/plans/PERF-786-simplify-abort-check.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-786
 slug: simplify-abort-check
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-16
-completed: ""
-result: ""
+completed: 2024-06-17
+result: improved
 ---
 
 # PERF-786: Simplify Abort Check in CaptureLoop Fast Path
@@ -79,3 +79,9 @@ Run a basic canvas composition to ensure no pipeline breaks.
 
 ## Correctness Check
 - The output MP4 should render correctly.
+
+## Results Summary
+- **Best render time**: 3.009s (vs baseline ~3.03s)
+- **Improvement**: 1%
+- **Kept experiments**: Simplify abort check in CaptureLoop fast path
+- **Discarded experiments**: none

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1278,3 +1278,10 @@ Last updated by: PERF-764
 ## What Works
 - Removed `timesArray` and `compTimesArray` typed arrays in favor of inline math for time calculations (~3.385s -> fast path).
 - PERF-783
+
+## Performance Trajectory
+Current best: 3.009s (baseline was ~3.03s, -1%)
+Last updated by: PERF-786
+
+## What Works
+- Simplification of abort check in single-worker fast path. It slightly improved execution time by ~1% by hoisting the `signal.aborted` condition checks out of the hot path inside the `for` loops in `packages/renderer/src/core/CaptureLoop.ts`. (PERF-786)

--- a/packages/renderer/.sys/perf-results-PERF-786.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-786.tsv
@@ -1,0 +1,1 @@
+1	3.009	150	49.85	63.1	keep	Simplify abort check in CaptureLoop fast path

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -144,10 +144,19 @@ export class CaptureLoop {
         const signal = this.jobOptions?.signal;
         const onProgress = this.jobOptions?.onProgress;
         const hasProcessFn = !!strategy.processCaptureResult;
+
+        let aborted = false;
+        let abortListener: (() => void) | null = null;
+        if (signal) {
+            if (signal.aborted) aborted = true;
+            abortListener = () => { aborted = true; };
+            signal.addEventListener('abort', abortListener);
+        }
+
         try {
             if (hasProcessFn) {
                 for (let i = 0; i < totalFrames; i++) {
-                    if (capturedErrors.length > 0 || (signal && signal.aborted)) break;
+                    if (aborted || capturedErrors.length > 0) break;
 
                     await timeDriver.setTime(page, (startFrame + i) * compTimeStep);
                     const buffer = strategy.processCaptureResult!(await strategy.capture(page, i * timeStep));
@@ -173,7 +182,7 @@ export class CaptureLoop {
                 }
             } else {
                 for (let i = 0; i < totalFrames; i++) {
-                    if (capturedErrors.length > 0 || (signal && signal.aborted)) break;
+                    if (aborted || capturedErrors.length > 0) break;
 
                     await timeDriver.setTime(page, (startFrame + i) * compTimeStep);
                     const buffer = await strategy.capture(page, i * timeStep);
@@ -200,6 +209,10 @@ export class CaptureLoop {
             }
         } catch (e) {
             fatalError = e;
+        } finally {
+            if (signal && abortListener) {
+                signal.removeEventListener('abort', abortListener);
+            }
         }
 
         if (fatalError) throw fatalError;


### PR DESCRIPTION
💡 What: Hoisted and simplified the abort check in the single-worker fast path.
🎯 Why: To reduce loop instruction overhead by moving the property access out of the tight loop.
📊 Impact: Expected to slightly reduce wall-clock render time.
🔬 Verification: Passed verification and benchmark tests, and code review found it functionally correct.
📎 Plan: .sys/plans/PERF-786-simplify-abort-check.md

---
*PR created automatically by Jules for task [4011340810620986553](https://jules.google.com/task/4011340810620986553) started by @BintzGavin*