### PR TITLE
📋 PLAYER: Document Instance Constants

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -110,3 +110,7 @@
 ## [v0.77.64] - Documenting and Exposing Media Constants
 **Learning**: Standard `HTMLMediaElement` constants like `HAVE_NOTHING` and `NETWORK_EMPTY` are exposed as both static properties on the constructor and instance properties on the prototype. They were implemented statically in `<helios-player>` but missing from the instance API and documentation.
 **Action**: When achieving API parity with built-in DOM elements, ensure constants are available on both the instance and constructor as expected by standard JavaScript usage patterns, and explicitly document them in the README.
+
+## [v0.78.3] - Redundant Instance Constants Plan
+**Learning:** A plan (`.sys/plans/2024-05-24-PLAYER-Instance-Constants.md`) was marked as pending but the constants (`HAVE_NOTHING`, `NETWORK_EMPTY`, etc.) were actually already implemented as getters on the instance and static readonly properties on the class. However, they were not documented in the README.
+**Action:** When finding a pending implementation plan, first check if the feature has already been implemented. If it has, mark the plan as an `IMPOSSIBLE: DUPLICATION` in the status file and create a new plan to document the gap if necessary.

--- a/.sys/plans/2027-03-03-PLAYER-Document-Instance-Constants.md
+++ b/.sys/plans/2027-03-03-PLAYER-Document-Instance-Constants.md
@@ -1,0 +1,21 @@
+#### 1. Context & Goal
+- **Objective**: Document the `HTMLMediaElement` instance and class constants in the README.
+- **Trigger**: Vision gap identified. The README is missing documentation for standard `HTMLMediaElement` instance and class constants (like `HAVE_NOTHING`, `NETWORK_EMPTY`, etc.) which are already implemented in `<helios-player>`.
+- **Impact**: Improves API documentation parity with the actual implementation and standard web APIs.
+
+#### 2. File Inventory
+- **Modify**: `README.md` (Add documentation for `HTMLMediaElement` constants)
+- **Read-Only**: `packages/player/src/index.ts` (To verify implemented properties)
+
+#### 3. Implementation Spec
+- **Architecture**: Update the README file to include a new sub-section under the API documentation detailing the standard `HTMLMediaElement` class and instance constants (`HAVE_NOTHING`, `HAVE_METADATA`, `HAVE_CURRENT_DATA`, `HAVE_FUTURE_DATA`, `HAVE_ENOUGH_DATA`, `NETWORK_EMPTY`, `NETWORK_IDLE`, `NETWORK_LOADING`, `NETWORK_NO_SOURCE`).
+- **Pseudo-Code**:
+  - Locate the API Parity section in `README.md`.
+  - Append the list of class and instance constants.
+- **Public API Changes**: None (documentation only).
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `cat README.md | grep -A 15 "### HTMLMediaElement Constants"`
+- **Success Criteria**: The README contains the documented constants.
+- **Edge Cases**: None.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -268,7 +268,7 @@
 [v0.77.63] ✅ Completed: Created `2027-03-01-PLAYER-Implement-Video-API-Parity-Methods.md` execution plan to achieve deeper API parity with the HTMLVideoElement interface.
 [v0.78.0] ✅ Completed: Implement Video API Parity Methods - Added `getVideoPlaybackQuality`, `requestVideoFrameCallback`, and `cancelVideoFrameCallback` to complete HTMLVideoElement API parity.
 
-### Pending Implementations
-- API Parity: Implement missing `HTMLMediaElement` instance constants (e.g. `HAVE_NOTHING`, `NETWORK_EMPTY`) and document them. See plan: `.sys/plans/2024-05-24-PLAYER-Instance-Constants.md`
+
 [v0.78.1] ✅ Completed: Discovered missing HTMLMediaElement parity method (`setMediaKeys`). Created plan `.sys/plans/2027-03-02-PLAYER-Implement-setMediaKeys.md` to implement it.
 [v0.78.2] ✅ Completed: Implement setMediaKeys - Added mediaKeys property and setMediaKeys method to complete HTMLMediaElement parity.
+[v0.78.3] ✅ Completed: Discovered that `.sys/plans/2024-05-24-PLAYER-Instance-Constants.md` is an IMPOSSIBLE: DUPLICATION plan. The missing constants are already implemented. Created plan `.sys/plans/2027-03-03-PLAYER-Document-Instance-Constants.md` to document them.


### PR DESCRIPTION
- Discovered that the instance/class constants pending plan was a duplicate since they are already implemented.
- Cleaned up docs/status/PLAYER.md to remove the old pending plan and mark it as impossible/duplicate.
- Created an execution plan .sys/plans/2027-03-03-PLAYER-Document-Instance-Constants.md to document the implemented HTMLMediaElement class and instance constants in the README.
- Recorded learning in .jules/PLAYER.md

---
*PR created automatically by Jules for task [12812641249334072153](https://jules.google.com/task/12812641249334072153) started by @BintzGavin*