### PR TITLE
✨ PLAYER: Blocked Status Update

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -160,3 +160,5 @@ This backlog tracks concrete deliverables derived from [`AGENTS.md`](../AGENTS.m
 
 - [ ] [v0.79.15] PLAYER Blocked: Waiting for a new, valid plan in /.sys/plans/
 - [x] [v0.46.65] CLI Blocked: Waiting for a new, valid plan in /.sys/plans/
+
+- [ ] [v0.79.16] PLAYER Blocked: Waiting for a new, valid plan in /.sys/plans/

--- a/docs/status/PLAYER.md
+++ b/docs/status/PLAYER.md
@@ -1,4 +1,4 @@
-**Version**: 0.79.15
+**Version**: 0.79.16
 
 [v0.78.5] ✅ Completed: Discovered missing composition setters on the public API wrapper. Created plan `.sys/plans/2027-03-05-PLAYER-Expose-Composition-Setters.md` to expose `setDuration`, `setFps`, `setSize`, and `setMarkers`.
 [v0.78.4] ✅ Completed: Discovered missing HTMLMediaElement-like parity methods (`setPlaybackRange`, `clearPlaybackRange`) in HeliosPlayer public API. Created plan `.sys/plans/2027-03-04-PLAYER-Expose-Playback-Range-Methods.md` to implement them.
@@ -311,3 +311,4 @@
 [v0.79.15] ✅ Completed: Implement Promise for play() - Modified play() to return a Promise that resolves when playback begins or rejects if it fails, matching HTMLMediaElement parity.
 
 [v0.79.15] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner.
+[v0.79.16] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner.


### PR DESCRIPTION
Updated the PLAYER status file and project backlog to indicate that the PLAYER executor is blocked, as no new plan files were found in `/.sys/plans/`.

- Incremented version to `v0.79.16` in `docs/status/PLAYER.md`
- Appended `[v0.79.16] 🚫 Blocked: No new plan found in /.sys/plans/ for PLAYER. Waiting for Planner.` to `docs/status/PLAYER.md`
- Added `- [ ] [v0.79.16] PLAYER Blocked: Waiting for a new, valid plan in /.sys/plans/` to the Blocked Items section of `docs/BACKLOG.md`
- Verified tests pass for `packages/player`

---
*PR created automatically by Jules for task [8107350370453263307](https://jules.google.com/task/8107350370453263307) started by @BintzGavin*