### PR TITLE
📋 RENDERER: Unroll buffer type dispatch in multi-worker writer chunk loops

### DIFF
--- a/.sys/plans/PERF-1003-unroll-buffer-type-dispatch-in-multi-worker-writer-chunk-loop.md
+++ b/.sys/plans/PERF-1003-unroll-buffer-type-dispatch-in-multi-worker-writer-chunk-loop.md
@@ -1,0 +1,110 @@
+---
+id: PERF-1003
+slug: unroll-buffer-type-dispatch-in-multi-worker-writer-chunk-loop
+status: unclaimed
+claimed_by: ""
+created: 2024-07-14
+completed: ""
+result: ""
+---
+
+# PERF-1003: Unroll buffer type dispatch in multi-worker writer chunk loops
+
+## Focus Area
+The multi-worker frame rendering writer chunk loop in `packages/renderer/src/core/CaptureLoop.ts` (around line 820).
+
+## Background Research
+Currently, the main frame-processing chunk loop for multi-worker captures uses a generic variable `buffer` and unconditionally checks `(buffer as any).length`, then invokes `stream.write(buffer as any)`. However, `buffer` can be either a `Buffer` object (DOM strategy) or a `string` (Canvas strategy). In V8, repeatedly calling `.length` on mixed types (String vs Node.js Buffer) in a tight loop forces the runtime into a polymorphic inline cache (PIC) state, which prevents Turbofan from optimizing the property access.
+By duplicating the `while (nextFrameToWrite < chunkEnd)` inner loop and branching on `if (isDomStrategyWriter)` *before* entering it, V8's JIT compiler can maintain a monomorphic state inside each respective loop. We can safely use `isDomStrategyWriter` exactly as it's defined earlier in the method (`const isDomStrategyWriter = this.pool[0].strategy.constructor.name === 'DomStrategy';`). This is the same experiment proposed in PERF-987 and PERF-994, which were unclaimed/uncompleted.
+
+## Benchmark Configuration
+- **Composition URL**: Standard DOM and Canvas benchmarks
+- **Render Settings**: 1080p, 60fps, 10s
+- **Mode**: `dom` and `canvas` (multi-worker)
+- **Metric**: Wall-clock render time in seconds
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Bottleneck analysis**: Unoptimized polymorphic property access `(buffer as any).length` inside the multi-worker chunk stream writing loop causes unnecessary V8 dynamic evaluation overhead.
+- **Current estimated render time**: Baseline from RENDERER-EXPERIMENTS.md.
+
+## Implementation Spec
+
+### Step 1: Branch on `isDomStrategyWriter` for the chunk loop
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**:
+In the multi-worker path (around line 820), locate the chunk processing loop:
+```typescript
+              while (nextFrameToWrite < chunkEnd) {
+                const ringIndex = nextFrameToWrite & ringMask;
+                if (frameBufferRing[ringIndex] === null) {
+                  break;
+                }
+
+                const buffer = frameBufferRing[ringIndex]!;
+                pendingBytes += (buffer as any).length;
+                const writeSuccess = stream.write(buffer as any);
+
+                if (!writeSuccess && pendingBytes >= 16777216) {
+                  await this.drainPromise;
+                  pendingBytes = 0;
+                }
+
+                nextFrameToWrite++;
+              }
+```
+Replace this loop with an `if (isDomStrategyWriter) { ... } else { ... }` block that duplicates the loop logic.
+Inside the `isDomStrategyWriter` branch, cast the buffer: `const buf = buffer as unknown as Buffer;` and use `buf.length` and `stream.write(buf)`.
+Inside the `else` branch, keep the existing `(buffer as any).length` and `stream.write(buffer as any)`.
+
+```typescript
+              if (isDomStrategyWriter) {
+                while (nextFrameToWrite < chunkEnd) {
+                  const ringIndex = nextFrameToWrite & ringMask;
+                  if (frameBufferRing[ringIndex] === null) {
+                    break;
+                  }
+
+                  const buffer = frameBufferRing[ringIndex]!;
+                  const buf = buffer as unknown as Buffer;
+                  pendingBytes += buf.length;
+                  const writeSuccess = stream.write(buf);
+
+                  if (!writeSuccess && pendingBytes >= 16777216) {
+                    await this.drainPromise;
+                    pendingBytes = 0;
+                  }
+
+                  nextFrameToWrite++;
+                }
+              } else {
+                while (nextFrameToWrite < chunkEnd) {
+                  const ringIndex = nextFrameToWrite & ringMask;
+                  if (frameBufferRing[ringIndex] === null) {
+                    break;
+                  }
+
+                  const buffer = frameBufferRing[ringIndex]!;
+                  pendingBytes += (buffer as any).length;
+                  const writeSuccess = stream.write(buffer as any);
+
+                  if (!writeSuccess && pendingBytes >= 16777216) {
+                    await this.drainPromise;
+                    pendingBytes = 0;
+                  }
+
+                  nextFrameToWrite++;
+                }
+              }
+```
+
+**Why**: Provides V8 with a guaranteed monomorphic type context inside the tight loop, avoiding inline cache misses and de-optimizations when evaluating the buffer length.
+
+## Canvas Smoke Test
+Run `npx vitest -t "verify-canvas-strategy"` to ensure the Canvas strategy path works.
+
+## Correctness Check
+Run `npx vitest -t "verify-dom-strategy-capture"` to ensure the DOM path is still functioning correctly.
+
+## Prior Art
+Similar unrolling of buffer type dispatch has worked previously (e.g., PERF-882, PERF-1000).


### PR DESCRIPTION
📋 RENDERER: Unroll buffer type dispatch in multi-worker writer chunk loops

💡 What: Create an experiment plan to unroll buffer type dispatch in the multi-worker writer chunk loops of CaptureLoop.ts.
🎯 Why: Resolves unoptimized polymorphic property access `(buffer as any).length` inside the multi-worker chunk stream writing loop that causes unnecessary V8 dynamic evaluation overhead.
🔬 Approach: Branch on `if (isDomStrategyWriter)` before entering the inner loop to maintain V8 monomorphic context.
📎 Plan: .sys/plans/PERF-1003-unroll-buffer-type-dispatch-in-multi-worker-writer-chunk-loop.md

---
*PR created automatically by Jules for task [2947386243638650859](https://jules.google.com/task/2947386243638650859) started by @BintzGavin*