### PR TITLE
✨ RENDERER: Hoist free worker dispatch above wait block (PERF-931)

### DIFF
--- a/.sys/plans/PERF-931-hoist-dispatch.md
+++ b/.sys/plans/PERF-931-hoist-dispatch.md
@@ -1,7 +1,7 @@
 ---
 id: PERF-931
 slug: hoist-dispatch
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-07-06
 completed: ""

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -173,3 +173,7 @@ Last updated by: PERF-873
 - **PERF-929**: Hoisted loop-carried induction variables (`freeWorkersHead` and `nextFrameToSubmit`) in `CaptureLoop.ts` multi-worker dispatch loops.
   - **Improvement**: Microbenchmarks showed a ~27% reduction in loop overhead by allowing V8 TurboFan to pipeline the induction variables inside registers without doing closure writes until the loop completes.
   - **Plan ID**: PERF-929
+
+- **PERF-931**: Hoisted free worker dispatch logic (`if (freeWorkersHead > 0)`) in multi-worker writer chunk loops to execute *before* the inner wait loop (`await writerWaiterPromise`).
+  - **Improvement**: Microbenchmarks showed a ~30% improvement by preventing pipeline stalls, ensuring idle workers are dispatched immediately before the main thread yields to wait.
+  - **Plan ID**: PERF-931

--- a/packages/renderer/.sys/perf-results-PERF-931.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-931.tsv
@@ -1,0 +1,3 @@
+run	render_time_ms	frames	fps_effective	peak_mem_mb	status	description
+1	69.39	1000	14.41	0.0	keep	baseline
+2	48.36	1000	20.67	0.0	keep	hoist free worker dispatch above wait block

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -1212,6 +1212,33 @@ export class CaptureLoop {
               let chunkEnd = nextFrameToWrite + progressInterval; if (chunkEnd > totalFrames) chunkEnd = totalFrames;
 
 
+              if (freeWorkersHead > 0) {
+                const maxSubmits = nextFrameToWrite + maxPipelineDepth;
+                  const limit = maxSubmits < totalFrames ? maxSubmits : totalFrames;
+                  let dispatches = limit - nextFrameToSubmit;
+                  if (dispatches > 0) {
+                    dispatches = Math.min(dispatches, freeWorkersHead);
+                    let h = freeWorkersHead;
+                    let n = nextFrameToSubmit;
+                    for (let d = 0; d < dispatches; d++) {
+                      h--;
+                      const w = freeWorkers[h];
+                      frameBufferRing[n & ringMask] = null;
+                      workerThenables[w].resolve(n);
+                      n++;
+                    }
+                    freeWorkersHead = h;
+                    nextFrameToSubmit = n;
+                  }
+                  if (nextFrameToSubmit === totalFrames) {
+                    for (let j = 0; j < freeWorkersHead; j++) {
+                      const w = freeWorkers[j];
+                      workerThenables[w].resolve(-1);
+                    }
+                    freeWorkersHead = 0;
+                }
+              }
+
               while (nextFrameToWrite < chunkEnd) {
                 const ringIndex = nextFrameToWrite & ringMask;
                 if (frameBufferRing[ringIndex] === null) {
@@ -1241,33 +1268,6 @@ export class CaptureLoop {
                 nextFrameToWrite++;
               }
 
-              if (freeWorkersHead > 0) {
-                const maxSubmits = nextFrameToWrite + maxPipelineDepth;
-                  const limit = maxSubmits < totalFrames ? maxSubmits : totalFrames;
-                  let dispatches = limit - nextFrameToSubmit;
-                  if (dispatches > 0) {
-                    dispatches = Math.min(dispatches, freeWorkersHead);
-                    let h = freeWorkersHead;
-                    let n = nextFrameToSubmit;
-                    for (let d = 0; d < dispatches; d++) {
-                      h--;
-                      const w = freeWorkers[h];
-                      frameBufferRing[n & ringMask] = null;
-                      workerThenables[w].resolve(n);
-                      n++;
-                    }
-                    freeWorkersHead = h;
-                    nextFrameToSubmit = n;
-                  }
-                  if (nextFrameToSubmit === totalFrames) {
-                    for (let j = 0; j < freeWorkersHead; j++) {
-                      const w = freeWorkers[j];
-                      workerThenables[w].resolve(-1);
-                    }
-                    freeWorkersHead = 0;
-                }
-              }
-
               if (nextFrameToWrite < chunkEnd) {
                 const ringIndex = nextFrameToWrite & ringMask;
                 while (frameBufferRing[ringIndex] === null && !aborted) {
@@ -1291,25 +1291,6 @@ export class CaptureLoop {
               let chunkEnd = nextFrameToWrite + progressInterval; if (chunkEnd > totalFrames) chunkEnd = totalFrames;
 
 
-              while (nextFrameToWrite < chunkEnd) {
-                const ringIndex = nextFrameToWrite & ringMask;
-                if (frameBufferRing[ringIndex] === null) {
-                  break;
-                }
-
-                const buffer = frameBufferRing[ringIndex]!;
-
-                pendingBytes += (buffer as any).length;
-                const writeSuccess = stream.write(buffer as any);
-
-                if (!writeSuccess && pendingBytes >= 16777216) {
-                  await this.drainPromise;
-                  pendingBytes = 0;
-                }
-
-                nextFrameToWrite++;
-              }
-
               if (freeWorkersHead > 0) {
                 const maxSubmits = nextFrameToWrite + maxPipelineDepth;
                   const limit = maxSubmits < totalFrames ? maxSubmits : totalFrames;
@@ -1335,6 +1316,25 @@ export class CaptureLoop {
                     }
                     freeWorkersHead = 0;
                 }
+              }
+
+              while (nextFrameToWrite < chunkEnd) {
+                const ringIndex = nextFrameToWrite & ringMask;
+                if (frameBufferRing[ringIndex] === null) {
+                  break;
+                }
+
+                const buffer = frameBufferRing[ringIndex]!;
+
+                pendingBytes += (buffer as any).length;
+                const writeSuccess = stream.write(buffer as any);
+
+                if (!writeSuccess && pendingBytes >= 16777216) {
+                  await this.drainPromise;
+                  pendingBytes = 0;
+                }
+
+                nextFrameToWrite++;
               }
 
               if (nextFrameToWrite < chunkEnd) {


### PR DESCRIPTION
💡 **What**: Hoisted free worker dispatch logic in multi-worker writer chunk loops.
🎯 **Why**: Executes dispatch logic before inner wait loops, preventing pipeline stalls by ensuring idle workers are immediately dispatched with new frames instead of remaining idle while the main thread waits.
📊 **Impact**: ~30% improvement in execution speed in microbenchmarks for the hot multi-worker chunked dispatch loop.
🔬 **Verification**: 4-gate verification passed, including TS compilation, Canvas smoke test, and test suite baseline verifications.

| run | render_time_ms | frames | fps_effective | peak_mem_mb | status | description |
|---|---|---|---|---|---|---|
| 1 | 69.39 | 1000 | 14.41 | 0.0 | keep | baseline |
| 2 | 48.36 | 1000 | 20.67 | 0.0 | keep | hoist free worker dispatch above wait block |

📎 **Plan**: `.sys/plans/PERF-931-hoist-dispatch.md`

---
*PR created automatically by Jules for task [16987029298132535363](https://jules.google.com/task/16987029298132535363) started by @BintzGavin*