### PR TITLE
📋 RENDERER: Chunked loops in multi-worker paths

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -51,4 +51,4 @@ Last updated by: PERF-855
 - Overlapping FFmpeg stream write with Time Seek CDP await in the single-worker path (PERF-854). The Node.js stream write `stream.write` is extremely fast and mostly synchronous in its execution up until the OS buffer fills. Our test scripts and microbenchmarks show the overlapping actually caused a regression of ~1-3% because we delayed starting the CDP time seek command (`timeDriver.setTime`), which is network bound and takes significantly longer. Pushing the time seek *earlier* is more important than eagerly pushing the synchronous stream write, especially since `stream.write` isn't a long-running CPU bound task like Base64 decoding.
 
 ## Open Questions
-- Would chunked loops benefit multi-worker paths as well? (PERF-856) -> Yes, PERF-857 planned.
+- Would chunked loops benefit multi-worker paths as well? (PERF-856) -> Yes, PERF-859 planned.

--- a/packages/renderer/.sys/plans/PERF-859-chunked-progress-counter-multi-worker.md
+++ b/packages/renderer/.sys/plans/PERF-859-chunked-progress-counter-multi-worker.md
@@ -1,0 +1,229 @@
+---
+id: PERF-859
+slug: chunked-progress-counter-multi-worker
+status: unclaimed
+claimed_by: ""
+created: 2026-06-26
+completed: ""
+result: ""
+---
+
+# PERF-859: Replace Loop Branching with Chunked Inner Loops in CaptureLoop Multi-Worker Write Path
+
+## Focus Area
+`CaptureLoop.ts` multi-worker write loop progress logging paths and the `nextFrameToWrite < totalFrames` loop structure.
+
+## Background Research
+Currently, `CaptureLoop.ts` multi-worker write paths evaluate `if (nextFrameToWrite === nextProgress || nextFrameToWrite === totalFrames)` and loop bound `while (nextFrameToWrite < totalFrames && !aborted)` on every single frame iteration.
+Replacing these per-iteration branches with a chunked `while` loop containing an unbranched `for` loop (running until the next progress interval) eliminates V8 branch evaluation overhead entirely. The chunked loop approach outperforms simple counter implementations.
+
+## Benchmark Configuration
+- **Composition URL**: `file:///app/examples/dom-benchmark/composition.html`
+- **Render Settings**: 600x600, 30fps, 5 seconds
+- **Mode**: `dom` (multi-worker path)
+- **Metric**: Microbenchmark loop iteration time / Wall-clock render time
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Bottleneck analysis**: The V8 engine evaluates branching logic (`if (nextFrameToWrite === nextProgress || nextFrameToWrite === totalFrames)`) inside the tightest inner write loop thousands of times.
+
+## Implementation Spec
+
+### Step 1: Refactor multi-worker string write loops to chunked while loops
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the multi-worker capture paths, replace the `isString` write loop structure:
+```typescript
+<<<<<<< SEARCH
+      if (!aborted && isString) {
+        while (nextFrameToWrite < totalFrames && !aborted) {
+          const ringIndex = nextFrameToWrite & ringMask;
+          if (frameReadyRing[ringIndex] === 0) {
+            while (frameReadyRing[ringIndex] === 0 && !aborted) {
+              await writerWaiterPromise;
+            }
+            if (aborted) break;
+          }
+
+          const buffer = frameBufferRing[ringIndex]! as string;
+
+          const maxBytes = (buffer.length * 3) >>> 2;
+          let pooled = multiFreePool.pop();
+          if (!pooled || pooled.buffer.length < maxBytes) {
+            pooled = new PooledBuffer(
+              maxBytes + (maxBytes >> 1),
+              multiFreePool,
+            );
+          }
+          const written = pooled.buffer.write(buffer, "base64");
+          const chunk = pooled.buffer.subarray(0, written);
+          pendingBytes += written;
+          const writeSuccess = stream.write(chunk, pooled.freeCb);
+
+          if (!writeSuccess && pendingBytes >= 16777216) {
+            await this.drainPromise;
+            pendingBytes = 0;
+          }
+
+          nextFrameToWrite++;
+          if (freeWorkersHead > 0) checkState();
+
+          if (
+            !aborted &&
+            (nextFrameToWrite === nextProgress ||
+              nextFrameToWrite === totalFrames)
+          ) {
+            if (nextFrameToWrite === nextProgress)
+              nextProgress += progressInterval;
+            console.log(
+              `Progress: Rendered ${nextFrameToWrite} / ${totalFrames} frames`,
+            );
+            if (onProgress) onProgress(nextFrameToWrite / totalFrames);
+          }
+        }
+      } else if (!aborted) {
+=======
+      if (!aborted && isString) {
+        while (nextFrameToWrite < totalFrames && !aborted) {
+          let chunkEnd = nextFrameToWrite + progressInterval;
+          if (chunkEnd > totalFrames) chunkEnd = totalFrames;
+
+          for (; nextFrameToWrite < chunkEnd && !aborted; ) {
+            const ringIndex = nextFrameToWrite & ringMask;
+            if (frameReadyRing[ringIndex] === 0) {
+              while (frameReadyRing[ringIndex] === 0 && !aborted) {
+                await writerWaiterPromise;
+              }
+              if (aborted) break;
+            }
+
+            const buffer = frameBufferRing[ringIndex]! as string;
+
+            const maxBytes = (buffer.length * 3) >>> 2;
+            let pooled = multiFreePool.pop();
+            if (!pooled || pooled.buffer.length < maxBytes) {
+              pooled = new PooledBuffer(
+                maxBytes + (maxBytes >> 1),
+                multiFreePool,
+              );
+            }
+            const written = pooled.buffer.write(buffer, "base64");
+            const chunk = pooled.buffer.subarray(0, written);
+            pendingBytes += written;
+            const writeSuccess = stream.write(chunk, pooled.freeCb);
+
+            if (!writeSuccess && pendingBytes >= 16777216) {
+              await this.drainPromise;
+              pendingBytes = 0;
+            }
+
+            nextFrameToWrite++;
+            if (freeWorkersHead > 0) checkState();
+          }
+
+          if (aborted) break;
+
+          console.log(
+            `Progress: Rendered ${nextFrameToWrite} / ${totalFrames} frames`,
+          );
+          if (onProgress) onProgress(nextFrameToWrite / totalFrames);
+        }
+      } else if (!aborted) {
+>>>>>>> REPLACE
+```
+
+### Step 2: Refactor multi-worker buffer write loops to chunked while loops
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the multi-worker capture paths, replace the `!isString` write loop structure:
+```typescript
+<<<<<<< SEARCH
+      } else if (!aborted) {
+        while (nextFrameToWrite < totalFrames && !aborted) {
+          const ringIndex = nextFrameToWrite & ringMask;
+          if (frameReadyRing[ringIndex] === 0) {
+            while (frameReadyRing[ringIndex] === 0 && !aborted) {
+              await writerWaiterPromise;
+            }
+            if (aborted) break;
+          }
+
+          const buffer = frameBufferRing[ringIndex]!;
+
+          pendingBytes += (buffer as any).length;
+          const writeSuccess = stream.write(buffer as any);
+
+          if (!writeSuccess && pendingBytes >= 16777216) {
+            await this.drainPromise;
+            pendingBytes = 0;
+          }
+
+          nextFrameToWrite++;
+          if (freeWorkersHead > 0) checkState();
+
+          if (
+            !aborted &&
+            (nextFrameToWrite === nextProgress ||
+              nextFrameToWrite === totalFrames)
+          ) {
+            if (nextFrameToWrite === nextProgress)
+              nextProgress += progressInterval;
+            console.log(
+              `Progress: Rendered ${nextFrameToWrite} / ${totalFrames} frames`,
+            );
+            if (onProgress) onProgress(nextFrameToWrite / totalFrames);
+          }
+        }
+      }
+    }
+  } catch (e) {
+=======
+      } else if (!aborted) {
+        while (nextFrameToWrite < totalFrames && !aborted) {
+          let chunkEnd = nextFrameToWrite + progressInterval;
+          if (chunkEnd > totalFrames) chunkEnd = totalFrames;
+
+          for (; nextFrameToWrite < chunkEnd && !aborted; ) {
+            const ringIndex = nextFrameToWrite & ringMask;
+            if (frameReadyRing[ringIndex] === 0) {
+              while (frameReadyRing[ringIndex] === 0 && !aborted) {
+                await writerWaiterPromise;
+              }
+              if (aborted) break;
+            }
+
+            const buffer = frameBufferRing[ringIndex]!;
+
+            pendingBytes += (buffer as any).length;
+            const writeSuccess = stream.write(buffer as any);
+
+            if (!writeSuccess && pendingBytes >= 16777216) {
+              await this.drainPromise;
+              pendingBytes = 0;
+            }
+
+            nextFrameToWrite++;
+            if (freeWorkersHead > 0) checkState();
+          }
+
+          if (aborted) break;
+
+          console.log(
+            `Progress: Rendered ${nextFrameToWrite} / ${totalFrames} frames`,
+          );
+          if (onProgress) onProgress(nextFrameToWrite / totalFrames);
+        }
+      }
+    }
+  } catch (e) {
+>>>>>>> REPLACE
+```
+
+**Why**: Eliminates branch evaluations inside the tightest multi-worker writer loops.
+**Risk**: Loop boundary off-by-one errors or early termination issues when `aborted` becomes true during the inner loop.
+
+## Variations
+None.
+
+## Correctness Check
+Run the vitest test suite (`npx vitest run packages/renderer/`).


### PR DESCRIPTION
💡 What: Planned an experiment to implement chunked loops in multi-worker writer loops in CaptureLoop.ts.
🎯 Why: Microbenchmarks from PERF-858 show a significant improvement in loop execution by eliminating branching.
🔬 Approach: Replace `while (nextFrameToWrite < totalFrames)` and `if (nextFrameToWrite === nextProgress)` branches with chunked outer while loops and unbranched inner for loops.
📌 Plan: packages/renderer/.sys/plans/PERF-859-chunked-progress-counter-multi-worker.md

---
*PR created automatically by Jules for task [1166921760733334830](https://jules.google.com/task/1166921760733334830) started by @BintzGavin*