### PR TITLE
📋 RENDERER: Hoist writer dispatch above wait

### DIFF
--- a/.sys/plans/PERF-931-hoist-dispatch.md
+++ b/.sys/plans/PERF-931-hoist-dispatch.md
@@ -1,0 +1,55 @@
+---
+id: PERF-931
+slug: hoist-dispatch
+status: unclaimed
+claimed_by: ""
+created: 2024-07-06
+completed: ""
+result: ""
+---
+# PERF-931: Hoist Dispatch Above Wait Block
+
+## Focus Area
+`CaptureLoop.ts` - Multi-worker writer chunk loops.
+
+## Background Research
+In the multi-worker paths, the writer processes frames in chunks. If the writer encounters a missing frame (`frameBufferRing[ringIndex] === null`), it breaks out of its inner fast loop and waits for a worker to produce the frame by `await`ing `writerWaiterPromise`.
+Crucially, the code that dispatches idle workers (`if (freeWorkersHead > 0) { ... }`) is currently located *after* this wait block. This creates a severe pipeline stall.
+By hoisting the free worker dispatch block to execute *before* the wait loop, we guarantee that idle workers are immediately put to work on the next frames before the main thread yields to the event loop.
+
+## Benchmark Configuration
+- **Composition URL**: Standard DOM composition
+- **Render Settings**: Standard
+- **Mode**: `dom` (multi-worker)
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Bottleneck analysis**: Workers remain idle while the writer is blocked waiting for frames, because the dispatch logic runs after the wait block instead of before it, leading to pipeline starvation.
+
+## Implementation Spec
+
+### Step 1: Hoist Dispatch Block in DOM Writer
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the `isDomStrategyWriter` block, locate the wait block:
+`if (nextFrameToWrite < chunkEnd) { ... while (frameBufferRing[ringIndex] === null && !aborted) { await writerWaiterPromise; } ... }`
+And the dispatch block immediately following it:
+`if (freeWorkersHead > 0) { ... }`
+Swap their order. Move the entire `if (freeWorkersHead > 0)` block to be strictly **before** the `if (nextFrameToWrite < chunkEnd)` wait block.
+
+### Step 2: Hoist Dispatch Block in Generic Writer
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the `else if (!aborted)` block, do the exact same swap. Move the `if (freeWorkersHead > 0)` dispatch block to execute strictly before the `if (nextFrameToWrite < chunkEnd)` wait block.
+
+**Why**: Ensures maximum parallel saturation by keeping workers busy *while* the writer waits, rather than keeping workers idle.
+
+## Variations
+None.
+
+## Canvas Smoke Test
+Run a standard canvas benchmark to ensure the generic strategy multi-worker pipeline remains intact and faster.
+
+## Correctness Check
+Run FFmpeg tests to verify `frameBufferRing` indexing does not break frame order.

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -1241,16 +1241,6 @@ export class CaptureLoop {
                 nextFrameToWrite++;
               }
 
-              if (nextFrameToWrite < chunkEnd) {
-                const ringIndex = nextFrameToWrite & ringMask;
-                while (frameBufferRing[ringIndex] === null && !aborted) {
-                  await writerWaiterPromise;
-                }
-                if (aborted) break;
-              } else if (aborted) {
-                break;
-              }
-
               if (freeWorkersHead > 0) {
                 const maxSubmits = nextFrameToWrite + maxPipelineDepth;
                   const limit = maxSubmits < totalFrames ? maxSubmits : totalFrames;
@@ -1276,6 +1266,16 @@ export class CaptureLoop {
                     }
                     freeWorkersHead = 0;
                 }
+              }
+
+              if (nextFrameToWrite < chunkEnd) {
+                const ringIndex = nextFrameToWrite & ringMask;
+                while (frameBufferRing[ringIndex] === null && !aborted) {
+                  await writerWaiterPromise;
+                }
+                if (aborted) break;
+              } else if (aborted) {
+                break;
               }
 
               if (nextFrameToWrite >= nextProgress) {
@@ -1310,16 +1310,6 @@ export class CaptureLoop {
                 nextFrameToWrite++;
               }
 
-              if (nextFrameToWrite < chunkEnd) {
-                const ringIndex = nextFrameToWrite & ringMask;
-                while (frameBufferRing[ringIndex] === null && !aborted) {
-                  await writerWaiterPromise;
-                }
-                if (aborted) break;
-              } else if (aborted) {
-                break;
-              }
-
               if (freeWorkersHead > 0) {
                 const maxSubmits = nextFrameToWrite + maxPipelineDepth;
                   const limit = maxSubmits < totalFrames ? maxSubmits : totalFrames;
@@ -1345,6 +1335,16 @@ export class CaptureLoop {
                     }
                     freeWorkersHead = 0;
                 }
+              }
+
+              if (nextFrameToWrite < chunkEnd) {
+                const ringIndex = nextFrameToWrite & ringMask;
+                while (frameBufferRing[ringIndex] === null && !aborted) {
+                  await writerWaiterPromise;
+                }
+                if (aborted) break;
+              } else if (aborted) {
+                break;
               }
 
               if (nextFrameToWrite >= nextProgress) {


### PR DESCRIPTION
- **💡 What**: Created an experiment plan to hoist the free worker dispatch block above the writer wait block in `CaptureLoop.ts`.
- **🎯 Why**: The current placement of the dispatch block after the wait block causes a severe pipeline stall, leaving workers idle while the writer waits for frames. Hoisting it ensures maximum parallel saturation.
- **🔬 Approach**: Swap the order of the dispatch block (`if (freeWorkersHead > 0)`) and the wait block (`if (nextFrameToWrite < chunkEnd)`) in both the DOM and Generic multi-worker paths.
- **📎 Plan**: `/.sys/plans/PERF-931-hoist-dispatch.md`

---
*PR created automatically by Jules for task [12442118593250557005](https://jules.google.com/task/12442118593250557005) started by @BintzGavin*