### PR TITLE
✨ RENDERER: Prebind base64 pool callback (Discarded)

### DIFF
--- a/.sys/plans/PERF-810-prebind-base64-pool-callback.md
+++ b/.sys/plans/PERF-810-prebind-base64-pool-callback.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-810
 slug: prebind-base64-pool-callback
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-06-20
 completed: ""
-result: ""
+result: "Crash - test failed"
 ---
 # PERF-810: Prebind Base64 Pool Callback
 

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -230,6 +230,7 @@ Last updated by: PERF-726
   - **Plan ID**: PERF-740
 
 ## What Doesn't Work (and Why)
+- Prebound base64 freePool callback in CaptureLoop.ts (PERF-810) — Discarded because `stream.write(chunk, cb)` strictly queues the callback correctly in node.js internal mechanics, but attempting to mutate the bound object and recycle the `Buffer` instance by appending the bound callback triggered a deep corruption in stream processing, causing ffmpeg slice decoding failures and crashing the verify-trace pipeline.
 - **PERF-781**: Infinite Node.js Stream Buffering (No Drain Await)
   - **What I tried**: Removed the `await this.drainPromise` in the FFmpeg stdin writing block in the single-worker fast path to decouple Chromium frame generation from FFmpeg processing.
   - **WHY it didn't work**: The median render time in the fast path regressed to ~2.96s (vs baseline median ~2.069s). While it theoretically avoids event loop stalls from `drainPromise`, removing the backpressure causes memory pressure and seems to disrupt V8's optimization of the hot loop, likely due to uncontrolled stream buffer expansion or garbage collection.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -237,3 +237,4 @@ run	28.646	600	20.95	60.0	discard	PERF-739 Eager CDP Session Initialization in D
 1001	1.948	150	77.00	120.0	keep	Static Buffer Type Resolution in CaptureLoop (PERF-808)
 1002	0.001277	0	0.00	0.0	keep	monomorphic base64 (microbenchmark)
 809	1.682	150	0.00	0.0	keep	monomorphic base64 ring buffer (microbenchmark)
+1	0.000	0	0.00	0.0	discard	PERF-810 Prebind base64 callback


### PR DESCRIPTION
Attempted to prebind the callback for the base64 decode pool in CaptureLoop.ts to eliminate per-frame closure allocations. This was intended to reduce garbage collection pressure in V8 and lower frame write latency.

While microbenchmarks showed an improvement, the changes triggered a stream processing corruption that crashed the verify-trace pipeline. The code changes have been reverted and the failure has been documented.

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	PERF-810 Prebind base64 callback
```

---
*PR created automatically by Jules for task [4351032978149136306](https://jules.google.com/task/4351032978149136306) started by @BintzGavin*