### PR TITLE
📋 PLAYER: Implement encrypted Event

### DIFF
--- a/.jules/PLAYER.md
+++ b/.jules/PLAYER.md
@@ -18,3 +18,7 @@
 ## [0.79.11] - Implement remote property
 **Learning:** Implementing missing API parity properties like `remote` improves standard compliance even if they are stubbed.
 **Action:** Always check the HTMLMediaElement specification for missing properties.
+
+## [v0.79.16] - Implement encrypted Event
+**Learning:** Found that standard events like `encrypted` should be included for HTMLMediaElement parity even if the underlying feature (EME/DRM) is not explicitly supported by the core, in order to complete the standard API surface and pass standard compliance checkers.
+**Action:** Include all standard HTMLMediaElement event handlers and document them for API parity.

--- a/.sys/plans/2027-03-08-PLAYER-Implement-encrypted-Event.md
+++ b/.sys/plans/2027-03-08-PLAYER-Implement-encrypted-Event.md
@@ -1,0 +1,26 @@
+#### 1. Context & Goal
+- **Objective**: Implement the standard `onencrypted` media event handler property and document the `encrypted` event for `HeliosPlayer`.
+- **Trigger**: HTMLMediaElement parity gap identified (the `encrypted` event handler is missing from the codebase).
+- **Impact**: Achieves deeper API parity with standard HTMLMediaElement by providing the `onencrypted` property and documenting it, even though EME is unsupported.
+
+#### 2. File Inventory
+- **Create**: None.
+- **Modify**: `packages/player/src/index.ts` - Add `onencrypted` getter and setter.
+- **Modify**: `packages/player/README.md` - Document `onencrypted` and `encrypted`.
+- **Read-Only**: None.
+
+#### 3. Implementation Spec
+- **Architecture**: Web Components standard event mapping.
+- **Pseudo-Code**:
+  - Add a private backing field for the `onencrypted` event handler.
+  - Implement a public getter that returns the current handler.
+  - Implement a public setter that removes the old event listener if it exists, assigns the new handler, and attaches the new event listener if the new handler is not null.
+  - Update the Event Handlers section in `README.md` to include `onencrypted`.
+  - Update the Events section in `README.md` to include `encrypted`.
+- **Public API Changes**: Exposes `onencrypted` on `HeliosPlayer`.
+- **Dependencies**: None.
+
+#### 4. Test Plan
+- **Verification**: Run `npm run build -w packages/player` and `npm run test -w packages/player`.
+- **Success Criteria**: `onencrypted` property exists and compiles.
+- **Edge Cases**: None (standard boilerplate for events).


### PR DESCRIPTION
Creates a specification plan to implement the missing `onencrypted` media event in the `HeliosPlayer` Web Component.

This gap was identified by comparing standard HTMLMediaElement events to the current implementation. Although Helios does not currently support Encrypted Media Extensions (EME), adding the property and documenting the event is required to achieve full standard API parity. The execution plan provides exact instructions on how to add this property getter/setter pattern to `packages/player/src/index.ts` and document it in the README.

The Planner journal has also been updated with this learning.

---
*PR created automatically by Jules for task [13738673059007691239](https://jules.google.com/task/13738673059007691239) started by @BintzGavin*