### PR TITLE
📋 RENDERER: Inline Strategy Call overhead in the Hot Loop

### DIFF
--- a/.sys/plans/PERF-824-inline-strategy-calls.md
+++ b/.sys/plans/PERF-824-inline-strategy-calls.md
@@ -1,0 +1,120 @@
+---
+id: PERF-824
+slug: inline-strategy-calls
+status: unclaimed
+claimed_by: ""
+created: 2024-06-23
+completed: ""
+result: ""
+---
+
+# PERF-824: Inline Strategy Call overhead in the Hot Loop
+
+## Focus Area
+`CaptureLoop.ts` fast path execution context
+
+## Background Research
+Currently, inside the heavily optimized inner chunked loop in `CaptureLoop.ts` we have two abstract method calls:
+```typescript
+nextCapturePromise = strategy.capture(page, (i + 1) * timeStep);
+const buf = strategy.processCaptureResult!(rawResult);
+```
+
+For DOM rendering, `strategy` is ALWAYS an instance of `DomStrategy`. We know this statically because `DomStrategy` is the only strategy that supports the `dom` mode, and this codebase targets DOM rendering optimizations exclusively.
+
+Function calls in V8, especially polymorphic or megamorphic ones through an interface (`RenderStrategy`), incur significant dispatch overhead compared to monomorphic direct calls or inlined code. Furthermore, `DomStrategy.capture` is just:
+```typescript
+  capture(page: Page, frameTime: number): Promise<any> {
+    return this.cdpSession!.send('HeadlessExperimental.beginFrame', this.beginFrameParams);
+  }
+```
+And `DomStrategy.processCaptureResult` is just:
+```typescript
+  processCaptureResult(result: any): string | Buffer {
+    const data = result.screenshotData;
+    if (data) {
+      this.lastFrameData = data;
+    }
+    return this.lastFrameData as string | Buffer;
+  }
+```
+
+By extracting the `cdpSession` and `beginFrameParams` references at the start of `CaptureLoop` and calling them directly, we can eliminate the interface dispatch and function call overhead entirely in the hot loop.
+
+## Benchmark Configuration
+- **Composition URL**: `file:///app/examples/dom-benchmark/composition.html`
+- **Render Settings**: 600x600, 30fps, 5 seconds
+- **Mode**: `dom`
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: 1.831s
+- **Bottleneck analysis**: Interface dispatch overhead in the inner fast-path loop.
+
+## Implementation Spec
+
+### Step 1: Pre-bind DOM Strategy fields in single-worker path
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In `CaptureLoop.ts`, before the main single-worker `try { ... }` block, try to detect if we're using a `DomStrategy` by checking for the `cdpSession` property. If so, pre-bind the CDP session and parameters:
+
+```typescript
+        const isDomStrategy = !!(strategy as any).cdpSession;
+        const cdpSession = isDomStrategy ? (strategy as any).cdpSession : null;
+        const beginFrameParams = isDomStrategy ? (strategy as any).beginFrameParams : null;
+```
+
+### Step 2: Inline Capture and Process calls
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+Inside the inner chunked loops (e.g., `for (let i = currentFrame; i < prefetchEnd; i++)`), replace the generic strategy calls with inlined checks:
+
+Instead of:
+```typescript
+nextCapturePromise = strategy.capture(page, (i + 1) * timeStep);
+```
+Use:
+```typescript
+if (isDomStrategy) {
+    nextCapturePromise = cdpSession.send('HeadlessExperimental.beginFrame', beginFrameParams);
+} else {
+    nextCapturePromise = strategy.capture(page, (i + 1) * timeStep);
+}
+```
+
+Instead of:
+```typescript
+const buf = strategy.processCaptureResult!(rawResult) as string;
+```
+Use:
+```typescript
+let buf;
+if (isDomStrategy) {
+    const data = rawResult.screenshotData;
+    if (data) {
+        (strategy as any).lastFrameData = data;
+    }
+    buf = (strategy as any).lastFrameData as string;
+} else {
+    buf = strategy.processCaptureResult!(rawResult) as string;
+}
+```
+
+Apply this specifically to the hottest inner loop (Single Worker `hasProcessFn` -> `isString`).
+
+**Why**: Direct object property access and CDP calls are monomorphic and heavily optimized by V8 compared to dynamic interface dispatch.
+**Risk**: If `DomStrategy` internals change, this might break. But since `DomStrategy` is in the same package and its structure is known, it's a manageable tradeoff for performance.
+
+## Variations
+- Instead of generic inlining, completely split the execution path into `if (isDomStrategy)` vs `else` at the very top level, so the inner loop has zero conditional checks for strategy type.
+
+## Canvas Smoke Test
+Run `npx tsx scripts/benchmark-perf.ts --mode canvas` to ensure `canvas` mode is not broken (the `isDomStrategy` check protects it).
+
+## Correctness Check
+Run the `dom` mode benchmark script to verify output is identical.
+
+## Prior Art
+- PERF-820: Successfully unswitched conditionals from the inner loop.
+- PERF-785: Eliminated overhead from inside hot loops.


### PR DESCRIPTION
💡 What: An experiment plan to inline DomStrategy capture and process calls in the single-worker CaptureLoop fast path.
🎯 Why: To eliminate interface dispatch and function call overhead from V8 within the most heavily utilized chunked loop in DOM rendering.
🔬 Approach: Pre-bind `cdpSession` and `beginFrameParams` references at the top of the single-worker path, and replace `strategy.capture()` and `strategy.processCaptureResult()` with inlined CDP calls and property accesses.
📎 Plan: .sys/plans/PERF-824-inline-strategy-calls.md

---
*PR created automatically by Jules for task [16914749207585565462](https://jules.google.com/task/16914749207585565462) started by @BintzGavin*