### PR TITLE
✨ RENDERER: Unroll writer wait loop in CaptureLoop

### DIFF
--- a/.sys/perf-results-PERF-913.tsv
+++ b/.sys/perf-results-PERF-913.tsv
@@ -1,0 +1,3 @@
+run	time_ms	status	description
+1	139.40	keep	baseline
+2	135.69	keep	unroll writer wait loop

--- a/.sys/plans/PERF-913-unroll-writer-wait-loop.md
+++ b/.sys/plans/PERF-913-unroll-writer-wait-loop.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-913
 slug: unroll-writer-wait-loop
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-07-04
 completed: ""
-result: ""
+result: "keep"
 ---
 # PERF-913: Unroll Writer Wait Loop in Multi-Worker Capture
 

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -138,3 +138,6 @@ Last updated by: PERF-873
 ## What Works
 - **PERF-910**: Removed dead mathematically unreachable code in `CaptureLoop.ts` fast loop else blocks. Evaluated loop counts per microbenchmark frame simulation dropped drastically from ~275ms down to ~64ms.
 - **PERF-911**: Replaced `>=` relational comparison with strict equality `===` for `nextFrameToSubmit` vs `totalFrames` in `CaptureLoop.ts`. Because `nextFrameToSubmit` cannot logically exceed `totalFrames` (due to tight upstream dispatches limit), strict equality reduces dynamic evaluator overhead and yields ~3.5% microbenchmark improvement.
+- **What Works:** PERF-913 unrolled the writer wait loop (`while (frameBufferRing[ringIndex] === null && !aborted)`) inside the multi-worker fast paths of `CaptureLoop.ts`.
+  - **Improvement:** Removed V8 branch evaluation overhead by eliminating `continue` loop jumps during frame polling. This yielded a ~2.6% microbenchmark improvement in wait loop processing.
+  - **Plan ID:** PERF-913

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -1134,10 +1134,10 @@ export class CaptureLoop {
             if (aborted) break;
 
             const ringIndex = nextFrameToWrite & ringMask;
-            if (frameBufferRing[ringIndex] === null) {
+            while (frameBufferRing[ringIndex] === null && !aborted) {
               await writerWaiterPromise;
-              continue;
             }
+            if (aborted) break;
 
             const buffer = frameBufferRing[ringIndex]!;
 


### PR DESCRIPTION
✨ RENDERER: Unroll writer wait loop in CaptureLoop

💡 What: Replaced outer loop continue with inner while wait loop.
🎯 Why: Avoid V8 context restart on yield.
📊 Impact: ~2.6% improvement in microbenchmark.
🔬 Verification: Passed compilation, test suite, output validation.
📎 Plan: PERF-913

```
run	time_ms	status	description
1	139.40	keep	baseline
2	135.69	keep	unroll writer wait loop
```

---
*PR created automatically by Jules for task [7156077133612485255](https://jules.google.com/task/7156077133612485255) started by @BintzGavin*