### PR TITLE
✨ PLAYER: Remove preservesPitch documentation

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -1,87 +1,117 @@
-# Context: Player (`packages/player`)
+# Component Context: helios-player
 
-## Section A: Component Structure
-The `HeliosPlayer` is a standard Web Component (Custom Element: `<helios-player>`).
+## Description
+A Web Component providing a UI for the Helios rendering engine. It runs the composition within a sandboxed iframe, providing playback controls, timeline scrubbing, a diagnostics overlay, audio mixing, and client-side rendering/export functionality.
 
-**Shadow DOM Layout**:
-- `.helios-wrapper`: Main container.
-- `iframe`: Isolates user code (untrusted content).
-- `.ui-overlay`: Contains the standard playback controls.
-- `video.pip-video`: Hidden video element used exclusively to proxy the canvas stream for Picture-in-Picture.
-- `.loading-overlay`, `.error-overlay`, `.export-overlay`, `.status-overlay`: State-specific overlays.
+## Component Structure
+The `<helios-player>` component uses a Shadow DOM for encapsulation:
+- **Wrapper**: A container element applying the aspect ratio or fixed dimensions.
+  - **Iframe Container**: Holds the sandboxed `<iframe>` where the user's composition is loaded.
+  - **UI Overlay**: Absolute positioned container for all controls.
+    - **Top Bar**: Displays the media title/artist, if provided.
+    - **Center Controls**: Big play button, error displays, loading spinner.
+    - **Bottom Bar**: Contains the scrubber timeline, play/pause button, time display, volume control, track selector, settings menu (playback speed, loop range, diagnostics shortcut), fullscreen toggle, picture-in-picture toggle, and export button.
+    - **Modals/Menus**: Settings overlay, Diagnostics overlay, Captions menu, Audio track menu.
 
-## Section B: Events
-The component dispatches standard HTML5 Media events:
-- `play`, `pause`, `ended`, `timeupdate`, `durationchange`, `volumechange`, `ratechange`, `seeked`, `seeking`, `error`, `loadedmetadata`, `loadeddata`, `canplay`, `canplaythrough`, `playing`, `waiting`, `emptied`, `stalled`, `suspend`, `abort`, `progress`
-
-Custom extensions:
-- `error` events carry a `code` and `message` compatible with `MediaError`.
-- `audiometering` events report stereo RMS and Peak audio levels.
-
-## Section C: Attributes
-Observed attributes:
-- `src`: The URL of the content to load into the iframe.
-- `interactive`: Enable direct interaction with the composition.
+## Attributes
+The element observes the following attributes for state reflection:
+- `src`: URL of the composition page to load in the iframe.
+- `width`: Width of the player (aspect ratio calculation).
+- `height`: Height of the player (aspect ratio calculation).
+- `autoplay`: Automatically start playback when connected.
+- `loop`: Loop playback when the end is reached.
+- `controls`: Show the UI controls overlay.
+- `export-mode`: Strategy for client-side export: `auto`, `canvas`, or `dom`.
+- `canvas-selector`: CSS selector for the canvas element (used in `canvas` export mode).
+- `export-format`: Output format: `mp4`, `webm`, `png`, or `jpeg`.
+- `poster`: URL of an image to display before playback starts.
+- `preload`: `auto` or `none`. If `none`, defers loading the iframe until interaction.
+- `input-props`: JSON string of properties to pass to the composition.
+- `interactive`: Enable direct interaction with the composition (disables click-to-pause).
+- `controlslist`: Space-separated list of features to disable: `nodownload`, `nofullscreen`.
 - `sandbox`: Security flags for the iframe.
