### PR TITLE
📋 PLAYER: Implement autoPictureInPicture

### DIFF
--- a/.sys/plans/2027-03-06-PLAYER-Implement-autoPictureInPicture.md
+++ b/.sys/plans/2027-03-06-PLAYER-Implement-autoPictureInPicture.md
@@ -1,0 +1,35 @@
+#### 1. Context & Goal
+- **Objective**: Implement the `autoPictureInPicture` property on `HeliosPlayer` to bridge a vision gap.
+- **Trigger**: The HTMLVideoElement standard interface defines `autoPictureInPicture`, but it is currently missing in the `HeliosPlayer` implementation and documentation.
+- **Impact**: Brings the `HeliosPlayer` Web Component closer to complete drop-in parity with native `HTMLVideoElement`, allowing seamless integration with libraries that expect this property to control automatic PiP behavior.
+
+#### 2. File Inventory
+- **Create**: None
+- **Modify**:
+  - `packages/player/src/index.ts` - Add `autoPictureInPicture` property getter/setter mapping to the internal `pipVideo` element.
+  - `packages/player/README.md` - Document the `autoPictureInPicture` property.
+- **Read-Only**:
+  - `packages/player/src/features/api_parity.test.ts` (or similar tests to understand existing test patterns, though this plan does not instruct direct file edits).
+
+#### 3. Implementation Spec
+- **Architecture**: Web Component API Parity. The `HeliosPlayer` should proxy the `autoPictureInPicture` property to its internal `<video>` element (`this.pipVideo`), which actually handles the PiP logic. If the internal video element isn't ready or doesn't support it, we'll store it on a local fallback state (or directly check `this.pipVideo` since it is initialized in the constructor).
+- **Pseudo-Code**:
+  ```typescript
+  // In packages/player/src/index.ts inside HeliosPlayer class
+  public get autoPictureInPicture(): boolean {
+    return this.pipVideo.autoPictureInPicture ?? false;
+  }
+  public set autoPictureInPicture(val: boolean) {
+    this.pipVideo.autoPictureInPicture = val;
+  }
+  ```
+- **Public API Changes**:
+  - Added `autoPictureInPicture` (boolean) to `HeliosPlayer` instance properties.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: `npm run test -w packages/player`
+- **Success Criteria**:
+  - The test suite passes.
+  - The newly added `autoPictureInPicture` property correctly sets and gets the value from the internal `pipVideo` element.
+- **Edge Cases**: Ensure the property does not throw if set early in the component lifecycle.

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -278,7 +278,7 @@
 [v0.78.1] ✅ Completed: Discovered missing HTMLMediaElement parity method (`setMediaKeys`). Created plan `.sys/plans/2027-03-02-PLAYER-Implement-setMediaKeys.md` to implement it.
 [v0.78.2] ✅ Completed: Implement setMediaKeys - Added mediaKeys property and setMediaKeys method to complete HTMLMediaElement parity.
 [v0.78.3] ✅ Completed: Discovered that `.sys/plans/2024-05-24-PLAYER-Instance-Constants.md` is an IMPOSSIBLE: DUPLICATION plan. The missing constants are already implemented. Created plan `.sys/plans/2027-03-03-PLAYER-Document-Instance-Constants.md` to document them.
-**Version**: 0.79.5
+**Version**: 0.79.8
 
 [v0.78.3] ✅ Completed: Document HTMLMediaElement Constants - Added documentation for HTMLMediaElement instance and class constants to the README.
 [v0.78.4] ✅ Completed: Document Playback Range Methods - Added `setPlaybackRange` and `clearPlaybackRange` to the README methods section.
@@ -295,3 +295,5 @@
 
 [v0.79.6] ✅ Completed: Discovered that 2027-03-05-PLAYER-Remove-preservesPitch-Documentation.md and 2027-03-06-PLAYER-Remove-preservesPitch-Docs.md are IMPOSSIBLE: DUPLICATION plans. The preservesPitch documentation is already removed. Documented as impossible and discarded.
 [v0.79.7] ✅ Completed: Discovered that .sys/plans/2027-03-05-PLAYER-Remove-Unsupported-EME.md is an IMPOSSIBLE: DUPLICATION plan. The mediaKeys removal is already fully implemented. Documented as impossible and discarded.
+
+[v0.79.8] ✅ Completed: Discovered missing HTMLVideoElement parity property (`autoPictureInPicture`). Created plan `.sys/plans/2027-03-06-PLAYER-Implement-autoPictureInPicture.md` to implement it.


### PR DESCRIPTION
Creates a plan file in `.sys/plans` to document the vision gap and provide an execution specification for proxying the `autoPictureInPicture` property to the internal `pipVideo` element. This achieves further drop-in API parity with HTMLVideoElement. Also updates the status tracker.

---
*PR created automatically by Jules for task [13745386838171391016](https://jules.google.com/task/13745386838171391016) started by @BintzGavin*