### PR TITLE
📋 RENDERER: Unswitch capture branch for initial frames

### DIFF
--- a/.sys/plans/PERF-827-unswitch-capture-branch-initial-frames.md
+++ b/.sys/plans/PERF-827-unswitch-capture-branch-initial-frames.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-827
 slug: unswitch-capture-branch-initial-frames
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-06-23
-completed: ""
-result: ""
+completed: "2026-06-23"
+result: "improved"
 ---
 
 # PERF-827: Inline Strategy Calls for Initial Frames in Single-Worker Fast Path
@@ -110,3 +110,8 @@ Run the `dom` mode benchmark script to verify output is identical.
 ## Prior Art
 - PERF-824: Plan to inline strategy calls in single-worker path (missed the initial frames).
 - PERF-825: Plan to inline strategy calls in multi-worker path.
+
+## Results Summary
+- **Improvement**: Minor pipeline initialization improvement for single worker
+- **Kept experiments**: PERF-827
+- **Discarded experiments**: None

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 1.831s (baseline was 1.831s, -0%)
 Last updated by: PERF-822
 
 ## What Works
+- PERF-827: Unswitch capture branch for initial frames in single-worker path (Consistency and minor init opt)
 - PERF-828: Enlarge and Pre-allocate Base64 Pool for Hot Paths (Calculated size based on width/height upfront) - (~9% microbenchmark improvement)
 - PERF-824: Inlined DomStrategy capture and processCaptureResult in CaptureLoop single worker path (~43% microbenchmark improvement)
 - Inlined DomStrategy capture and processCaptureResult in CaptureLoop multi worker path (PERF-825) - ~42% faster in microbenchmark

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -188,7 +188,11 @@ export class CaptureLoop {
                     if (timePromise) {
                         await timePromise;
                     }
-                    nextCapturePromise = strategy.capture(page, 0);
+                    if (isDomStrategy) {
+                        nextCapturePromise = domCdpSession!.send('HeadlessExperimental.beginFrame', domBeginFrameParams);
+                    } else {
+                        nextCapturePromise = strategy.capture(page, 0);
+                    }
                 }
 
                 if (totalFrames > 0) {
@@ -198,9 +202,22 @@ export class CaptureLoop {
                         if (timePromise) {
                             await timePromise;
                         }
-                        nextCapturePromise = strategy.capture(page, timeStep);
+                        if (isDomStrategy) {
+                            nextCapturePromise = domCdpSession!.send('HeadlessExperimental.beginFrame', domBeginFrameParams);
+                        } else {
+                            nextCapturePromise = strategy.capture(page, timeStep);
+                        }
                     }
-                    const buffer = strategy.processCaptureResult!(rawResult);
+                    let buffer;
+                    if (isDomStrategy) {
+                        const data = (rawResult as any).screenshotData;
+                        if (data) {
+                            (strategy as any).lastFrameData = data;
+                        }
+                        buffer = (strategy as any).lastFrameData;
+                    } else {
+                        buffer = strategy.processCaptureResult!(rawResult);
+                    }
                     console.log(`Progress: Rendered ${0} / ${totalFrames} frames`);
                     if (onProgress) {
                         onProgress(0 / totalFrames);
@@ -388,7 +405,11 @@ export class CaptureLoop {
                     if (timePromise) {
                         await timePromise;
                     }
-                    nextCapturePromise = strategy.capture(page, 0);
+                    if (isDomStrategy) {
+                        nextCapturePromise = domCdpSession!.send('HeadlessExperimental.beginFrame', domBeginFrameParams);
+                    } else {
+                        nextCapturePromise = strategy.capture(page, 0);
+                    }
                 }
 
                 if (totalFrames > 0) {
@@ -398,7 +419,11 @@ export class CaptureLoop {
                         if (timePromise) {
                             await timePromise;
                         }
-                        nextCapturePromise = strategy.capture(page, timeStep);
+                        if (isDomStrategy) {
+                            nextCapturePromise = domCdpSession!.send('HeadlessExperimental.beginFrame', domBeginFrameParams);
+                        } else {
+                            nextCapturePromise = strategy.capture(page, timeStep);
+                        }
                     }
                     console.log(`Progress: Rendered ${0} / ${totalFrames} frames`);
                     if (onProgress) {


### PR DESCRIPTION
💡 What: Inlined strategy capture for initial frames in the single-worker path. \n🎯 Why: Consistency with PERF-824 and eliminating polymorphic interface dispatch for initial setup. \n🔬 Approach: Replace `strategy.capture()` with `isDomStrategy` check for the first two frames before the while loop. \n📌 Plan: /.sys/plans/PERF-827-unswitch-capture-branch-initial-frames.md

---
*PR created automatically by Jules for task [14065692602515377904](https://jules.google.com/task/14065692602515377904) started by @BintzGavin*