### PR TITLE
PERF-998: Unroll isDomStrategy checks in single-worker hasProcessFn path

### DIFF
--- a/.sys/plans/PERF-998-unroll-isdomstrategy-hasprocessfn-initial.md
+++ b/.sys/plans/PERF-998-unroll-isdomstrategy-hasprocessfn-initial.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-998
 slug: unroll-isdomstrategy-hasprocessfn-initial
-status: unclaimed
+status: complete
 claimed_by: ""
 created: 2024-07-26
 completed: ""
-result: ""
+result: "kept"
 ---
 
 # PERF-998: Unroll isDomStrategy checks in single-worker hasProcessFn path

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -7,6 +7,9 @@ Last updated by: PERF-975
 
 - **PERF-951**: Created experiment plan to cache decoded Base64 `Buffer` objects earlier in the multi-worker loop to relieve hot writer loop CPU pressure in `CaptureLoop.ts`.
 ## What Works
+- **PERF-998**: Unrolled `isDomStrategy` checks in single-worker `hasProcessFn` path in `CaptureLoop.ts`.
+  - **Improvement:** Removed redundant dynamic checks in single-worker `hasProcessFn` path. Same as PERF-995.
+  - **Plan ID:** PERF-998
 - **Merged duplicated multi-worker loops in !hasProcessFn**: Reduced AST size and improved JIT. ~1.5% faster (PERF-996)
 - **Merged duplicated multi-worker loops in !hasProcessFn**: Reduced AST size and improved JIT. ~1.5% faster (PERF-996)
 - **Cached decoded Base64 buffers for unchanged frames in single-worker !hasProcessFn path**

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -193,68 +193,83 @@ export class CaptureLoop {
         let nextProgress = progressInterval;
         if (hasProcessFn) {
           let nextCapturePromise = null;
-          if (totalFrames > 0) {
-            const timePromise = timeDriver.setTime(
-              page,
-              startFrame * compTimeStep,
-            );
-            if (isDomStrategy) {
-              nextCapturePromise = domBeginFrame!();
-            } else {
-              if (timePromise) {
-                await timePromise;
-              }
-              nextCapturePromise = strategy.capture(page, 0);
-            }
-          }
-
-          if (totalFrames > 0) {
-            const rawResult = await nextCapturePromise;
-            if (1 < totalFrames) {
-              const timePromise = timeDriver.setTime(
+          if (isDomStrategy) {
+            if (totalFrames > 0) {
+              timeDriver.setTime(
                 page,
-                (startFrame + 1) * compTimeStep,
+                startFrame * compTimeStep,
               );
-              if (isDomStrategy) {
-                nextCapturePromise = domBeginFrame!();
-              } else {
-                if (timePromise) {
-                  await timePromise;
-                }
-                nextCapturePromise = strategy.capture(page, timeStep);
-              }
+              nextCapturePromise = domBeginFrame!();
             }
-            let buffer;
-            if (isDomStrategy) {
+
+            if (totalFrames > 0) {
+              const rawResult = await nextCapturePromise;
+              if (1 < totalFrames) {
+                timeDriver.setTime(
+                  page,
+                  (startFrame + 1) * compTimeStep,
+                );
+                nextCapturePromise = domBeginFrame!();
+              }
               const data = (rawResult as any).screenshotData;
               if (data) {
                 domLastFrameData = data;
               }
-              buffer = domLastFrameData;
-            } else {
-              buffer = strategy.processCaptureResult!(rawResult);
-            }
-            console.log(`Progress: Rendered ${0} / ${totalFrames} frames`);
-            if (onProgress) {
-              onProgress(0 / totalFrames);
-            }
-            let writeSuccess = false;
-            if (isDomStrategy) {
+              let buffer = domLastFrameData;
+              console.log(`Progress: Rendered ${0} / ${totalFrames} frames`);
+              if (onProgress) {
+                onProgress(0 / totalFrames);
+              }
               if ((rawResult as any).screenshotData || !domLastFrameBuffer) {
                 domLastFrameBuffer = Buffer.from(buffer as string, "base64");
               }
               const buf = domLastFrameBuffer;
               pendingBytes += buf.length;
-              writeSuccess = stream.write(buf);
-            } else {
-              pendingBytes += (buffer as any).length;
-              writeSuccess = stream.write(buffer as any);
+              let writeSuccess = stream.write(buf);
+
+              if (!writeSuccess && pendingBytes >= 16777216) {
+                await this.drainPromise;
+                pendingBytes = 0;
+              }
+            }
+          } else {
+            if (totalFrames > 0) {
+              const timePromise = timeDriver.setTime(
+                page,
+                startFrame * compTimeStep,
+              );
+              if (timePromise) {
+                await timePromise;
+              }
+              nextCapturePromise = strategy.capture(page, 0);
             }
 
-            if (!writeSuccess && pendingBytes >= 16777216) {
-              await this.drainPromise;
-              pendingBytes = 0;
+            if (totalFrames > 0) {
+              const rawResult = await nextCapturePromise;
+              if (1 < totalFrames) {
+                const timePromise = timeDriver.setTime(
+                  page,
+                  (startFrame + 1) * compTimeStep,
+                );
+                if (timePromise) {
+                  await timePromise;
+                }
+                nextCapturePromise = strategy.capture(page, timeStep);
+              }
+              let buffer = strategy.processCaptureResult!(rawResult);
+              console.log(`Progress: Rendered ${0} / ${totalFrames} frames`);
+              if (onProgress) {
+                onProgress(0 / totalFrames);
+              }
+              pendingBytes += (buffer as any).length;
+              let writeSuccess = stream.write(buffer as any);
+
+              if (!writeSuccess && pendingBytes >= 16777216) {
+                await this.drainPromise;
+                pendingBytes = 0;
+              }
             }
+          }
 
             if (isDomStrategy) {
 


### PR DESCRIPTION
Unrolled `isDomStrategy` checks in the single-worker `hasProcessFn` path in `CaptureLoop.ts`.
This isolates the DOM and Canvas initialization branches to remove redundant branch evaluations.

Also updated the experiment status in `docs/status/RENDERER-EXPERIMENTS.md` and the plan status in `.sys/plans/PERF-998-unroll-isdomstrategy-hasprocessfn-initial.md`.

---
*PR created automatically by Jules for task [7350203158197606127](https://jules.google.com/task/7350203158197606127) started by @BintzGavin*