### PR TITLE
📋 RENDERER: Eliminate inner loop branch in CaptureLoop

### DIFF
--- a/.sys/plans/PERF-822-eliminate-branch.md
+++ b/.sys/plans/PERF-822-eliminate-branch.md
@@ -1,0 +1,49 @@
+---
+id: PERF-822
+slug: eliminate-branch
+status: unclaimed
+claimed_by: ""
+created: 2024-06-23
+completed: ""
+result: ""
+---
+
+# PERF-822: Eliminate `i + 1 < totalFrames` Branch in CaptureLoop Hot Paths
+
+## Focus Area
+`packages/renderer/src/core/CaptureLoop.ts` single-worker fast paths.
+
+## Background Research
+Inside the single-worker `CaptureLoop` hot paths, there is a check `if (i + 1 < totalFrames)` evaluated on every single frame inside the inner `for (let i = currentFrame; i < endFrame; i++)` loop. This check is necessary to prevent requesting a CDP frame for an out-of-bounds frame index at the very end of the composition.
+However, since the loop bounds are deterministic (processing in chunks of `progressInterval`), we can hoist this branch entirely. By structuring the inner loops so that they unconditionally pre-fetch the next frame up to `endFrame - 1`, and then handling the final frame (when `endFrame === totalFrames`) separately, we can eliminate a branch condition evaluated thousands of times in the hottest path of the DOM renderer.
+
+## Benchmark Configuration
+- **Composition URL**: `file:///app/examples/dom-benchmark/composition.html`
+- **Render Settings**: 600x600, 30fps, 5 seconds
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: 2.573s (from RENDERER-EXPERIMENTS.md)
+- **Bottleneck analysis**: The `if (i + 1 < totalFrames)` branch adds unnecessary branch prediction pressure in the single-worker capture loop.
+
+## Implementation Spec
+
+### Step 1: Hoist branch in String and Buffer Paths
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the single-worker fast path blocks containing the `if (isString)` checks, modify the chunked loop `for (let i = currentFrame; i < endFrame; i++)` to hoist the `i + 1 < totalFrames` check. By calculating `const prefetchEnd = endFrame === totalFrames ? endFrame - 1 : endFrame;`, the inner loop can iterate up to `prefetchEnd` without needing the `if (i + 1 < totalFrames)` bounds check. The final frame logic (if `endFrame === totalFrames`) can then be handled outside the loop.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run `npx tsx packages/renderer/scripts/benchmark-perf.ts --mode canvas` to ensure `canvas` mode is not broken.
+
+## Correctness Check
+Run the `dom` mode benchmark script to verify progress logs correctly emit in chunks and render finishes without regressions.
+
+## Prior Art
+- PERF-794: Successfully hoisted progress checks.
+- PERF-820/821: Unswitched isString loops.


### PR DESCRIPTION
💡 What: Create PERF-822 experiment plan.
🎯 Why: The `i + 1 < totalFrames` check evaluates inside the inner loop on every frame. Hoisting it improves hot loop performance.
🔬 Approach: Split the `CaptureLoop.ts` single-worker loop to unconditionally prefetch frames and handle the final frame separately.
📎 Plan: /.sys/plans/PERF-822-eliminate-branch.md

---
*PR created automatically by Jules for task [10502284936092707901](https://jules.google.com/task/10502284936092707901) started by @BintzGavin*