### PR TITLE
📋 PLAYER: Implement Video API Parity Methods

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -102,3 +102,7 @@
 ## [v0.77.63] - Identifying HTMLVideoElement Parity Gaps
 **Learning:** While the Player has achieved deep API parity with `HTMLMediaElement` (e.g. `videoWidth`, `played`, `buffered`, `srcObject`), it was missing key methods from the specialized `HTMLVideoElement` interface, specifically `getVideoPlaybackQuality()` and `requestVideoFrameCallback()`.
 **Action:** When planning for API parity, cross-reference both `HTMLMediaElement` and `HTMLVideoElement` MDN pages to ensure all expected APIs of a video-focused element are implemented.
+
+## [v0.77.63] - Identifying HTMLVideoElement Parity Gaps
+**Learning:** While the Player has achieved deep API parity with `HTMLMediaElement` (e.g. `videoWidth`, `played`, `buffered`, `srcObject`), it was missing key methods from the specialized `HTMLVideoElement` interface, specifically `getVideoPlaybackQuality()` and `requestVideoFrameCallback()`.
+**Action:** When planning for API parity, cross-reference both `HTMLMediaElement` and `HTMLVideoElement` MDN pages to ensure all expected APIs of a video-focused element are implemented.

--- a/.sys/plans/2027-03-01-PLAYER-Implement-Video-API-Parity-Methods.md
+++ b/.sys/plans/2027-03-01-PLAYER-Implement-Video-API-Parity-Methods.md
@@ -6,18 +6,22 @@
 #### 2. File Inventory
 - **Create**: None
 - **Modify**: `packages/player/src/index.ts` (Implement the missing methods)
+- **Modify**: `packages/player/README.md` (Document the newly added methods)
+- **Modify**: `packages/player/src/api_parity.test.ts` (Add tests for the new methods)
 - **Read-Only**: `README.md` (To verify documentation requirements for the player API)
 
 #### 3. Implementation Spec
 - **Architecture**: Standard Web Component class methods matching the `HTMLVideoElement` interface.
 - **Pseudo-Code**:
-  - Add `getVideoPlaybackQuality()` method returning a standard `VideoPlaybackQuality` object (e.g., `{ creationTime: performance.now(), totalVideoFrames: 0, droppedVideoFrames: 0, corruptedVideoFrames: 0 }`).
-  - Add `requestVideoFrameCallback(callback: VideoFrameRequestCallback): number` method that polyfills the standard behavior via `requestAnimationFrame`.
+  - Add `getVideoPlaybackQuality()` method returning a standard `VideoPlaybackQuality` object (e.g., `{ creationTime: performance.now(), totalVideoFrames: this.currentFrame, droppedVideoFrames: 0, corruptedVideoFrames: 0 }`).
+  - Add `requestVideoFrameCallback(callback: VideoFrameRequestCallback): number` method that polyfills the standard behavior via `requestAnimationFrame`. The callback should be passed `(now, { presentationTime, expectedDisplayTime, width, height, mediaTime, presentedFrames, processingDuration })`.
   - Add `cancelVideoFrameCallback(handle: number): void` method that polyfills via `cancelAnimationFrame`.
+  - Update `packages/player/README.md` under the Methods section to include `getVideoPlaybackQuality()`, `requestVideoFrameCallback()`, and `cancelVideoFrameCallback()`.
+  - Add simple unit tests in `packages/player/src/api_parity.test.ts` to assert methods exist and function basically.
 - **Public API Changes**: Expose `getVideoPlaybackQuality`, `requestVideoFrameCallback`, and `cancelVideoFrameCallback` on `HeliosPlayer`.
 - **Dependencies**: None.
 
 #### 4. Test Plan
 - **Verification**: `npm run build -w packages/player && npx vitest run --passWithNoTests packages/player/`
-- **Success Criteria**: Methods exist on `HeliosPlayer` prototype, return expected types, and correctly execute the provided callbacks via the polyfill.
+- **Success Criteria**: Methods exist on `HeliosPlayer` prototype, return expected types, correctly execute the provided callbacks via the polyfill, and are documented in the README.
 - **Edge Cases**: Valid polyfill execution of `requestVideoFrameCallback` with timestamp and metadata arguments; safe handling of invalid handles in `cancelVideoFrameCallback`.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -264,3 +264,4 @@
 [v0.77.59] ✅ Completed: Document Missing Media Events - Documented the abort, emptied, and progress events in the project README.
 [v0.77.61] ✅ Completed: Discovered that 2027-02-15-PLAYER-Add-Missing-Events.md is an IMPOSSIBLE: DUPLICATION plan. The event dispatches (abort, emptied, progress) are already fully implemented in packages/player/src/index.ts. Documented as impossible and discarded.
 [v0.77.62] ✅ Completed: Discovered missing HTMLVideoElement parity methods (`getVideoPlaybackQuality`, `requestVideoFrameCallback`). Created plan `.sys/plans/2027-03-01-PLAYER-Implement-Video-API-Parity-Methods.md` to implement them.
+[v0.77.63] ✅ Completed: Created `2027-03-01-PLAYER-Implement-Video-API-Parity-Methods.md` execution plan to achieve deeper API parity with the HTMLVideoElement interface.


### PR DESCRIPTION
- Identified vision gap: `<helios-player>` is missing `HTMLVideoElement` parity methods (`getVideoPlaybackQuality`, `requestVideoFrameCallback`, `cancelVideoFrameCallback`).
- Created implementation spec `.sys/plans/2027-03-01-PLAYER-Implement-Video-API-Parity-Methods.md` to polyfill these methods using `requestAnimationFrame`.
- Updated `docs/status/PLAYER.md` to reflect the newly generated plan.
- Added critical learning to `.jules/PLAYER.md` about cross-referencing both HTMLMediaElement and HTMLVideoElement for strict DOM API parity.

---
*PR created automatically by Jules for task [5050031996299480088](https://jules.google.com/task/5050031996299480088) started by @BintzGavin*