### PR TITLE
✨ RENDERER: PERF-835 Hoist progress check in multi-worker write loop

### DIFF
--- a/.sys/plans/PERF-835-hoist-progress-check-multi-worker.md
+++ b/.sys/plans/PERF-835-hoist-progress-check-multi-worker.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-835
 slug: hoist-progress-check-multi-worker
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-06-24
 completed: ""
-result: ""
+result: "discarded"
 ---
 
 # PERF-835: Hoist nextFrameToWrite Progress Check in Multi-Worker Loop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -15,6 +15,8 @@ Last updated by: PERF-822
 - PERF-822: Eliminate `i + 1 < totalFrames` branch in CaptureLoop hot paths (~11% microbenchmark improvement)
 
 ## What Doesn't Work (and Why)
+- PERF-835: Unrolled and hoisted chunked multi-worker progress reporting loops into a single while loop.
+  - **WHY it didn't work**: The modification caused the pipeline to hang entirely, indicating that flattening the nested loops likely removed critical yielding (`await writerWaiterPromise`) logic or progress increments necessary for async loop traversal in multi-worker scenarios.
 - PERF-836: Unrolling the `nextFrameToSubmit - nextFrameToWrite < maxPipelineDepth` check in the multi-worker CaptureLoop path. Microbenchmarks showed a ~14% performance degradation. This is likely due to the inner fast-loop increasing closure allocations or V8 engine failing to optimize the deeply nested structure properly, outweighing the minor savings from avoiding branch checks.
 - PERF-800: Exponential Capacity Growth for Base64 Decode Buffer. Discarded as obsolete. The Base64 decode buffer reallocation logic has already been hoisted to CaptureLoop.ts, where it naturally uses 1.5x exponential growth.
 - Tried to optimize Base64 buffer allocation in DomStrategy.ts (PERF-805), but the buffer allocation logic has been hoisted to CaptureLoop.ts and the optimization is already present. Discarded as obsolete.

--- a/packages/renderer/.sys/perf-results-PERF-835.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-835.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	hung pipeline when flattening multi-worker progress loop

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -273,3 +273,4 @@ PERF-831	Cache DomStrategy lastFrameData Locally	33.791	9.127
 1	0.000	0	0.00	0.0	discard	PERF-800: Obsolete (Base64 buffer allocation hoisted to CaptureLoop.ts with exponential growth)
 
 2	0.000	0	0.0	0.0	discard	PERF-836: Unroll Branching in Multi-Worker Loop Submission
+1	0.000	0	0.00	0.0	discard	hung pipeline when flattening multi-worker progress loop


### PR DESCRIPTION
💡 What: Attempted to flatten nested `while` loops for chunked progress reporting into single `while (nextFrameToWrite < totalFrames)` loops in the multi-worker path of `CaptureLoop.ts`. The experiment was discarded because it caused the pipeline to hang.
🎯 Why: The original structure calculated `endFrame` on every chunk and caused branch prediction misses. Flattening it eliminates the `endFrame` variable and an inner loop structure. However, removing the inner block logic likely removed critical yielding (`await writerWaiterPromise`) or progress increments necessary for async loop traversal in multi-worker scenarios.
🔬 Approach: Replaced nested chunked structures with flat loop logic across both `isString === true` and `isString === false` branches. The code was reverted and the failure logged.
📎 Plan: .sys/plans/PERF-835-hoist-progress-check-multi-worker.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	hung pipeline when flattening multi-worker progress loop

---
*PR created automatically by Jules for task [14312315092838520028](https://jules.google.com/task/14312315092838520028) started by @BintzGavin*