### PR TITLE
✨ RENDERER: [Remove Redundant isDomStrategy checks in single-worker path]

### DIFF
--- a/.sys/plans/PERF-961-remove-redundant-is-dom-strategy-single-worker.md
+++ b/.sys/plans/PERF-961-remove-redundant-is-dom-strategy-single-worker.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-961
 slug: remove-redundant-is-dom-strategy-single-worker
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2025-03-05
-completed: ""
-result: ""
+completed: "2025-03-05"
+result: "Removed redundant isDomStrategy checks and dead else blocks in CaptureLoop.ts"
 ---
 
 # PERF-961: Remove Redundant `isDomStrategy` Checks in Single-Worker Loop

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -863,3 +863,5 @@ Each agent should update **their own dedicated progress file** instead of this f
 
 ### PLAYER v0.79.5
 - ✅ Completed: Remove Unsupported EME - Removed the unsupported setMediaKeys method and mediaKeys property from both the codebase and documentation.
+
+- Completed PERF-961: Removed redundant `isDomStrategy` check in CaptureLoop.ts

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -4,6 +4,7 @@ Last updated by: PERF-941
 
 - **PERF-951**: Created experiment plan to cache decoded Base64 `Buffer` objects earlier in the multi-worker loop to relieve hot writer loop CPU pressure in `CaptureLoop.ts`.
 ## What Works
+- **PERF-961**: Removed redundant `if (isDomStrategy)` and its dead `else` block in the single-worker path of `CaptureLoop.ts`. Because the outer block already checks `isDomStrategy`, the inner check is tautological and the else branch unreachable. Eliminating this reduces V8 parser overhead and AST complexity.
 - PERF-960: Overlapped domBeginFrame with Base64 Decode in Single-Worker Loop (hasProcessFn = false)
   - Improvement: CPU improvement by overlapping decoding time with browser capture
   - Plan ID: PERF-960

