### PR TITLE
📋 RENDERER: [PERF-848] Hoist Redundant aborted checks in single-worker capture loops

### DIFF
--- a/.sys/plans/PERF-848-remove-redundant-single-worker-aborted-checks.md
+++ b/.sys/plans/PERF-848-remove-redundant-single-worker-aborted-checks.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-848
 slug: remove-redundant-single-worker-aborted-checks
-status: unclaimed
-claimed_by: ""
+status: discarded
+claimed_by: "jules"
 created: 2024-06-25
 completed: ""
 result: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -29,6 +29,7 @@ Last updated by: PERF-832
 - PERF-822: Eliminate `i + 1 < totalFrames` branch in CaptureLoop hot paths (~11% microbenchmark improvement)
 
 ## What Doesn't Work (and Why)
+- Removing redundant aborted checks in single worker loop (slower by 0.00%) - PERF-848
 - PERF-836: Unrolling the `nextFrameToSubmit - nextFrameToWrite < maxPipelineDepth` check in the multi-worker CaptureLoop path. Microbenchmarks showed a ~14% performance degradation. This is likely due to the inner fast-loop increasing closure allocations or V8 engine failing to optimize the deeply nested structure properly, outweighing the minor savings from avoiding branch checks.
 - PERF-800: Exponential Capacity Growth for Base64 Decode Buffer. Discarded as obsolete. The Base64 decode buffer reallocation logic has already been hoisted to CaptureLoop.ts, where it naturally uses 1.5x exponential growth.
 - Tried to optimize Base64 buffer allocation in DomStrategy.ts (PERF-805), but the buffer allocation logic has been hoisted to CaptureLoop.ts and the optimization is already present. Discarded as obsolete.


### PR DESCRIPTION
💡 What: Removed nested `if (aborted) break;` checks in single worker path.
🎯 Why: Attempted to reduce V8 hot loop branching overhead. However, benchmark resulted in 0% improvement so the code changes were reverted.
🔬 Approach: Used search and replace to remove unneeded checks inside for loops.
📎 Plan: .sys/plans/PERF-848-remove-redundant-single-worker-aborted-checks.md

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
768	1.831	150	81.92	0.0	keep	PERF-848-baseline
152	1.831	150	81.92	0.0	keep	PERF-848-experiment
```

---
*PR created automatically by Jules for task [14487576772329795385](https://jules.google.com/task/14487576772329795385) started by @BintzGavin*