### PR TITLE
📋 RENDERER: Remove dead isDomStrategy branch in multi-worker path

### DIFF
--- a/.sys/plans/PERF-971-hoist-dombeginframe-multi-worker-nodeprocess-true.md
+++ b/.sys/plans/PERF-971-hoist-dombeginframe-multi-worker-nodeprocess-true.md
@@ -1,0 +1,121 @@
+---
+id: PERF-971
+slug: hoist-dombeginframe-multi-worker-nodeprocess-true
+status: unclaimed
+claimed_by: ""
+created: 2024-07-10
+completed: ""
+result: ""
+---
+
+# PERF-971: Hoist domBeginFrame before Base64 Decode in Multi-Worker Loop (hasProcessFn = true)
+
+## Focus Area
+The multi-worker DOM strategy chunked loop in `packages/renderer/src/core/CaptureLoop.ts` when `hasProcessFn` is true (around lines 750-780).
+
+## Background Research
+PERF-960, PERF-878, and PERF-970 successfully optimized DOM loops by overlapping CPU-bound operations with Chromium rendering. By invoking `domBeginFrame!()` to dispatch the capture command for frame N+1 before doing synchronous operations on frame N, Chromium can generate pixels concurrently with Node's CPU work.
+
+In the multi-worker `hasProcessFn = true` path, the chunk loop currently reads:
+```typescript
+              try {
+                timeDriver.setTime(
+                  page,
+                  (startFrame + i) * compTimeStep,
+                );
+                let buffer: any;
+                const rawResult = await domBeginFrame!();
+                const data = rawResult.screenshotData;
+                let buf: Buffer;
+                if (data || !domLastFrameBuffer) {
+                  if (data) domLastFrameData = data;
+                  buf = Buffer.from(domLastFrameData as string, "base64");
+                  domLastFrameBuffer = buf;
+                } else {
+                  buf = domLastFrameBuffer;
+                }
+                buffer = buf;
+                frameBufferRing[ringIndex] = buffer;
+
+              } catch (e) {
+```
+
+The multi-worker loop does not pre-fetch the next frame like the chunked single worker loop because of synchronization issues found in PERF-879 (which corrupted the synchronized timestamps).
+
+Wait, the multi-worker loop doesn't have a `nextCapturePromise` because each worker loop is fetching exactly one frame at `i = nextFrameToSubmit++`. Eagerly fetching the next frame by stepping `nextFrameToSubmit` and calling `timeDriver.setTime()` before the current frame is written caused frame timing regressions in Shadow DOM synchronization (verified by `verify-cdp-shadow-dom-sync.ts`), which is why PERF-879 was discarded.
+
+Wait, if we can't pre-fetch the next frame in the multi worker path, we can't overlap it with Base64 decode. The single worker pipeline overlaps N+1's capture with N's CPU decode. In the multi worker path, there's no N+1 for this particular worker thread, it must wait for the writer thread to release it to get another task.
+
+Wait, what else is un-optimized?
+Let's look at `CaptureLoop.ts` around `hasProcessFn = true`.
+What if we avoid dynamic type evaluation or simplify the `hasProcessFn` condition for the multi-worker loop?
+Ah, if `hasProcessFn = true`, there's a `isDomStrategy` check inside.
+
+Wait, what did PERF-960 and PERF-970 do?
+PERF-970: Hoist domBeginFrame before Base64 Decode in Single-Worker Loop (hasProcessFn = true).
+PERF-960: Hoist domBeginFrame before Base64 Decode in Single-Worker Loop (hasProcessFn = false).
+PERF-878: Overlap domBeginFrame with Base64 Decode in DOM Fast Paths.
+
+So the single worker chunked loops are fully optimized.
+
+Let's look for other optimizations. What about `isDomStrategy`?
+```typescript
+              try {
+                timeDriver.setTime(
+                  page,
+                  (startFrame + i) * compTimeStep,
+                );
+                let buffer: any;
+                const rawResult = await domBeginFrame!();
+                const data = (rawResult as any).screenshotData;
+```
+Here, in the `hasProcessFn = false` branch for multi-workers (around line 840):
+```typescript
+          if (isDomStrategy) {
+            let maxSubmits = nextFrameToWrite + maxPipelineDepth;
+            while (!aborted && nextFrameToSubmit < totalFrames) {
+              let i: number;
+              // ...
+              try {
+                timeDriver.setTime(
+                  page,
+                  (startFrame + i) * compTimeStep,
+                );
+                let buffer: any;
+                const rawResult = await domBeginFrame!();
+                const data = (rawResult as any).screenshotData;
+                let buf: Buffer;
+                if (data || !domLastFrameBuffer) {
+                  if (data) domLastFrameData = data;
+                  buf = Buffer.from(domLastFrameData as string, "base64");
+                  domLastFrameBuffer = buf;
+                } else {
+                  buf = domLastFrameBuffer;
+                }
+                buffer = buf;
+                frameBufferRing[ringIndex] = buffer;
+```
+This looks almost identical to the `hasProcessFn = true` `isDomStrategy` branch!
+Wait, if `isDomStrategy` is true, does it matter if `hasProcessFn` is true or false?
+`hasProcessFn` is `!!strategy.processCaptureResult`. Does `DomStrategy` have `processCaptureResult`? No, it's a DOM strategy. It returns screenshotData directly.
+
+Wait, why are there two `isDomStrategy` branches in the multi-worker path?
+```typescript
+        if (hasProcessFn) {
+          if (isDomStrategy) {
+            // ...
+          } else {
+            // ...
+          }
+        } else {
+          if (isDomStrategy) {
+            // ...
+          } else {
+            // ...
+          }
+        }
+```
+If `isDomStrategy` is true, the strategy is `DomStrategy`. `DomStrategy` does not have `processCaptureResult`. Thus `hasProcessFn` is always `false` when `isDomStrategy` is true.
+So the `hasProcessFn = true` and `isDomStrategy = true` branch is fundamentally unreachable dead code!
+
+Let's verify this hypothesis.

