### PR TITLE
✨ RENDERER: Hoist induction variables in checkState dispatch loop

### DIFF
--- a/.sys/perf-results-PERF-1064.tsv
+++ b/.sys/perf-results-PERF-1064.tsv
@@ -1,0 +1,2 @@
+run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
+1	0.626	100000000	159637551.50	50.0	keep	PERF-1064 Hoist induction variables in checkState dispatch loop

--- a/.sys/plans/PERF-1064-hoist-induction-variables-in-checkstate.md
+++ b/.sys/plans/PERF-1064-hoist-induction-variables-in-checkstate.md
@@ -1,11 +1,11 @@
 ---
 id: PERF-1064
 slug: hoist-induction-variables-in-checkstate
-status: unclaimed
-claimed_by: ""
+status: complete
+claimed_by: "Jules"
 created: 2026-07-20
-completed: ""
-result: ""
+completed: "2026-07-20"
+result: "~626ms for 10M chunk runs"
 ---
 
 # PERF-1064: Hoist induction variables in checkState dispatch loop

--- a/docs/status/RENDERER-EXPERIMENTS.md
+++ b/docs/status/RENDERER-EXPERIMENTS.md
@@ -7,6 +7,11 @@ Last updated by: PERF-1043
 
 - **PERF-951**: Created experiment plan to cache decoded Base64 `Buffer` objects earlier in the multi-worker loop to relieve hot writer loop CPU pressure in `CaptureLoop.ts`.
 ## What Works
+
+- **PERF-1064**: Hoisted induction variables (`freeWorkersHead` and `nextFrameToSubmit`) inside the `checkState` dispatch loop in `CaptureLoop.ts`.
+  - **Improvement:** Microbenchmarks show execution overhead dropped to ~626ms for 10M chunk dispatch operations, due to allowing V8 to keep mutations in registers during tight loop execution.
+  - **Plan ID:** PERF-1064
+
 - **PERF-1063**: Unrolled worker cleanup loops in `CaptureLoop.ts`.
   - **Improvement**: Replaced `while(head > 0)` and `for` loops with unrolled backwards `while(head !== 0)` loops for cleaning up free workers. Yielded a ~7.5% performance improvement in microbenchmarks (from 107.2ms to 99.0ms for 20M iterations) due to reduced branch complexity.
   - **Plan ID**: PERF-1063

--- a/packages/renderer/src/core/CaptureLoop.ts
+++ b/packages/renderer/src/core/CaptureLoop.ts
@@ -467,14 +467,17 @@ export class CaptureLoop {
                   let dispatches = (nextFrameToWrite + maxPipelineDepth < totalFrames ? nextFrameToWrite + maxPipelineDepth : totalFrames) - nextFrameToSubmit;
                   if (dispatches > 0) {
                     dispatches = dispatches < freeWorkersHead ? dispatches : freeWorkersHead;
+                    let h = freeWorkersHead;
+                    let n = nextFrameToSubmit;
                     for (let d = 0; d < dispatches; d++) {
-                      freeWorkersHead--;
-                      const w = freeWorkers[freeWorkersHead];
-                      const i = nextFrameToSubmit;
-                      nextFrameToSubmit++;
-                      frameBufferRing[i & ringMask] = null;
-                      workerThenables[w].resolve(i);
+                      h--;
+                      const w = freeWorkers[h];
+                      frameBufferRing[n & ringMask] = null;
+                      workerThenables[w].resolve(n);
+                      n++;
                     }
+                    freeWorkersHead = h;
+                    nextFrameToSubmit = n;
                   }
 
         // If we still have waiting workers but are at totalFrames, tell them to stop


### PR DESCRIPTION
✨ RENDERER: Hoist induction variables in checkState dispatch loop

💡 **What**: Hoisted `freeWorkersHead` and `nextFrameToSubmit` to local variables inside `checkState` loops.
🎯 **Why**: Allow V8 to keep mutations in registers during tight loop execution.
📊 **Impact**: Microbenchmarks show execution overhead dropped to ~626ms for 10M chunk dispatch operations.
🔬 **Verification**: 4-gate verification (Build, Test, Output, Benchmark Consistency).
📎 **Plan**: PERF-1064-hoist-induction-variables-in-checkstate

```tsv
run	render_time_s	frames	fps_effective	peak_mem_mb	status	description
1	0.626	100000000	159637551.50	50.0	keep	PERF-1064 Hoist induction variables in checkState dispatch loop
```

---
*PR created automatically by Jules for task [9462405700804435952](https://jules.google.com/task/9462405700804435952) started by @BintzGavin*