-- `width`, `height`: Dimensions of the player.
-- `controls`: Boolean attribute to toggle the UI overlay.
-- `loop`: Boolean attribute to enable looping playback.
-- `autoplay`: Boolean attribute for auto-playback.
-- `muted`: Boolean attribute to start the player muted.
-- `playsinline`: Indicates that the video is to be played "inline", within the element's playback area.
-- `poster`: Image URL displayed before playback starts.
-- `preload`: Strategy for preloading (none, metadata, auto).
-- `export-width`, `export-height`: Optional target dimensions for exported media.
-- `export-bitrate`: Optional target bitrate for video exports.
-- `canvas-selector`: CSS selector for the primary canvas inside the iframe (default: `canvas`).
-- `disableremoteplayback`: Reflected boolean attribute.
-- `mediagroup`: Reflected string attribute.
+- `export-width`: Target width for client-side export.
+- `export-height`: Target height for client-side export.
+- `muted`: Automatically mute the player's audio upon loading.
+- `playsinline`: Indicates that the video is to be played inline.
+- `export-bitrate`: Target bitrate for client-side export (bps).
+- `export-filename`: Filename for client-side export (without extension).
+- `export-caption-mode`: Strategy for caption export: `burn-in` or `file`.
+- `disablepictureinpicture`: Hides the Picture-in-Picture button.
+- `media-title`: Title of the composition for OS Media Session.
+- `media-artist`: Artist name for OS Media Session.
+- `media-album`: Album name for OS Media Session.
+- `media-artwork`: URL of artwork for OS Media Session (defaults to poster).
+- `crossorigin`: CORS setting for this media element.
 
-## Section D: Public API
-- `play(): Promise<void>`
-- `pause(): void`
-- `seek(timeInSeconds: number): Promise<void>`
-- `fastSeek(timeInSeconds: number): void`
-- `setPlaybackRange(startFrame: number, endFrame: number): void`
-- `clearPlaybackRange(): void`
-- `setDuration(seconds: number): void`
-- `setFps(fps: number): void`
-- `setSize(width: number, height: number): void`
-- `setMarkers(markers: Marker[]): void`
-- `setMediaKeys(mediaKeys: MediaKeys | null): Promise<void>`
-- `captureStream(): Promise<MediaStream>`
-- `export(options?: ExportOptions): Promise<void>`
-- `diagnose(): Promise<DiagnosticReport>`
-- `getController(): HeliosController | null`
-- `startAudioMetering(): void`
-- `stopAudioMetering(): void`
-- `addTextTrack(kind: TextTrackKind, label?: string, language?: string): TextTrack`
-- `getVideoPlaybackQuality(): VideoPlaybackQuality`
-- `requestVideoFrameCallback(callback: VideoFrameRequestCallback): number`
-- `cancelVideoFrameCallback(handle: number): void`
+## Methods (HTMLMediaElement Subset & API Parity)
+- `setDuration(seconds: number): void;`
+- `setFps(fps: number): void;`
+- `setSize(width: number, height: number): void;`
+- `setMarkers(markers: Marker[]): void;`
+- `play(): Promise<void>;`
+- `pause(): void;`
+- `load(): void;`
+- `addTextTrack(kind: TextTrackKind, label?: string, language?: string): TextTrack;`
+- `fastSeek(time: number): void;`
+- `canPlayType(type: string): CanPlayTypeResult;`
+- `captureStream(): Promise<MediaStream>;`
+- `startAudioMetering(): void;`
+- `stopAudioMetering(): void;`
+- `setPlaybackRange(startFrame: number, endFrame: number): void;`
+- `clearPlaybackRange(): void;`
+- `setSinkId(sinkId: string): Promise<void>;`
+- `setMediaKeys(mediaKeys: MediaKeys | null): Promise<void>;`
 
