### PR TITLE
✨ STUDIO: Improve TimecodeInput Test Coverage

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -821,3 +821,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### PLAYER v0.78.6
 - ✅ Completed: Document Playback Range Methods - Added `setPlaybackRange` and `clearPlaybackRange` to the README methods section.
+
+### STUDIO v0.122.4
+- ✅ Completed: Improve TimecodeInput Coverage - Mocked framesToTimecode and added tests for fallback logic to reach 100% test coverage.

--- a/docs/status/STUDIO.md
+++ b/docs/status/STUDIO.md
@@ -1,4 +1,4 @@
-**Version**: 0.122.3
+**Version**: 0.122.4
 
 - [v0.121.28] ✅ Completed: Improve AssistantModal Coverage - Reached 90%+ test coverage for AssistantModal.
 
@@ -246,3 +246,4 @@
 - [v0.122.0] ✅ Completed: Improve Omnibar Test Coverage - Reached 100% test coverage for Omnibar by adding tests for commands, asset icons, and keyboard boundary edge cases.
 - [v0.122.2] ✅ Completed: Improve CaptionsPanel Coverage - Increased coverage to 100% by testing file uploads and time formatting edge cases (2026-06-18-STUDIO-Improve-CaptionsPanel-Coverage.md).
 - [v0.122.3] ✅ Completed: Improve TimecodeInput Coverage - Created plan to test catch blocks in TimecodeInput component (2026-06-18-STUDIO-Improve-TimecodeInput-Coverage.md).
+- [v0.122.4] ✅ Completed: Improve TimecodeInput Coverage - Mocked framesToTimecode and added tests for fallback logic to reach 100% test coverage.

--- a/packages/studio/src/components/Controls/TimecodeInput.test.tsx
+++ b/packages/studio/src/components/Controls/TimecodeInput.test.tsx
@@ -4,6 +4,14 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { TimecodeInput } from './TimecodeInput';
 import { framesToTimecode, timecodeToFrames } from '@helios-project/core';
 
+vi.mock('@helios-project/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@helios-project/core')>();
+  return {
+    ...actual,
+    framesToTimecode: vi.fn(actual.framesToTimecode),
+  };
+});
+
 describe('TimecodeInput', () => {
   const mockOnChange = vi.fn();
   const fps = 30;
@@ -48,6 +56,35 @@ describe('TimecodeInput', () => {
     expect(mockOnChange).toHaveBeenCalledWith(3);
   });
 
+
+
+  it('handles error state gracefully on invalid timecode with undefined value', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Test with missing value so (value || 0) hits the 0 fallback
+    render(<TimecodeInput value={undefined as any} fps={fps} onChange={mockOnChange} />);
+    const input = screen.getByDisplayValue('00:00:00:00');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'invalid-timecode' } });
+    fireEvent.blur(input);
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+    expect(screen.getByDisplayValue('00:00:00:00')).toBeInTheDocument();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('reverts to original value with undefined value when Escape is pressed', () => {
+    render(<TimecodeInput value={undefined as any} fps={fps} onChange={mockOnChange} />);
+    const input = screen.getByDisplayValue('00:00:00:00');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '00:00:03:00' } });
+
+    fireEvent.keyDown(input, { key: 'Escape', code: 'Escape' });
+
+    expect(screen.getByDisplayValue('00:00:00:00')).toBeInTheDocument();
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
   it('handles error state gracefully on invalid timecode', () => {
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     render(<TimecodeInput value={1} fps={fps} onChange={mockOnChange} />);
@@ -88,13 +125,12 @@ describe('TimecodeInput', () => {
   });
 
   it('falls back to 00:00:00:00 when value is undefined/error in rendering', () => {
-    // Testing the catch block in the useEffect by passing weird values or mocking framesToTimecode to throw
-    const originalFramesToTimecode = (global as any).framesToTimecode;
+    vi.mocked(framesToTimecode).mockImplementationOnce(() => {
+      throw new Error("Mocked parsing error");
+    });
 
     render(<TimecodeInput value={NaN} fps={fps} onChange={mockOnChange} />);
 
-    // In our component, if value is NaN, Math.round((NaN || 0) * fps) is 0
-    // so it normally renders 00:00:00:00 without throwing.
     expect(screen.getByDisplayValue('00:00:00:00')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR improves the test coverage of the `TimecodeInput` component in the Studio package. 

Specifically, it:
1. Mocks `framesToTimecode` from `@helios-project/core` to inject parsing errors.
2. Adds tests to cover the fallback branch where `framesToTimecode` throws an error during the `useEffect` sync.
3. Adds tests covering the handling of `undefined` values during `value` fallback cases.

The changes bring the statement, branch, and line coverage of `TimecodeInput.tsx` to 100%.

Also properly tracks completion in `docs/status/STUDIO.md` and `docs/PROGRESS.md` under version `0.122.4`.

---
*PR created automatically by Jules for task [17028126213878639286](https://jules.google.com/task/17028126213878639286) started by @BintzGavin*