--- a/.sys/plans/PERF-971-remove-dead-is-dom-strategy-multi-worker.md
+++ b/.sys/plans/PERF-971-remove-dead-is-dom-strategy-multi-worker.md
@@ -1,0 +1,73 @@
+---
+id: PERF-971
+slug: remove-dead-is-dom-strategy-multi-worker
+status: unclaimed
+claimed_by: ""
+created: 2024-07-10
+completed: ""
+result: ""
+---
+
+# PERF-971: Remove dead isDomStrategy branch in multi-worker hasProcessFn path
+
+## Focus Area
+The multi-worker loop in `packages/renderer/src/core/CaptureLoop.ts`. Specifically, the nested `if (isDomStrategy)` check inside the `if (hasProcessFn)` block.
+
+## Background Research
+In `packages/renderer/src/core/CaptureLoop.ts`, the multi-worker loop starts around line 715:
+```typescript
+        const hasProcessFn = !!strategy.processCaptureResult;
+
+        const isDomStrategy = !!(strategy as any).beginFrameParams;
+```
+
+It then branches based on `hasProcessFn`:
+```typescript
+        if (hasProcessFn) {
+          if (isDomStrategy) {
+            // DEAD CODE!
+```
+
+`DomStrategy` does not define `processCaptureResult`. Therefore, if `isDomStrategy` is true, `hasProcessFn` must be false. (And conversely, if `hasProcessFn` is true, it is not the `DomStrategy`).
+
+The entire `if (isDomStrategy)` block nested inside `if (hasProcessFn)` in the multi-worker path is mathematically unreachable dead code. We successfully performed this exact same dead code elimination for the single-worker path in PERF-907 and PERF-961.
+
+## Benchmark Configuration
+- **Composition URL**: Standard DOM benchmark
+- **Render Settings**: Standard
+- **Mode**: `dom` (multi worker)
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Bottleneck analysis**: The V8 parser and JIT compiler evaluate and parse unreachable AST branches, inflating bytecode size and reducing instruction cache density.
+
+## Implementation Spec
+
+### Step 1: Remove dead `if (isDomStrategy)` branch in multi-worker `hasProcessFn`
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the multi-worker section (after `if (poolLen === 1)` block finishes, inside the `else`), find:
+
+```typescript
+        if (hasProcessFn) {
+          if (isDomStrategy) {
+             // ... ~40 lines of code ...
+             // writerWaiterPromise.resolve();
+             // }
+          } else {
+            let maxSubmits = nextFrameToWrite + maxPipelineDepth;
+```
+Remove the `if (isDomStrategy) { ... } else {` wrapper, unconditionally executing the `else` block contents when `hasProcessFn` is true.
+
+```typescript
+        if (hasProcessFn) {
+            let maxSubmits = nextFrameToWrite + maxPipelineDepth;
+            while (!aborted && nextFrameToSubmit < totalFrames) {
+              // ...
+```
+
+**Why**: By completely removing this unreachable block, we decrease the V8 parser overhead, shrink the AST, and eliminate an unnecessary boolean check from the engine's perspective. It maintains logical correctness because `hasProcessFn` guarantees `!isDomStrategy`.
+
+## Correctness Check
+Run `npm test -w packages/renderer` to ensure `run-all.ts` still passes.


### PR DESCRIPTION
📋 RENDERER: Remove dead isDomStrategy branch in multi-worker path

💡 What: Creating PERF-971 experiment plan to remove the unreachable `if (isDomStrategy)` branch inside the `hasProcessFn` block of the multi-worker loop.
🎯 Why: V8 parser overhead and JIT caching bloat.
🔬 Approach: Unconditionally executing the `else` block contents when `hasProcessFn` is true, as `DomStrategy` does not define `processCaptureResult`.
📎 Plan: `/.sys/plans/PERF-971-remove-dead-is-dom-strategy-multi-worker.md`

---
*PR created automatically by Jules for task [15974570600526309629](https://jules.google.com/task/15974570600526309629) started by @BintzGavin*