### PR TITLE
📋 RENDERER: Eliminate Redundant aborted Checks in Chunked Loop Conditions

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -62,3 +62,4 @@ Last updated by: PERF-855
 ## Open Questions
 - Would chunked loops benefit multi-worker paths as well? (PERF-856) -> Yes, PERF-859 planned.
 - PERF-860: Single-worker chunked loops planned.
+- PERF-862: Eliminate redundant aborted checks in chunked loop conditions planned.

--- a/packages/renderer/.sys/plans/PERF-862-eliminate-for-loop-aborted-checks.md
+++ b/packages/renderer/.sys/plans/PERF-862-eliminate-for-loop-aborted-checks.md
@@ -1,0 +1,78 @@
+---
+id: PERF-862
+slug: eliminate-for-loop-aborted-checks
+status: unclaimed
+claimed_by: ""
+created: 2024-05-28
+completed: ""
+result: ""
+---
+
+# PERF-862: Eliminate Redundant `aborted` Checks in Chunked Loop Conditions
+
+## Focus Area
+The single-worker capture loops and multi-worker writer loops in `packages/renderer/src/core/CaptureLoop.ts`. Specifically, eliminating the `&& !aborted` check from the inner `for` loop conditions.
+
+## Background Research
+In previous optimization passes (PERF-861, PERF-859), the inner loops were chunked using a `while (i < totalFrames - 1 && !aborted)` outer loop and a `for (; i < chunkEnd && !aborted; i++)` inner loop to process frames in batches of `progressInterval`.
+While redundant `if (aborted) break;` statements were previously removed from the loop bodies (PERF-848, PERF-855), the `!aborted` check still evaluates on every single frame inside the inner `for` loop condition.
+
+The `aborted` state can only become `true` asynchronously (via the `AbortSignal`). If an abort is triggered mid-chunk:
+1. In the multi-worker writer path, if we have to wait for a frame, the explicit `if (aborted) break;` inside the `writerWaiterPromise` wait loop will catch it and break out. If frames are already buffered and ready, processing the remaining frames in the current chunk (at most 100 frames) before checking `aborted` at the outer `while` loop boundary adds microscopic CPU overhead.
+2. In the single-worker path, if a fatal error occurs during capture, the exception is caught by the outer `try/catch` block, immediately exiting the loop without needing the `!aborted` condition. If it's a soft abort, finishing the current fast-path chunk is perfectly acceptable.
+
+By removing `&& !aborted` from the inner `for` loops, we eliminate a per-iteration branch evaluation overhead in V8 on the absolute hottest code paths in the renderer.
+
+## Benchmark Configuration
+- **Composition URL**: The standard DOM benchmark composition (e.g., `benchmark-perf.ts`)
+- **Render Settings**: Standard resolution, 300,000 iterations for microbenchmark scripts
+- **Mode**: `dom` (both single-worker and multi-worker)
+- **Metric**: Wall-clock render time / microbenchmark median iteration time
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Current estimated render time**: Baseline is PERF-861 performance for single-worker and PERF-859 for multi-worker.
+- **Bottleneck analysis**: The V8 engine evaluates the `&& !aborted` condition on every frame processed in the inner `for` loop, causing unnecessary branch prediction and evaluation overhead.
+
+## Implementation Spec
+
+### Step 1: Remove `aborted` checks from single-worker `for` loops
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+Locate the 8 occurrences of the inner `for` loop in the single-worker path, which look like this:
+```typescript
+for (; i < chunkEnd && !aborted; i++) {
+```
+Change them to:
+```typescript
+for (; i < chunkEnd; i++) {
+```
+**Why**: Eliminates per-iteration branch evaluation. The chunk size is small enough that deferring the abort check to the outer `while` loop is safe.
+**Risk**: If an abort happens, a few extra frames may be processed synchronously before exiting. This is negligible.
+
+### Step 2: Remove `aborted` checks from multi-worker writer `for` loops
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+Locate the 2 occurrences of the inner `for` loop in the multi-worker writer path, which look like this:
+```typescript
+for (; nextFrameToWrite < chunkEnd && !aborted; ) {
+```
+Change them to:
+```typescript
+for (; nextFrameToWrite < chunkEnd; ) {
+```
+**Why**: Same reasoning. The inner `await writerWaiterPromise` loop already safely handles breaking out if aborted while waiting.
+
+### Step 3: Run Validation Tests
+- Execute `npm run test -w packages/renderer` to ensure the capture pipeline doesn't hang or fail.
+- Run the microbenchmark node scripts to measure single and multi worker improvements.
+- Execute full pre-commit verifications.
+
+## Variations
+None. This is a direct boolean evaluation elimination.
+
+## Canvas Smoke Test
+Run a standard canvas strategy benchmark to ensure the `!isDomStrategy` paths function identically and don't infinite loop.
+
+## Correctness Check
+Verify that throwing an error or triggering the abort signal still gracefully stops the render (the outer `while` loops will catch it at the chunk boundary).


### PR DESCRIPTION
💡 What: Planned PERF-862 to eliminate redundant && !aborted branch conditions inside chunked inner for loops. \n🎯 Why: Evaluated on every single frame, it adds unnecessary V8 branch prediction overhead, which can be safely deferred to the outer chunk loops. \n🔬 Approach: Remove the !aborted check from the inner for loops in single-worker and multi-worker fast paths. \n📌 Plan: packages/renderer/.sys/plans/PERF-862-eliminate-for-loop-aborted-checks.md

---
*PR created automatically by Jules for task [1450830471574337539](https://jules.google.com/task/1450830471574337539) started by @BintzGavin*