### PR TITLE
✨ RENDERER: Fix Progress Spam in Multi-Worker Chunked Loops

### DIFF
--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -1382,10 +1382,13 @@ export class CaptureLoop {
 
               if (freeWorkersHead > 0) checkState();
 
-              console.log(
-                `Progress: Rendered ${nextFrameToWrite} / ${totalFrames} frames`,
-              );
-              if (onProgress) onProgress(nextFrameToWrite / totalFrames);
+              if (nextFrameToWrite >= nextProgress) {
+                nextProgress += progressInterval;
+                console.log(
+                  `Progress: Rendered ${nextFrameToWrite} / ${totalFrames} frames`,
+                );
+                if (onProgress) onProgress(nextFrameToWrite / totalFrames);
+              }
             }
           } else if (!aborted) {
             while (nextFrameToWrite < totalFrames && !aborted) {
@@ -1423,10 +1426,13 @@ export class CaptureLoop {
 
               if (freeWorkersHead > 0) checkState();
 
-              console.log(
-                `Progress: Rendered ${nextFrameToWrite} / ${totalFrames} frames`,
-              );
-              if (onProgress) onProgress(nextFrameToWrite / totalFrames);
+              if (nextFrameToWrite >= nextProgress) {
+                nextProgress += progressInterval;
+                console.log(
+                  `Progress: Rendered ${nextFrameToWrite} / ${totalFrames} frames`,
+                );
+                if (onProgress) onProgress(nextFrameToWrite / totalFrames);
+              }
             }
           }
         }


### PR DESCRIPTION
Restore conditional checks for nextProgress in multi-worker chunked write loops to ensure progress logs and events correctly honor progressInterval.

---
*PR created automatically by Jules for task [2534037432746725145](https://jules.google.com/task/2534037432746725145) started by @BintzGavin*