### PR TITLE
📋 RENDERER: Cache DomStrategy lastFrameData

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,7 @@ Current best: 1.831s (baseline was 1.831s, -0%)
 Last updated by: PERF-822
 
 ## What Works
+- PERF-831: Cached DomStrategy lastFrameData in CaptureLoop fast paths (~73% microbenchmark loop improvement)
 - PERF-830: Overlapped `timeDriver.setTime()` CDP promise with CPU-bound Base64 decoding in single-worker fast path (~15% microbenchmark improvement)
 - PERF-829: Pre-bind DOM Session and Begin Frame Params in CaptureLoop Fast Paths (~33% microbenchmark improvement)
 - PERF-827: Unswitch capture branch for initial frames in single-worker path (Consistency and minor init opt)

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -264,3 +264,4 @@ PERF-824	873.3	Single-worker DomStrategy inlining (no-op here since benchmark is
 828	100.105	300	0	5.4	keep	PERF-828: Enlarge and Pre-allocate Base64 Pool for Hot Paths (raw opt ms)
 1	0.0	0	0.0	0.0	keep	baseline: 8.83ms, opt: 5.92ms (PERF-829)
 1	0.325	300	923.20	0.0	keep	overlap time seek with base64 decode
+PERF-831	Cache DomStrategy lastFrameData Locally	33.791	9.127

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -179,6 +179,7 @@ export class CaptureLoop {
         const domCdpSession = isDomStrategy ? (strategy as any).cdpSession : null;
         const domBeginFrameParams = isDomStrategy ? (strategy as any).beginFrameParams : null;
         const domBeginFrame = isDomStrategy ? domCdpSession!.send.bind(domCdpSession, 'HeadlessExperimental.beginFrame', domBeginFrameParams) : null;
+        let domLastFrameData: any = isDomStrategy ? (strategy as any).lastFrameData : null;
 
         try {
             let isString: boolean | null = null;
@@ -213,9 +214,9 @@ export class CaptureLoop {
                     if (isDomStrategy) {
                         const data = (rawResult as any).screenshotData;
                         if (data) {
-                            (strategy as any).lastFrameData = data;
+                            domLastFrameData = data;
                         }
-                        buffer = (strategy as any).lastFrameData;
+                        buffer = domLastFrameData;
                     } else {
                         buffer = strategy.processCaptureResult!(rawResult);
                     }
@@ -270,9 +271,9 @@ export class CaptureLoop {
                                 if (isDomStrategy) {
                                     const data = rawResult.screenshotData;
                                     if (data) {
-                                        (strategy as any).lastFrameData = data;
+                                        domLastFrameData = data;
                                     }
-                                    buf = (strategy as any).lastFrameData as string;
+                                    buf = domLastFrameData as string;
                                 } else {
                                     buf = strategy.processCaptureResult!(rawResult) as string;
                                 }
@@ -299,9 +300,9 @@ export class CaptureLoop {
                                 if (isDomStrategy) {
                                     const data = rawResult.screenshotData;
                                     if (data) {
-                                        (strategy as any).lastFrameData = data;
+                                        domLastFrameData = data;
                                     }
-                                    buf = (strategy as any).lastFrameData as string;
+                                    buf = domLastFrameData as string;
                                 } else {
                                     buf = strategy.processCaptureResult!(rawResult) as string;
                                 }
@@ -355,9 +356,9 @@ export class CaptureLoop {
                                 if (isDomStrategy) {
                                     const data = rawResult.screenshotData;
                                     if (data) {
-                                        (strategy as any).lastFrameData = data;
+                                        domLastFrameData = data;
                                     }
-                                    buf = (strategy as any).lastFrameData;
+                                    buf = domLastFrameData;
                                 } else {
                                     buf = strategy.processCaptureResult!(rawResult);
                                 }
@@ -376,9 +377,9 @@ export class CaptureLoop {
                                 if (isDomStrategy) {
                                     const data = rawResult.screenshotData;
                                     if (data) {
-                                        (strategy as any).lastFrameData = data;
+                                        domLastFrameData = data;
                                     }
-                                    buf = (strategy as any).lastFrameData;
+                                    buf = domLastFrameData;
                                 } else {
                                     buf = strategy.processCaptureResult!(rawResult);
                                 }
@@ -657,6 +658,7 @@ export class CaptureLoop {
         const domCdpSession = isDomStrategy ? (strategy as any).cdpSession : null;
         const domBeginFrameParams = isDomStrategy ? (strategy as any).beginFrameParams : null;
         const domBeginFrame = isDomStrategy ? domCdpSession!.send.bind(domCdpSession, 'HeadlessExperimental.beginFrame', domBeginFrameParams) : null;
+        let domLastFrameData: any = isDomStrategy ? (strategy as any).lastFrameData : null;
 
         if (hasProcessFn) {
             while (!aborted) {
@@ -689,9 +691,9 @@ export class CaptureLoop {
                         const rawResult = await domBeginFrame!();
                         const data = rawResult.screenshotData;
                         if (data) {
-                            (strategy as any).lastFrameData = data;
+                            domLastFrameData = data;
                         }
-                        buffer = (strategy as any).lastFrameData;
+                        buffer = domLastFrameData;
                     } else {
                         buffer = strategy.processCaptureResult!(await strategy.capture(page, i * timeStep));
                     }


### PR DESCRIPTION
💡 What: Cached the `(strategy as any).lastFrameData` property locally within the single-worker and multi-worker fast paths of `CaptureLoop.ts`.
🎯 Why: To eliminate repeated V8 dynamic property lookups on the `strategy` object inside the hottest frame generation loops. This simple caching significantly reduced the loop iteration overhead during DOM mode rendering.
🔬 Approach: Hoisted the object property into a local loop variable (`domLastFrameData`) which tracks the current `screenshotData` natively within the execution block rather than crossing the class context.
📎 Plan: `.sys/plans/PERF-831-cache-dom-strategy-last-frame-data.md`

---
*PR created automatically by Jules for task [5508749537307108116](https://jules.google.com/task/5508749537307108116) started by @BintzGavin*