### PR TITLE
✨ RENDERER: PERF-886 remove redundant array nulling

### DIFF
--- a/.sys/plans/PERF-886-remove-redundant-array-nulling.md
+++ b/.sys/plans/PERF-886-remove-redundant-array-nulling.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-886
 slug: remove-redundant-array-nulling
-status: unclaimed
-claimed_by: ""
+status: completed
+claimed_by: "perf-886"
 created: 2024-05-25
 completed: ""
-result: ""
+result: "improved"
 ---
 
 # PERF-886: Remove Redundant Array Nulling in Multi-Worker Loop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -83,7 +83,6 @@ Last updated by: PERF-873
 
 ## Open Questions
 - PERF-885: Inline and De-duplicate Worker Dispatch in Multi-Worker Loop planned.
-- PERF-886: Remove Redundant Array Nulling in Multi-Worker Loop planned.
 - PERF-877: Fix Progress Spam in Multi-Worker Chunked Loops planned
 - Would chunked loops benefit multi-worker paths as well? (PERF-856) -> Yes, PERF-859 planned.
 - PERF-860: Single-worker chunked loops planned.
@@ -102,3 +101,6 @@ Last updated by: PERF-873
 - **What Works:** PERF-881 inlined the `checkState()` closure function within the multi-worker DOM paths of `CaptureLoop.ts`.
   - **Improvement:** ~9.5% improvement in microbenchmarks for tight wait loops by eliminating synchronous function call overhead in hot loops.
   - **Plan ID:** PERF-881
+- **What Works:** PERF-886 removed redundant `frameBufferRing[ringIndex] = null` assignments in the multi-worker `CaptureLoop.ts` path.
+  - **Improvement:** Reduced redundant array store operations in hot loops.
+  - **Plan ID:** PERF-886

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -1048,7 +1048,6 @@ export class CaptureLoop {
           const ringIndex = i & ringMask;
 
           frameReadyRing[ringIndex] = 0;
-          frameBufferRing[ringIndex] = null;
 
           workerThenables[w].resolve(i);
         }
@@ -1109,7 +1108,6 @@ export class CaptureLoop {
                 const ringIndex = i & ringMask;
 
                 frameReadyRing[ringIndex] = 0;
-                frameBufferRing[ringIndex] = null;
               } else {
                 freeWorkers[freeWorkersHead++] = workerIndex;
                 if (capturedErrors.length > 0 || (signal && signal.aborted)) {
@@ -1132,7 +1130,6 @@ export class CaptureLoop {
                     const n = nextFrameToSubmit++;
                     const ringIndex = n & ringMask;
                     frameReadyRing[ringIndex] = 0;
-                    frameBufferRing[ringIndex] = null;
                     workerThenables[w].resolve(n);
                   }
                   if (nextFrameToSubmit >= totalFrames) {
@@ -1181,7 +1178,6 @@ export class CaptureLoop {
                 const ringIndex = i & ringMask;
 
                 frameReadyRing[ringIndex] = 0;
-                frameBufferRing[ringIndex] = null;
               } else {
                 freeWorkers[freeWorkersHead++] = workerIndex;
                 if (capturedErrors.length > 0 || (signal && signal.aborted)) {
@@ -1204,7 +1200,6 @@ export class CaptureLoop {
                     const n = nextFrameToSubmit++;
                     const ringIndex = n & ringMask;
                     frameReadyRing[ringIndex] = 0;
-                    frameBufferRing[ringIndex] = null;
                     workerThenables[w].resolve(n);
                   }
                   if (nextFrameToSubmit >= totalFrames) {
@@ -1255,7 +1250,6 @@ export class CaptureLoop {
                 const ringIndex = i & ringMask;
 
                 frameReadyRing[ringIndex] = 0;
-                frameBufferRing[ringIndex] = null;
               } else {
                 freeWorkers[freeWorkersHead++] = workerIndex;
                 if (capturedErrors.length > 0 || (signal && signal.aborted)) {
@@ -1278,7 +1272,6 @@ export class CaptureLoop {
                     const n = nextFrameToSubmit++;
                     const ringIndex = n & ringMask;
                     frameReadyRing[ringIndex] = 0;
-                    frameBufferRing[ringIndex] = null;
                     workerThenables[w].resolve(n);
                   }
                   if (nextFrameToSubmit >= totalFrames) {
@@ -1322,7 +1315,6 @@ export class CaptureLoop {
                 const ringIndex = i & ringMask;
 
                 frameReadyRing[ringIndex] = 0;
-                frameBufferRing[ringIndex] = null;
               } else {
                 freeWorkers[freeWorkersHead++] = workerIndex;
                 if (capturedErrors.length > 0 || (signal && signal.aborted)) {
@@ -1345,7 +1337,6 @@ export class CaptureLoop {
                     const n = nextFrameToSubmit++;
                     const ringIndex = n & ringMask;
                     frameReadyRing[ringIndex] = 0;
-                    frameBufferRing[ringIndex] = null;
                     workerThenables[w].resolve(n);
                   }
                   if (nextFrameToSubmit >= totalFrames) {
@@ -1466,7 +1457,6 @@ export class CaptureLoop {
                   const n = nextFrameToSubmit++;
                   const ringIndex = n & ringMask;
                   frameReadyRing[ringIndex] = 0;
-                  frameBufferRing[ringIndex] = null;
                   workerThenables[w].resolve(n);
                 }
                 if (nextFrameToSubmit >= totalFrames) {
@@ -1545,7 +1535,6 @@ export class CaptureLoop {
                     const n = nextFrameToSubmit++;
                     const ringIndex = n & ringMask;
                     frameReadyRing[ringIndex] = 0;
-                    frameBufferRing[ringIndex] = null;
                     workerThenables[w].resolve(n);
                   }
                   if (nextFrameToSubmit >= totalFrames) {
@@ -1620,7 +1609,6 @@ export class CaptureLoop {
                     const n = nextFrameToSubmit++;
                     const ringIndex = n & ringMask;
                     frameReadyRing[ringIndex] = 0;
-                    frameBufferRing[ringIndex] = null;
                     workerThenables[w].resolve(n);
                   }
                   if (nextFrameToSubmit >= totalFrames) {


### PR DESCRIPTION
💡 What: Removed redundant frameBufferRing array nulling.
🎯 Why: Relying solely on frameReadyRing avoids unnecessary array store operations in hot loops.
🔬 Approach: Removed frameBufferRing[ringIndex] = null; assignments.
📎 Plan: .sys/plans/PERF-886-remove-redundant-array-nulling.md

---
*PR created automatically by Jules for task [5815961623425389289](https://jules.google.com/task/5815961623425389289) started by @BintzGavin*