### PR TITLE
📋 RENDERER: [PERF-849] Discard peeling single-worker last frame

### DIFF
--- a/.sys/plans/PERF-849-peel-single-worker-last-frame.md
+++ b/.sys/plans/PERF-849-peel-single-worker-last-frame.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-849
 slug: peel-single-worker-last-frame
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "claim-PERF-849"
 created: 2024-06-25
-completed: ""
-result: ""
+completed: "2026-06-25"
+result: "discarded"
 ---
 
 # PERF-849: Peel Last Frame Iteration in Single-Worker CaptureLoop Fast Paths

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -29,6 +29,7 @@ Last updated by: PERF-832
 - PERF-822: Eliminate `i + 1 < totalFrames` branch in CaptureLoop hot paths (~11% microbenchmark improvement)
 
 ## What Doesn't Work (and Why)
+- PERF-849: Peeling the last frame iteration in the single-worker fast path frame loops to avoid `if (i < totalFrames - 1)` check actually increases execution time in V8 (likely due to deoptimization or code duplication). Discarded.
 - Removing redundant aborted checks in single worker loop (slower by 0.00%) - PERF-848
 - PERF-836: Unrolling the `nextFrameToSubmit - nextFrameToWrite < maxPipelineDepth` check in the multi-worker CaptureLoop path. Microbenchmarks showed a ~14% performance degradation. This is likely due to the inner fast-loop increasing closure allocations or V8 engine failing to optimize the deeply nested structure properly, outweighing the minor savings from avoiding branch checks.
 - PERF-800: Exponential Capacity Growth for Base64 Decode Buffer. Discarded as obsolete. The Base64 decode buffer reallocation logic has already been hoisted to CaptureLoop.ts, where it naturally uses 1.5x exponential growth.

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -285,3 +285,4 @@ PERF-831	Cache DomStrategy lastFrameData Locally	33.791	9.127
 
 1	0.109	600	0.00	0.0	keep	PERF-840: Remove redundant checkState after drainPromise
 1	0.109	600	0.00	0.0	keep	PERF-840: Remove redundant checkState after drainPromise
+1	1.831	0	0.0	0.0	discard	PERF-849: Peeling the final frame loop iteration in single-worker fast path increases execution time


### PR DESCRIPTION
💡 What: Discarded PERF-849 which proposed peeling the last iteration out of single-worker fast loops. 
🎯 Why: Microbenchmarks showed increased execution time, likely due to V8 deoptimization or code duplication. 
🔬 Approach: Tested removing the branch and found it to be slower. 
📎 Plan: .sys/plans/PERF-849-peel-single-worker-last-frame.md

---
*PR created automatically by Jules for task [18048477081753317807](https://jules.google.com/task/18048477081753317807) started by @BintzGavin*