### PR TITLE
PLAYER: Implement remote property for HTMLMediaElement parity

### DIFF
--- a/.sys/llmdocs/context-player.md
+++ b/.sys/llmdocs/context-player.md
@@ -1,47 +1,111 @@
+
 # Component Structure
-Wrapper > Iframe + Controls Overlay
+```html
+<helios-player>
+  #shadow-root (open)
+    <div class="player-wrapper">
+      <iframe class="sandbox-iframe" sandbox="allow-scripts allow-same-origin"></iframe>
+      <div class="status-overlay"></div>
+      <div class="controls-overlay">
+        <!-- Play/Pause, Volume, Fullscreen, PIP, Scrubber -->
+      </div>
+    </div>
+</helios-player>
+```
 
 # Events
-- enterpictureinpicture
-- leavepictureinpicture
-- playing
-- waiting
-- suspend
-- stalled
-- abort
-- emptied
-- progress
-- error
-- audiometering
-- seeking
-- seeked
+- `timeupdate`: Fired when current time changes.
+- `play`: Fired when playback starts.
+- `pause`: Fired when playback is paused.
+- `ended`: Fired when playback reaches the end.
+- `durationchange`: Fired when duration is updated.
+- `volumechange`: Fired when volume or muted state changes.
+- `loadedmetadata`: Fired when composition metadata is loaded.
+- `canplay`: Fired when the player has enough data to begin playback.
+- `error`: Fired when an error occurs.
+- `enterpictureinpicture`: Fired when PIP mode starts.
+- `leavepictureinpicture`: Fired when PIP mode ends.
+- `audiometering`: Fired when audio levels are metered.
+- `seeking`: Fired when seeking starts.
+- `seeked`: Fired when seeking completes.
+- `playing`: Fired when playback is ready to start after having been paused or delayed due to lack of data.
+- `waiting`: Fired when playback has stopped because of a temporary lack of data.
+- `suspend`: Fired when media data loading has been suspended.
+- `stalled`: Fired when the user agent is trying to fetch media data, but data is unexpectedly not forthcoming.
+- `abort`: Fired when media data loading has been aborted.
+- `emptied`: Fired when the media has become empty.
+- `progress`: Fired periodically as the user agent is downloading media data.
 
 # Attributes
-- src
-- width
-- height
-- autoplay
-- loop
-- controls
-- export-format
-- input-props
-- poster
-- muted
-- interactive
-- preload
-- controlslist
-- sandbox
-- export-caption-mode
-- disablepictureinpicture
-- export-width
-- export-height
-- export-bitrate
-- export-filename
-- media-title
-- media-artist
-- media-album
-- media-artwork
-- export-mode
-- canvas-selector
-- playsinline
-- crossorigin
+- `src`: URL of the composition bundle.
+- `autoplay`: Starts playback automatically when loaded.
+- `loop`: Loops playback automatically.
+- `controls`: Displays native player controls.
+- `poster`: URL of an image to show before playback starts.
+- `interactive`: Enables mouse/touch interaction with the composition.
+- `muted`: Mutes audio playback.
+- `playsinline`: Indicates that the video is to be played "inline".
+- `disableremoteplayback`: Disables remote playback.
+- `mediagroup`: Links multiple media elements together.
+
+# Public Methods (HTMLMediaElement Parity)
+- `play(): Promise<void>`
+- `pause(): void`
+- `load(): void`
+- `fastSeek(time: number): void`
+- `canPlayType(type: string): string`
+- `captureStream(): MediaStream`
+- `setSinkId(sinkId: string): Promise<void>`
+- `getStartDate(): Date`
+- `getVideoPlaybackQuality(): VideoPlaybackQuality`
+- `requestVideoFrameCallback(callback: VideoFrameRequestCallback): number`
+- `cancelVideoFrameCallback(handle: number): void`
+
+# Public Properties (HTMLMediaElement Parity)
+- `currentTime: number`
+- `duration: number`
+- `paused: boolean`
+- `ended: boolean`
+- `volume: number`
+- `muted: boolean`
+- `playbackRate: number`
+- `defaultPlaybackRate: number`
+- `src: string`
+- `currentSrc: string`
+- `readyState: number`
+- `networkState: number`
+- `error: MediaError | null`
+- `crossOrigin: string | null`
+- `preload: string`
+- `autoplay: boolean`
+- `loop: boolean`
+- `controls: boolean`
+- `defaultMuted: boolean`
+- `seeking: boolean`
+- `buffered: TimeRanges`
+- `seekable: TimeRanges`
+- `played: TimeRanges`
+- `audioTracks: HeliosAudioTrackList`
+- `videoTracks: HeliosVideoTrackList`
+- `textTracks: HeliosTextTrackList`
+- `disableRemotePlayback: boolean`
+- `mediaGroup: string`
+- `sinkId: string`
+- `autoPictureInPicture: boolean`
+- `remote: any`
+
+# Custom Public Properties / Methods
+- `interactive: boolean`
+- `isScrubbing: boolean`
+- `getSchema(): HeliosSchema | null`
+- `startAudioMetering(): void`
+- `stopAudioMetering(): void`
+- `mediaTitle: string`
+- `mediaArtist: string`
+- `mediaAlbum: string`
+- `mediaArtwork: string`
+- `setDuration(durationInFrames: number): void`
+- `setFps(fps: number): void`
+- `setSize(width: number, height: number): void`
+- `setMarkers(markers: Marker[]): void`
+- `getController(): HeliosController | null`

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,3 +1,6 @@
+### PLAYER v0.79.12
+- ✅ Completed: Implement remote property - Added remote property returning a mock RemotePlayback object to complete HTMLMediaElement parity.
+
 ### PLAYER v0.79.4
 - ✅ Completed: Remove preservesPitch documentation - Removed preservesPitch from the player README as it is currently unsupported by the core architecture.
 

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: 0.79.11
+**Version**: 0.79.12
 
 [v0.78.5] ✅ Completed: Discovered missing composition setters on the public API wrapper. Created plan `.sys/plans/2027-03-05-PLAYER-Expose-Composition-Setters.md` to expose `setDuration`, `setFps`, `setSize`, and `setMarkers`.
 [v0.78.4] ✅ Completed: Discovered missing HTMLMediaElement-like parity methods (`setPlaybackRange`, `clearPlaybackRange`) in HeliosPlayer public API. Created plan `.sys/plans/2027-03-04-PLAYER-Expose-Playback-Range-Methods.md` to implement them.
