### PR TITLE
✨ RENDERER: Cache Decoded Base64 Buffers for Unchanged Frames

### DIFF
--- a/.sys/perf-results-PERF-965.tsv
+++ b/.sys/perf-results-PERF-965.tsv
@@ -1,0 +1,5 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	9.521	600	63.02	190.2	keep	baseline (PERF-964 output)
+2	8.845	600	67.83	195.1	keep	Cache decoded buffers for unchanged frames
+3	8.790	600	68.26	194.8	keep	Cache decoded buffers for unchanged frames
+4	8.812	600	68.08	196.3	keep	Cache decoded buffers for unchanged frames

--- a/.sys/plans/PERF-965-cache-decoded-buffer-unchanged-frames.md
+++ b/.sys/plans/PERF-965-cache-decoded-buffer-unchanged-frames.md
@@ -1,11 +1,12 @@
 ---
 id: PERF-965
 slug: cache-decoded-buffer-unchanged-frames
-status: unclaimed
+status: complete
+claimed_by: "jules"
 claimed_by: ""
 created: 2024-07-10
-completed: ""
-result: ""
+completed: "2024-07-10"
+result: "keep"
 ---
 
 # PERF-965: Cache Decoded Base64 Buffers for Unchanged Frames in Single-Worker Loop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -4,6 +4,7 @@ Last updated by: PERF-941
 
 - **PERF-951**: Created experiment plan to cache decoded Base64 `Buffer` objects earlier in the multi-worker loop to relieve hot writer loop CPU pressure in `CaptureLoop.ts`.
 ## What Works
+- Cached decoded Buffer objects for unchanged frames to avoid redundant synchronous CPU-bound string decoding (~7% faster) (PERF-965)
 - **PERF-961**: Removed redundant `if (isDomStrategy)` and its dead `else` block in the single-worker path of `CaptureLoop.ts`. Because the outer block already checks `isDomStrategy`, the inner check is tautological and the else branch unreachable. Eliminating this reduces V8 parser overhead and AST complexity.
 - PERF-960: Overlapped domBeginFrame with Base64 Decode in Single-Worker Loop (hasProcessFn = false)
   - Improvement: CPU improvement by overlapping decoding time with browser capture

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -190,6 +190,7 @@ export class CaptureLoop {
       let domLastFrameData: any = isDomStrategy
         ? (strategy as any).lastFrameData
         : null;
+      let domLastFrameBuffer: Buffer | null = null;
 
       try {
 
@@ -243,7 +244,10 @@ export class CaptureLoop {
             }
             let writeSuccess = false;
             if (isDomStrategy) {
-              const buf = Buffer.from(buffer as string, "base64");
+              if ((rawResult as any).screenshotData || !domLastFrameBuffer) {
+                domLastFrameBuffer = Buffer.from(buffer as string, "base64");
+              }
+              const buf = domLastFrameBuffer;
               pendingBytes += buf.length;
               writeSuccess = stream.write(buf);
             } else {
@@ -267,10 +271,14 @@ export class CaptureLoop {
                     const rawResult = await nextCapturePromise;
 
                     const data = rawResult.screenshotData;
-                    if (data) {
-                      domLastFrameData = data;
+                    let buf: Buffer;
+                    if (data || !domLastFrameBuffer) {
+                      if (data) domLastFrameData = data;
+                      buf = Buffer.from(domLastFrameData as string, "base64");
+                      domLastFrameBuffer = buf;
+                    } else {
+                      buf = domLastFrameBuffer;
                     }
-                    const buf = Buffer.from(domLastFrameData as string, "base64");
 
                     timeDriver.setTime(
                       page,
@@ -304,10 +312,14 @@ export class CaptureLoop {
                   const rawResult = await nextCapturePromise;
 
                   const data = rawResult.screenshotData;
-                  if (data) {
-                    domLastFrameData = data;
+                  let buf: Buffer;
+                  if (data || !domLastFrameBuffer) {
+                    if (data) domLastFrameData = data;
+                    buf = Buffer.from(domLastFrameData as string, "base64");
+                    domLastFrameBuffer = buf;
+                  } else {
+                    buf = domLastFrameBuffer;
                   }
-                  const buf = Buffer.from(domLastFrameData as string, "base64");
 
                   pendingBytes += buf.length;
                   const writeSuccessStr = stream.write(buf);


### PR DESCRIPTION
💡 What: Cached decoded `Buffer` objects instead of re-decoding raw Base64 strings for static frames in the single-worker chunked loop.
🎯 Why: To completely eliminate synchronous CPU-bound string decoding overhead (`Buffer.from`) during static periods, preventing main thread blocking on duplicate work.
📊 Impact: Render time decreased from 9.521s to 8.812s (~7% improvement).
🔬 Verification: Passed compilation, test suite, and ffprobe validation (correct resolution, framerate, duration, and codec).
📎 Plan: PERF-965

run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	9.521	600	63.02	190.2	keep	baseline (PERF-964 output)
2	8.845	600	67.83	195.1	keep	Cache decoded buffers for unchanged frames
3	8.790	600	68.26	194.8	keep	Cache decoded buffers for unchanged frames
4	8.812	600	68.08	196.3	keep	Cache decoded buffers for unchanged frames

---
*PR created automatically by Jules for task [10910748030243418826](https://jules.google.com/task/10910748030243418826) started by @BintzGavin*