-Properties:
-- `HAVE_NOTHING`, `HAVE_METADATA`, `HAVE_CURRENT_DATA`, `HAVE_FUTURE_DATA`, `HAVE_ENOUGH_DATA`: Instance media constant values.
-- `NETWORK_EMPTY`, `NETWORK_IDLE`, `NETWORK_LOADING`, `NETWORK_NO_SOURCE`: Instance media constant values.
-- `currentTime: number`
-- `duration: number`
-- `volume: number`
-- `playbackRate: number`
-- `paused: boolean`
-- `ended: boolean`
-- `error: MediaError | null`
-- `onaudiometering: ((event: Event) => void) | null`
-- `readyState: number`
-- `networkState: number`
-- `srcObject: MediaStream | MediaSource | Blob | null`
-- `audioTracks: AudioTrackList`
-- `videoTracks: VideoTrackList`
-- `textTracks: TextTrackList`
-- `mediaSession: MediaSession`
-- `mediaKeys: MediaKeys | null`
-- `onplaying`, `onwaiting`, `onsuspend`, `onstalled`, `onabort`, `onemptied`, `onprogress`: Standard media event handler properties.
+## Properties (HTMLMediaElement Subset & API Parity)
+- `src`, `autoplay`, `loop`, `controls`, `poster`, `preload`, `sandbox`, `interactive`
+- `currentTime`: Current playback position in seconds.
+- `duration`: Total duration in seconds (read-only).
+- `paused`: Whether playback is paused (read-only).
+- `ended`: Whether playback has reached the end (read-only).
+- `volume`: Audio volume (0.0 to 1.0).
+- `muted`: Audio mute state.
+- `playbackRate`: Playback speed (default 1.0).
+- `width`, `height`: Player dimensions.
+- `videoWidth`, `videoHeight`: Intrinsic composition dimensions (read-only).
+- `buffered`, `seekable`: TimeRanges objects (always 0-duration, read-only).
+- `seeking`: Whether the player is currently seeking (read-only).
+- `readyState`: The current readiness state (0-4) (read-only).
+- `networkState`: The current network state (0-3) (read-only).
+- `error`: MediaError or null (read-only).
+- `currentSrc`: Absolute URL of the chosen media resource (read-only).
+- `played`: TimeRanges of the media source played (read-only).
+- `defaultMuted`: Reflected defaultMuted attribute.
+- `defaultPlaybackRate`: The default rate of playback.
+- `textTracks`: TextTrackList (read-only).
+- `audioTracks`: AudioTrackList (read-only).
+- `videoTracks`: VideoTrackList (read-only).
+- `disableRemotePlayback`: Reflected disableremoteplayback attribute.
+- `mediaGroup`: Reflected mediagroup attribute.
+- `sinkId`: Current audio sink id (read-only).
+- `mediaKeys`: MediaKeys object (read-only).
 
-## Section E: Export Capabilities
-The player supports client-side export utilizing `@helios-project/core` rendering.
-Supported Formats: `mp4`, `webm`, `png`, `jpeg`
-Supported Features: Resizing, Bitrate control, Audio merging, Caption rendering.
+## Custom Helios Methods
+- `getController(): HeliosController | null;`
+- `getSchema(): Promise<HeliosSchema | undefined>;`
+- `diagnose(): Promise<DiagnosticReport>;`
+- `requestPictureInPicture(): Promise<PictureInPictureWindow>;`
+- `export(options?: HeliosExportOptions): Promise<void>;`
+- `getVideoPlaybackQuality(): VideoPlaybackQuality;`
+- `requestVideoFrameCallback(callback: VideoFrameRequestCallback): number;`
+- `cancelVideoFrameCallback(handle: number): void;`
+
+## Custom Helios Properties
+- `fps`: Frames per second of the composition (read-only).
+- `currentFrame`: Current frame index.
+- `inputProps`: JSON object of input properties.
+- `exportMode`, `exportFormat`, `exportFilename`, `exportWidth`, `exportHeight`, `exportBitrate`, `exportCaptionMode`, `canvasSelector`, `controlsList`
+- `mediaTitle`, `mediaArtist`, `mediaAlbum`, `mediaArtwork`
+
+## Events
+The component dispatches standard HTMLMediaElement events and some custom events:
+- Standard: `play`, `pause`, `playing`, `waiting`, `suspend`, `stalled`, `seeking`, `seeked`, `ended`, `timeupdate`, `volumechange`, `ratechange`, `durationchange`, `loadstart`, `loadedmetadata`, `loadeddata`, `canplay`, `canplaythrough`, `error`, `abort`, `emptied`, `progress`
+- Custom/Extended:
+  - `audiometering`: Fired during playback reporting stereo RMS and Peak levels.
+  - `resize`: Fired when player dimensions change.
+  - `enterpictureinpicture`, `leavepictureinpicture`: Fired on PiP state changes.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -155,4 +155,5 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] [v0.46.40] CLI Unblocked: Generated plan /.sys/plans/2027-06-05-CLI-Command-Coverage-Tests-V4.md
 - [x] [v0.46.43] CLI Unblocked: Generated plan /.sys/plans/2027-06-05-CLI-Command-Coverage-Tests-V6.md
 - [x] [v0.46.57] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/
