### PR TITLE
📋 RENDERER: Eliminate Dead domLastFrameData Variable in CaptureLoop.ts

### DIFF
--- a/.sys/plans/PERF-1047-eliminate-dead-domlastframedata.md
+++ b/.sys/plans/PERF-1047-eliminate-dead-domlastframedata.md
@@ -1,0 +1,143 @@
+---
+id: PERF-1047
+slug: eliminate-dead-domlastframedata
+status: unclaimed
+claimed_by: ""
+created: 2025-01-01
+completed: ""
+result: ""
+---
+
+# PERF-1047: Eliminate Dead domLastFrameData Variable
+
+## Focus Area
+Single-worker DOM strategy hot paths in `CaptureLoop.ts`. This targets redundant assignments of a variable that is no longer read from or utilized downstream.
+
+## Background Research
+In earlier versions of `CaptureLoop.ts`, `domLastFrameData` was used to cache the string payload from Playwright's CDP `screenshotData` response before converting it to a `Buffer`. However, since PERF-965/PERF-969, we now cache the `domLastFrameBuffer` (`Buffer` object) directly to avoid redundant base64 decoding on unchanged frames.
+
+Currently, in the single-worker `isDomStrategy` paths (lines 186, 216, 252, and 287), we still assign `domLastFrameData = data;`. However, `domLastFrameData` is never actually read back! The cache hit path (the `else` blocks on lines 255 and 290) completely ignores it, opting instead to reuse `domLastFrameBuffer!`.
+
+Assigning to an unused variable inside the hottest loops in the renderer wastes CPU cycles on V8 closure writes, increases AST depth, and complicates the JIT compiler's ability to optimize the loop. Eliminating this dead variable simplifies the fast path.
+
+## Benchmark Configuration
+- **Composition URL**: Any standard DOM composition
+- **Render Settings**: Standard benchmark settings
+- **Mode**: `dom`
+- **Metric**: Microbenchmark loop execution time / Wall-clock render time
+- **Minimum runs**: 3 per experiment, report median
+
+## Baseline
+- **Bottleneck analysis**: Minor V8 AST and variable assignment overhead inside the single-worker `isDomStrategy` loops.
+
+## Implementation Spec
+
+### Step 1: Remove `domLastFrameData` Declaration
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**: Remove the initialization of `domLastFrameData`:
+```typescript
+<<<<<<< SEARCH
+      const domBeginFrame = isDomStrategy
+        ? () => domCdpSession!.send("HeadlessExperimental.beginFrame", domBeginFrameParams)
+        : null;
+      let domLastFrameData: any = isDomStrategy
+        ? (strategy as any).lastFrameData
+        : null;
+      let domLastFrameBuffer: Buffer | null = null;
+=======
+      const domBeginFrame = isDomStrategy
+        ? () => domCdpSession!.send("HeadlessExperimental.beginFrame", domBeginFrameParams)
+        : null;
+      let domLastFrameBuffer: Buffer | null = null;
+>>>>>>> REPLACE
+```
+
+### Step 2: Remove First Assignment
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**: Remove the dead assignment to `domLastFrameData` and its read into `buffer` on initial frame setup:
+```typescript
+<<<<<<< SEARCH
+            nextCapturePromise = domBeginFrame!();
+          }
+          const data = (rawResult as any).screenshotData;
+          if (data) {
+            domLastFrameData = data;
+          }
+          let buffer = domLastFrameData;
+          console.log(`Progress: Rendered ${0} / ${totalFrames} frames`);
+          if (onProgress) {
+            onProgress(0 / totalFrames);
+          }
+          if ((rawResult as any).screenshotData || !domLastFrameBuffer) {
+            domLastFrameBuffer = Buffer.from(buffer as string, "base64");
+          }
+=======
+            nextCapturePromise = domBeginFrame!();
+          }
+          const data = (rawResult as any).screenshotData;
+          console.log(`Progress: Rendered ${0} / ${totalFrames} frames`);
+          if (onProgress) {
+            onProgress(0 / totalFrames);
+          }
+          if (data || !domLastFrameBuffer) {
+            domLastFrameBuffer = Buffer.from((data || (strategy as any).lastFrameData) as string, "base64");
+          }
+>>>>>>> REPLACE
+```
+
+### Step 3: Remove Assignment in Inner Chunk Loop
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**: Remove the assignment inside the inner `for (; i < chunkEnd; i++)` chunk loop:
+```typescript
+<<<<<<< SEARCH
+            nextCapturePromise = domBeginFrame!();
+            const data = rawResult.screenshotData;
+            if (data) {
+              domLastFrameData = data;
+              buf = Buffer.from(data as string, "base64");
+              domLastFrameBuffer = buf;
+            } else {
+=======
+            nextCapturePromise = domBeginFrame!();
+            const data = rawResult.screenshotData;
+            if (data) {
+              buf = Buffer.from(data as string, "base64");
+              domLastFrameBuffer = buf;
+            } else {
+>>>>>>> REPLACE
+```
+
+### Step 4: Remove Assignment in Final Frame Check
+**File**: `packages/renderer/src/core/CaptureLoop.ts`
+**What to change**: Remove the assignment in the `if (!aborted && totalFrames > 1)` block:
+```typescript
+<<<<<<< SEARCH
+          const rawResult = await nextCapturePromise;
+
+          let buf: any;
+          const data = rawResult.screenshotData;
+          if (data) {
+            domLastFrameData = data;
+            buf = Buffer.from(data as string, "base64");
+            domLastFrameBuffer = buf;
+          } else {
+=======
+          const rawResult = await nextCapturePromise;
+
+          let buf: any;
+          const data = rawResult.screenshotData;
+          if (data) {
+            buf = Buffer.from(data as string, "base64");
+            domLastFrameBuffer = buf;
+          } else {
+>>>>>>> REPLACE
+```
+
+**Why**: `domLastFrameData` is a dead variable and its assignments in the hot loops are mathematically useless.
+**Risk**: Negligible. The cached Base64 encoded string payload is handled appropriately during initial frame setup without the redundant variable.
+
+## Canvas Smoke Test
+Verify rendering works fine using canvas strategy `npm run start`.
+
+## Correctness Check
+Verify DOM output is still correct: run `npx tsx tests/verify-cdp-shadow-dom-sync.ts`.


### PR DESCRIPTION
💡 **What**: The experiment being planned focuses on eliminating the dead domLastFrameData variable and its assignments within the single-worker isDomStrategy path of CaptureLoop.ts.
🎯 **Why**: Removing dead assignments from the inner tight loops reduces V8 closure writes, AST complexity, and evaluation overhead in the single-worker path.
🔬 **Approach**: Simply delete the assignments since they are completely unused.
📎 **Plan**: /.sys/plans/PERF-1047-eliminate-dead-domlastframedata.md

---
*PR created automatically by Jules for task [5366466050453754945](https://jules.google.com/task/5366466050453754945) started by @BintzGavin*