### PR TITLE
📋 RENDERER: Static Buffer-Callback Pairing for Base64 Pool

### DIFF
--- a/.sys/plans/PERF-818-static-buffer-callback-pairing.md
+++ b/.sys/plans/PERF-818-static-buffer-callback-pairing.md
@@ -1,0 +1,127 @@
+---
+id: PERF-818
+slug: static-buffer-callback-pairing
+status: unclaimed
+claimed_by: ""
+created: 2024-06-22
+completed: ""
+result: ""
+---
+
+# PERF-818: Static Buffer-Callback Pairing for Base64 Pool
+
+## Focus Area
+`CaptureLoop.ts` single-worker and multi-worker fast paths (Base64 decoding buffer pool).
+
+## Background Research
+PERF-810 attempted to eliminate per-frame closure allocations in the Base64 decode pool by prebinding a single callback. However, because it tried to mutate the bound reference dynamically across different frames, it caused stream queueing corruption under FFmpeg backpressure.
+Currently, `stream.write(chunk, () => { freePool.push(buf!); })` allocates a new anonymous closure function for every single frame. This adds garbage collection pressure and CPU overhead inside the renderer's hottest loop.
+By introducing a `PooledBuffer` class that pairs a `Buffer` instance directly with its own dedicated, permanently bound `freeCb` method, we can completely eliminate per-frame closure allocations. When `stream.write` is called, it simply receives the static `pooled.freeCb` reference. When the callback fires, it pushes its specific `PooledBuffer` instance back to the pool, guaranteeing thread-safe, corruption-free recycling.
+
+## Benchmark Configuration
+- **Composition URL**: `file:///app/examples/dom-benchmark/composition.html`
+- **Render Settings**: 600x600, 30fps, 5 seconds
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: ~1.831s
+- **Bottleneck analysis**: Anonymous closure allocation on every frame for the backpressure `stream.write` callback causes unnecessary Garbage Collection pressure inside the V8 hot loop.
+
+## Implementation Spec
+
+### Step 1: Define the `PooledBuffer` Class
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+At the top of the file, outside the `CaptureLoop` class, define a static container:
+```typescript
+class PooledBuffer {
+    public buffer: Buffer;
+    public freeCb: () => void;
+    constructor(size: number, pool: PooledBuffer[]) {
+        this.buffer = Buffer.allocUnsafe(size);
+        this.freeCb = () => {
+            pool.push(this);
+        };
+    }
+}
+```
+
+### Step 2: Update the Single-Worker Pool Initialization
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the single-worker fast path (`if (poolLen === 1)` block), change the `freePool` initialization:
+```typescript
+        const POOL_SIZE = 64;
+        const INITIAL_BUFFER_SIZE = 512 * 1024;
+        const freePool: PooledBuffer[] = new Array(POOL_SIZE);
+        for (let i = 0; i < POOL_SIZE; i++) {
+            freePool[i] = new PooledBuffer(INITIAL_BUFFER_SIZE, freePool);
+        }
+```
+
+### Step 3: Apply `PooledBuffer` in the Single-Worker Hot Loops
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+Inside **both** the `if (hasProcessFn)` loop and the `else` loop in the single worker path, update the base64 `isString` decoding block to use the paired properties:
+```typescript
+                    if (isString) {
+                        const str = buffer as string;
+                        const maxBytes = (str.length * 3) >>> 2;
+                        let pooled = freePool.pop();
+                        if (!pooled || pooled.buffer.length < maxBytes) {
+                            pooled = new PooledBuffer(maxBytes + (maxBytes >> 1), freePool);
+                        }
+                        const written = pooled.buffer.write(str, 'base64');
+                        const chunk = pooled.buffer.subarray(0, written);
+                        writeSuccess = stream.write(chunk, pooled.freeCb);
+                    } else {
+                        writeSuccess = stream.write(buffer as any);
+                    }
+```
+
+### Step 4: Update the Multi-Worker Pool Initialization
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the multi-worker `else` block, update the `multiFreePool` initialization:
+```typescript
+    const MULTI_POOL_SIZE = 64;
+    const MULTI_INITIAL_BUFFER_SIZE = 512 * 1024;
+    const multiFreePool: PooledBuffer[] = new Array(MULTI_POOL_SIZE);
+    for (let i = 0; i < MULTI_POOL_SIZE; i++) {
+        multiFreePool[i] = new PooledBuffer(MULTI_INITIAL_BUFFER_SIZE, multiFreePool);
+    }
+```
+
+### Step 5: Apply `PooledBuffer` in the Multi-Worker Loop
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the multi-worker write loop (`while (nextFrameToWrite < totalFrames && !aborted)`), update the `isString` decoding block:
+```typescript
+            if (isString) {
+                const str = buffer as string;
+                const maxBytes = (str.length * 3) >>> 2;
+                let pooled = multiFreePool.pop();
+                if (!pooled || pooled.buffer.length < maxBytes) {
+                    pooled = new PooledBuffer(maxBytes + (maxBytes >> 1), multiFreePool);
+                }
+                const written = pooled.buffer.write(str, 'base64');
+                const chunk = pooled.buffer.subarray(0, written);
+                writeSuccess = stream.write(chunk, pooled.freeCb);
+            } else {
+                writeSuccess = stream.write(buffer as any);
+            }
+```
+
+**Why**: By embedding the callback natively into a dedicated `PooledBuffer` container class, we achieve strict 1:1 mapping between the memory buffer and its recycling mechanism. V8 can heavily inline the `stream.write(chunk, pooled.freeCb)` call without having to dynamically allocate, garbage collect, or track a new anonymous closure function for every single frame rendered, significantly reducing V8 engine overhead in the hottest code path.
+
+## Canvas Smoke Test
+Run `npm run build -w packages/renderer` to ensure typescript compilation passes.
+
+## Correctness Check
+Run the DOM benchmark. If it succeeds without `EPIPE` or frame slice corruption, the `PooledBuffer` state logic is sound and correctly handles Node.js stream backpressure.
+
+## Prior Art
+- PERF-810 attempted prebinding but caused FFmpeg backpressure corruption because it dynamically mutated a single callback instance. This plan fixes the architectural flaw by using object-oriented static pairing.
+- PERF-815 proved explicit Base64 memory pool management is an effective V8 optimization.


### PR DESCRIPTION
💡 What: Create PERF-818 experiment plan to eliminate per-frame callback allocation during Base64 decoding.
🎯 Why: Anonymous closure allocations on every frame for `stream.write` cause unnecessary GC pressure in the V8 hot loop.
🔬 Approach: Introduce a `PooledBuffer` class that pairs a `Buffer` instance directly with its own permanently bound `freeCb` method.
📎 Plan: /.sys/plans/PERF-818-static-buffer-callback-pairing.md

---
*PR created automatically by Jules for task [4072238346951035022](https://jules.google.com/task/4072238346951035022) started by @BintzGavin*