### PR TITLE
✨ PLAYER: Document Missing Media Events

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -15,7 +15,7 @@ The `HeliosPlayer` is a standard Web Component (Custom Element: `<helios-player>
 - `emptied`: Dispatched when the media has become empty.
 - `progress`: Dispatched periodically as the browser loads a resource.
 The component dispatches standard HTML5 Media events:
-- `play`, `pause`, `ended`, `timeupdate`, `durationchange`, `volumechange`, `ratechange`, `seeked`, `seeking`, `error`, `loadedmetadata`, `loadeddata`, `canplay`, `canplaythrough`, `playing`, `waiting`, `emptied`, `stalled`, `suspend`, `abort`
+- `play`, `pause`, `ended`, `timeupdate`, `durationchange`, `volumechange`, `ratechange`, `seeked`, `seeking`, `error`, `loadedmetadata`, `loadeddata`, `canplay`, `canplaythrough`, `playing`, `waiting`, `emptied`, `stalled`, `suspend`, `abort`, `progress`
 
 Custom extensions:
 - `error` events carry a `code` and `message` compatible with `MediaError`.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -778,3 +778,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### CLI v0.46.48
 - ✅ Completed: CLI Command Coverage Tests V8 - Implemented test coverage for missing branches in job.ts.
+
+### PLAYER v0.77.59
+- ✅ Completed: Document Missing Media Events - Documented the abort, emptied, and progress events in the project README.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,5 @@
 [v0.77.53] ✅ Completed: Identified missing HTMLMediaElement events (`abort`, `emptied`, `progress`) in `<helios-player>`. Created plan `.sys/plans/2027-02-15-PLAYER-Add-Missing-Events.md` to implement them.
-**Version**: 0.77.58
+**Version**: 0.77.59
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
 [v0.77.52] ✅ Completed: Fix API Parity Events - Implemented synthetic dispatches for missing media events (suspend, stalled, waiting) to improve HTMLMediaElement API parity.
 [0.77.49] ✅ Completed: Document Missing Event Handlers - Documented onplaying, onwaiting, onsuspend, and onstalled properties and events.
@@ -260,3 +260,4 @@
 
 [v0.77.56] ✅ Completed: Implement Missing Media Event Dispatches - Added missing synthetic event dispatches for abort, emptied, and progress to improve HTMLMediaElement API parity.
 [v0.77.57] ✅ Completed: Discovered that `2027-02-18-PLAYER-Implement-Missing-Media-Event-Dispatches.md` is an IMPOSSIBLE: DUPLICATION plan. The event dispatches (`abort`, `emptied`, `progress`) are already fully implemented in the code. Documented as impossible and discarded.[v0.77.58] ✅ Completed: Discovered that `2027-02-18-PLAYER-Implement-Missing-Media-Properties.md` is an IMPOSSIBLE: DUPLICATION plan. The missing standard properties and methods (`disableRemotePlayback`, `mediaGroup`, `sinkId`, `setSinkId`) are already fully implemented in the code. Documented as impossible and discarded.
+[v0.77.59] ✅ Completed: Document Missing Media Events - Documented the abort, emptied, and progress events in the project README.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -266,6 +266,9 @@ The element dispatches the following custom events:
 - `loadeddata`: Fired when data for the current frame is available.
 - `canplay`: Fired when the browser can resume playback of the media.
 - `canplaythrough`: Fired when the browser estimates it can play through the media without buffering.
+- `abort`: Fired when the loading of the media has been aborted.
+- `emptied`: Fired when the media has become empty.
+- `progress`: Fired periodically as the browser loads a resource.
 - `resize`: Fired when the player dimensions change.
 - `enterpictureinpicture`: Fired when the player enters Picture-in-Picture mode.
 - `leavepictureinpicture`: Fired when the player leaves Picture-in-Picture mode.


### PR DESCRIPTION
Added documentation for abort, emptied, and progress events to README.md.

---
*PR created automatically by Jules for task [4177381311480253136](https://jules.google.com/task/4177381311480253136) started by @BintzGavin*