### PR TITLE
✨ RENDERER: Discard PERF-917 base64 stream write optimization

### DIFF
--- a/.sys/perf-results-PERF-917.tsv
+++ b/.sys/perf-results-PERF-917.tsv
@@ -1,0 +1,3 @@
+1	1.156	5000	0.00	0.0	discard	PERF-917 test direct base64 stream write (baseline: 0.860s)
+1	0.994	5000	0.00	0.0	discard	PERF-917 direct base64 stream write (baseline: 0.868s)
+2	2.895	5000	0.00	0.0	discard	PERF-917 direct base64 stream write 150KB (baseline: 1.665s)

--- a/.sys/plans/PERF-917-fast-base64-stream-write-multi-worker.md
+++ b/.sys/plans/PERF-917-fast-base64-stream-write-multi-worker.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-917
 slug: fast-base64-stream-write-multi-worker
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor-session"
 created: 2024-07-05
-completed: ""
-result: ""
+completed: 2024-07-05
+result: failed
 ---
 # PERF-917: Optimize Base64 Stream Writes for Multi-Worker Paths
 
@@ -83,3 +83,9 @@ Run canvas benchmark to ensure `Buffer` paths aren't broken.
 
 ## Correctness Check
 Run FFmpeg tests (`npm test -w packages/renderer`) to verify PNG frames encode properly.
+
+## Results Summary
+- **Best render time**: 2894.59ms (vs baseline 1664.59ms in 150KB microbenchmark)
+- **Improvement**: -73.89%
+- **Kept experiments**: None
+- **Discarded experiments**: Replaced multi-worker user-space pooling with native `stream.write(str, "base64")`.

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -141,3 +141,6 @@ Last updated by: PERF-873
 - **What Works:** PERF-913 unrolled the writer wait loop (`while (frameBufferRing[ringIndex] === null && !aborted)`) inside the multi-worker fast paths of `CaptureLoop.ts`.
   - **Improvement:** Removed V8 branch evaluation overhead by eliminating `continue` loop jumps during frame polling. This yielded a ~2.6% microbenchmark improvement in wait loop processing.
   - **Plan ID:** PERF-913
+- **PERF-917**: Evaluated native `stream.write(str, "base64")` to avoid user-space pooling in multi-worker `CaptureLoop.ts`.
+  - **WHY it didn't work:** Microbenchmarks under Node v22 demonstrated that native stream base64 writing introduces significant overhead (multiple transformations/allocations under the hood) compared to the highly optimized `buffer.write(str, "base64")` within pre-allocated user-space V8 buffers. Performance regressions were up to ~74% for 150KB payloads.
+  - **Plan ID:** PERF-917


### PR DESCRIPTION
💡 What: Evaluated native `stream.write(str, 'base64')` vs user-space pooling.
🎯 Why: Optimize FFmpeg String Stream Writes in multi-worker path.
📊 Impact: Regressed performance by ~74% for 150KB payloads.
🔬 Verification: Microbenchmarks on Node v22.
📎 Plan: .sys/plans/PERF-917-fast-base64-stream-write-multi-worker.md
TSV Data:
1	1.156	5000	0.00	0.0	discard	PERF-917 test direct base64 stream write (baseline: 0.860s)
1	0.994	5000	0.00	0.0	discard	PERF-917 direct base64 stream write (baseline: 0.868s)
2	2.895	5000	0.00	0.0	discard	PERF-917 direct base64 stream write 150KB (baseline: 1.665s)

---
*PR created automatically by Jules for task [3934385577568737321](https://jules.google.com/task/3934385577568737321) started by @BintzGavin*