### PR TITLE
✨ RENDERER: Discard PERF-912 (already implemented)

### DIFF
--- a/.sys/plans/PERF-912-unroll-progress-check.md
+++ b/.sys/plans/PERF-912-unroll-progress-check.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-912
 slug: unroll-progress-check
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-07-04
-completed: ""
-result: ""
+completed: "2024-07-04"
+result: "failed"
 ---
 # PERF-912: Unroll Progress Check inside Single and Multi-Worker Inner Fast Loops
 
@@ -67,3 +67,9 @@ Run `npx vitest run verify-canvas` to ensure the canvas path is untouched.
 
 ## Correctness Check
 Run `npm test -w packages/renderer` to ensure no frame synchronization regressions occurred.
+
+## Results Summary
+- **Best render time**: X.XXXs (vs baseline Y.YYYs)
+- **Improvement**: 0%
+- **Kept experiments**: None
+- **Discarded experiments**: PERF-912 unroll progress check

--- a/packages/renderer/.sys/perf-results-PERF-912.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-912.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.000	0	0.00	0.0	discard	Plan requested unrolling progress check, but it was already unrolled.

--- a/packages/renderer/docs/status/RENDERER-EXPERIMENTS.md
+++ b/packages/renderer/docs/status/RENDERER-EXPERIMENTS.md
@@ -9,6 +9,8 @@ Last updated by: PERF-823
 - [PERF-271] Combined `.catch` and `.then` handlers into a single `.then(resolve, reject)` in `CaptureLoop.ts` to reduce GC overhead and microtask serialization delays (~26.9% faster).
 
 ## What Doesn't Work (and Why)
+
+- PERF-912 attempted to replace omitted-initializer `for (; i < chunkEnd; i++)` loops with strict `while (i < chunkEnd) { ... i++ }` blocks in `CaptureLoop.ts` fast loops. However, the plan actually says "Unroll Progress Check inside Single and Multi-Worker Inner Fast Loops" and the progress check was already unrolled in the codebase (the chunking logic was already there). We discarded this change as it was a hallucinated task and introduced maintainability risks (infinite loops if a `continue` was added).
 - [PERF-466] Attempted to return direct promise chain in CdpTimeDriver.runSetTime instead of using async/await. DISCARDED because performance did not improve (median 23.91s vs 20.43s baseline). The overhead of async/await state machine in the hot loop is negligible compared to other factors like IPC, and the structural change slightly degraded execution time.
 - [PERF-409] Attempted to replace `Promise.race` with a manual wrapper promise in `CdpTimeDriver.ts` stability check. DISCARDED as IMPOSSIBLE DUPLICATION. Previous experiments (PERF-361/PERF-411) showed V8 handles Promise.race arrays very efficiently, and manual tracking adds overhead.
 - [PERF-361] Attempted to avoid `Promise.race` allocation in `SeekTimeDriver` injected script. DISCARDED because it was slower (48.761s vs 46.298s baseline). V8 handles the Promise.race array wrapper very efficiently, and the manual state machine added overhead.


### PR DESCRIPTION
✨ RENDERER: Discard PERF-912 (already implemented)

💡 What: Discarded the PERF-912 plan to unroll progress checks.
🎯 Why: The progress checks (chunking) were already unrolled in the codebase, and the plan essentially requested an impossible duplication.
📊 Impact: 0%
🔬 Verification: Checked CaptureLoop.ts source code and it already uses chunkEnd loops.
📎 Plan: PERF-912

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.000	0	0.00	0.0	discard	Plan requested unrolling progress check, but it was already unrolled.

---
*PR created automatically by Jules for task [13513640663337223937](https://jules.google.com/task/13513640663337223937) started by @BintzGavin*