### PR TITLE
✨ PLAYER: Expose Playback Range Methods

### DIFF
--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1762,6 +1762,18 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     }
   }
 
+  public setPlaybackRange(startFrame: number, endFrame: number): void {
+    if (this.controller) {
+      this.controller.setPlaybackRange(startFrame, endFrame);
+    }
+  }
+
+  public clearPlaybackRange(): void {
+    if (this.controller) {
+      this.controller.clearPlaybackRange();
+    }
+  }
+
   static get observedAttributes() {
     return ["src", "width", "height", "autoplay", "loop", "controls", "export-format", "input-props", "poster", "muted", "interactive", "preload", "controlslist", "sandbox", "export-caption-mode", "disablepictureinpicture", "export-width", "export-height", "export-bitrate", "export-filename", "media-title", "media-artist", "media-album", "media-artwork", "export-mode", "canvas-selector", "playsinline", "crossorigin"];
   }


### PR DESCRIPTION
✨ PLAYER: Expose Playback Range Methods

💡 What: Added `setPlaybackRange` and `clearPlaybackRange` methods to the `HeliosPlayer` public API in `packages/player/src/index.ts`.
🎯 Why: The underlying `HeliosController` and the component UI supported setting loop points (in/out), but this functionality was missing from the Web Component's public interface, preventing programmatic access by consumers.
📊 Impact: Third-party applications and scripts can now programmatically set and clear playback loops on the `<helios-player>` instance.
🔬 Verification: Added methods were validated for TypeScript build completeness and test suites pass locally via `npm run test -w packages/player`.

---
*PR created automatically by Jules for task [3978528517620597589](https://jules.google.com/task/3978528517620597589) started by @BintzGavin*