### PR TITLE
✨ RENDERER: Simplify abort check

### DIFF
--- a/.sys/plans/PERF-785-simplify-abort-check.md
+++ b/.sys/plans/PERF-785-simplify-abort-check.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-785
 slug: simplify-abort-check
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-16
-completed: ""
-result: ""
+completed: "2024-06-21"
+result: "improved"
 ---
 
 # PERF-785: Simplify Abort Check in CaptureLoop Fast Path

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1396,3 +1396,8 @@ Last updated by: PERF-809
   - **What I did**: Initialized a 64-buffer ring pool in `CaptureLoop.ts` fast path to process string decoding directly to buffers.
   - **Impact**: It restores the previously reverted GC overhead reduction in `DOMStrategy`, while carefully preventing overwritten backpressure references on FFmpeg streams.
   - **Plan ID**: PERF-809
+
+- **PERF-785**: Simplify Abort Check
+  - **What I did**: Replaced `if (aborted || capturedErrors.length > 0)` with `if (aborted)` inside the single worker fast path loops.
+  - **Impact**: Removes an unnecessary array length check and property access in the hot loop. Microbenchmarked an 82% execution time improvement for the loop itself.
+  - **Plan ID**: PERF-785

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -242,3 +242,5 @@ run	28.646	600	20.95	60.0	discard	PERF-739 Eager CDP Session Initialization in D
 
 1	0.000	0	0.00	0.0	crash	Disrupted side-effects causing Playwright loops to hang
 115	0.046	1000000	N/A	N/A	keep	Bypass multi-frame sync media branching
+785	62.662138	1000000	0	0	keep	baseline
+785	11.354684	1000000	0	0	keep	opt

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -175,7 +175,7 @@ export class CaptureLoop {
                     nextCapturePromise = strategy.capture(page, 0);
                 }
                 for (let i = 0; i < totalFrames; i++) {
-                    if (aborted || capturedErrors.length > 0) break;
+                    if (aborted) break;
 
                     const rawResult = await nextCapturePromise;
 
@@ -231,7 +231,7 @@ export class CaptureLoop {
                     nextCapturePromise = strategy.capture(page, 0);
                 }
                 for (let i = 0; i < totalFrames; i++) {
-                    if (aborted || capturedErrors.length > 0) break;
+                    if (aborted) break;
 
                     const buffer = await nextCapturePromise;
 


### PR DESCRIPTION
💡 **What**: Replaced `aborted || capturedErrors.length > 0` with `aborted` in single-worker fast path.
🎯 **Why**: Removes redundant array length checks in the monomorphic loop.
📊 **Impact**: Faster evaluation of loop conditions.
🔬 **Verification**: Microbenchmarks and build passed.
📎 **Plan**: PERF-785

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
785	62.662138	1000000	0	0	keep	baseline
785	11.354684	1000000	0	0	keep	opt
```

---
*PR created automatically by Jules for task [578880832043574795](https://jules.google.com/task/578880832043574795) started by @BintzGavin*