### PR TITLE
✨ RENDERER: Discard PERF-817 N-Frame Pipeline Lookahead

### DIFF
--- a/.sys/plans/PERF-817-n-frame-pipeline-lookahead.md
+++ b/.sys/plans/PERF-817-n-frame-pipeline-lookahead.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-817
 slug: n-frame-pipeline-lookahead
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-06-22
-completed: ""
-result: ""
+completed: "2026-06-22"
+result: "failed"
 ---
 
 # PERF-817: N-Frame Pipeline Lookahead (Deep Overlap)
@@ -103,3 +103,10 @@ Run `npm run build` and ensure the `packages/player` tests pass to verify `canva
 
 ## Correctness Check
 Run the `dom` mode benchmark script (`cd packages/renderer && npx tsx scripts/benchmark-perf.ts --mode dom`). Ensure progress reporting is still emitted sequentially and the output video correctly captures all frames without skipping or corrupting.
+
+
+## Results Summary
+- **Best render time**: N/A (crash)
+- **Improvement**: 0%
+- **Kept experiments**: []
+- **Discarded experiments**: [N-frame pipeline lookahead]

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1401,3 +1401,8 @@ Last updated by: PERF-809
   - **What I did**: Replaced `if (aborted || capturedErrors.length > 0)` with `if (aborted)` inside the single worker fast path loops.
   - **Impact**: Removes an unnecessary array length check and property access in the hot loop. Microbenchmarked an 82% execution time improvement for the loop itself.
   - **Plan ID**: PERF-785
+
+- **PERF-817**: N-Frame Pipeline Lookahead
+  - **What I tried**: Replacing the 1-frame lookahead in the CaptureLoop with an N-frame (4) pipeline array of promises.
+  - **WHY it didn't work**: The Chromium CDP protocol enforces a strict constraint that `HeadlessExperimental.beginFrame` cannot be called if another frame request is currently pending (`Another frame is pending` Protocol error). As a result, queuing up multiple CDP frames sequentially without awaiting the previous one causes an immediate crash. We are limited by Chromium's architecture to a maximum of 1 active frame request at a time per session. Discarded.
+  - **Plan ID**: PERF-817

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -244,3 +244,4 @@ run	28.646	600	20.95	60.0	discard	PERF-739 Eager CDP Session Initialization in D
 115	0.046	1000000	N/A	N/A	keep	Bypass multi-frame sync media branching
 785	62.662138	1000000	0	0	keep	baseline
 785	11.354684	1000000	0	0	keep	opt
+1	0.000	0	0.00	0.0	crash	N-frame lookahead (Protocol error: Another frame is pending)


### PR DESCRIPTION
💡 **What**: Tried to replace the 1-frame lookahead in the CaptureLoop with an N-frame (4) pipeline array of promises.
🎯 **Why**: To overlap multiple CDP frame capture commands to mask IPC latency.
📊 **Impact**: N/A (crashed)
🔬 **Verification**: The benchmark crashed with `Protocol error (HeadlessExperimental.beginFrame): Another frame is pending`.
📎 **Plan**: PERF-817

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	crash	N-frame lookahead (Protocol error: Another frame is pending)

---
*PR created automatically by Jules for task [15511286004015696650](https://jules.google.com/task/15511286004015696650) started by @BintzGavin*