### PR TITLE
✨ RENDERER: Discard PERF-873 due to integration test failure

### DIFF
--- a/.sys/plans/PERF-873-hoist-i-plus-1-startframe.md
+++ b/.sys/plans/PERF-873-hoist-i-plus-1-startframe.md
@@ -1,5 +1,7 @@
 ---
-status: unclaimed
+status: complete
+completed: 2024-06-29
+result: discarded
 ---
 
 # Plan: Pre-calculate `startFrame + 1` to reduce additions in `CaptureLoop.ts`
@@ -15,3 +17,9 @@ In the `CaptureLoop.ts` multi-worker fast path, the loop evaluates `(startFrame 
 2. Inside the loop, change `(startFrame + i + 1)` to `(startFramePlusOne + i)`.
 3. Test and benchmark.
 4. Record results.
+
+## Results Summary
+- **Best render time**: -12% on inner loop microbenchmark, but failed integration tests
+- **Improvement**: Regressed
+- **Kept experiments**: None
+- **Discarded experiments**: Hoisting `startFrame + 1` into `startFramePlusOne` outside the inner `for` loops in `CaptureLoop.ts`

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -1,6 +1,6 @@
 ## Performance Trajectory
 Current best: 1.831s (baseline was 1.831s, -0%)
-Last updated by: PERF-855
+Last updated by: PERF-873
 
 ## What Works
 - **What Works:** PERF-868 replaced the if-statement branch for chunkEnd boundaries with Math.min in the CaptureLoop.ts fast paths.
@@ -67,6 +67,10 @@ Last updated by: PERF-855
 - PERF-846: Discarded as obsolete. Duplicate of PERF-848.
 - Overlapping FFmpeg stream write with Time Seek CDP await in the single-worker path (PERF-854). The Node.js stream write `stream.write` is extremely fast and mostly synchronous in its execution up until the OS buffer fills. Our test scripts and microbenchmarks show the overlapping actually caused a regression of ~1-3% because we delayed starting the CDP time seek command (`timeDriver.setTime`), which is network bound and takes significantly longer. Pushing the time seek *earlier* is more important than eagerly pushing the synchronous stream write, especially since `stream.write` isn't a long-running CPU bound task like Base64 decoding.
 - PERF-860 was discarded as the microbenchmarks showed that a chunked implementation with peeled final frame loop boundaries is slower than the fast counter. A new plan, PERF-861, was created to properly unbranch the inner loop by peeling the final frame entirely out of the while loop.
+
+
+- **What Doesn't Work**: PERF-873 attempted to hoist the `startFrame + 1` calculation outside the inner chunked loops in `CaptureLoop.ts` to reduce addition operations per frame. Microbenchmarks showed a ~9-12% improvement in pure loop overhead. However, when integrated into the codebase, the experiment caused regressions in the test suite (`verify-cdp-shadow-dom-sync.ts`). The optimization was discarded to maintain frame correctness.
+  - Plan: `PERF-873`
 
 ## Open Questions
 - Would chunked loops benefit multi-worker paths as well? (PERF-856) -> Yes, PERF-859 planned.

--- a/packages/renderer/.sys/perf-results-PERF-873.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-873.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.561	100000000	178253119.00	0.0	keep	baseline (microbenchmark 100M iterations)
+2	0.493	100000000	202839756.00	0.0	discard	hoist startFrame + 1 in inner loop
+3	0.0	0	0	0.0	crash	integration tests verify-cdp-shadow-dom-sync.ts failed


### PR DESCRIPTION
💡 **What**: Executed and discarded PERF-873, which attempted to hoist `startFrame + 1` calculation out of the `CaptureLoop.ts` inner chunk loops.
🎯 **Why**: To reduce addition operations per frame evaluation in hot capture paths.
📊 **Impact**: Microbenchmarks showed a ~12% loop overhead reduction, but the experiment failed the `verify-cdp-shadow-dom-sync.ts` integration test, indicating correct frame synchronization was broken.
🔬 **Verification**: Code reverted. Run logged in TSV and RENDERER-EXPERIMENTS.md.
📎 **Plan**: `/.sys/plans/PERF-873-hoist-i-plus-1-startframe.md`

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.561	100000000	178253119.00	0.0	keep	baseline (microbenchmark 100M iterations)
2	0.493	100000000	202839756.00	0.0	discard	hoist startFrame + 1 in inner loop
3	0.0	0	0	0.0	crash	integration tests verify-cdp-shadow-dom-sync.ts failed

---
*PR created automatically by Jules for task [18271722701536633288](https://jules.google.com/task/18271722701536633288) started by @BintzGavin*