### PR TITLE
📋 RENDERER: Unroll buffer type dispatch in single worker

### DIFF
--- a/.sys/plans/PERF-988-unroll-buffer-type-dispatch-in-single-worker.md
+++ b/.sys/plans/PERF-988-unroll-buffer-type-dispatch-in-single-worker.md
@@ -1,0 +1,117 @@
+---
+id: PERF-988
+slug: unroll-buffer-type-dispatch-in-single-worker
+status: unclaimed
+claimed_by: ""
+created: 2026-07-13
+completed: ""
+result: ""
+---
+
+# PERF-988: Unroll \`isDomStrategy\` checks in single-worker initial frame processing
+
+## Focus Area
+The single-worker \`!hasProcessFn\` fast path initialization logic in \`CaptureLoop.ts\` (around lines 410-465) where \`isDomStrategy\` branches repeatedly.
+
+## Background Research
+When a single worker renders the composition without a process function, the loop primes the 0th and 1st frames before entering a fast while-loop that iterates the remainder. During this initialization, the \`isDomStrategy\` boolean is checked in 3 separate \`if\` blocks:
+\`\`\`typescript
+if (totalFrames > 0) { ... if (isDomStrategy) { ... } else { ... } }
+...
+if (totalFrames > 0) { ... if (1 < totalFrames) { ... if (isDomStrategy) { ... } else { ... } }
+  // ...
+  if (isDomStrategy) { ... } else { ... }
+}
+\`\`\`
+Evaluating \`isDomStrategy\` 3 times sequentially during this block creates redundant parsing and branching instructions in V8's hot path AST.
+
+We can optimize this by hoisting the \`isDomStrategy\` check out to wrap the entire \`if (totalFrames > 0)\` initialization sequence. This fully decouples the initial frame processing logic into two parallel, contiguous blocks (one strictly for DOM, one strictly for Canvas), preventing interleaved condition evaluations.
+
+## Benchmark Configuration
+- **Composition URL**: Standard DOM benchmark
+- **Render Settings**: Standard
+- **Mode**: \`dom\` and \`canvas\` (single worker)
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Bottleneck analysis**: Repeated V8 branch evaluations and AST parser overhead in single-worker initialization.
+
+## Implementation Spec
+
+### Step 1: Hoist \`isDomStrategy\` to unroll initial single worker frame processing
+**File**: \`packages/renderer/src/core/CaptureLoop.ts\`
+**What to change**:
+In the \`!hasProcessFn\` path (around line 410):
+\`\`\`typescript
+        } else {
+          let nextCapturePromise = null;
+          if (isDomStrategy) {
+            if (totalFrames > 0) {
+              timeDriver.setTime(page, startFrame * compTimeStep);
+              nextCapturePromise = domBeginFrame!();
+            }
+
+            if (totalFrames > 0) {
+              const bufRaw = await nextCapturePromise;
+              if (1 < totalFrames) {
+                timeDriver.setTime(page, (startFrame + 1) * compTimeStep);
+                nextCapturePromise = domBeginFrame!();
+              }
+              console.log(\`Progress: Rendered 0 / \${totalFrames} frames\`);
+              if (onProgress) onProgress(0 / totalFrames);
+
+              const data = (bufRaw as any).screenshotData;
+              if (data) {
+                domLastFrameData = data;
+                domLastFrameBuffer = Buffer.from(data as string, "base64");
+              } else if (!domLastFrameBuffer) {
+                domLastFrameBuffer = Buffer.from(bufRaw as string, "base64");
+              }
+              const buf = domLastFrameBuffer!;
+              pendingBytes += buf.length;
+              const writeSuccess = stream.write(buf);
+
+              if (!writeSuccess && pendingBytes >= 16777216) {
+                await this.drainPromise;
+                pendingBytes = 0;
+              }
+            }
+
+            // existing isDomStrategy main chunk loop (while (i < totalFrames - 1))
+          } else {
+            if (totalFrames > 0) {
+              const timePromise = timeDriver.setTime(page, startFrame * compTimeStep);
+              if (timePromise) await timePromise;
+              nextCapturePromise = strategy.capture(page, 0);
+            }
+
+            if (totalFrames > 0) {
+              const buffer = await nextCapturePromise;
+              if (1 < totalFrames) {
+                const timePromise = timeDriver.setTime(page, (startFrame + 1) * compTimeStep);
+                if (timePromise) await timePromise;
+                nextCapturePromise = strategy.capture(page, timeStep);
+              }
+              console.log(\`Progress: Rendered 0 / \${totalFrames} frames\`);
+              if (onProgress) onProgress(0 / totalFrames);
+
+              pendingBytes += (buffer as any).length;
+              const writeSuccess = stream.write(buffer as any);
+
+              if (!writeSuccess && pendingBytes >= 16777216) {
+                await this.drainPromise;
+                pendingBytes = 0;
+              }
+            }
+
+            // existing !isDomStrategy main chunk loop (while (i < totalFrames - 1))
+          }
+        }
+\`\`\`
+Re-arrange the existing code to match the block above. Notice that \`if (isDomStrategy)\` wraps everything now, combining both the initial frames setup block and seamlessly transitioning into the pre-existing unswitched chunk loop blocks \`if (isDomStrategy) { let i = 1; while (...) } else { let i = 1; while (...) }\`.
+
+**Why**: Unrolling this reduces the number of inline cache nodes created during V8 JIT and gives the compiler a unified, predictable execution path, speeding up function compilation footprint and parsing time.
+
+## Correctness Check
+Run \`npm test -w packages/renderer\` to ensure nothing is broken.


### PR DESCRIPTION
💡 What: Create PERF-988 plan to unroll isDomStrategy in single worker initialization.
🎯 Why: Avoid redundant branch evaluation in the hot path.
🔬 Approach: Hoist the isDomStrategy check out of the initial frame processing loops.
📎 Plan: .sys/plans/PERF-988-unroll-buffer-type-dispatch-in-single-worker.md

---
*PR created automatically by Jules for task [9006459468288734996](https://jules.google.com/task/9006459468288734996) started by @BintzGavin*