### PR TITLE
✨ PLAYER: Implement standard media constants on instances

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -53,6 +53,8 @@ Observed attributes:
 - `addTextTrack(kind: TextTrackKind, label?: string, language?: string): TextTrack`
 
 Properties:
+- `HAVE_NOTHING`, `HAVE_METADATA`, `HAVE_CURRENT_DATA`, `HAVE_FUTURE_DATA`, `HAVE_ENOUGH_DATA`: Instance media constant values.
+- `NETWORK_EMPTY`, `NETWORK_IDLE`, `NETWORK_LOADING`, `NETWORK_NO_SOURCE`: Instance media constant values.
 - `currentTime: number`
 - `duration: number`
 - `volume: number`

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,4 +1,7 @@
 #
+### PLAYER v0.78.1
+- ✅ Completed: Implement Instance Constants - Added standard media constants (e.g., HAVE_NOTHING, NETWORK_EMPTY) to the HeliosPlayer instance for HTMLMediaElement parity.
+
 ### PLAYER v0.78.0
 - ✅ Completed: Implement Video API Parity Methods - Added `getVideoPlaybackQuality`, `requestVideoFrameCallback`, and `cancelVideoFrameCallback` to complete HTMLVideoElement API parity.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,6 @@
 [v0.77.53] ✅ Completed: Identified missing HTMLMediaElement events (`abort`, `emptied`, `progress`) in `<helios-player>`. Created plan `.sys/plans/2027-02-15-PLAYER-Add-Missing-Events.md` to implement them.
-**Version**: 0.78.0
+**Version**: 0.78.1
+[v0.78.1] ✅ Completed: Implement Instance Constants - Added standard media constants (e.g., HAVE_NOTHING, NETWORK_EMPTY) to the HeliosPlayer instance for HTMLMediaElement parity.
 [v0.77.60] ✅ Completed: Discovered that 2026-06-03-PLAYER-configurable-export-resolution.md is an IMPOSSIBLE: DUPLICATION plan. The export-width and export-height properties are already fully implemented and verified in the codebase. Documented as impossible and discarded.
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
 [v0.77.52] ✅ Completed: Fix API Parity Events - Implemented synthetic dispatches for missing media events (suspend, stalled, waiting) to improve HTMLMediaElement API parity.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13052,7 +13052,7 @@
     },
     "packages/player": {
       "name": "@helios-project/player",
-      "version": "0.76.20",
+      "version": "0.78.1",
       "license": "ELv2",
       "dependencies": {
         "@helios-project/core": "^5.13.0",
@@ -13259,6 +13259,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/studio/node_modules/@helios-project/player": {
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@helios-project/player/-/player-0.76.8.tgz",
+      "integrity": "sha512-AMZV6cio9w+2FLF5mUT5H64idZ0ykhJ044ksyVuW6my7WMjD1xSyfayUQMShXDFtHOhLFgAEXzJfpm/x1LV0DA==",
+      "license": "ELv2",
+      "dependencies": {
+        "@helios-project/core": "^5.13.0",
+        "mediabunny": "^1.32.2"
       }
     },
     "packages/studio/node_modules/cssstyle": {

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -156,6 +156,16 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `cancelVideoFrameCallback(handle: number): void` - Cancels a previously registered video frame callback.
 
 ### Properties
+- `HAVE_NOTHING` (number, read-only): Constant representing no media data available (0).
+- `HAVE_METADATA` (number, read-only): Constant representing media metadata available (1).
+- `HAVE_CURRENT_DATA` (number, read-only): Constant representing data for current playback position available (2).
+- `HAVE_FUTURE_DATA` (number, read-only): Constant representing data for current and future playback position available (3).
+- `HAVE_ENOUGH_DATA` (number, read-only): Constant representing enough data available to play through (4).
+- `NETWORK_EMPTY` (number, read-only): Constant representing uninitialized network state (0).
+- `NETWORK_IDLE` (number, read-only): Constant representing idle network state (1).
+- `NETWORK_LOADING` (number, read-only): Constant representing loading network state (2).
+- `NETWORK_NO_SOURCE` (number, read-only): Constant representing no source network state (3).
+
 - `disableRemotePlayback` (boolean): Reflected disableremoteplayback attribute.
 - `mediaGroup` (string): Reflected mediagroup attribute.
 - `sinkId` (string, read-only): Returns the current audio sink id.

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helios-project/player",
-  "version": "0.76.20",
+  "version": "0.78.1",
   "description": "Web Component player for Helios compositions.",
   "author": "Gavin Bintz <me@gavinbintz.com>",
   "license": "ELv2",

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -19,6 +19,18 @@ describe('HeliosPlayer API Parity', () => {
     document.body.appendChild(player);
   });
 
+  it('should support standard media constants on instances', () => {
+    expect(player.HAVE_NOTHING).toBe(0);
+    expect(player.HAVE_METADATA).toBe(1);
+    expect(player.HAVE_CURRENT_DATA).toBe(2);
+    expect(player.HAVE_FUTURE_DATA).toBe(3);
+    expect(player.HAVE_ENOUGH_DATA).toBe(4);
+    expect(player.NETWORK_EMPTY).toBe(0);
+    expect(player.NETWORK_IDLE).toBe(1);
+    expect(player.NETWORK_LOADING).toBe(2);
+    expect(player.NETWORK_NO_SOURCE).toBe(3);
+  });
+
   afterEach(() => {
     document.body.innerHTML = '';
   });

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -944,6 +944,17 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   private _readyState: number = HeliosPlayer.HAVE_NOTHING;
   private _networkState: number = HeliosPlayer.NETWORK_EMPTY;
 
+  public get HAVE_NOTHING(): number { return HeliosPlayer.HAVE_NOTHING; }
+  public get HAVE_METADATA(): number { return HeliosPlayer.HAVE_METADATA; }
+  public get HAVE_CURRENT_DATA(): number { return HeliosPlayer.HAVE_CURRENT_DATA; }
+  public get HAVE_FUTURE_DATA(): number { return HeliosPlayer.HAVE_FUTURE_DATA; }
+  public get HAVE_ENOUGH_DATA(): number { return HeliosPlayer.HAVE_ENOUGH_DATA; }
+
+  public get NETWORK_EMPTY(): number { return HeliosPlayer.NETWORK_EMPTY; }
+  public get NETWORK_IDLE(): number { return HeliosPlayer.NETWORK_IDLE; }
+  public get NETWORK_LOADING(): number { return HeliosPlayer.NETWORK_LOADING; }
+  public get NETWORK_NO_SOURCE(): number { return HeliosPlayer.NETWORK_NO_SOURCE; }
+
   public get readyState(): number {
     return this._readyState;
   }


### PR DESCRIPTION
Implement standard media constants on the Player instance to increase HTMLMediaElement API parity. Update state tracking files and system docs in line with Executor Protocol.

---
*PR created automatically by Jules for task [16457073316526050358](https://jules.google.com/task/16457073316526050358) started by @BintzGavin*