### PR TITLE
🚀 RENDERER: PERF-893 Remove Math.min from Multi-Worker Dispatch

### DIFF
--- a/.sys/plans/PERF-893-remove-math-min.md
+++ b/.sys/plans/PERF-893-remove-math-min.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-893
 slug: remove-math-min
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "jules"
 created: 2026-06-19
-completed: ""
-result: ""
+completed: "2026-06-19"
+result: "improved"
 ---
 
 # PERF-893: Remove Math.min from Multi-Worker Dispatch

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -1038,10 +1038,11 @@ export class CaptureLoop {
         }
 
         // See if we can assign tasks to waiting workers
-        const maxSubmits = Math.min(totalFrames, nextFrameToWrite + maxPipelineDepth);
+        const maxSubmits = nextFrameToWrite + maxPipelineDepth;
         while (
           freeWorkersHead > 0 &&
-          nextFrameToSubmit < maxSubmits
+          nextFrameToSubmit < totalFrames &&
+                    nextFrameToSubmit < maxSubmits
         ) {
           const w = freeWorkers[--freeWorkersHead];
           const i = nextFrameToSubmit++;
@@ -1117,9 +1118,10 @@ export class CaptureLoop {
                   }
                   writerWaiterPromise.resolve();
                 } else {
-                  const maxSubmits = Math.min(totalFrames, nextFrameToWrite + maxPipelineDepth);
+                  const maxSubmits = nextFrameToWrite + maxPipelineDepth;
                   while (
                     freeWorkersHead > 0 &&
+                    nextFrameToSubmit < totalFrames &&
                     nextFrameToSubmit < maxSubmits
                   ) {
                     const w = freeWorkers[--freeWorkersHead];
@@ -1183,9 +1185,10 @@ export class CaptureLoop {
                   }
                   writerWaiterPromise.resolve();
                 } else {
-                  const maxSubmits = Math.min(totalFrames, nextFrameToWrite + maxPipelineDepth);
+                  const maxSubmits = nextFrameToWrite + maxPipelineDepth;
                   while (
                     freeWorkersHead > 0 &&
+                    nextFrameToSubmit < totalFrames &&
                     nextFrameToSubmit < maxSubmits
                   ) {
                     const w = freeWorkers[--freeWorkersHead];
@@ -1251,9 +1254,10 @@ export class CaptureLoop {
                   }
                   writerWaiterPromise.resolve();
                 } else {
-                  const maxSubmits = Math.min(totalFrames, nextFrameToWrite + maxPipelineDepth);
+                  const maxSubmits = nextFrameToWrite + maxPipelineDepth;
                   while (
                     freeWorkersHead > 0 &&
+                    nextFrameToSubmit < totalFrames &&
                     nextFrameToSubmit < maxSubmits
                   ) {
                     const w = freeWorkers[--freeWorkersHead];
@@ -1312,9 +1316,10 @@ export class CaptureLoop {
                   }
                   writerWaiterPromise.resolve();
                 } else {
-                  const maxSubmits = Math.min(totalFrames, nextFrameToWrite + maxPipelineDepth);
+                  const maxSubmits = nextFrameToWrite + maxPipelineDepth;
                   while (
                     freeWorkersHead > 0 &&
+                    nextFrameToSubmit < totalFrames &&
                     nextFrameToSubmit < maxSubmits
                   ) {
                     const w = freeWorkers[--freeWorkersHead];
@@ -1425,10 +1430,11 @@ export class CaptureLoop {
                 }
                 writerWaiterPromise.resolve();
               } else {
-                const maxSubmits = Math.min(totalFrames, nextFrameToWrite + maxPipelineDepth);
+                const maxSubmits = nextFrameToWrite + maxPipelineDepth;
                 while (
                   freeWorkersHead > 0 &&
-                  nextFrameToSubmit < maxSubmits
+                  nextFrameToSubmit < totalFrames &&
+                    nextFrameToSubmit < maxSubmits
                 ) {
                   const w = freeWorkers[--freeWorkersHead];
                   const n = nextFrameToSubmit++;
@@ -1499,9 +1505,10 @@ export class CaptureLoop {
                   }
                   writerWaiterPromise.resolve();
                 } else {
-                  const maxSubmits = Math.min(totalFrames, nextFrameToWrite + maxPipelineDepth);
+                  const maxSubmits = nextFrameToWrite + maxPipelineDepth;
                   while (
                     freeWorkersHead > 0 &&
+                    nextFrameToSubmit < totalFrames &&
                     nextFrameToSubmit < maxSubmits
                   ) {
                     const w = freeWorkers[--freeWorkersHead];
@@ -1569,9 +1576,10 @@ export class CaptureLoop {
                   }
                   writerWaiterPromise.resolve();
                 } else {
-                  const maxSubmits = Math.min(totalFrames, nextFrameToWrite + maxPipelineDepth);
+                  const maxSubmits = nextFrameToWrite + maxPipelineDepth;
                   while (
                     freeWorkersHead > 0 &&
+                    nextFrameToSubmit < totalFrames &&
                     nextFrameToSubmit < maxSubmits
                   ) {
                     const w = freeWorkers[--freeWorkersHead];


### PR DESCRIPTION
💡 **What**: Removed the `Math.min` call from the multi-worker dispatch logic in `CaptureLoop.ts`.
🎯 **Why**: Precalculating the maximum pipeline depth sum and replacing `Math.min` with inline boolean evaluation removes synchronous function call overhead in tight V8 engine loops.
🔬 **Approach**: Extract loop boundary conditions (`maxSubmits = nextFrameToWrite + maxPipelineDepth`) and use `nextFrameToSubmit < totalFrames && nextFrameToSubmit < maxSubmits` directly inside the loop criteria.
📎 **Plan**: `/.sys/plans/PERF-893-remove-math-min.md`

---
*PR created automatically by Jules for task [18009771385037593700](https://jules.google.com/task/18009771385037593700) started by @BintzGavin*