### PR TITLE
✨ RENDERER: Hoist maxSubmits loop boundary

### DIFF
--- a/.sys/plans/PERF-903-hoist-max-submits-inner-loop.md
+++ b/.sys/plans/PERF-903-hoist-max-submits-inner-loop.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-903
 slug: hoist-max-submits-inner-loop
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-07-03
 completed: ""
@@ -77,3 +77,10 @@ Run `npx vitest run verify-canvas` to ensure the canvas path is untouched.
 
 ## Correctness Check
 Run `npm test -w packages/renderer` to ensure no frame synchronization regressions occurred.
+
+## Results Summary
+```tsv
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	7.700	10000000	1298701.30	100.0	keep	baseline
+2	7.073	10000000	1413827.23	100.0	keep	hoist maxSubmits loop boundary
+```

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -3,6 +3,9 @@ Current best: 1.831s (baseline was 1.831s, -0%)
 Last updated by: PERF-873
 
 ## What Works
+- **What Works:** PERF-903 hoisted the `nextFrameToSubmit - nextFrameToWrite < maxPipelineDepth` loop boundary condition out of the inner single-worker and multi-worker wait loops inside `runWorker` in `CaptureLoop.ts` by precalculating `maxSubmits`.
+  - **Improvement:** ~8-9% performance improvement in the tight loop iteration time in microbenchmarks (from ~7.7s to ~7.0s for 10M iterations).
+  - **Plan ID:** PERF-903
 - **What Works:** PERF-922 separated compound pre-decrement and post-increment operations (`const w = freeWorkers[--freeWorkersHead]; const n = nextFrameToSubmit++;`) into separate statements in the multi-worker paths of `CaptureLoop.ts`.
   - **Improvement:** ~8.8% faster overhead in microbenchmarks. Uncoupling the math from the load allows V8/CPU to pipeline operations rather than forcing sequential evaluation.
   - **Plan ID:** PERF-922

--- a/packages/renderer/.sys/perf-results-PERF-903.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-903.tsv
@@ -1,0 +1,3 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	7.700	10000000	1298701.30	100.0	keep	baseline
+2	7.073	10000000	1413827.23	100.0	keep	hoist maxSubmits loop boundary

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -963,12 +963,10 @@ export class CaptureLoop {
 
         if (hasProcessFn) {
           if (isDomStrategy) {
+            let maxSubmits = nextFrameToWrite + maxPipelineDepth;
             while (!aborted && nextFrameToSubmit < totalFrames) {
               let i: number;
-              if (
-                nextFrameToSubmit - nextFrameToWrite <
-                maxPipelineDepth
-              ) {
+              if (nextFrameToSubmit < maxSubmits) {
                 i = nextFrameToSubmit++;
                 const ringIndex = i & ringMask;
 
@@ -976,6 +974,7 @@ export class CaptureLoop {
               } else {
                 freeWorkers[freeWorkersHead++] = workerIndex;
                 i = (await workerThenables[workerIndex]) as any as number;
+                maxSubmits = nextFrameToWrite + maxPipelineDepth;
               }
 
               if (i === -1) break;
@@ -1004,12 +1003,10 @@ export class CaptureLoop {
               writerWaiterPromise.resolve();
             }
           } else {
+            let maxSubmits = nextFrameToWrite + maxPipelineDepth;
             while (!aborted && nextFrameToSubmit < totalFrames) {
               let i: number;
-              if (
-                nextFrameToSubmit - nextFrameToWrite <
-                maxPipelineDepth
-              ) {
+              if (nextFrameToSubmit < maxSubmits) {
                 i = nextFrameToSubmit++;
                 const ringIndex = i & ringMask;
 
@@ -1017,6 +1014,7 @@ export class CaptureLoop {
               } else {
                 freeWorkers[freeWorkersHead++] = workerIndex;
                 i = (await workerThenables[workerIndex]) as any as number;
+                maxSubmits = nextFrameToWrite + maxPipelineDepth;
               }
 
               if (i === -1) break;
@@ -1047,12 +1045,10 @@ export class CaptureLoop {
           }
         } else {
           if (isDomStrategy) {
+            let maxSubmits = nextFrameToWrite + maxPipelineDepth;
             while (!aborted && nextFrameToSubmit < totalFrames) {
               let i: number;
-              if (
-                nextFrameToSubmit - nextFrameToWrite <
-                maxPipelineDepth
-              ) {
+              if (nextFrameToSubmit < maxSubmits) {
                 i = nextFrameToSubmit++;
                 const ringIndex = i & ringMask;
 
@@ -1060,6 +1056,7 @@ export class CaptureLoop {
               } else {
                 freeWorkers[freeWorkersHead++] = workerIndex;
                 i = (await workerThenables[workerIndex]) as any as number;
+                maxSubmits = nextFrameToWrite + maxPipelineDepth;
               }
 
               if (i === -1) break;
@@ -1083,12 +1080,10 @@ export class CaptureLoop {
               writerWaiterPromise.resolve();
             }
           } else {
+            let maxSubmits = nextFrameToWrite + maxPipelineDepth;
             while (!aborted && nextFrameToSubmit < totalFrames) {
               let i: number;
-              if (
-                nextFrameToSubmit - nextFrameToWrite <
-                maxPipelineDepth
-              ) {
+              if (nextFrameToSubmit < maxSubmits) {
                 i = nextFrameToSubmit++;
                 const ringIndex = i & ringMask;
 
@@ -1096,6 +1091,7 @@ export class CaptureLoop {
               } else {
                 freeWorkers[freeWorkersHead++] = workerIndex;
                 i = (await workerThenables[workerIndex]) as any as number;
+                maxSubmits = nextFrameToWrite + maxPipelineDepth;
               }
 
               if (i === -1) break;

--- a/patch_recalc.js
+++ b/patch_recalc.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+
+const path = 'packages/renderer/src/core/CaptureLoop.ts';
+let code = fs.readFileSync(path, 'utf8');
+
+// There are 4 places where we do:
+// i = (await workerThenables[workerIndex]) as any as number;
+
+const findText = 'i = (await workerThenables[workerIndex]) as any as number;';
+const replaceText = findText + '\\n                maxSubmits = nextFrameToWrite + maxPipelineDepth;';
+
+// Regex replacement
+code = code.replace(/i = \(await workerThenables\[workerIndex\]\) as any as number;/g,
+`i = (await workerThenables[workerIndex]) as any as number;
+                maxSubmits = nextFrameToWrite + maxPipelineDepth;`);
+
+fs.writeFileSync(path, code);


### PR DESCRIPTION
💡 **What**: The experiment run and its outcome: Hoisted the `maxSubmits` loop boundary condition out of the inner wait loops in `CaptureLoop.ts`. Kept.
🎯 **Why**: The performance bottleneck targeted: The subtraction operation inside the inner while loop condition was evaluated on every single chunk iteration.
📊 **Impact**: Before/after render times and percentage improvement: microbenchmark wall time improved ~8-9%.
🔬 **Verification**: What was tested (4-gate verification, benchmark results).
📎 **Plan**: Reference the plan file (`/.sys/plans/PERF-903-hoist-max-submits-inner-loop.md`)

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	7.700	10000000	1298701.30	100.0	keep	baseline
2	7.073	10000000	1413827.23	100.0	keep	hoist maxSubmits loop boundary
```

---
*PR created automatically by Jules for task [4348861493900682386](https://jules.google.com/task/4348861493900682386) started by @BintzGavin*