### PR TITLE
✨ RENDERER: Claimed PERF-1013

### DIFF
--- a/.sys/plans/PERF-1013-unroll-buffer-type-dispatch-in-multi-worker-chunk-writer.md
+++ b/.sys/plans/PERF-1013-unroll-buffer-type-dispatch-in-multi-worker-chunk-writer.md
@@ -1,8 +1,8 @@
 ---
 id: PERF-1013
 slug: unroll-buffer-type-dispatch-in-multi-worker-chunk-writer
-status: unclaimed
-claimed_by: ""
+status: claimed
+claimed_by: "executor-session"
 created: 2024-10-18
 completed: ""
 result: ""


### PR DESCRIPTION
💡 What: Claimed PERF-1013 to unroll buffer type dispatch in the multi-worker writer chunk loops.
🎯 Why: The current multi-worker writer loops have polymorphic access to stream.write and buffer.length, so we need to branch on isDomStrategyWriter to unroll and isolate DOM and Canvas chunks.
📊 Impact: N/A
🔬 Verification: Compilation and unit tests
📎 Plan: .sys/plans/PERF-1013-unroll-buffer-type-dispatch-in-multi-worker-chunk-writer.md

---
*PR created automatically by Jules for task [11523141035797098022](https://jules.google.com/task/11523141035797098022) started by @BintzGavin*