### PR TITLE
✨ PLAYER: Implement Video API Parity Methods

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -75,3 +75,4 @@ Supported Formats: `mp4`, `webm`, `png`, `jpeg`
 Supported Features: Resizing, Bitrate control, Audio merging, Caption rendering.
 
 - `onplaying`, `onwaiting`, `onsuspend`, `onstalled`: Standard media event handler properties.
+\n## Section D: Methods\n- `getVideoPlaybackQuality()`: Returns playback quality metrics.\n- `requestVideoFrameCallback(callback: VideoFrameRequestCallback): number`: Registers a callback to be fired when a new frame is rendered.\n- `cancelVideoFrameCallback(handle: number): void`: Cancels a previously registered video frame callback.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,4 +1,7 @@
 #
+### PLAYER v0.78.0
+- ✅ Completed: Implement Video API Parity Methods - Added `getVideoPlaybackQuality`, `requestVideoFrameCallback`, and `cancelVideoFrameCallback` to complete HTMLVideoElement API parity.
+
 ### PLAYER v0.77.57
 - ✅ Completed: Discovered that `2027-02-18-PLAYER-Implement-Missing-Media-Event-Dispatches.md` is an IMPOSSIBLE: DUPLICATION plan. The event dispatches (`abort`, `emptied`, `progress`) are already fully implemented in the code. Documented as impossible and discarded.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,5 @@
 [v0.77.53] ✅ Completed: Identified missing HTMLMediaElement events (`abort`, `emptied`, `progress`) in `<helios-player>`. Created plan `.sys/plans/2027-02-15-PLAYER-Add-Missing-Events.md` to implement them.
-**Version**: 0.77.61
+**Version**: 0.78.0
 [v0.77.60] ✅ Completed: Discovered that 2026-06-03-PLAYER-configurable-export-resolution.md is an IMPOSSIBLE: DUPLICATION plan. The export-width and export-height properties are already fully implemented and verified in the codebase. Documented as impossible and discarded.
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
 [v0.77.52] ✅ Completed: Fix API Parity Events - Implemented synthetic dispatches for missing media events (suspend, stalled, waiting) to improve HTMLMediaElement API parity.
@@ -265,3 +265,4 @@
 [v0.77.61] ✅ Completed: Discovered that 2027-02-15-PLAYER-Add-Missing-Events.md is an IMPOSSIBLE: DUPLICATION plan. The event dispatches (abort, emptied, progress) are already fully implemented in packages/player/src/index.ts. Documented as impossible and discarded.
 [v0.77.62] ✅ Completed: Discovered missing HTMLVideoElement parity methods (`getVideoPlaybackQuality`, `requestVideoFrameCallback`). Created plan `.sys/plans/2027-03-01-PLAYER-Implement-Video-API-Parity-Methods.md` to implement them.
 [v0.77.63] ✅ Completed: Created `2027-03-01-PLAYER-Implement-Video-API-Parity-Methods.md` execution plan to achieve deeper API parity with the HTMLVideoElement interface.
+[v0.78.0] ✅ Completed: Implement Video API Parity Methods - Added `getVideoPlaybackQuality`, `requestVideoFrameCallback`, and `cancelVideoFrameCallback` to complete HTMLVideoElement API parity.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -151,6 +151,9 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `captureStream(): Promise<MediaStream>` - Returns a MediaStream capturing the player's canvas (if same-origin).
 - `startAudioMetering(): void` - Starts audio metering calculation.
 - `stopAudioMetering(): void` - Stops audio metering calculation.
+- `getVideoPlaybackQuality(): VideoPlaybackQuality` - Returns an object containing the video playback quality metrics.
+- `requestVideoFrameCallback(callback: VideoFrameRequestCallback): number` - Registers a callback to be fired when a new frame is rendered.
+- `cancelVideoFrameCallback(handle: number): void` - Cancels a previously registered video frame callback.
 
 ### Properties
 - `disableRemotePlayback` (boolean): Reflected disableremoteplayback attribute.

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -149,6 +149,22 @@ describe('HeliosPlayer API Parity', () => {
     expect(player.height).toBe(0);
   });
 
+  it('should support getVideoPlaybackQuality method', () => {
+    const quality = player.getVideoPlaybackQuality();
+    expect(quality.creationTime).toBeDefined();
+    expect(quality.totalVideoFrames).toBe(0);
+    expect(quality.droppedVideoFrames).toBe(0);
+    expect(quality.corruptedVideoFrames).toBe(0);
+  });
+
+  it('should support requestVideoFrameCallback and cancelVideoFrameCallback methods', () => {
+    const callback = vi.fn();
+    const handle = player.requestVideoFrameCallback(callback);
+    expect(typeof handle).toBe('number');
+
+    player.cancelVideoFrameCallback(handle);
+  });
+
   it('should support videoWidth and videoHeight', () => {
     // Default 0
     expect(player.videoWidth).toBe(0);

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -843,6 +843,18 @@ template.innerHTML = `
   </div>
 `;
 
+export interface VideoFrameCallbackMetadata {
+  presentationTime: DOMHighResTimeStamp;
+  expectedDisplayTime: DOMHighResTimeStamp;
+  width: number;
+  height: number;
+  mediaTime: number;
+  presentedFrames: number;
+  processingDuration: number;
+}
+
+export type VideoFrameRequestCallback = (now: DOMHighResTimeStamp, metadata: VideoFrameCallbackMetadata) => void;
+
 export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHost, VideoTrackHost {
   private iframe: HTMLIFrameElement;
   private pipVideo: HTMLVideoElement;
@@ -1164,6 +1176,34 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     // We strictly play Helios compositions, not standard video MIME types.
     // Return empty string to be spec-compliant for video/mp4 etc.
     return "";
+  }
+
+  public getVideoPlaybackQuality(): VideoPlaybackQuality {
+    return {
+      creationTime: performance.now(),
+      totalVideoFrames: this.currentFrame,
+      droppedVideoFrames: 0,
+      corruptedVideoFrames: 0
+    };
+  }
+
+  public requestVideoFrameCallback(callback: VideoFrameRequestCallback): number {
+    return requestAnimationFrame((now: DOMHighResTimeStamp) => {
+      const metadata: VideoFrameCallbackMetadata = {
+        presentationTime: now,
+        expectedDisplayTime: now,
+        width: this.videoWidth,
+        height: this.videoHeight,
+        mediaTime: this.currentTime,
+        presentedFrames: this.currentFrame,
+        processingDuration: 0,
+      };
+      callback(now, metadata);
+    });
+  }
+
+  public cancelVideoFrameCallback(handle: number): void {
+    cancelAnimationFrame(handle);
   }
 
   public get defaultMuted(): boolean {


### PR DESCRIPTION
💡 What: Added getVideoPlaybackQuality, requestVideoFrameCallback, cancelVideoFrameCallback.
🎯 Why: Close gap in HTMLVideoElement API parity.
📊 Impact: Deeper compatibility with third-party wrappers.
🔬 Verification: Unit tests pass.

---
*PR created automatically by Jules for task [5825926196016127318](https://jules.google.com/task/5825926196016127318) started by @BintzGavin*