### PR TITLE
✨ RENDERER: Unswitch timePromise in CaptureLoop fast paths

### DIFF
--- a/.sys/plans/PERF-870-hoist-timepromise.md
+++ b/.sys/plans/PERF-870-hoist-timepromise.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-870
 slug: hoist-timepromise
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-06-28
-completed: ""
-result: ""
+completed: "2024-06-29"
+result: "improved"
 ---
 
 # PERF-870: Unswitch `timePromise` checks in `CaptureLoop.ts`

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -70,3 +70,7 @@ Last updated by: PERF-855
 - PERF-860: Single-worker chunked loops planned.
 - PERF-862: Eliminate redundant aborted checks in chunked loop conditions planned.
 - PERF-864: Unroll frame ready check from multi-worker fast path write loops planned.
+
+- **What Works:** PERF-870 unswitched the `timePromise` checks in the single-worker and multi-worker fast paths of `CaptureLoop.ts`.
+  - **Improvement:** Reduced V8 branch evaluation overhead by eliminating `if (timePromise)` checks where `timePromise` is guaranteed to be a Promise (in `isDomStrategy` paths).
+  - **Plan ID:** PERF-870

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -302,7 +302,7 @@ export class CaptureLoop {
                     const written = pooled.buffer.write(buf, "base64");
                     const chunk = pooled.buffer.subarray(0, written);
 
-                    if (timePromise) await timePromise;
+                    await timePromise;
                     nextCapturePromise = domBeginFrame!();
 
                     pendingBytes += written;
@@ -474,7 +474,7 @@ export class CaptureLoop {
                       page,
                       (startFrame + i + 1) * compTimeStep,
                     );
-                    if (timePromise) await timePromise;
+                    await timePromise;
                     nextCapturePromise = domBeginFrame!();
 
                     let buf;
@@ -695,7 +695,7 @@ export class CaptureLoop {
                     const written = pooled.buffer.write(buf, "base64");
                     const chunk = pooled.buffer.subarray(0, written);
 
-                    if (timePromise) await timePromise;
+                    await timePromise;
 
                     nextCapturePromise = domBeginFrame!();
 
@@ -862,7 +862,7 @@ export class CaptureLoop {
                       page,
                       (startFrame + i + 1) * compTimeStep,
                     );
-                    if (timePromise) await timePromise;
+                    await timePromise;
 
                     nextCapturePromise = domBeginFrame!();
 
@@ -1131,9 +1131,7 @@ export class CaptureLoop {
                   page,
                   (startFrame + i) * compTimeStep,
                 );
-                if (timePromise) {
-                  await timePromise;
-                }
+                await timePromise;
                 let buffer: any;
                 const rawResult = await domBeginFrame!();
                 const data = rawResult.screenshotData;
@@ -1222,9 +1220,7 @@ export class CaptureLoop {
                   page,
                   (startFrame + i) * compTimeStep,
                 );
-                if (timePromise) {
-                  await timePromise;
-                }
+                await timePromise;
                 let buffer: any;
                 buffer = await domBeginFrame!();
                 frameBufferRing[ringIndex] = buffer;


### PR DESCRIPTION
💡 What: Eliminated `if (timePromise)` checks inside `isDomStrategy` blocks in `CaptureLoop.ts`.
🎯 Why: To reduce V8 branch evaluation overhead, as `timeDriver.setTime()` always returns a valid Promise for DOM render mode.
🔬 Approach: Replaced `if (timePromise) await timePromise;` with `await timePromise;` where applicable.
📎 Plan: .sys/plans/PERF-870-hoist-timepromise.md

---
*PR created automatically by Jules for task [15447768112374687420](https://jules.google.com/task/15447768112374687420) started by @BintzGavin*