### PR TITLE
📋 RENDERER: Discard PERF-858 Duplicate Plan

### DIFF
--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -41,6 +41,7 @@ Last updated by: PERF-855
 - PERF-822: Eliminate `i + 1 < totalFrames` branch in CaptureLoop hot paths (~11% microbenchmark improvement)
 
 ## What Doesn't Work (and Why)
+- PERF-858: Discarded as duplicate. The chunked loop approach in the multi-worker path was already successfully implemented and kept under PERF-859.
 - PERF-849: Peeling the last frame iteration in the single-worker fast path frame loops to avoid `if (i < totalFrames - 1)` check actually increases execution time in V8 (likely due to deoptimization or code duplication). Discarded.
 - Removing redundant aborted checks in single worker loop (slower by 0.00%) - PERF-848
 - PERF-836: Unrolling the `nextFrameToSubmit - nextFrameToWrite < maxPipelineDepth` check in the multi-worker CaptureLoop path. Microbenchmarks showed a ~14% performance degradation. This is likely due to the inner fast-loop increasing closure allocations or V8 engine failing to optimize the deeply nested structure properly, outweighing the minor savings from avoiding branch checks.

--- a/packages/renderer/.sys/perf-results-PERF-858.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-858.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	duplicate of PERF-859

--- a/packages/renderer/.sys/plans/PERF-858-chunked-progress-counter-multi-worker.md
+++ b/packages/renderer/.sys/plans/PERF-858-chunked-progress-counter-multi-worker.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-858
 slug: chunked-progress-counter-multi-worker
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2026-06-26
 completed: ""
-result: ""
+result: "discard"
 ---
 
 # PERF-858: Replace Loop Branching with Chunked Inner Loops in CaptureLoop Multi-Worker Write Path
@@ -227,3 +227,9 @@ None.
 
 ## Correctness Check
 Run the vitest test suite (`npx vitest run packages/renderer/`).
+
+## Results Summary
+- **Best render time**: N/A
+- **Improvement**: 0%
+- **Kept experiments**: None
+- **Discarded experiments**: PERF-858 (Discarded as duplicate, superseded by PERF-859)


### PR DESCRIPTION
💡 What: Discarded the unclaimed PERF-858 plan as a duplicate. Updated the RENDERER-EXPERIMENTS.md journal and generated the discard TSV results file.
🎯 Why: The optimization described in PERF-858 (refactoring the multi-worker writer path with unbranched chunked while loops) was already successfully tested and merged under PERF-859.
🔬 Approach: Marked the plan file as complete and discarded, recorded the discard reason in the TSV and journal, without modifying the underlying CaptureLoop codebase.
📌 Plan: /.sys/plans/PERF-858-chunked-progress-counter-multi-worker.md

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	duplicate of PERF-859

---
*PR created automatically by Jules for task [4438804784523233152](https://jules.google.com/task/4438804784523233152) started by @BintzGavin*