### PR TITLE
✨ RENDERER: Discard PERF-805 (Obsolete Optimization)

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -15,5 +15,6 @@ Last updated by: PERF-822
 - PERF-822: Eliminate `i + 1 < totalFrames` branch in CaptureLoop hot paths (~11% microbenchmark improvement)
 
 ## What Doesn't Work (and Why)
+- Tried to optimize Base64 buffer allocation in DomStrategy.ts (PERF-805), but the buffer allocation logic has been hoisted to CaptureLoop.ts and the optimization is already present. Discarded as obsolete.
 
 ## Open Questions

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -269,3 +269,4 @@ PERF-831	Cache DomStrategy lastFrameData Locally	33.791	9.127
 2	1.830	150	81.96	200.0	keep	PERF-833 unswitched isDomStrategy
 3	1.830	150	81.96	200.0	keep	PERF-833 unswitched isDomStrategy
 4	1.830	150	81.96	200.0	keep	PERF-833 unswitched isDomStrategy
+1	0.000	0	0.00	0.0	discard	PERF-805 discarded as obsolete because DomStrategy logic was moved to CaptureLoop

--- a/packages/renderer/.sys/plans/PERF-805-base64-buffer-allocation.md
+++ b/packages/renderer/.sys/plans/PERF-805-base64-buffer-allocation.md
@@ -1,5 +1,6 @@
 ---
-status: claimed
+status: complete
+result: "Discarded"
 ---
 # PERF-805: Optimize Base64 Decode Buffer Allocation
 
@@ -18,3 +19,6 @@ Base64 encoding represents 3 bytes of data for every 4 characters. Currently in 
 5. Update `docs/status/RENDERER-EXPERIMENTS.md` with the outcome.
 6. Record results to `packages/renderer/.sys/perf-results-PERF-805.tsv`.
 7. Mark plan complete and PR changes.
+
+## Results Summary
+Discarded as obsolete: The Base64 decode logic in `DomStrategy.ts` was refactored and hoisted to `CaptureLoop.ts` in previous experiments, and the `(length * 3) >>> 2` bitwise optimization is already natively present in the codebase. No changes necessary.


### PR DESCRIPTION
💡 What: Discarded PERF-805.
🎯 Why: The experiment proposed optimizing Base64 buffer allocation inside DomStrategy.ts. However, the codebase has evolved: buffer logic was hoisted to CaptureLoop.ts and the proposed bitwise math optimization is already implemented.
🔬 Verification: Ran microbenchmarks locally to confirm the bitwise shift works, but discarded due to obsolescence.
📎 Plan: /.sys/plans/PERF-805-base64-buffer-allocation.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	PERF-805 discarded as obsolete because DomStrategy logic was moved to CaptureLoop

---
*PR created automatically by Jules for task [10387721518875451823](https://jules.google.com/task/10387721518875451823) started by @BintzGavin*