--- a/packages/renderer/.sys/perf-results-PERF-961.tsv
+++ b/packages/renderer/.sys/perf-results-PERF-961.tsv
@@ -1,0 +1,4 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.882	150	170.06	50.0	keep	remove redundant isDomStrategy
+2	1.029	150	145.77	50.0	keep	remove redundant isDomStrategy
+3	0.903	150	166.11	50.0	keep	remove redundant isDomStrategy

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -257,7 +257,6 @@ export class CaptureLoop {
             }
 
             if (isDomStrategy) {
-              if (isDomStrategy) {
 
                 let i = 1;
                 while (i < totalFrames - 1 && !aborted) {
@@ -329,76 +328,6 @@ export class CaptureLoop {
                     }
                   }
                 }
-              } else {
-
-                let i = 1;
-                while (i < totalFrames - 1 && !aborted) {
-                  const chunkEnd = Math.min(i + progressInterval, totalFrames - 1);
-
-
-                  for (; i < chunkEnd; i++) {
-                    const rawResult = await nextCapturePromise;
-
-                    const timePromise = timeDriver.setTime(
-                      page,
-                      (startFrame + i + 1) * compTimeStep,
-                    );
-
-                    const buf = Buffer.from(strategy.processCaptureResult!(rawResult) as string, "base64");
-
-                    if (timePromise) await timePromise;
-                    nextCapturePromise = strategy.capture(
-                      page,
-                      (i + 1) * timeStep,
-                    );
-
-                    pendingBytes += buf.length;
-                    const writeSuccessStr = stream.write(buf);
-
-                    if (writeSuccessStr) {} else if (pendingBytes >= 16777216) {
-                      await this.drainPromise;
-                      pendingBytes = 0;
-                    }
-                  }
-
-                  if (aborted) break;
-
-                  if (i - 1 === nextProgress) {
-                    nextProgress += progressInterval;
-                    console.log(
-                      `Progress: Rendered ${i - 1} / ${totalFrames} frames`,
-                    );
-                    if (onProgress) {
-                      onProgress((i - 1) / totalFrames);
-                    }
-                  }
-                }
-
-                if (!aborted && totalFrames > 1) {
-                  const rawResult = await nextCapturePromise;
-
-                  const buf = Buffer.from(strategy.processCaptureResult!(rawResult) as string, "base64");
-
-                  pendingBytes += buf.length;
-                  const writeSuccessStr = stream.write(buf);
-
-                  if (writeSuccessStr) {} else if (pendingBytes >= 16777216) {
-                    await this.drainPromise;
-                    pendingBytes = 0;
-                  }
-
-                  i++;
-                  if (i - 1 === nextProgress || i === totalFrames) {
-                    if (i - 1 === nextProgress) nextProgress += progressInterval;
-                    console.log(
-                      `Progress: Rendered ${i - 1} / ${totalFrames} frames`,
-                    );
-                    if (onProgress) {
-                      onProgress((i - 1) / totalFrames);
-                    }
-                  }
-                }
-              }
             } else {
 
                 let i = 1;
@@ -523,7 +452,6 @@ export class CaptureLoop {
             }
 
             if (isDomStrategy) {
-              if (isDomStrategy) {
 
                 let i = 1;
                 while (i < totalFrames - 1 && !aborted) {
@@ -587,77 +515,6 @@ export class CaptureLoop {
                     }
                   }
                 }
-              } else {
-
-                let i = 1;
-                while (i < totalFrames - 1 && !aborted) {
-                  const chunkEnd = Math.min(i + progressInterval, totalFrames - 1);
-
-
-                  for (; i < chunkEnd; i++) {
-                    const rawResult = await nextCapturePromise;
-
-                    const timePromise = timeDriver.setTime(
-                      page,
-                      (startFrame + i + 1) * compTimeStep,
-                    );
-
-                    const buf = Buffer.from(rawResult as unknown as string, "base64");
-
-                    if (timePromise) await timePromise;
-
-                    nextCapturePromise = strategy.capture(
-                      page,
-                      (i + 1) * timeStep,
-                    );
-
-                    pendingBytes += buf.length;
-                    const writeSuccessStr = stream.write(buf);
-
-                    if (writeSuccessStr) {} else if (pendingBytes >= 16777216) {
-                      await this.drainPromise;
-                      pendingBytes = 0;
-                    }
-                  }
-
-                  if (aborted) break;
-
-                  if (i - 1 === nextProgress) {
-                    nextProgress += progressInterval;
-                    console.log(
-                      `Progress: Rendered ${i - 1} / ${totalFrames} frames`,
-                    );
-                    if (onProgress) {
-                      onProgress((i - 1) / totalFrames);
-                    }
-                  }
-                }
-
-                if (!aborted && totalFrames > 1) {
-                  const rawResult = await nextCapturePromise;
-
-                  const buf = Buffer.from(rawResult as unknown as string, "base64");
-
-                  pendingBytes += buf.length;
-                  const writeSuccessStr = stream.write(buf);
-
-                  if (writeSuccessStr) {} else if (pendingBytes >= 16777216) {
-                    await this.drainPromise;
-                    pendingBytes = 0;
-                  }
-
-                  i++;
-                  if (i - 1 === nextProgress || i === totalFrames) {
-                    if (i - 1 === nextProgress) nextProgress += progressInterval;
-                    console.log(
-                      `Progress: Rendered ${i - 1} / ${totalFrames} frames`,
-                    );
-                    if (onProgress) {
-                      onProgress((i - 1) / totalFrames);
-                    }
-                  }
-                }
-              }
             } else {
 
                 let i = 1;


### PR DESCRIPTION
💡 **What**: Executed PERF-961 to remove redundant nested `if (isDomStrategy)` checks and their dead `else` blocks in the single-worker capture path.
🎯 **Why**: The outer block already checks for `isDomStrategy`, making the inner check a tautology and its `else` branch fundamentally unreachable dead code. Removing this reduces AST complexity, decreases parser overhead, and slims down V8's JIT compilation footprint in the hot loop.
📊 **Impact**: Microbenchmark concurrent capture times remained stable, showing ~15-20% variance due to environment noise, but structurally eliminated unused evaluations in hot loops.
🔬 **Verification**:
- Successfully ran `npm run build` with no TS errors.
- Successfully ran targeted tests (`verify-cdp-driver.ts`, `verify-frame-count.ts`, `verify-dom-strategy-capture.ts`).
- Documentation files updated appropriately.
📎 **Plan**: `.sys/plans/PERF-961-remove-redundant-is-dom-strategy-single-worker.md`

```
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.882	150	170.06	50.0	keep	remove redundant isDomStrategy
2	1.029	150	145.77	50.0	keep	remove redundant isDomStrategy
3	0.903	150	166.11	50.0	keep	remove redundant isDomStrategy
```

---
*PR created automatically by Jules for task [14197323063176658911](https://jules.google.com/task/14197323063176658911) started by @BintzGavin*