### PR TITLE
✨ RENDERER: Optimize DOM Rendering Hot Path

### DIFF
--- a/.sys/plans/PERF-803-optimize-dom-rendering-hot-path.md
+++ b/.sys/plans/PERF-803-optimize-dom-rendering-hot-path.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-803
 slug: optimize-dom-rendering-hot-path
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor"
 created: 2024-05-24
-completed: ""
-result: ""
+completed: "2024-05-24"
+result: "improved"
 ---
 
 # PERF-803: Optimize DOM Rendering Hot Path via Bitwise Capacity Math and Getter Aliasing

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1324,3 +1324,7 @@ Last updated by: PERF-793
   - **What I did**: Updated `DomStrategy.ts` to reallocate the decode buffer exponentially by a factor of 1.5 when the buffer size is exceeded.
   - **Impact**: It correctly allocates capacity logarithmically instead of linearly per frame when dimensions grow.
   - **Plan ID**: PERF-800
+- **PERF-803**: Optimize DOM Rendering Hot Path
+  - **What I did**: Replaced math exact re-allocation checks in `DomStrategy.ts` with bitwise logic `buf.length + (buf.length >> 1)`, and alias decoding buffers locally. In `CdpTimeDriver.ts`, deferred the subtraction of `timeInSeconds - previousTime` until after the dom mode early exit block to save arithmetic computations.
+  - **Impact**: Micro-optimizations resulting in faster frame captures.
+  - **Plan ID**: PERF-803

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -230,3 +230,4 @@ run	28.646	600	20.95	60.0	discard	PERF-739 Eager CDP Session Initialization in D
 1	3.010	150	49.83	60.0	keep	bypass byte length calculation
 1	1.85	150	81.08	45.0	keep	PERF-800: Exponential Capacity Growth for Base64 Decode Buffer
 1	0.000	150	0.00	0.0	keep	PERF-801-streamline-ffmpeg-writes
+803	1.948	600	308.12	38.5	keep	PERF-803: Optimize DOM Rendering Hot Path via Bitwise Capacity Math and Getter Aliasing

--- a/packages/renderer/src/drivers/CdpTimeDriver.ts
+++ b/packages/renderer/src/drivers/CdpTimeDriver.ts
@@ -199,15 +199,11 @@ export class CdpTimeDriver implements TimeDriver {
   }
 
   setTime(page: Page, timeInSeconds: number): Promise<void> | void {
-    const delta = timeInSeconds - this.currentTime;
-
     // If delta is 0 or negative, we don't advance.
     // In a renderer loop, time usually moves forward.
-    if (delta <= 0) {
+    if (timeInSeconds <= this.currentTime) {
         return;
     }
-
-    // Convert to milliseconds for CDP
 
 // 1. Synchronize media elements
     if (this.hasMedia) {
@@ -216,6 +212,7 @@ export class CdpTimeDriver implements TimeDriver {
 
     // 2. Advance virtual time
     // This triggers the browser event loop and requestAnimationFrame
+    const previousTime = this.currentTime;
     this.currentTime = timeInSeconds;
 
     if (this.mode === 'dom') {
@@ -223,6 +220,8 @@ export class CdpTimeDriver implements TimeDriver {
       return;
     }
 
+    // Convert to milliseconds for CDP
+    const delta = timeInSeconds - previousTime;
     this.setVirtualTimePolicyParams.budget = delta * 1000;
     this.client!.send('Emulation.setVirtualTimePolicy', this.setVirtualTimePolicyParams);
     return this.timePromise as any as Promise<void>;

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -173,14 +173,16 @@ export class DomStrategy implements RenderStrategy {
     if (result.screenshotData) {
       const b64 = result.screenshotData;
       const chars = b64.length;
-      if (!this.decodeBuffer || chars > this.decodeBuffer.length) {
-        const newCapacity = this.decodeBuffer
-          ? Math.max(chars, Math.floor(this.decodeBuffer.length * 1.5))
+      let buf = this.decodeBuffer;
+      if (!buf || chars > buf.length) {
+        const newCapacity = buf
+          ? Math.max(chars, buf.length + (buf.length >> 1))
           : chars;
-        this.decodeBuffer = Buffer.allocUnsafe(newCapacity);
+        buf = Buffer.allocUnsafe(newCapacity);
+        this.decodeBuffer = buf;
       }
-      const bytesWritten = this.decodeBuffer.write(b64, 'base64');
-      this.lastFrameData = this.decodeBuffer.subarray(0, bytesWritten);
+      const bytesWritten = buf.write(b64, 'base64');
+      this.lastFrameData = buf.subarray(0, bytesWritten);
     }
     return this.lastFrameData as Buffer;
   }


### PR DESCRIPTION
This commit addresses PERF-803 by replacing the mathematical buffer size checks with bitwise math and aliasing getters to streamline DOM Rendering hot paths.

---
*PR created automatically by Jules for task [18323295538104640693](https://jules.google.com/task/18323295538104640693) started by @BintzGavin*