### PR TITLE
✨ PLAYER: Implement setMediaKeys

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -45,6 +45,7 @@ Observed attributes:
 - `pause(): void`
 - `seek(timeInSeconds: number): Promise<void>`
 - `fastSeek(timeInSeconds: number): void`
+- `setMediaKeys(mediaKeys: MediaKeys | null): Promise<void>`
 - `captureStream(): Promise<MediaStream>`
 - `export(options?: ExportOptions): Promise<void>`
 - `diagnose(): Promise<DiagnosticReport>`
@@ -70,6 +71,7 @@ Properties:
 - `videoTracks: VideoTrackList`
 - `textTracks: TextTrackList`
 - `mediaSession: MediaSession`
+- `mediaKeys: MediaKeys | null`
 
 ## Section E: Export Capabilities
 The player supports client-side export utilizing `@helios-project/core` rendering.

--- a/docs/PROGRESS-PLAYER.md
+++ b/docs/PROGRESS-PLAYER.md
@@ -331,3 +331,6 @@
 - ✅ Completed: Refactor Player Export - Extracted `ClientSideExporter`, added cancellation support, and modularized controllers.
 - ✅ Completed: Sandbox and Bridge - Implemented `postMessage` bridge and sandboxed iframe support.
 - ✅ Completed: Refactor Player Control Logic - Verified `<helios-player>` uses `window.helios` and supports client-side export.
+
+### PLAYER v0.78.2
+- ✅ Completed: Implement setMediaKeys - Added mediaKeys property and setMediaKeys method to complete HTMLMediaElement parity.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,5 +1,5 @@
 [v0.77.53] ✅ Completed: Identified missing HTMLMediaElement events (`abort`, `emptied`, `progress`) in `<helios-player>`. Created plan `.sys/plans/2027-02-15-PLAYER-Add-Missing-Events.md` to implement them.
-**Version**: 0.78.1
+**Version**: 0.78.2
 [v0.78.1] ✅ Completed: Implement Instance Constants - Added standard media constants (e.g., HAVE_NOTHING, NETWORK_EMPTY) to the HeliosPlayer instance for HTMLMediaElement parity.
 [v0.77.60] ✅ Completed: Discovered that 2026-06-03-PLAYER-configurable-export-resolution.md is an IMPOSSIBLE: DUPLICATION plan. The export-width and export-height properties are already fully implemented and verified in the codebase. Documented as impossible and discarded.
 [v0.77.41] ✅ Completed: Discovered undocumented event handler properties in implementation missing from README. Created plan `.sys/plans/2027-02-15-PLAYER-Document-Event-Handlers.md` to document `onplay`, `onpause`, etc.
@@ -271,3 +271,4 @@
 ### Pending Implementations
 - API Parity: Implement missing `HTMLMediaElement` instance constants (e.g. `HAVE_NOTHING`, `NETWORK_EMPTY`) and document them. See plan: `.sys/plans/2024-05-24-PLAYER-Instance-Constants.md`
 [v0.78.1] ✅ Completed: Discovered missing HTMLMediaElement parity method (`setMediaKeys`). Created plan `.sys/plans/2027-03-02-PLAYER-Implement-setMediaKeys.md` to implement it.
+[v0.78.2] ✅ Completed: Implement setMediaKeys - Added mediaKeys property and setMediaKeys method to complete HTMLMediaElement parity.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -137,6 +137,7 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 ### Methods
 
 - `setSinkId(sinkId: string): Promise<void>` - Sets the audio sink id.
+- `setMediaKeys(mediaKeys: MediaKeys | null): Promise<void>` - Sets the MediaKeys object to use for decrypting media.
 
 - `play(): Promise<void>` - Starts playback.
 - `getSchema(): Promise<HeliosSchema | undefined>` - Retrieves the input properties schema from the composition.
@@ -169,6 +170,7 @@ The `<helios-player>` element implements a subset of the HTMLMediaElement interf
 - `disableRemotePlayback` (boolean): Reflected disableremoteplayback attribute.
 - `mediaGroup` (string): Reflected mediagroup attribute.
 - `sinkId` (string, read-only): Returns the current audio sink id.
+- `mediaKeys` (MediaKeys | null, read-only): The MediaKeys object associated with the media element.
 
 - `src` (string): URL of the composition page to load in the iframe.
 - `autoplay` (boolean): Reflected autoplay attribute.

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -422,6 +422,17 @@ describe('HeliosPlayer API Parity', () => {
     expect(player.defaultMuted).toBe(false);
   });
 
+  it('should support mediaKeys property and setMediaKeys method', async () => {
+    expect(player.mediaKeys).toBeNull();
+
+    const mockMediaKeys = {} as MediaKeys;
+    await player.setMediaKeys(mockMediaKeys);
+    expect(player.mediaKeys).toBe(mockMediaKeys);
+
+    await player.setMediaKeys(null);
+    expect(player.mediaKeys).toBeNull();
+  });
+
   it('should support defaultPlaybackRate property', () => {
     const rateSpy = vi.fn();
     player.addEventListener('ratechange', rateSpy);

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1347,6 +1347,16 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     return Promise.resolve();
   }
 
+  private _mediaKeys: MediaKeys | null = null;
+  public get mediaKeys(): MediaKeys | null {
+    return this._mediaKeys;
+  }
+
+  public async setMediaKeys(mediaKeys: MediaKeys | null): Promise<void> {
+    this._mediaKeys = mediaKeys;
+    return Promise.resolve();
+  }
+
   public get seeking(): boolean {
     // Return internal scrubbing state as seeking
     return this.isScrubbing || this._isSeeking;


### PR DESCRIPTION
Implemented HTMLMediaElement API parity for `mediaKeys` and `setMediaKeys` in `@helios-project/player`. Includes tests, status update, and documentation updates.

---
*PR created automatically by Jules for task [2614162081189207344](https://jules.google.com/task/2614162081189207344) started by @BintzGavin*