### PR TITLE
✨ RENDERER: Fix infinite loop on short renders

### DIFF
--- a/.sys/perf-results-PERF-920.tsv
+++ b/.sys/perf-results-PERF-920.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.341	5	14.66	0.0	keep	fix infinite loop short renders

--- a/.sys/plans/PERF-920-fix-infinite-loop-short-renders.md
+++ b/.sys/plans/PERF-920-fix-infinite-loop-short-renders.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-920
 slug: fix-infinite-loop-short-renders
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2024-07-06
-completed: ""
-result: ""
+completed: "2024-07-06"
+result: "keep"
 ---
 # PERF-920: Fix Infinite Loop on Short Renders by Enforcing Minimum Progress Interval
 
@@ -69,3 +69,9 @@ None.
 
 ## Correctness Check
 Run FFmpeg verify scripts with a 5-frame composition to ensure they complete successfully.
+
+## Results Summary
+```
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.341	5	14.66	0.0	keep	fix infinite loop short renders
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -149,3 +149,8 @@ Last updated by: PERF-873
 - **PERF-918**: Optimized the free worker dispatch boundary conditions in `CaptureLoop.ts` by replacing the inner `if (dispatches > freeWorkersHead)` bound condition with `Math.min(dispatches, freeWorkersHead)`.
   - **Improvement:** Microbenchmarks showed execution speed reduction of ~24% due to V8's native compilation of `Math.min` into branchless conditional moves, bypassing branch predictors on the queue management paths.
   - **Plan ID:** PERF-918
+
+## What Works
+- **PERF-920**: Enforced a minimum `progressInterval` of 1 in `CaptureLoop.ts`.
+  - **Improvement:** Fixed an infinite loop / process hang during short (< 10 frames) chunked rendering paths.
+  - **Plan ID:** PERF-920

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -138,7 +138,8 @@ export class CaptureLoop {
     const capturedErrors = this.capturedErrors;
     const stdin = this.ffmpegManager.stdin;
 
-    const progressInterval = Math.floor(totalFrames / 10);
+    let progressInterval = Math.floor(totalFrames / 10);
+    if (progressInterval < 1) progressInterval = 1;
 
     const timeStep = 1000 / fps;
     const compTimeStep = 1 / fps;


### PR DESCRIPTION
💡 **What**: Added a lower bound of `1` for `progressInterval` in `CaptureLoop.ts`.
🎯 **Why**: When `totalFrames` was less than 10 (e.g., short 5 frame compositions), `progressInterval` evaluated to `0`, causing the `chunkEnd` boundaries to never increment and trapping the render loop in an infinite cycle.
📊 **Impact**: Fixed process hangs and infinite loops on very short composition renders.
🔬 **Verification**: 4-gate verification completed. Isolated short render test completes successfully rather than timing out. Full `npm test` suite passed with no new regressions.
📎 **Plan**: `/.sys/plans/PERF-920-fix-infinite-loop-short-renders.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.341	5	14.66	0.0	keep	fix infinite loop short renders
```

---
*PR created automatically by Jules for task [14275344228318992](https://jules.google.com/task/14275344228318992) started by @BintzGavin*