### PR TITLE
📋 RENDERER: Unroll isDomStrategy in multi-worker runWorker loop

### DIFF
--- a/.sys/plans/PERF-1027-unroll-isdomstrategy-multi-worker-runworker.md
+++ b/.sys/plans/PERF-1027-unroll-isdomstrategy-multi-worker-runworker.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-1027
 slug: unroll-isdomstrategy-multi-worker-runworker
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "executor"
 created: 2024-10-18
-completed: ""
-result: ""
+completed: "2024-10-18"
+result: "improved"
 ---
 
 # PERF-1027: Unroll `isDomStrategy` check in multi-worker `runWorker` actor loop (`!hasProcessFn` path)

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -7,6 +7,10 @@ Last updated by: PERF-975
 
 - **PERF-951**: Created experiment plan to cache decoded Base64 `Buffer` objects earlier in the multi-worker loop to relieve hot writer loop CPU pressure in `CaptureLoop.ts`.
 ## What Works
+- **What Works:** PERF-1027 unrolled the `isDomStrategy` check in the multi-worker `runWorker` loop (`!hasProcessFn` path) of `CaptureLoop.ts`.
+  - **Improvement:** Removed redundant V8 branch evaluation overhead inside the hot loop.
+  - **Plan ID:** PERF-1027
+
 - **PERF-998**: Unrolled `isDomStrategy` checks in single-worker `hasProcessFn` path in `CaptureLoop.ts`.
   - **Improvement:** Removed redundant dynamic checks in single-worker `hasProcessFn` path. Same as PERF-995.
   - **Plan ID:** PERF-998

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -697,25 +697,25 @@ export class CaptureLoop {
               writerWaiterPromise.resolve();
             }
         } else {
-          let maxSubmits = nextFrameToWrite + maxPipelineDepth;
-          while (!aborted && nextFrameToSubmit < totalFrames) {
-            let i: number;
-            if (nextFrameToSubmit < maxSubmits) {
-              i = nextFrameToSubmit++;
+          if (isDomStrategy) {
+            let maxSubmits = nextFrameToWrite + maxPipelineDepth;
+            while (!aborted && nextFrameToSubmit < totalFrames) {
+              let i: number;
+              if (nextFrameToSubmit < maxSubmits) {
+                i = nextFrameToSubmit++;
+                const ringIndex = i & ringMask;
+                frameBufferRing[ringIndex] = null;
+              } else {
+                freeWorkers[freeWorkersHead++] = workerIndex;
+                i = (await workerThenables[workerIndex]) as any as number;
+                maxSubmits = nextFrameToWrite + maxPipelineDepth;
+              }
+
+              if (i === -1) break;
               const ringIndex = i & ringMask;
-              frameBufferRing[ringIndex] = null;
-            } else {
-              freeWorkers[freeWorkersHead++] = workerIndex;
-              i = (await workerThenables[workerIndex]) as any as number;
-              maxSubmits = nextFrameToWrite + maxPipelineDepth;
-            }
 
-            if (i === -1) break;
-            const ringIndex = i & ringMask;
-
-            try {
-              let buffer: any;
-              if (isDomStrategy) {
+              try {
+                let buffer: any;
                 timeDriver.setTime(page, (startFrame + i) * compTimeStep);
                 const rawResult = await domBeginFrame!();
                 const data = (rawResult as any).screenshotData;
@@ -728,20 +728,46 @@ export class CaptureLoop {
                   buf = domLastFrameBuffer!;
                 }
                 buffer = buf;
+                frameBufferRing[ringIndex] = buffer;
+              } catch (e) {
+                fatalError = e;
+                aborted = true;
+                checkState();
+              }
+              writerWaiterPromise.resolve();
+            }
+          } else {
+            let maxSubmits = nextFrameToWrite + maxPipelineDepth;
+            while (!aborted && nextFrameToSubmit < totalFrames) {
+              let i: number;
+              if (nextFrameToSubmit < maxSubmits) {
+                i = nextFrameToSubmit++;
+                const ringIndex = i & ringMask;
+                frameBufferRing[ringIndex] = null;
               } else {
+                freeWorkers[freeWorkersHead++] = workerIndex;
+                i = (await workerThenables[workerIndex]) as any as number;
+                maxSubmits = nextFrameToWrite + maxPipelineDepth;
+              }
+
+              if (i === -1) break;
+              const ringIndex = i & ringMask;
+
+              try {
+                let buffer: any;
                 const timePromise = timeDriver.setTime(page, (startFrame + i) * compTimeStep);
                 if (timePromise) {
                   await timePromise;
                 }
                 buffer = await strategy.capture(page, i * timeStep);
+                frameBufferRing[ringIndex] = buffer;
+              } catch (e) {
+                fatalError = e;
+                aborted = true;
+                checkState();
               }
-              frameBufferRing[ringIndex] = buffer;
-            } catch (e) {
-              fatalError = e;
-              aborted = true;
-              checkState();
+              writerWaiterPromise.resolve();
             }
-            writerWaiterPromise.resolve();
           }
         }
       };


### PR DESCRIPTION
This unrolls the `isDomStrategy` check inside the multi-worker `runWorker` chunk loop (`!hasProcessFn` path), as outlined in PERF-1027, to avoid redundant check processing overhead and allow V8 to optimize the monomorphic paths.

---
*PR created automatically by Jules for task [5797705886698072901](https://jules.google.com/task/5797705886698072901) started by @BintzGavin*