### PR TITLE
✨ PLAYER: Configurable Export Resolution

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -36,6 +36,8 @@ Observed attributes:
 - `playsinline`: Indicates that the video is to be played "inline", within the element's playback area.
 - `poster`: Image URL displayed before playback starts.
 - `preload`: Strategy for preloading (none, metadata, auto).
+- `export-width`, `export-height`: Optional target dimensions for exported media.
+- `export-bitrate`: Optional target bitrate for video exports.
 - `canvas-selector`: CSS selector for the primary canvas inside the iframe (default: `canvas`).
 
 ## Section D: Public API

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -781,3 +781,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### PLAYER v0.77.59
 - ✅ Completed: Document Missing Media Events - Documented the abort, emptied, and progress events in the project README.
+
+### PLAYER v0.77.60
+- ✅ Completed: Discovered that `2026-06-03-PLAYER-configurable-export-resolution.md` is an IMPOSSIBLE: DUPLICATION plan. The `export-width` and `export-height` properties are already fully implemented and verified in the codebase. Documented as impossible and discarded.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,6 @@
 [v0.77.53] ✅ Completed: Identified missing HTMLMediaElement events (`abort`, `emptied`, `progress`) in `<helios-player>`. Created plan `.sys/plans/2027-02-15-PLAYER-Add-Missing-Events.md` to implement them.
-**Version**: 0.77.59
+**Version**: 0.77.60
+[v0.77.60] ✅ Completed: Discovered that 2026-06-03-PLAYER-configurable-export-resolution.md is an IMPOSSIBLE: DUPLICATION plan. The export-width and export-height properties are already fully implemented and verified in the codebase. Documented as impossible and discarded.
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
 [v0.77.52] ✅ Completed: Fix API Parity Events - Implemented synthetic dispatches for missing media events (suspend, stalled, waiting) to improve HTMLMediaElement API parity.
 [0.77.49] ✅ Completed: Document Missing Event Handlers - Documented onplaying, onwaiting, onsuspend, and onstalled properties and events.


### PR DESCRIPTION
Discard duplicate plan for export-width and export-height properties as they were already implemented in previous commits. Cleans up planning pipeline.

---
*PR created automatically by Jules for task [3034019725041029072](https://jules.google.com/task/3034019725041029072) started by @BintzGavin*