### PR TITLE
✨ RENDERER: Record PERF-804 discard (bypassing writableLength)

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1208,6 +1208,11 @@ Last updated by: PERF-764
   - **Plan ID**: PERF-760
 
 ## What Doesn't Work (and Why)
+- **PERF-804**: Bypass stream.writableLength and buffer property lookup
+  - **What I tried**: Bypassed `stream.writableLength` getter by accessing `_writableState` directly in `CaptureLoop.ts` fast path, and cached `buf.length` locally in `DomStrategy.ts`.
+  - **WHY it worked/didn't work**: The performance regressed and induced instability in some environments due to accessing internal Node.js `_writableState` directly and possibly complicating TurboFan's optimization of inline variable caches. Discarded.
+  - **Plan ID**: PERF-804
+
 - Inlining `processCaptureResult` into `DomStrategy.capture()` via `.then(this.processCaptureResultBound)` (PERF-757): Regressed median render time to ~2.513s (vs ~2.441s baseline). Returning a chained Promise via `.then()` incurred more microtask allocation overhead than explicitly evaluating the ternary condition (`hasProcessFn ? ...`) which V8 inline caches efficiently.
 
 - **PERF-765**: Optimize CaptureLoop Write

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -231,3 +231,4 @@ run	28.646	600	20.95	60.0	discard	PERF-739 Eager CDP Session Initialization in D
 1	1.85	150	81.08	45.0	keep	PERF-800: Exponential Capacity Growth for Base64 Decode Buffer
 1	0.000	150	0.00	0.0	keep	PERF-801-streamline-ffmpeg-writes
 803	1.948	600	308.12	38.5	keep	PERF-803: Optimize DOM Rendering Hot Path via Bitwise Capacity Math and Getter Aliasing
+1	2.311	150	64.91	81.6	discard	PERF-804: bypass writableLength and cache length

--- a/packages/renderer/.sys/plans/PERF-804.md
+++ b/packages/renderer/.sys/plans/PERF-804.md
@@ -1,0 +1,7 @@
+---
+status: complete
+---
+# PERF-804
+Experiment to bypass stream.writableLength getter and reduce duplicate buffer length properties lookups.
+
+Discarded due to performance regression and stability issues.


### PR DESCRIPTION
# ✨ RENDERER: Record PERF-804 discard

Discarded experiment: Bypassing `stream.writableLength` getter by directly accessing `_writableState`, and caching buffer length in `DomStrategy.ts`. The median render time in the fast path slightly regressed to ~2.311s (vs baseline median ~2.069s). It induced performance regressions and instability. The code changes were reverted.

Results:
```
1	2.311	150	64.91	81.6	discard	PERF-804: bypass writableLength and cache length
```

---
*PR created automatically by Jules for task [15483180781924693911](https://jules.google.com/task/15483180781924693911) started by @BintzGavin*