### PR TITLE
📋 RENDERER: Unroll isString dynamic type check in multi-worker loops

### DIFF
--- a/.sys/plans/PERF-884-unroll-is-string-multi-worker.md
+++ b/.sys/plans/PERF-884-unroll-is-string-multi-worker.md
@@ -1,0 +1,90 @@
+---
+id: PERF-884
+slug: unroll-is-string-multi-worker
+status: unclaimed
+claimed_by: ""
+created: 2024-05-24
+completed: ""
+result: ""
+---
+
+# PERF-884: Unroll isString in Capture Loops
+
+## Focus Area
+The multi-worker and single-worker write loops in `packages/renderer/src/core/CaptureLoop.ts`. Specifically, eliminating the per-iteration `typeof buffer === "string"` check since the type of buffer is known a priori based on the strategy type (`isDomStrategy` or canvas strategy).
+
+## Background Research
+In `CaptureLoop.ts`, the multi-worker path uses a ring buffer to store incoming frames from workers, and a main thread writer loop pulls them out and pipes them to FFmpeg. Currently, the inner loop dynamically evaluates `isString = typeof buffer === "string";` on the first frame to branch to the chunked string loop or buffer loop.
+
+Since we already distinguish the strategies (via `isDomStrategy`), we know statically whether a strategy produces base64 strings or direct memory buffers. By replacing `isString = typeof buffer === "string";` with `isString = isDomStrategy ? true : typeof buffer === "string";`, we avoid dynamic type evaluation.
+
+## Benchmark Configuration
+- **Composition URL**: Any standard DOM benchmark
+- **Render Settings**: 1080p, 60FPS
+- **Mode**: `dom` (with multiple workers)
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Bottleneck analysis**: V8 dynamic type checking and branching (`typeof buffer === "string"`) inside the multi-worker loop setup.
+
+## Implementation Spec
+
+### Step 1: Hoist `isString` evaluation in multi-worker paths
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the single worker path (around line 247):
+```typescript
+<<<<<<< SEARCH
+            }
+            isString = typeof buffer === "string";
+
+            let writeSuccess = false;
+=======
+            }
+            isString = isDomStrategy ? true : typeof buffer === "string";
+
+            let writeSuccess = false;
+>>>>>>> REPLACE
+```
+And around line 643:
+```typescript
+<<<<<<< SEARCH
+            const buffer = bufRaw;
+            isString = typeof buffer === "string";
+
+            let writeSuccess = false;
+=======
+            const buffer = bufRaw;
+            isString = isDomStrategy ? true : typeof buffer === "string";
+
+            let writeSuccess = false;
+>>>>>>> REPLACE
+```
+In the multi-worker path (around line 1419):
+```typescript
+<<<<<<< SEARCH
+              if (onProgress) {
+                onProgress(currentFrame / totalFrames);
+              }
+            }
+
+            isString = typeof buffer === "string";
+
+            let writeSuccess = false;
+=======
+              if (onProgress) {
+                onProgress(currentFrame / totalFrames);
+              }
+            }
+
+            isString = isDomStrategy ? true : typeof buffer === "string";
+
+            let writeSuccess = false;
+>>>>>>> REPLACE
+```
+
+**Why**: Eliminates dynamic type checking in the hot loops when `isDomStrategy` is already true.
+
+## Correctness Check
+Run `npm test -w packages/renderer` to ensure DOM base64 output still decodes correctly.


### PR DESCRIPTION
💡 What: Plan to replace dynamic typeof buffer === "string" check with isDomStrategy boolean evaluation.
🎯 Why: Eliminates V8 dynamic type checking overhead in the hot multi-worker chunked write loops.
🔬 Approach: Use the statically known strategy type (isDomStrategy) to unroll the buffer type evaluation.
📎 Plan: /.sys/plans/PERF-884-unroll-is-string-multi-worker.md

---
*PR created automatically by Jules for task [1215742168719709907](https://jules.google.com/task/1215742168719709907) started by @BintzGavin*