### PR TITLE
✨ RENDERER: Fix Progress Spam in Multi-Worker Chunked Loops

### DIFF
--- a/.sys/plans/PERF-877-fix-multi-chunk-progress-spam.md
+++ b/.sys/plans/PERF-877-fix-multi-chunk-progress-spam.md
@@ -1,0 +1,64 @@
+---
+id: PERF-877
+slug: fix-multi-chunk-progress-spam
+status: unclaimed
+claimed_by: ""
+created: 2024-06-29
+completed: ""
+result: ""
+---
+
+# PERF-877: Fix Progress Spam in Multi-Worker Chunked Loops
+
+## Focus Area
+The multi-worker chunked write loops in `CaptureLoop.ts` unconditionally emit progress logs and events at the end of every outer loop iteration, rather than adhering to the `progressInterval` interval.
+
+## Background Research
+In recent optimizations (PERF-859, PERF-868), chunked loops were introduced to the multi-worker fast paths in `CaptureLoop.ts`. The inner loops process up to `progressInterval` frames at a time. However, if the inner loop breaks early because a frame is not yet ready (which is common in multi-worker where frames are produced asynchronously out of order), the outer loop emits a progress event immediately, regardless of how many frames were actually processed.
+
+This causes extreme progress spam: it can emit a log and event for every single frame (or even multiple times for the same frame if it has to await `writerWaiterPromise` multiple times), rather than once every `progressInterval` frames. This spams stdout and unnecessarily calls the `onProgress` callback too frequently.
+
+## Benchmark Configuration
+- **Composition URL**: Any standard DOM benchmark composition
+- **Render Settings**: 1920x1080, 60 FPS, 5 seconds
+- **Mode**: `dom` (multi worker)
+- **Metric**: Frequency of `console.log('Progress: ...')` output
+- **Minimum runs**: 1 per experiment
+
+## Baseline
+- **Bottleneck analysis**: The outer loop in `CaptureLoop.ts` (around lines 1385-1389 and 1426-1430) executes `if (onProgress) onProgress(...)` on every outer iteration, without checking against `nextProgress`.
+
+## Implementation Spec
+
+### Step 1: Restore conditional check for progress emission in multi-worker chunked loops
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the multi-worker chunked fast paths (there are two `while (nextFrameToWrite < totalFrames && !aborted)` loops in the base64 string path and buffer path, around lines 1385-1389 and 1426-1430), replace the unconditional progress logging:
+```typescript
+              console.log(
+                `Progress: Rendered ${nextFrameToWrite} / ${totalFrames} frames`,
+              );
+              if (onProgress) onProgress(nextFrameToWrite / totalFrames);
+```
+With a conditional check that uses `nextProgress`, matching the single-worker path's logic (which was fixed during single-worker chunking):
+```typescript
+              if (nextFrameToWrite >= nextProgress) {
+                nextProgress += progressInterval;
+                console.log(
+                  `Progress: Rendered ${nextFrameToWrite} / ${totalFrames} frames`,
+                );
+                if (onProgress) onProgress(nextFrameToWrite / totalFrames);
+              }
+```
+
+**Why**: Restoring this condition ensures that progress events are only emitted at the correct intervals (`progressInterval`), even when the chunked loop exits early due to unready frames. It eliminates unnecessary I/O spam and callback overhead.
+**Risk**: None. This just fixes a bug introduced by loop restructuring.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run `npm test -w packages/renderer` and check stdout. It should no longer spam `Progress: Rendered X / Y` for every single frame.
+
+## Correctness Check
+Run the DOM verification script and ensure it succeeds, and that progress is logged cleanly at expected intervals.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -58,6 +58,8 @@ Last updated by: PERF-873
   - **Plan ID:** PERF-864
 
 ## What Doesn't Work (and Why)
+- IMPOSSIBLE: DUPLICATION: PERF-876 proposed removing the per-iteration progress check from multi-worker fast paths. However, this was marked as obsolete/discarded because the chunked loop implementations (PERF-859, PERF-868) already hoisted the progress check naturally, making the original PERF-876 plan redundant.
+  - Plan: `PERF-876`
 - PERF-867: Attempted to optimize the drain condition `!writeSuccess && pendingBytes >= 16777216` by reordering it to `pendingBytes >= 16777216 && !writeSuccess`. Microbenchmarks showed no improvement and in some cases slight regression (e.g., from 48.5ms to 52.4ms in tight loops) due to `writeSuccess` being a highly predictable boolean that is cheaper to evaluate first. The experiment was discarded.
 - PERF-865 attempted to implement a faster `ReusableThenable` in `CaptureLoop.ts` by reducing redundant V8 object property accesses. Microbenchmarks showed a ~5.4% regression in execution speed, likely due to V8's hidden class optimizations being disrupted. The change was discarded.
 - PERF-858: Discarded as duplicate. The chunked loop approach in the multi-worker path was already successfully implemented and kept under PERF-859.
@@ -76,6 +78,7 @@ Last updated by: PERF-873
   - Plan: `PERF-873`
 
 ## Open Questions
+- PERF-877: Fix Progress Spam in Multi-Worker Chunked Loops planned
 - Would chunked loops benefit multi-worker paths as well? (PERF-856) -> Yes, PERF-859 planned.
 - PERF-860: Single-worker chunked loops planned.
 - PERF-862: Eliminate redundant aborted checks in chunked loop conditions planned.


### PR DESCRIPTION
💡 What: Drafted PERF-877 to restore conditional checks for progress emission in the multi-worker chunked loops of CaptureLoop.ts. Also marked PERF-876 as discarded since chunking naturally handled the progress unrolling.
🎯 Why: Chunking broke the interval logic, causing progress spam for every unready frame iteration, polluting I/O and slowing down the loop.
🔬 Approach: Reintroduce `if (nextFrameToWrite >= nextProgress)` around the progress emit and increment `nextProgress += progressInterval` in the outer loop scope.
📎 Plan: /.sys/plans/PERF-877-fix-multi-chunk-progress-spam.md

---
*PR created automatically by Jules for task [17796218015660427936](https://jules.google.com/task/17796218015660427936) started by @BintzGavin*