### PR TITLE
📋 PLAYER: Plan Expose Composition Setters

### DIFF
--- a/.sys/plans/2027-03-05-PLAYER-Expose-Composition-Setters.md
+++ b/.sys/plans/2027-03-05-PLAYER-Expose-Composition-Setters.md
@@ -1,0 +1,40 @@
+#### 1. Context & Goal
+- **Objective**: Expose `setDuration`, `setFps`, `setSize`, and `setMarkers` methods on the public `HeliosPlayer` API wrapper.
+- **Trigger**: Vision gap. The internal `HeliosController` has these features (implemented in v0.61.0), and the README documents them as "Dynamic Composition Updates", but they were omitted from the public `<helios-player>` Web Component interface.
+- **Impact**: Unlocks dynamic composition updates from the host application (like Studio) without having to manually dig out the internal controller. Matches documented capabilities.
+
+#### 2. File Inventory
+- **Create**: []
+- **Modify**:
+  - `packages/player/src/index.ts` (Add the missing public methods)
+- **Read-Only**:
+  - `packages/player/src/controllers.ts` (Reference for method signatures)
+
+#### 3. Implementation Spec
+- **Architecture**: Standard Web Components API method forwarding. The `<helios-player>` class will simply forward these calls to its internal `HeliosController`.
+- **Pseudo-Code**:
+  ```typescript
+  public setDuration(seconds: number): void {
+    if (this.controller) this.controller.setDuration(seconds);
+  }
+  public setFps(fps: number): void {
+    if (this.controller) this.controller.setFps(fps);
+  }
+  public setSize(width: number, height: number): void {
+    if (this.controller) this.controller.setSize(width, height);
+  }
+  public setMarkers(markers: Marker[]): void {
+    if (this.controller) this.controller.setMarkers(markers);
+  }
+  ```
+- **Public API Changes**:
+  - `setDuration(seconds: number): void` added to `HeliosPlayer`.
+  - `setFps(fps: number): void` added to `HeliosPlayer`.
+  - `setSize(width: number, height: number): void` added to `HeliosPlayer`.
+  - `setMarkers(markers: Marker[]): void` added to `HeliosPlayer`.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm run build -w packages/player && npm run test -w packages/player`
+- **Success Criteria**: The code compiles and tests pass. A small check script can confirm the methods exist on the prototype.
+- **Edge Cases**: The methods should safely no-op if the controller is not yet initialized.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,6 +1,7 @@
+[v0.78.5] ✅ Completed: Discovered missing composition setters on the public API wrapper. Created plan `.sys/plans/2027-03-05-PLAYER-Expose-Composition-Setters.md` to expose `setDuration`, `setFps`, `setSize`, and `setMarkers`.
 [v0.78.4] ✅ Completed: Discovered missing HTMLMediaElement-like parity methods (`setPlaybackRange`, `clearPlaybackRange`) in HeliosPlayer public API. Created plan `.sys/plans/2027-03-04-PLAYER-Expose-Playback-Range-Methods.md` to implement them.
 [v0.77.53] ✅ Completed: Identified missing HTMLMediaElement events (`abort`, `emptied`, `progress`) in `<helios-player>`. Created plan `.sys/plans/2027-02-15-PLAYER-Add-Missing-Events.md` to implement them.
-**Version**: 0.78.4
+**Version**: 0.78.5
 [v0.78.4] ✅ Completed: Discovered missing HTMLMediaElement-like parity methods (`setPlaybackRange`, `clearPlaybackRange`) in HeliosPlayer public API. Created plan `.sys/plans/2027-03-04-PLAYER-Expose-Playback-Range-Methods.md` to implement them.
 [v0.78.4] ✅ Completed: Discovered missing HTMLMediaElement-like parity methods (`setPlaybackRange`, `clearPlaybackRange`) in HeliosPlayer public API. Created plan `.sys/plans/2027-03-04-PLAYER-Expose-Playback-Range-Methods.md` to implement them.
 [v0.78.1] ✅ Completed: Implement Instance Constants - Added standard media constants (e.g., HAVE_NOTHING, NETWORK_EMPTY) to the HeliosPlayer instance for HTMLMediaElement parity.


### PR DESCRIPTION
Generated plan file .sys/plans/2027-03-05-PLAYER-Expose-Composition-Setters.md to expose composition setter methods (setDuration, setFps, setSize, setMarkers) on the public HeliosPlayer wrapper class.

---
*PR created automatically by Jules for task [12720509645198471155](https://jules.google.com/task/12720509645198471155) started by @BintzGavin*