### PR TITLE
✨ CLI: Mark domain as blocked waiting for valid plan

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -159,3 +159,4 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 - [ ] [v0.79.14] PLAYER Blocked: Waiting for a new, valid plan in /.sys/plans/
 
 - [ ] [v0.79.15] PLAYER Blocked: Waiting for a new, valid plan in /.sys/plans/
+- [x] [v0.46.65] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/

--- a/docs/PROGRESS-CLI.md
+++ b/docs/PROGRESS-CLI.md
@@ -1,3 +1,6 @@
+### CLI v0.46.65
+- 🛑 Blocked: Waiting for a new, valid plan in /.sys/plans/
+
 ### CLI v0.46.53
 - ✅ Completed: CLI Command Coverage Tests V9 - Implemented tests to achieve 100% line coverage for the render command.
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -60,6 +60,9 @@
 ### PLAYER v0.77.36
 - ✅ Completed: Discovered that 2026-06-21-PLAYER-Smart-Controls.md is an IMPOSSIBLE: DUPLICATION plan. The smart controls for CC and PiP are already fully implemented. Documented as duplicate and discarded.
 
+### CLI v0.46.65
+- 🛑 Blocked: Waiting for a new, valid plan in /.sys/plans/
+
 #### CLI v0.46.63
 - ✅ Completed: CLI Registry Client Coverage Tests - Implemented unit tests for caching logic and fallback handlers in RegistryClient, achieving 100% branch and line coverage.
 

--- a/docs/status/CLI.md
+++ b/docs/status/CLI.md
@@ -1,4 +1,4 @@
-**Version**: 0.46.61
+**Version**: 0.46.65
 
 [v0.46.61] 🟢 IMPOSSIBLE: DUPLICATION - CLI Registry Client Coverage Tests - Plan already implemented.
 
@@ -8,7 +8,7 @@
 
 [v0.46.51] 🟢 Completed: CLI Command Coverage Tests Spec V9 - Created specification plan 2027-06-05-CLI-Command-Coverage-Tests-V9.md for covering missing exit prompt branches in deploy subcommands.
 
-**Version**: 0.46.64
+**Version**: 0.46.65
 
 [v0.46.63] ✅ Completed: CLI Registry Client Coverage Tests - Implemented unit tests for caching logic and fallback handlers in RegistryClient, achieving 100% branch and line coverage.
 
@@ -208,3 +208,5 @@ The Helios CLI is the primary user interface for component registry, project sca
 
 [v0.46.62] 🟢 IMPOSSIBLE: DUPLICATION - CLI Add Command Scaffold - Plan already implemented.
 [v0.46.64] 🟢 IMPOSSIBLE: DUPLICATION - CLI Registry Components List Command - Plan already implemented.
+
+- [x] [v0.46.65] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/


### PR DESCRIPTION
✨ CLI: Mark domain as blocked waiting for valid plan

💡 What: Updated the CLI domain status, progress, and backlog files to reflect a blocked state.
🎯 Why: File system verification indicated no new, valid implementation plans existed in `/.sys/plans/` for the CLI domain. Following the EXECUTOR protocol, work must halt and the blocked status must be documented.
📊 Impact: Prevents the CLI agent from stalling or hallucinating unapproved work, properly delegating the next step to the PLANNER.
🔬 Verification: Ran `npm run test -w packages/cli` (passed) and verified `git diff --cached` for accurate file updates across `docs/status/CLI.md`, `docs/PROGRESS.md`, `docs/PROGRESS-CLI.md`, and `docs/BACKLOG.md`.

---
*PR created automatically by Jules for task [1713606857668755025](https://jules.google.com/task/1713606857668755025) started by @BintzGavin*