### PR TITLE
📋 RENDERER: Fix Infinite Loop on Short Renders

### DIFF
--- a/.sys/plans/PERF-920-fix-infinite-loop-short-renders.md
+++ b/.sys/plans/PERF-920-fix-infinite-loop-short-renders.md
@@ -1,0 +1,71 @@
+---
+id: PERF-920
+slug: fix-infinite-loop-short-renders
+status: unclaimed
+claimed_by: ""
+created: 2024-07-06
+completed: ""
+result: ""
+---
+# PERF-920: Fix Infinite Loop on Short Renders by Enforcing Minimum Progress Interval
+
+## Focus Area
+`CaptureLoop.ts` - Initialization of `progressInterval` for chunked rendering boundaries.
+
+## Background Research
+In single-worker chunked loops, the `progressInterval` is currently calculated at initialization time:
+```typescript
+const progressInterval = Math.floor(totalFrames / 10);
+```
+
+When rendering very short sequences where `totalFrames < 10` (e.g., a single frame thumbnail render or a 5-frame preview), `progressInterval` evaluates to `0`.
+
+Later in the chunked fast paths, the chunk boundary is computed using `progressInterval`:
+```typescript
+let chunkEnd = i + progressInterval; if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
+for (; i < chunkEnd; i++) {
+  // process frames
+}
+```
+
+If `progressInterval` is `0` and `i` is not yet at the very end, `chunkEnd` becomes `i` (or is clamped to `totalFrames - 1` if we're at the very end). If `chunkEnd === i`, the `for` loop condition `i < i` immediately evaluates to false, so the inner loop never executes. Consequently, `i` never increments.
+However, the outer `while` loop condition `i < totalFrames - 1` remains true, creating a permanent infinite loop. This completely hangs the renderer process for any composition with fewer than 10 frames.
+
+Using an inline conditional `let progressInterval = Math.floor(totalFrames / 10); if (progressInterval < 1) progressInterval = 1;` guarantees progress is always made and avoids the hang.
+
+## Benchmark Configuration
+- **Composition URL**: Any short composition (< 10 frames)
+- **Render Settings**: Standard, but `frameCount: 5`
+- **Mode**: `dom` (single-worker)
+- **Metric**: Execution completion
+- **Minimum runs**: 1
+
+## Baseline
+- **Bottleneck analysis**: Infinite loop caused by `0` progress chunking.
+
+## Implementation Spec
+
+### Step 1: Enforce minimum `progressInterval`
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+Change the initialization of `progressInterval` (around line 141).
+From:
+```typescript
+const progressInterval = Math.floor(totalFrames / 10);
+```
+To:
+```typescript
+let progressInterval = Math.floor(totalFrames / 10);
+if (progressInterval < 1) progressInterval = 1;
+```
+
+**Why**: Prevents zero-width chunking that leads to an infinite loop for short renders without invoking function overhead.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+None.
+
+## Correctness Check
+Run FFmpeg verify scripts with a 5-frame composition to ensure they complete successfully.

--- a/bm.js
+++ b/bm.js
@@ -1,0 +1,32 @@
+const iterations = 10000000;
+let progressInterval = 10;
+let totalFrames = 100;
+let nextFrameToWrite = 1;
+
+let start = performance.now();
+let chunkEnd1 = 0;
+for (let j = 0; j < iterations; j++) {
+    let chunkEnd = nextFrameToWrite + progressInterval; if (chunkEnd > totalFrames) chunkEnd = totalFrames;
+    chunkEnd1 = chunkEnd;
+}
+let end = performance.now();
+console.log(`Manual: ${end - start}ms`);
+
+start = performance.now();
+let chunkEnd2 = 0;
+for (let j = 0; j < iterations; j++) {
+    const chunkEnd = Math.min(nextFrameToWrite + progressInterval, totalFrames);
+    chunkEnd2 = chunkEnd;
+}
+end = performance.now();
+console.log(`Math.min: ${end - start}ms`);
+
+start = performance.now();
+let chunkEnd3 = 0;
+for (let j = 0; j < iterations; j++) {
+    const limit = nextFrameToWrite + progressInterval;
+    const chunkEnd = limit < totalFrames ? limit : totalFrames;
+    chunkEnd3 = chunkEnd;
+}
+end = performance.now();
+console.log(`Ternary: ${end - start}ms`);

--- a/bm2.js
+++ b/bm2.js
@@ -1,0 +1,26 @@
+const iterations = 10000000;
+let freeWorkersHead = 10;
+let dispatches = 5;
+
+let start = performance.now();
+for (let j = 0; j < iterations; j++) {
+    let d = dispatches;
+    if (d > freeWorkersHead) d = freeWorkersHead;
+}
+let end = performance.now();
+console.log(`Manual: ${end - start}ms`);
+
+start = performance.now();
+for (let j = 0; j < iterations; j++) {
+    let d = Math.min(dispatches, freeWorkersHead);
+}
+end = performance.now();
+console.log(`Math.min: ${end - start}ms`);
+
+start = performance.now();
+for (let j = 0; j < iterations; j++) {
+    let d = dispatches;
+    d = d < freeWorkersHead ? d : freeWorkersHead;
+}
+end = performance.now();
+console.log(`Ternary: ${end - start}ms`);

--- a/bm3.js
+++ b/bm3.js
@@ -1,0 +1,27 @@
+const iterations = 10000000;
+
+const totalFrames = 100;
+let progressInterval = 10;
+let nextFrameToWrite = 5;
+
+let start = performance.now();
+for (let j = 0; j < iterations; j++) {
+    let chunkEnd = nextFrameToWrite + progressInterval; if (chunkEnd > totalFrames) chunkEnd = totalFrames;
+}
+let end = performance.now();
+console.log(`Manual: ${end - start}ms`);
+
+start = performance.now();
+for (let j = 0; j < iterations; j++) {
+    const chunkEnd = Math.min(nextFrameToWrite + progressInterval, totalFrames);
+}
+end = performance.now();
+console.log(`Math.min: ${end - start}ms`);
+
+start = performance.now();
+for (let j = 0; j < iterations; j++) {
+    const limit = nextFrameToWrite + progressInterval;
+    const chunkEnd = limit < totalFrames ? limit : totalFrames;
+}
+end = performance.now();
+console.log(`Ternary: ${end - start}ms`);

--- a/bm4.js
+++ b/bm4.js
@@ -1,0 +1,22 @@
+const iterations = 10000000;
+
+let sum1 = 0;
+let start = performance.now();
+for (let j = 0; j < iterations; j++) {
+    const val = Math.max(1, j);
+    sum1 += val;
+}
+let end = performance.now();
+console.log(`Math.max: ${end - start}ms`);
+
+let sum2 = 0;
+start = performance.now();
+for (let j = 0; j < iterations; j++) {
+    let val = j;
+    if (val < 1) val = 1;
+    sum2 += val;
+}
+end = performance.now();
+console.log(`Manual: ${end - start}ms`);
+
+console.log(sum1 === sum2);

--- a/test_loop.js
+++ b/test_loop.js
@@ -1,0 +1,24 @@
+const totalFrames = 5;
+const progressInterval = Math.floor(totalFrames / 10);
+let i = 1;
+let nextProgress = progressInterval;
+let iterations = 0;
+
+while (i < totalFrames - 1) {
+  let chunkEnd = i + progressInterval;
+  if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
+
+  for (; i < chunkEnd; i++) {
+    // simulate work
+  }
+
+  if (i - 1 === nextProgress) {
+    nextProgress += progressInterval;
+  }
+
+  iterations++;
+  if (iterations > 10) {
+    console.log("INFINITE LOOP DETECTED");
+    break;
+  }
+}

--- a/test_loop2.js
+++ b/test_loop2.js
@@ -1,0 +1,25 @@
+const totalFrames = 5;
+const progressInterval = Math.max(1, Math.floor(totalFrames / 10)); // <---- FIX
+let i = 1;
+let nextProgress = progressInterval;
+let iterations = 0;
+
+while (i < totalFrames - 1) {
+  let chunkEnd = i + progressInterval;
+  if (chunkEnd > totalFrames - 1) chunkEnd = totalFrames - 1;
+
+  for (; i < chunkEnd; i++) {
+    // simulate work
+  }
+
+  if (i - 1 === nextProgress) {
+    nextProgress += progressInterval;
+  }
+
+  iterations++;
+  if (iterations > 10) {
+    console.log("INFINITE LOOP DETECTED");
+    break;
+  }
+}
+console.log("Iterations:", iterations)


### PR DESCRIPTION
💡 What: Fix infinite loop when rendering compositions with fewer than 10 frames by enforcing a minimum progress interval.
🎯 Why: A progress interval of 0 causes the chunk loop boundary to become 0, preventing the inner loop from advancing frames and causing a permanent hang.
🔬 Approach: Clamp progress interval to a minimum of 1 using a fast inline check.
📎 Plan: .sys/plans/PERF-920-fix-infinite-loop-short-renders.md

---
*PR created automatically by Jules for task [14205544387802485293](https://jules.google.com/task/14205544387802485293) started by @BintzGavin*