### PR TITLE
📋 PLAYER: Document Missing Media Events

### DIFF
--- a/.sys/plans/2027-02-18-PLAYER-Document-Missing-Media-Events.md
+++ b/.sys/plans/2027-02-18-PLAYER-Document-Missing-Media-Events.md
@@ -1,0 +1,23 @@
+#### 1. Context & Goal
+- **Objective**: Document the missing standard media events (`abort`, `emptied`, `progress`) in the project README.
+- **Trigger**: The event dispatches were implemented in a previous cycle, but the `README.md` was not updated to reflect these events, leaving a vision gap.
+- **Impact**: Ensures complete and accurate API documentation parity with the `HeliosPlayer` implementation.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**: `packages/player/README.md`
+- **Read-Only**: `packages/player/src/index.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: N/A - Documentation only.
+- **Pseudo-Code**:
+  - Add `- \`abort\`: Fired when the loading of the media has been aborted.` to the "Events" section in `packages/player/README.md`.
+  - Add `- \`emptied\`: Fired when the media has become empty.` to the "Events" section in `packages/player/README.md`.
+  - Add `- \`progress\`: Fired periodically as the browser loads a resource.` to the "Events" section in `packages/player/README.md`.
+- **Public API Changes**: None (Documentation only).
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `cat packages/player/README.md | grep -E "abort|emptied|progress"`
+- **Success Criteria**: The output must contain the newly documented events in the Events list.
+- **Edge Cases**: Ensure alphabetical or logical placement within the existing events list does not break formatting.


### PR DESCRIPTION
Created an implementation plan to document the previously implemented media events (`abort`, `emptied`, `progress`) in the `packages/player/README.md` to ensure API parity and vision alignment.

Path: `.sys/plans/2027-02-18-PLAYER-Document-Missing-Media-Events.md`

---
*PR created automatically by Jules for task [5550213449008779106](https://jules.google.com/task/5550213449008779106) started by @BintzGavin*