### PR TITLE
✨ CLI: Mark Docker Adapter Regression Tests as Impossible

### DIFF
--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -1,3 +1,6 @@
+### CLI v0.46.52
+- ✅ Completed: CLI Docker Adapter Regression Tests - Logged the duplicated plan as impossible since docker-adapter template tests are already fully implemented.
+
 ### CLI v0.46.44
 - ✅ Completed: CLI Registry Types Regression Tests - Logged the duplicated plan as impossible since registry types regression tests are already fully implemented.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,6 +1,8 @@
+[v0.46.52] ✅ Completed: CLI Docker Adapter Regression Tests - Logged the duplicated plan as impossible since docker-adapter template tests are already fully implemented.
+
 [v0.46.51] 🟢 Completed: CLI Command Coverage Tests Spec V9 - Created specification plan 2027-06-05-CLI-Command-Coverage-Tests-V9.md for covering missing exit prompt branches in deploy subcommands.
 
-**Version**: 0.46.51
+**Version**: 0.46.52
 
 [v0.46.44] ✅ Completed: CLI Registry Types Regression Tests - Logged the duplicated plan as impossible since registry types regression tests are already fully implemented.
 [v0.46.41] ✅ Completed: CLI Docker Adapter Regression Tests - Logged the duplicated plan as impossible since docker-adapter template tests are already fully implemented.


### PR DESCRIPTION
Update documentation to mark the `2027-06-05-CLI-Docker-Adapter-Regression-Tests.md` plan as completed/impossible because the regression tests for Docker Compose adapter templates (`DOCKER_COMPOSE_ADAPTER_TEMPLATE` and `README_DOCKER_TEMPLATE`) are already fully implemented and verified in `packages/cli/src/templates/__tests__/cloud.test.ts`. Increments CLI version to `0.46.52`.

---
*PR created automatically by Jules for task [14821606029552397411](https://jules.google.com/task/14821606029552397411) started by @BintzGavin*