### PR TITLE
✨ PLAYER: Expose Composition Setters

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -45,6 +45,11 @@ Observed attributes:
 - `pause(): void`
 - `setPlaybackRange(startFrame: number, endFrame: number): void`
 - `clearPlaybackRange(): void`
+- `setDuration(seconds: number): void`
+- `setFps(fps: number): void`
+- `setSize(width: number, height: number): void`
+- `setMarkers(markers: Marker[]): void`
+
 - `seek(timeInSeconds: number): Promise<void>`
 - `fastSeek(timeInSeconds: number): void`
 - `setMediaKeys(mediaKeys: MediaKeys | null): Promise<void>`

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,4 +1,7 @@
 #
+### PLAYER v0.79.0
+- ✅ Completed: Expose Composition Setters - Exposed setDuration, setFps, setSize, and setMarkers on HeliosPlayer Web Component
+
 ### PLAYER v0.78.1
 - ✅ Completed: Implement Instance Constants - Added standard media constants (e.g., HAVE_NOTHING, NETWORK_EMPTY) to the HeliosPlayer instance for HTMLMediaElement parity.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: 0.78.6
+**Version**: 0.79.0
 
 [v0.78.5] ✅ Completed: Discovered missing composition setters on the public API wrapper. Created plan `.sys/plans/2027-03-05-PLAYER-Expose-Composition-Setters.md` to expose `setDuration`, `setFps`, `setSize`, and `setMarkers`.
 [v0.78.4] ✅ Completed: Discovered missing HTMLMediaElement-like parity methods (`setPlaybackRange`, `clearPlaybackRange`) in HeliosPlayer public API. Created plan `.sys/plans/2027-03-04-PLAYER-Expose-Playback-Range-Methods.md` to implement them.
@@ -282,3 +282,5 @@
 
 [v0.78.3] ✅ Completed: Document HTMLMediaElement Constants - Added documentation for HTMLMediaElement instance and class constants to the README.
 [v0.78.4] ✅ Completed: Document Playback Range Methods - Added `setPlaybackRange` and `clearPlaybackRange` to the README methods section.
+
+[v0.79.0] ✅ Completed: Expose Composition Setters - Exposed setDuration, setFps, setSize, and setMarkers on HeliosPlayer Web Component

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1,4 +1,4 @@
-import type { Helios, HeliosSchema, DiagnosticReport } from "@helios-project/core";
+import type { Helios, HeliosSchema, DiagnosticReport, Marker } from "@helios-project/core";
 import { DirectController, BridgeController } from "./controllers";
 import type { HeliosController } from "./controllers";
 import { AudioLevels } from "./features/audio-metering";
@@ -1771,6 +1771,30 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   public clearPlaybackRange(): void {
     if (this.controller) {
       this.controller.clearPlaybackRange();
+    }
+  }
+
+  public setDuration(seconds: number): void {
+    if (this.controller) {
+      this.controller.setDuration(seconds);
+    }
+  }
+
+  public setFps(fps: number): void {
+    if (this.controller) {
+      this.controller.setFps(fps);
+    }
+  }
+
+  public setSize(width: number, height: number): void {
+    if (this.controller) {
+      this.controller.setSize(width, height);
+    }
+  }
+
+  public setMarkers(markers: Marker[]): void {
+    if (this.controller) {
+      this.controller.setMarkers(markers);
     }
   }
 


### PR DESCRIPTION
Added `setDuration`, `setFps`, `setSize`, and `setMarkers` methods to the public `HeliosPlayer` Web Component API to allow host applications to dynamically update composition properties. Updated status, progress, and context documentation accordingly.

---
*PR created automatically by Jules for task [8891854587573450819](https://jules.google.com/task/8891854587573450819) started by @BintzGavin*