### PR TITLE
PLAYER: Remove Unsupported EME

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -61,7 +61,6 @@ The element observes the following attributes for state reflection:
 - `setPlaybackRange(startFrame: number, endFrame: number): void;`
 - `clearPlaybackRange(): void;`
 - `setSinkId(sinkId: string): Promise<void>;`
-- `setMediaKeys(mediaKeys: MediaKeys | null): Promise<void>;`
 
 ## Properties (HTMLMediaElement Subset & API Parity)
 - `src`, `autoplay`, `loop`, `controls`, `poster`, `preload`, `sandbox`, `interactive`
@@ -89,7 +88,6 @@ The element observes the following attributes for state reflection:
 - `disableRemotePlayback`: Reflected disableremoteplayback attribute.
 - `mediaGroup`: Reflected mediagroup attribute.
 - `sinkId`: Current audio sink id (read-only).
-- `mediaKeys`: MediaKeys object (read-only).
 
 ## Custom Helios Methods
 - `getController(): HeliosController | null;`

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -156,4 +156,3 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [x] [v0.46.43] CLI Unblocked: Generated plan /.sys/plans/2027-06-05-CLI-Command-Coverage-Tests-V6.md
 - [x] [v0.46.57] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/
 - [x] [v0.79.4] PLAYER Blocked: Waiting for a new, valid plan in /.sys/plans/
-- [ ] [v0.79.4] PLAYER Blocked: Waiting for a new, valid plan in /.sys/plans/

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -860,3 +860,6 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### STUDIO v0.122.8
 - ✅ Completed: STUDIO-Improve-AudioWaveform-Coverage - Verified useAudioWaveform already has 100% test coverage.
+
+### PLAYER v0.79.5
+- ✅ Completed: Remove Unsupported EME - Removed the unsupported setMediaKeys method and mediaKeys property from both the codebase and documentation.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: 0.79.4
+**Version**: 0.79.5
 
 [v0.78.5] ✅ Completed: Discovered missing composition setters on the public API wrapper. Created plan `.sys/plans/2027-03-05-PLAYER-Expose-Composition-Setters.md` to expose `setDuration`, `setFps`, `setSize`, and `setMarkers`.
 [v0.78.4] ✅ Completed: Discovered missing HTMLMediaElement-like parity methods (`setPlaybackRange`, `clearPlaybackRange`) in HeliosPlayer public API. Created plan `.sys/plans/2027-03-04-PLAYER-Expose-Playback-Range-Methods.md` to implement them.
@@ -278,7 +278,7 @@
 [v0.78.1] ✅ Completed: Discovered missing HTMLMediaElement parity method (`setMediaKeys`). Created plan `.sys/plans/2027-03-02-PLAYER-Implement-setMediaKeys.md` to implement it.
 [v0.78.2] ✅ Completed: Implement setMediaKeys - Added mediaKeys property and setMediaKeys method to complete HTMLMediaElement parity.
 [v0.78.3] ✅ Completed: Discovered that `.sys/plans/2024-05-24-PLAYER-Instance-Constants.md` is an IMPOSSIBLE: DUPLICATION plan. The missing constants are already implemented. Created plan `.sys/plans/2027-03-03-PLAYER-Document-Instance-Constants.md` to document them.
-**Version**: 0.79.4
+**Version**: 0.79.5
 
 [v0.78.3] ✅ Completed: Document HTMLMediaElement Constants - Added documentation for HTMLMediaElement instance and class constants to the README.
 [v0.78.4] ✅ Completed: Document Playback Range Methods - Added `setPlaybackRange` and `clearPlaybackRange` to the README methods section.
@@ -291,3 +291,4 @@
 
 [v0.79.4] ✅ Completed: Remove preservesPitch documentation - Removed preservesPitch from the player README as it is currently unsupported by the core architecture.
 [v0.79.4] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner.
+[v0.79.5] ✅ Completed: Remove Unsupported EME - Removed the unsupported setMediaKeys method and mediaKeys property from both the codebase and documentation.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -155,7 +155,6 @@ Both class-level and instance-level properties are provided for standard media s
 - `setSize(width: number, height: number): void` - Updates the composition dimensions dynamically.
 - `setMarkers(markers: Marker[]): void` - Updates the timeline markers dynamically.
 - `setSinkId(sinkId: string): Promise<void>` - Sets the audio sink id.
-- `setMediaKeys(mediaKeys: MediaKeys | null): Promise<void>` - Sets the MediaKeys object to use for decrypting media.
 
 - `play(): Promise<void>` - Starts playback.
 - `getController(): HeliosController | null` - Retrieves the underlying HeliosController instance, if connected.
@@ -182,7 +181,6 @@ Both class-level and instance-level properties are provided for standard media s
 - `disableRemotePlayback` (boolean): Reflected disableremoteplayback attribute.
 - `mediaGroup` (string): Reflected mediagroup attribute.
 - `sinkId` (string, read-only): Returns the current audio sink id.
-- `mediaKeys` (MediaKeys | null, read-only): The MediaKeys object associated with the media element.
 
 - `src` (string): URL of the composition page to load in the iframe.
 - `autoplay` (boolean): Reflected autoplay attribute.

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -422,17 +422,6 @@ describe('HeliosPlayer API Parity', () => {
     expect(player.defaultMuted).toBe(false);
   });
 
-  it('should support mediaKeys property and setMediaKeys method', async () => {
-    expect(player.mediaKeys).toBeNull();
-
-    const mockMediaKeys = {} as MediaKeys;
-    await player.setMediaKeys(mockMediaKeys);
-    expect(player.mediaKeys).toBe(mockMediaKeys);
-
-    await player.setMediaKeys(null);
-    expect(player.mediaKeys).toBeNull();
-  });
-
   it('should support defaultPlaybackRate property', () => {
     const rateSpy = vi.fn();
     player.addEventListener('ratechange', rateSpy);

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -1347,15 +1347,6 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
     return Promise.resolve();
   }
 
-  private _mediaKeys: MediaKeys | null = null;
-  public get mediaKeys(): MediaKeys | null {
-    return this._mediaKeys;
-  }
-
-  public async setMediaKeys(mediaKeys: MediaKeys | null): Promise<void> {
-    this._mediaKeys = mediaKeys;
-    return Promise.resolve();
-  }
 
   public get seeking(): boolean {
     // Return internal scrubbing state as seeking


### PR DESCRIPTION
💡 **What**: Removed the unsupported `setMediaKeys` method and `mediaKeys` property from the `packages/player` codebase, tests, and documentation.
🎯 **Why**: To close a vision gap where an exposed public API property lacked the necessary underlying architectural core support, and EME functionality is fundamentally incompatible with the composition model.
📊 **Impact**: Prevents misleading users about unsupported features and improves API parity hygiene.
🔬 **Verification**: `npm run build -w packages/player && npm run test -w packages/player`

---
*PR created automatically by Jules for task [948412133815417982](https://jules.google.com/task/948412133815417982) started by @BintzGavin*