### PR TITLE
📋 RENDERER: Remove Dead Dispatch Logic in Worker Wait Paths

### DIFF
--- a/.sys/plans/PERF-910-remove-dead-dispatch.md
+++ b/.sys/plans/PERF-910-remove-dead-dispatch.md
@@ -1,0 +1,97 @@
+---
+id: PERF-910
+slug: remove-dead-dispatch
+status: unclaimed
+claimed_by: ""
+created: 2024-07-04
+completed: ""
+result: ""
+---
+# PERF-910: Remove Dead Dispatch Logic in Worker Wait Paths
+
+## Focus Area
+`packages/renderer/src/core/CaptureLoop.ts` - The `runWorker` multi-worker fast paths' `else` block when `nextFrameToSubmit - nextFrameToWrite < maxPipelineDepth` evaluates to false.
+
+## Background Research
+Inside `CaptureLoop.ts`, when a worker finds the pipeline full, it enters an `else` block to wait for work. Inside this `else` block, there are checks for `if (aborted)`, `if (dispatches > 0)`, and `if (nextFrameToSubmit >= totalFrames)`.
+
+However, mathematically, all these conditions are **provably dead code**:
+1. `if (aborted)`: The `while` loop condition is `while (!aborted)`. Since there are no `await` statements (yielding of the event loop) between the `while` check and this `else` block, Node's synchronous execution guarantees `aborted` cannot change. It is always false.
+2. `if (dispatches > 0)`: This evaluates `maxSubmits - nextFrameToSubmit`. We only entered the `else` block because `nextFrameToSubmit - nextFrameToWrite >= maxPipelineDepth`, which means `nextFrameToSubmit >= maxSubmits`. Therefore, `dispatches` is always `<= 0`.
+3. `if (nextFrameToSubmit >= totalFrames)`: The `while` condition enforces `nextFrameToSubmit < totalFrames`. Without mutation in between, this is always false.
+
+This means a lot of complex logic inside the worker's tight hot-path is completely unreachable. It is a copy-paste artifact from the `checkState()` function. Removing it significantly reduces V8 JIT parser overhead and AST complexity for the hottest loops.
+
+## Benchmark Configuration
+- **Composition URL**: Any standard DOM composition
+- **Render Settings**: Standard 1080p, 60fps
+- **Mode**: `dom` (multi-worker)
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Bottleneck analysis**: Unreachable code bloats the AST of JIT-optimized hot loops, leading to poorer inlining and optimization bailout risks.
+
+## Implementation Spec
+
+### Step 1: Remove dead logic in `runWorker` wait paths
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In `CaptureLoop.ts`, locate the 4 instances inside `runWorker` where the worker falls back to wait (grep for `freeWorkers[freeWorkersHead++] = workerIndex;`).
+
+Replace the ENTIRE `else` block with just the two reachable lines.
+
+For example, replace this:
+```typescript
+              } else {
+                freeWorkers[freeWorkersHead++] = workerIndex;
+                if (aborted) {
+                  while (freeWorkersHead > 0) {
+                    const w = freeWorkers[--freeWorkersHead];
+                    workerThenables[w].resolve(-1);
+                  }
+                  writerWaiterPromise.resolve();
+                } else {
+                  const maxSubmits = nextFrameToWrite + maxPipelineDepth;
+                  const limit = maxSubmits < totalFrames ? maxSubmits : totalFrames;
+                  let dispatches = limit - nextFrameToSubmit;
+                  if (dispatches > 0) {
+                    if (dispatches > freeWorkersHead) dispatches = freeWorkersHead;
+                    while (dispatches-- > 0) {
+                      const w = freeWorkers[--freeWorkersHead];
+                      const n = nextFrameToSubmit++;
+                      frameBufferRing[n & ringMask] = null;
+                      workerThenables[w].resolve(n);
+                    }
+                  }
+                  if (nextFrameToSubmit >= totalFrames) {
+                    while (freeWorkersHead > 0) {
+                      const w = freeWorkers[--freeWorkersHead];
+                      workerThenables[w].resolve(-1);
+                    }
+                  }
+                }
+                i = (await workerThenables[workerIndex]) as any as number;
+              }
+```
+
+With this:
+```typescript
+              } else {
+                freeWorkers[freeWorkersHead++] = workerIndex;
+                i = (await workerThenables[workerIndex]) as any as number;
+              }
+```
+
+Apply this exact reduction to all 4 variations of the fast loops (`isDomStrategy` true/false, `hasProcessFn` true/false).
+
+**Why**: Removing dead code simplifies the execution path, reducing parser overhead and making the V8 engine's optimization pipeline much more efficient.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run `npx vitest run verify-canvas` to ensure basic multi-worker rendering remains stable.
+
+## Correctness Check
+Run multi-worker DOM verify scripts to ensure workers are still successfully sleeping and waking up correctly via `checkState` and writer loops.


### PR DESCRIPTION
💡 What: The experiment being planned is PERF-910, which targets the removal of mathematically unreachable dispatch logic inside the `runWorker` multi-worker fast paths in `CaptureLoop.ts`.
🎯 Why: The target code blocks are provably dead due to prior loop conditions and synchronous execution constraints. Removing them reduces V8 JIT parser overhead, shrinks the AST, and mitigates optimization bailout risks for the hottest paths.
🔬 Approach: Replace the complex `else` fallback blocks with a simplified, two-line implementation containing only the reachable worker sleep command.
📎 Plan: `/.sys/plans/PERF-910-remove-dead-dispatch.md`

---
*PR created automatically by Jules for task [11177274930175604825](https://jules.google.com/task/11177274930175604825) started by @BintzGavin*