### PR TITLE
📋 PLAYER: Implement setMediaKeys

### DIFF
--- a/.sys/plans/2027-03-02-PLAYER-Implement-setMediaKeys.md
+++ b/.sys/plans/2027-03-02-PLAYER-Implement-setMediaKeys.md
@@ -1,0 +1,28 @@
+#### 1. Context & Goal
+- **Objective**: Identify a gap in `HTMLMediaElement` parity for `<helios-player>` and generate a detailed Spec File for implementation.
+- **Trigger**: The Vision states the `<helios-player>` Web Component should be an `HTMLMediaElement` drop-in replacement. `setMediaKeys()` method is missing.
+- **Impact**: Achieves deeper `HTMLMediaElement` API parity, allowing compatibility with applications that might invoke this method (even if it just returns a rejected promise or null since DRM is not supported).
+
+#### 2. File Inventory
+- **Create**: (None)
+- **Modify**:
+  - `packages/player/src/index.ts`: Add `setMediaKeys` method.
+  - `packages/player/src/api_parity.test.ts`: Add tests to verify `setMediaKeys()` returns a rejected Promise.
+  - `packages/player/README.md`: Document the `setMediaKeys()` method.
+- **Read-Only**: `packages/player/package.json`
+
+#### 3. Implementation Spec
+- **Architecture**: Standard Web Component API mapping. The `setMediaKeys()` method will be implemented to return a rejected promise with `NotSupportedError`, as DRM/EME is not natively supported by the player or iframe bridge right now.
+- **Pseudo-Code**:
+  ```typescript
+  public setMediaKeys(mediaKeys: MediaKeys | null): Promise<void> {
+    return Promise.reject(new DOMException("setMediaKeys is not supported.", "NotSupportedError"));
+  }
+  ```
+- **Public API Changes**: Adds `setMediaKeys()` method.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm run test -w packages/player`
+- **Success Criteria**: `api_parity.test.ts` passes with verification that `setMediaKeys()` returns a rejected Promise.
+- **Edge Cases**: Verify behaviour with `null` parameter.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -270,3 +270,4 @@
 
 ### Pending Implementations
 - API Parity: Implement missing `HTMLMediaElement` instance constants (e.g. `HAVE_NOTHING`, `NETWORK_EMPTY`) and document them. See plan: `.sys/plans/2024-05-24-PLAYER-Instance-Constants.md`
+[v0.78.1] ✅ Completed: Discovered missing HTMLMediaElement parity method (`setMediaKeys`). Created plan `.sys/plans/2027-03-02-PLAYER-Implement-setMediaKeys.md` to implement it.


### PR DESCRIPTION
💡 What: Created a spec file to implement the missing setMediaKeys method for HTMLMediaElement parity.
🎯 Why: The Vision requires HeliosPlayer to act as a drop-in replacement for standard media elements.
🔬 Approach: Created a plan to return a rejected Promise with NotSupportedError.
📌 Plan: .sys/plans/2027-03-02-PLAYER-Implement-setMediaKeys.md

---
*PR created automatically by Jules for task [817118443935530164](https://jules.google.com/task/817118443935530164) started by @BintzGavin*