### PR TITLE
✨ RENDERER: Discard PERF-797 duplicate experiment

### DIFF
--- a/.sys/plans/PERF-797-hoist-stream-reference-and-bypass-getter.md
+++ b/.sys/plans/PERF-797-hoist-stream-reference-and-bypass-getter.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-797
 slug: hoist-stream-reference-and-bypass-getter
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-06-18
-completed: ""
-result: ""
+completed: "2026-06-20"
+result: "discard"
 ---
 
 # PERF-797: Hoist Stream Reference and Bypass Getter in CaptureLoop
@@ -65,3 +65,9 @@ Run the standard DOM benchmark and ensure the output video is generated without 
 
 ## Prior Art
 - PERF-777 (Bypass Stream Writable Getter in single worker CaptureLoop)
+
+## Results Summary
+- **Best render time**: N/A
+- **Improvement**: N/A
+- **Kept experiments**: None
+- **Discarded experiments**: PERF-797 (Duplicate of PERF-801/806)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1212,6 +1212,11 @@ Last updated by: PERF-764
   - **Plan ID**: PERF-760
 
 ## What Doesn't Work (and Why)
+- **PERF-797**: Hoist Stream Reference and Bypass Getter in CaptureLoop
+  - **What I tried**: Bypassing `stdin?.writable` and hoisting `stream`.
+  - **WHY it didn't work**: The planned optimizations were already implemented in previous experiments (PERF-801 and PERF-806). The plan was a duplicate and marked discarded.
+  - **Plan ID**: PERF-797
+
 - **PERF-804**: Bypass stream.writableLength and buffer property lookup
   - **What I tried**: Bypassed `stream.writableLength` getter by accessing `_writableState` directly in `CaptureLoop.ts` fast path, and cached `buf.length` locally in `DomStrategy.ts`.
   - **WHY it worked/didn't work**: The performance regressed and induced instability in some environments due to accessing internal Node.js `_writableState` directly and possibly complicating TurboFan's optimization of inline variable caches. Discarded.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -233,3 +233,4 @@ run	28.646	600	20.95	60.0	discard	PERF-739 Eager CDP Session Initialization in D
 803	1.948	600	308.12	38.5	keep	PERF-803: Optimize DOM Rendering Hot Path via Bitwise Capacity Math and Getter Aliasing
 1	2.311	150	64.91	81.6	discard	PERF-804: bypass writableLength and cache length
 1	0.500	0	0.00	0.0	keep	PERF-805: Optimize Base64 Decode Buffer Allocation via Bitwise Capacity Math
+1	0.000	0	0.00	0.0	discard	duplicate of PERF-801


### PR DESCRIPTION
💡 What: Discarded PERF-797 as duplicate
🎯 Why: Already implemented in PERF-801 and PERF-806
📊 Impact: None
🔬 Verification: npm run build
📎 Plan: .sys/plans/PERF-797-hoist-stream-reference-and-bypass-getter.md

```tsv
1	0.000	0	0.00	0.0	discard	duplicate of PERF-801
```

---
*PR created automatically by Jules for task [11314007510694881221](https://jules.google.com/task/11314007510694881221) started by @BintzGavin*