### PR TITLE
✨ RENDERER: Eliminate inner for loop aborted checks

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -54,6 +54,8 @@ Last updated by: PERF-855
 
 
 ## What Works
+- Removed redundant aborted checks in chunked inner for loops to eliminate V8 branch evaluation overhead (PERF-862)
+  - Plan ID: PERF-862
 - Removed 8 redundant inner aborted checks in single-worker fast loop to eliminate V8 per-iteration branch evaluation overhead (~1.4% faster in microbenchmark) (PERF-848)
 
 ## What Doesn't Work (and Why)

--- a/packages/renderer/.sys/perf-results.tsv
+++ b/packages/renderer/.sys/perf-results.tsv
@@ -289,3 +289,5 @@ PERF-831	Cache DomStrategy lastFrameData Locally	33.791	9.127
 1	0.000	0	0.00	0.0	keep	PERF-852 replaced modulo % progress check with fast counter in CaptureLoop.ts (microbenchmark improvement)
 1	0.000	300	0.00	0.0	keep	PERF-848
 PERF-853	CaptureLoop.ts single worker TimeSeek/Decode overlap	improved
+
+316	1.800	300	166.67	400.0	keep	PERF-862 single and multi worker loop condition optimizations

--- a/packages/renderer/.sys/plans/PERF-862-eliminate-for-loop-aborted-checks.md
+++ b/packages/renderer/.sys/plans/PERF-862-eliminate-for-loop-aborted-checks.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-862
 slug: eliminate-for-loop-aborted-checks
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-05-28
 completed: ""
-result: ""
+result: improved
 ---
 
 # PERF-862: Eliminate Redundant `aborted` Checks in Chunked Loop Conditions

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -276,7 +276,7 @@ export class CaptureLoop {
                   let chunkEnd = i + progressInterval;
                   if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
 
-                  for (; i < chunkEnd && !aborted; i++) {
+                  for (; i < chunkEnd; i++) {
                     const rawResult = await nextCapturePromise;
 
                     const timePromise = timeDriver.setTime(
@@ -373,7 +373,7 @@ export class CaptureLoop {
                   let chunkEnd = i + progressInterval;
                   if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
 
-                  for (; i < chunkEnd && !aborted; i++) {
+                  for (; i < chunkEnd; i++) {
                     const rawResult = await nextCapturePromise;
 
                     const timePromise = timeDriver.setTime(
@@ -467,7 +467,7 @@ export class CaptureLoop {
                   let chunkEnd = i + progressInterval;
                   if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
 
-                  for (; i < chunkEnd && !aborted; i++) {
+                  for (; i < chunkEnd; i++) {
                     const rawResult = await nextCapturePromise;
 
                     const timePromise = timeDriver.setTime(
@@ -540,7 +540,7 @@ export class CaptureLoop {
                   let chunkEnd = i + progressInterval;
                   if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
 
-                  for (; i < chunkEnd && !aborted; i++) {
+                  for (; i < chunkEnd; i++) {
                     const rawResult = await nextCapturePromise;
 
                     const timePromise = timeDriver.setTime(
@@ -674,7 +674,7 @@ export class CaptureLoop {
                   let chunkEnd = i + progressInterval;
                   if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
 
-                  for (; i < chunkEnd && !aborted; i++) {
+                  for (; i < chunkEnd; i++) {
                     const rawResult = await nextCapturePromise;
 
                     const timePromise = timeDriver.setTime(
@@ -762,7 +762,7 @@ export class CaptureLoop {
                   let chunkEnd = i + progressInterval;
                   if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
 
-                  for (; i < chunkEnd && !aborted; i++) {
+                  for (; i < chunkEnd; i++) {
                     const rawResult = await nextCapturePromise;
 
                     const timePromise = timeDriver.setTime(
@@ -855,7 +855,7 @@ export class CaptureLoop {
                   let chunkEnd = i + progressInterval;
                   if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
 
-                  for (; i < chunkEnd && !aborted; i++) {
+                  for (; i < chunkEnd; i++) {
                     const buf = await nextCapturePromise;
 
                     const timePromise = timeDriver.setTime(
@@ -917,7 +917,7 @@ export class CaptureLoop {
                   let chunkEnd = i + progressInterval;
                   if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
 
-                  for (; i < chunkEnd && !aborted; i++) {
+                  for (; i < chunkEnd; i++) {
                     const buf = await nextCapturePromise;
 
                     const timePromise = timeDriver.setTime(
@@ -1356,7 +1356,7 @@ export class CaptureLoop {
               let chunkEnd = nextFrameToWrite + progressInterval;
               if (chunkEnd > totalFrames) chunkEnd = totalFrames;
 
-              for (; nextFrameToWrite < chunkEnd && !aborted; ) {
+              for (; nextFrameToWrite < chunkEnd; ) {
                 const ringIndex = nextFrameToWrite & ringMask;
                 if (frameReadyRing[ringIndex] === 0) {
                   while (frameReadyRing[ringIndex] === 0 && !aborted) {
@@ -1401,7 +1401,7 @@ export class CaptureLoop {
               let chunkEnd = nextFrameToWrite + progressInterval;
               if (chunkEnd > totalFrames) chunkEnd = totalFrames;
 
-              for (; nextFrameToWrite < chunkEnd && !aborted; ) {
+              for (; nextFrameToWrite < chunkEnd; ) {
                 const ringIndex = nextFrameToWrite & ringMask;
                 if (frameReadyRing[ringIndex] === 0) {
                   while (frameReadyRing[ringIndex] === 0 && !aborted) {


### PR DESCRIPTION
💡 What: Removed redundant `!aborted` checks from the inner chunked `for` loops in single-worker and multi-worker fast paths.
🎯 Why: To eliminate per-iteration synchronous V8 branch evaluation overhead on the absolute hottest code paths.
🔬 Approach: Removed the boolean check since chunk sizes are small enough (progressInterval) that deferring the abort check to the outer `while` loop boundary is safe.
📌 Plan: PERF-862

316	1.800	300	166.67	400.0	keep	PERF-862 single and multi worker loop condition optimizations

---
*PR created automatically by Jules for task [16778535163613863537](https://jules.google.com/task/16778535163613863537) started by @BintzGavin*