### PR TITLE
✨ RENDERER: Discard PERF-800 (Obsolete Base64 Buffer Growth)

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -15,6 +15,7 @@ Last updated by: PERF-822
 - PERF-822: Eliminate `i + 1 < totalFrames` branch in CaptureLoop hot paths (~11% microbenchmark improvement)
 
 ## What Doesn't Work (and Why)
+- PERF-800: Exponential Capacity Growth for Base64 Decode Buffer. Discarded as obsolete. The Base64 decode buffer reallocation logic has already been hoisted to CaptureLoop.ts, where it naturally uses 1.5x exponential growth.
 - Tried to optimize Base64 buffer allocation in DomStrategy.ts (PERF-805), but the buffer allocation logic has been hoisted to CaptureLoop.ts and the optimization is already present. Discarded as obsolete.
 
 ## Open Questions

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -270,3 +270,4 @@ PERF-831	Cache DomStrategy lastFrameData Locally	33.791	9.127
 3	1.830	150	81.96	200.0	keep	PERF-833 unswitched isDomStrategy
 4	1.830	150	81.96	200.0	keep	PERF-833 unswitched isDomStrategy
 1	0.000	0	0.00	0.0	discard	PERF-805 discarded as obsolete because DomStrategy logic was moved to CaptureLoop
+1	0.000	0	0.00	0.0	discard	PERF-800: Obsolete (Base64 buffer allocation hoisted to CaptureLoop.ts with exponential growth)

--- a/packages/renderer/.sys/plans/PERF-800-exponential-buffer-growth.md
+++ b/packages/renderer/.sys/plans/PERF-800-exponential-buffer-growth.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-800
 slug: exponential-buffer-growth
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-06-19
-completed: ""
-result: ""
+completed: "2026-06-24"
+result: "discarded"
 ---
 
 # PERF-800: Exponential Capacity Growth for Base64 Decode Buffer
@@ -55,3 +55,10 @@ Run the DOM benchmark and inspect the output video to ensure frames are not corr
 
 ## Prior Art
 - PERF-798: Pre-allocated Base64 Buffer for DOM Strategy Capture
+
+
+## Results Summary
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	PERF-800: Obsolete (Base64 buffer allocation hoisted to CaptureLoop.ts with exponential growth)
+```


### PR DESCRIPTION
💡 What: Evaluated PERF-800 for implementation but found it to be obsolete.
🎯 Why: The Base64 decode buffer reallocation logic has already been hoisted to CaptureLoop.ts, where it naturally uses 1.5x exponential growth (`maxBytes + (maxBytes >> 1)`).
📊 Impact: 0% (Discarded, no code changes needed)
🔬 Verification: Verified CaptureLoop.ts logic. No new code to test.
📎 Plan: packages/renderer/.sys/plans/PERF-800-exponential-buffer-growth.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	PERF-800: Obsolete (Base64 buffer allocation hoisted to CaptureLoop.ts with exponential growth)

---
*PR created automatically by Jules for task [10053931201253450757](https://jules.google.com/task/10053931201253450757) started by @BintzGavin*