+- [x] [v0.79.4] PLAYER Blocked: Waiting for a new, valid plan in /.sys/plans/
 - [ ] [v0.79.4] PLAYER Blocked: Waiting for a new, valid plan in /.sys/plans/

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### PLAYER v0.79.4
+- ✅ Completed: Remove preservesPitch documentation - Removed preservesPitch from the player README as it is currently unsupported by the core architecture.
+
 #
 ### PLAYER v0.79.1
 - ✅ Completed: Discovered that 2027-03-04-PLAYER-Expose-Playback-Range-Methods.md is an IMPOSSIBLE: DUPLICATION plan. The setPlaybackRange and clearPlaybackRange methods are already fully implemented and documented. Documented as impossible and discarded.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -278,7 +278,7 @@
 [v0.78.1] ✅ Completed: Discovered missing HTMLMediaElement parity method (`setMediaKeys`). Created plan `.sys/plans/2027-03-02-PLAYER-Implement-setMediaKeys.md` to implement it.
 [v0.78.2] ✅ Completed: Implement setMediaKeys - Added mediaKeys property and setMediaKeys method to complete HTMLMediaElement parity.
 [v0.78.3] ✅ Completed: Discovered that `.sys/plans/2024-05-24-PLAYER-Instance-Constants.md` is an IMPOSSIBLE: DUPLICATION plan. The missing constants are already implemented. Created plan `.sys/plans/2027-03-03-PLAYER-Document-Instance-Constants.md` to document them.
-**Version**: 0.79.3
+**Version**: 0.79.4
 
 [v0.78.3] ✅ Completed: Document HTMLMediaElement Constants - Added documentation for HTMLMediaElement instance and class constants to the README.
 [v0.78.4] ✅ Completed: Document Playback Range Methods - Added `setPlaybackRange` and `clearPlaybackRange` to the README methods section.
@@ -289,4 +289,5 @@
 [v0.79.2] ✅ Completed: Discovered that 2027-03-05-PLAYER-Expose-Composition-Setters.md is an IMPOSSIBLE: DUPLICATION plan. The setDuration, setFps, setSize, and setMarkers methods are already fully implemented and documented. Documented as impossible and discarded.
 [v0.79.3] ✅ Completed: Document getController - Documented getController in the player README.
 
+[v0.79.4] ✅ Completed: Remove preservesPitch documentation - Removed preservesPitch from the player README as it is currently unsupported by the core architecture.
 [v0.79.4] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -221,7 +221,6 @@ Both class-level and instance-level properties are provided for standard media s
 - `played` (TimeRanges, read-only): The ranges of the media source that the browser has played.
 - `defaultMuted` (boolean): Reflected `defaultMuted` attribute.
 - `defaultPlaybackRate` (number): The default rate of playback.
-- `preservesPitch` (boolean): Whether pitch should be preserved when altering playback speed.
 - `srcObject` (MediaProvider | null): The media provider object assigned to the player.
 - `crossOrigin` (string | null): The CORS setting for this media element.
 - `exportMode` (string): Reflected export-mode attribute.


### PR DESCRIPTION
💡 What: Removed `preservesPitch` from the player README.
🎯 Why: The `preservesPitch` property is exposed in `HeliosPlayer` but lacks the required underlying architectural core support in `packages/core/src/drivers/DomDriver.ts` to function properly, causing a vision gap.
📊 Impact: Prevents misleading users about unsupported playback rate features until core support can be prioritized.
🔬 Verification: Ran `npm run test -w packages/player` and checked via `grep` that `preservesPitch` is removed from `packages/player/README.md`.

Ref: `.sys/plans/2027-03-05-PLAYER-Remove-preservesPitch-Documentation.md`

---
*PR created automatically by Jules for task [11804408059477746097](https://jules.google.com/task/11804408059477746097) started by @BintzGavin*