@@ -303,3 +303,5 @@
 
 
 [v0.79.11] ✅ Completed: Discovered missing HTMLMediaElement parity property (`remote`). Created plan `.sys/plans/2026-07-13-PLAYER-Implement-HTMLMediaElement-Parity.md` to implement it.
+
+[v0.79.12] ✅ Completed: Implement remote property - Added remote property returning a mock RemotePlayback object to complete HTMLMediaElement parity.

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -180,6 +180,7 @@ Both class-level and instance-level properties are provided for standard media s
 
 ### Properties
 - `disableRemotePlayback` (boolean): Reflected disableremoteplayback attribute.
+- `remote` (RemotePlayback): Returns a mock RemotePlayback object to complete HTMLMediaElement parity.
 - `mediaGroup` (string): Reflected mediagroup attribute.
 - `sinkId` (string, read-only): Returns the current audio sink id.
 

--- a/packages/player/src/api_parity.test.ts
+++ b/packages/player/src/api_parity.test.ts
@@ -79,6 +79,15 @@ describe('HeliosPlayer API Parity', () => {
     expect(player.hasAttribute('disableremoteplayback')).toBe(false);
   });
 
+  it('should implement remote property for RemotePlayback API parity', () => {
+    expect(player.remote).toBeDefined();
+    expect(player.remote.state).toBe('disconnected');
+    expect(typeof player.remote.watchAvailability).toBe('function');
+    expect(typeof player.remote.cancelWatchAvailability).toBe('function');
+    expect(typeof player.remote.prompt).toBe('function');
+  });
+
+
   it('should reflect mediagroup attribute as string property', () => {
     expect(player.mediaGroup).toBe('');
 

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -12,6 +12,13 @@ import { HeliosMediaSession } from "./features/media-session";
 export { ClientSideExporter };
 export type { HeliosController };
 
+class MockRemotePlayback extends EventTarget {
+  state = 'disconnected';
+  watchAvailability() { return Promise.resolve(-1); }
+  cancelWatchAvailability() { return Promise.resolve(); }
+  prompt() { return Promise.reject(new DOMException('Not supported', 'NotSupportedError')); }
+}
+
 export interface HeliosExportOptions {
   format?: 'mp4' | 'webm' | 'png' | 'jpeg';
   filename?: string;
@@ -1349,6 +1356,11 @@ export class HeliosPlayer extends HTMLElement implements TrackHost, AudioTrackHo
   public async setSinkId(sinkId: string): Promise<void> {
     this._sinkId = sinkId;
     return Promise.resolve();
+  }
+
+  private _remote: any = new MockRemotePlayback();
+  public get remote(): any {
+    return this._remote;
   }
 
 


### PR DESCRIPTION
Implemented the `remote` property in `HeliosPlayer` to mock the RemotePlayback API for better `HTMLMediaElement` parity.

---
*PR created automatically by Jules for task [17112514732240433167](https://jules.google.com/task/17112514732240433167) started by @BintzGavin*