### PR TITLE
📋 CLI: Command Coverage Tests Spec V9

### DIFF
--- a/.jules/CLI.md
+++ b/.jules/CLI.md
@@ -13,3 +13,6 @@
 ## [v0.46.49] - CLI Utils Coverage Tests Spec
 **Learning:** Found remaining uncovered branches in `packages/cli/src/utils` specifically related to failure catch blocks on file mutations in `examples.ts` and empty parent directory recursive pruning in `uninstall.ts` (lines 83, 119, 140, 147 in `examples.ts`, 50-54 in `uninstall.ts`, 35-50 in `package-manager.ts`, 132, 141 in `install.ts`).
 **Action:** Always mock `fs.writeFileSync` or `fs.readdirSync` with an error throwing impl to accurately hit file system handling fallback coverage lines.
+## [v0.46.51] - CLI Command Coverage Spec V9
+**Learning:** Checking coverage highlighted that missing branches existed for user aborts on prompts across the `deploy` subcommands (e.g. `typeof response.value === 'undefined'` check).
+**Action:** When tracking uncovered branches to improve test suites, ensure user prompt cancellations are addressed.

--- a/.sys/plans/2027-06-05-CLI-Command-Coverage-Tests-V9.md
+++ b/.sys/plans/2027-06-05-CLI-Command-Coverage-Tests-V9.md
@@ -1,0 +1,35 @@
+# CLI Command Coverage Tests Spec V9
+
+## 1. Context & Goal
+- **Objective**: Improve the test coverage for the `deploy` command to cover the exit/cancel condition when prompting for file overwriting.
+- **Trigger**: The recent coverage run shows that the lines checking `typeof response.value === 'undefined'` in the deploy subcommands are not covered.
+- **Impact**: Getting to 100% test coverage in the CLI module.
+
+## 2. File Inventory
+- **Create**: none
+- **Modify**: `packages/cli/src/commands/__tests__/deploy.test.ts`
+- **Read-Only**: `packages/cli/src/commands/deploy.ts`
+
+## 3. Implementation Spec
+- **Architecture**: In the deploy unit tests, I will add a new test case for each of the subcommands (like `setup`, `gcp`, `aws`, `cloudflare`, `cloudflare-sandbox`, `fly`, `azure`, `kubernetes`, `hetzner`, `modal`, `deno`, `vercel`) that mimics the user cancelling the prompt (Ctrl+C). This is achieved by having `prompts` resolve with an empty object `{}` so `response.value` is undefined. I will mock `process.exit` and assert it is called.
+- **Pseudo-Code**:
+  ```pseudo-code
+    mock fs.existsSync to return true
+    mock prompts to return {}
+    mock process.exit
+
+    call program.parseAsync with deploy subcommand
+
+    expect process.exit to have been called with 0
+
+    restore mockExit
+
+
+  ```
+- **Public API Changes**: none.
+- **Dependencies**: none.
+
+## 4. Test Plan
+- **Verification**: Run `npm run test -w packages/cli -- --coverage`
+- **Success Criteria**: The coverage report shows `packages/cli/src/commands/deploy.ts` branch and statement coverage at 100%. Uncovered lines 936-937, 973-974 and similar missing lines are gone.
+- **Edge Cases**: Make sure to restore the mock of `process.exit` correctly to avoid issues with other tests. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,4 +1,6 @@
-**Version**: 0.46.49
+[v0.46.51] 🟢 Completed: CLI Command Coverage Tests Spec V9 - Created specification plan 2027-06-05-CLI-Command-Coverage-Tests-V9.md for covering missing exit prompt branches in deploy subcommands.
+
+**Version**: 0.46.51
 
 [v0.46.44] ✅ Completed: CLI Registry Types Regression Tests - Logged the duplicated plan as impossible since registry types regression tests are already fully implemented.
 [v0.46.41] ✅ Completed: CLI Docker Adapter Regression Tests - Logged the duplicated plan as impossible since docker-adapter template tests are already fully implemented.


### PR DESCRIPTION
Created a plan to handle missing command coverage tests for user cancellations in deploy command.

---
*PR created automatically by Jules for task [5817328573589505361](https://jules.google.com/task/5817328573589505361) started by @BintzGavin*