### PR TITLE
📋 PLAYER: Remove preservesPitch documentation gap plan

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -7,3 +7,6 @@
 ## v0.79.2 - Missing Methods vs Internal Features
 **Learning:** Found that while a feature might be fully implemented internally (like `setPlaybackRange` in `HeliosController`), it can sometimes be omitted from the public `HeliosPlayer` API wrapper. We must explicitly check `packages/player/src/index.ts` to confirm public availability, rather than just trusting `HeliosController` or the UI shortcuts.
 **Action:** Always verify if internal controller capabilities are mapped to public Web Component methods.
+## v0.79.3 - preservesPitch gap
+**Learning:** Found that `preservesPitch` is exposed in `HeliosPlayer` and documented in `README.md`, but it requires core architectural changes in `packages/core/src/drivers/DomDriver.ts` to actually function. As a PLAYER domain planner, I cannot modify `packages/core`.
+**Action:** When an API property requires core logic that isn't implemented, it must be removed from the README to avoid misleading users until a core task can be scheduled.

--- a/.sys/plans/2027-03-05-PLAYER-Remove-preservesPitch-Documentation.md
+++ b/.sys/plans/2027-03-05-PLAYER-Remove-preservesPitch-Documentation.md
@@ -1,0 +1,21 @@
+#### 1. Context & Goal
+- **Objective**: Remove `preservesPitch` from the player README.
+- **Trigger**: The `preservesPitch` property is documented as part of the public API, but the underlying `Helios` core and its drivers do not actually implement pitch preservation logic. While `HeliosPlayer` has a getter and setter for it, it has no effect on actual playback. As the PLAYER planner, I cannot modify `packages/core`, so the best action is to remove the misleading documentation for now.
+- **Impact**: Improves documentation accuracy by not advertising unsupported functionality.
+
+#### 2. File Inventory
+- **Create**: []
+- **Modify**:
+  - `packages/player/README.md`: Remove the `- \`preservesPitch\`` line from the documentation.
+- **Read-Only**: `packages/core/src/drivers/DomDriver.ts`
+
+#### 3. Implementation Spec
+- **Architecture**: Simple documentation cleanup to match current reality and domain constraints.
+- **Pseudo-Code**: N/A - Documentation change only.
+- **Public API Changes**: `preservesPitch` property removed from the public API documentation (though the getter/setter methods remain internally).
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `cat packages/player/README.md | grep preservesPitch`
+- **Success Criteria**: No matches found.
+- **Edge Cases**: Ensure no other surrounding list items or documentation sections are accidentally removed or malformed.


### PR DESCRIPTION
Created plan `.sys/plans/2027-03-05-PLAYER-Remove-preservesPitch-Documentation.md` to remove unsupported `preservesPitch` documentation from README. Logged constraints in `.jules/PLAYER.md`.

---
*PR created automatically by Jules for task [11178241984227288149](https://jules.google.com/task/11178241984227288149) started by @BintzGavin*