### PR TITLE
📋 PLAYER: [Expose Media Constants]

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -106,3 +106,7 @@
 ## [v0.77.63] - Identifying HTMLVideoElement Parity Gaps
 **Learning:** While the Player has achieved deep API parity with `HTMLMediaElement` (e.g. `videoWidth`, `played`, `buffered`, `srcObject`), it was missing key methods from the specialized `HTMLVideoElement` interface, specifically `getVideoPlaybackQuality()` and `requestVideoFrameCallback()`.
 **Action:** When planning for API parity, cross-reference both `HTMLMediaElement` and `HTMLVideoElement` MDN pages to ensure all expected APIs of a video-focused element are implemented.
+
+## [v0.77.64] - Documenting and Exposing Media Constants
+**Learning**: Standard `HTMLMediaElement` constants like `HAVE_NOTHING` and `NETWORK_EMPTY` are exposed as both static properties on the constructor and instance properties on the prototype. They were implemented statically in `<helios-player>` but missing from the instance API and documentation.
+**Action**: When achieving API parity with built-in DOM elements, ensure constants are available on both the instance and constructor as expected by standard JavaScript usage patterns, and explicitly document them in the README.

--- a/.sys/plans/2024-05-24-PLAYER-Instance-Constants.md
+++ b/.sys/plans/2024-05-24-PLAYER-Instance-Constants.md
@@ -1,0 +1,30 @@
+#### 1. Context & Goal
+- **Objective**: Implement missing `HTMLMediaElement` instance constant properties (`HAVE_NOTHING`, `NETWORK_EMPTY`, etc.) on `<helios-player>` and update documentation.
+- **Trigger**: The constants are implemented as static on `HeliosPlayer`, but standard `HTMLMediaElement` exposes them on both the constructor and the instances. They are also missing from `README.md`.
+- **Impact**: Achieves deeper `HTMLMediaElement` API parity, allowing developers to check `player.readyState === player.HAVE_ENOUGH_DATA`.
+
+#### 2. File Inventory
+- **Create**: (None)
+- **Modify**:
+  - `packages/player/src/index.ts`: Add instance getters for the 9 media constants.
+  - `packages/player/src/api_parity.test.ts`: Add tests to verify constants exist on the player instance.
+  - `packages/player/README.md`: Document the 9 constant properties.
+- **Read-Only**: `packages/player/package.json`
+
+#### 3. Implementation Spec
+- **Architecture**: Standard Web Component API mapping. The constants will be exposed via instance getters returning the static readonly values on the `HeliosPlayer` class.
+- **Pseudo-Code**:
+  ```typescript
+  public get HAVE_NOTHING() { return HeliosPlayer.HAVE_NOTHING; }
+  public get HAVE_METADATA() { return HeliosPlayer.HAVE_METADATA; }
+  // ... continue for HAVE_CURRENT_DATA, HAVE_FUTURE_DATA, HAVE_ENOUGH_DATA
+  // ... continue for NETWORK_EMPTY, NETWORK_IDLE, NETWORK_LOADING, NETWORK_NO_SOURCE
+  ```
+- **Public API Changes**:
+  - Adds 9 new readonly properties to the `<helios-player>` instance: `HAVE_NOTHING`, `HAVE_METADATA`, `HAVE_CURRENT_DATA`, `HAVE_FUTURE_DATA`, `HAVE_ENOUGH_DATA`, `NETWORK_EMPTY`, `NETWORK_IDLE`, `NETWORK_LOADING`, `NETWORK_NO_SOURCE`.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm run test -w packages/player`
+- **Success Criteria**: All `api_parity.test.ts` pass, ensuring `player.HAVE_NOTHING === 0` and others are correctly exposed on the instance.
+- **Edge Cases**: Ensure the constants remain strictly read-only on the instance.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -266,3 +266,6 @@
 [v0.77.62] ✅ Completed: Discovered missing HTMLVideoElement parity methods (`getVideoPlaybackQuality`, `requestVideoFrameCallback`). Created plan `.sys/plans/2027-03-01-PLAYER-Implement-Video-API-Parity-Methods.md` to implement them.
 [v0.77.63] ✅ Completed: Created `2027-03-01-PLAYER-Implement-Video-API-Parity-Methods.md` execution plan to achieve deeper API parity with the HTMLVideoElement interface.
 [v0.78.0] ✅ Completed: Implement Video API Parity Methods - Added `getVideoPlaybackQuality`, `requestVideoFrameCallback`, and `cancelVideoFrameCallback` to complete HTMLVideoElement API parity.
+
+### Pending Implementations
+- API Parity: Implement missing `HTMLMediaElement` instance constants (e.g. `HAVE_NOTHING`, `NETWORK_EMPTY`) and document them. See plan: `.sys/plans/2024-05-24-PLAYER-Instance-Constants.md`


### PR DESCRIPTION
Identified gap where HAVE_NOTHING and NETWORK_EMPTY constants were static but not exposed on the component instance or documented. Created spec plan.

---
*PR created automatically by Jules for task [5927666585846757347](https://jules.google.com/task/5927666585846757347) started by @BintzGavin*