### PR TITLE
✨ RENDERER: Tune FFmpeg Stdin Backpressure Limit in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-789-tune-ffmpeg-stdin-backpressure.md
+++ b/.sys/plans/PERF-789-tune-ffmpeg-stdin-backpressure.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-789
 slug: tune-ffmpeg-stdin-backpressure
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2024-06-17
 completed: ""
 result: ""
@@ -70,3 +70,9 @@ Run a basic canvas composition to ensure rendering completes successfully withou
 ## Prior Art
 - PERF-781 (infinite buffering regressed performance)
 - PERF-689 (introduced the 16MB limit)
+
+## Results Summary
+- **Best render time**: 2.257s
+- **Improvement**: Regression
+- **Kept experiments**: None
+- **Discarded experiments**: 4MB writableLength threshold

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1285,3 +1285,8 @@ Last updated by: PERF-786
 
 ## What Works
 - Simplification of abort check in single-worker fast path. It slightly improved execution time by ~1% by hoisting the `signal.aborted` condition checks out of the hot path inside the `for` loops in `packages/renderer/src/core/CaptureLoop.ts`. (PERF-786)
+
+- **PERF-789**: Tune FFmpeg Stdin Backpressure
+  - **What I tried**: Lowered `stdin.writableLength` threshold from `16777216` (16MB) to `4194304` (4MB) in single-worker fast path.
+  - **WHY it didn't work**: The median render time in the fast path slightly regressed to ~2.274s (vs baseline median ~2.069s). The tighter synchronization caused more frequent yielding to FFmpeg which created more backpressure bottlenecks than a larger buffer space. The 16MB threshold correctly buffers chunks before pausing.
+  - **Plan ID**: PERF-789

--- a/packages/renderer/.sys/perf-results-PERF-789.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-789.tsv
@@ -1,0 +1,6 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	2.323	150	64.56	62.9	discard	4MB threshold
+2	2.257	150	66.45	62.9	discard	4MB threshold
+3	2.274	150	65.98	63.0	discard	4MB threshold
+4	2.314	150	64.82	63.0	discard	4MB threshold
+5	2.335	150	64.23	62.9	discard	4MB threshold


### PR DESCRIPTION
💡 What: Lowered stdin.writableLength threshold from 16MB to 4MB in single-worker fast path. Discarded as it regressed median render time to ~2.274s (vs ~2.069s).

🎯 Why: To tighten synchronization and reduce GC pauses.

📊 Impact: Regressed median render time by ~10%.

🔬 Verification: 4-gate verification failed. Discarded.

📎 Plan: .sys/plans/PERF-789-tune-ffmpeg-stdin-backpressure.md

## Results Summary
```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	2.323	150	64.56	62.9	discard	4MB threshold
2	2.257	150	66.45	62.9	discard	4MB threshold
3	2.274	150	65.98	63.0	discard	4MB threshold
4	2.314	150	64.82	63.0	discard	4MB threshold
5	2.335	150	64.23	62.9	discard	4MB threshold
```

---
*PR created automatically by Jules for task [15880924704994711445](https://jules.google.com/task/15880924704994711445) started by @BintzGavin*