### PR TITLE
fix(renderer): prevent DOM capture stalls

### DIFF
--- a/docs/site/api/renderer.md
+++ b/docs/site/api/renderer.md
@@ -50,7 +50,7 @@ const options: RendererOptions = {
 
   // Stability & Determinism
   randomSeed: 'my-seed', // Optional: Seed for deterministic randomness
-  stabilityTimeout: 30000, // Optional: Timeout for waitUntilStable (ms)
+  stabilityTimeout: 30000, // Optional: Timeout for stability waits and DOM capture (ms)
 
   // Browser Configuration
   browserConfig: {

--- a/docs/site/guides/rendering-videos.md
+++ b/docs/site/guides/rendering-videos.md
@@ -1,68 +1,154 @@
 ---
 title: "Rendering Videos"
-description: "How to export your compositions to video files."
+description: "Render complete videos, frame ranges, and distributed jobs."
 ---
 
 # Rendering Videos
 
-The `@helios-project/renderer` package allows you to turn your web-based composition into a video file (MP4).
+`@helios-project/renderer` loads a composition in Playwright, seeks it to exact frame times, captures each frame, and pipes the result to FFmpeg.
 
-## How it Works
+Use `mode: 'dom'` for HTML, CSS, WAAPI, and media elements. Use `mode: 'canvas'` for Canvas, WebGL, and browser-side WebCodecs output.
 
-1.  **Headless Browser**: The renderer launches a headless Chrome instance.
-2.  **Load Composition**: It loads your composition URL.
-3.  **Frame-by-Frame**: It advances the time deterministically, frame by frame.
-4.  **Capture**: It captures a screenshot (or canvas data) for each frame.
-5.  **Encode**: It pipes the frames to FFmpeg to encode the video.
+## Render a complete video
 
-## Basic Usage
+Create the renderer with an explicit resolution, frame rate, and duration, then pass the composition URL and output path to `render`:
 
-Create a Node.js script (e.g., `render.js`):
-
-```javascript
+```typescript
 import { Renderer } from '@helios-project/renderer';
 
-(async () => {
-  const renderer = new Renderer();
+const renderer = new Renderer({
+  width: 1920,
+  height: 1080,
+  fps: 30,
+  durationInSeconds: 10,
+  mode: 'dom',
+  inputProps: { title: 'Launch' },
+});
 
-  console.log('Starting render...');
+await renderer.render(
+  'http://localhost:5173/composition.html',
+  './output.mp4',
+  {
+    onProgress: progress => console.log(`${Math.round(progress * 100)}%`),
+  },
+);
+```
 
-  await renderer.render({
-    input: 'http://localhost:5173/composition.html', // Your local dev server
-    output: 'output.mp4',
+Keep the composition deterministic: use Helios as its clock, seed unavoidable randomness, and finish loading fonts, media, data, and models before capture.
+
+## Add audio
+
+Provide one audio file or a list of tracks in the renderer options:
+
+```typescript
+const renderer = new Renderer({
+  width: 1920,
+  height: 1080,
+  fps: 30,
+  durationInSeconds: 10,
+  audioTracks: [
+    { path: './voiceover.wav' },
+    { path: './music.mp3', volume: 0.35 },
+  ],
+});
+```
+
+DOM mode also discovers audio from `<audio>` and `<video>` elements. Use the renderer's audio pipeline instead of starting independent browser playback during capture.
+
+## Render an exact frame range
+
+Use both `startFrame` and `frameCount` when a worker renders only part of a composition:
+
+```typescript
+const renderer = new Renderer({
+  width: 1920,
+  height: 1080,
+  fps: 30,
+  durationInSeconds: 5,
+  startFrame: 300,
+  frameCount: 150,
+});
+```
+
+`startFrame` controls the composition time seen by Helios, animations, and media elements. Do not render frame zero and compensate inside composition code; that can make media and animation clocks disagree.
+
+Treat each range as half-open: a chunk with `startFrame: 300` and `frameCount: 150` owns frames 300 through 449.
+
+## Render chunks locally
+
+`RenderOrchestrator.render` plans frame ranges, renders them concurrently, concatenates the outputs, and performs the final explicit-audio mix:
+
+```typescript
+import { RenderOrchestrator } from '@helios-project/renderer';
+
+await RenderOrchestrator.render(
+  'http://localhost:5173/composition.html',
+  './output.mp4',
+  {
     width: 1920,
     height: 1080,
     fps: 30,
-    duration: 10
-  });
-
-  console.log('Render complete!');
-})();
+    durationInSeconds: 60,
+    mode: 'dom',
+    concurrency: 4,
+    audioFilePath: './soundtrack.wav',
+  },
+);
 ```
 
-Run it with `node render.js`.
+Here, `concurrency` is the number of render chunks executed together. It is not the number of pages used inside one renderer. Choose it from measurements on the actual composition and worker environment rather than a universal CPU or memory formula.
 
-## Adding Audio
+If one local chunk fails, `RenderOrchestrator.render` aborts its sibling executions. That process-local cancellation does not automatically cross machine or provider boundaries.
 
-You can mix an audio file into the final video.
+## Create a portable render plan
 
-```javascript
-await renderer.render({
-  // ...
-  audioFilePath: './soundtrack.mp3'
-});
+Use `RenderOrchestrator.plan` when another process or service will execute the chunks:
+
+```typescript
+import { RenderOrchestrator } from '@helios-project/renderer';
+
+const plan = RenderOrchestrator.plan(
+  'https://assets.example.com/composition.html',
+  './output.mp4',
+  {
+    width: 1920,
+    height: 1080,
+    fps: 30,
+    durationInSeconds: 60,
+    mode: 'dom',
+    concurrency: 4,
+  },
+);
+
+for (const chunk of plan.chunks) {
+  // Send chunk.options, chunk.startFrame, chunk.frameCount, and
+  // chunk.outputFile to the worker without recalculating the range.
+}
 ```
 
-The audio will be trimmed or looped to match the video duration (depending on future config, currently standard mix).
+The CLI can serialize the same plan and execute it through local or remote adapters:
 
-## Partial Rendering
+```bash
+helios render http://localhost:5173/composition.html \
+  --output output.mp4 \
+  --duration 60 \
+  --mode dom \
+  --concurrency 4 \
+  --emit-job render-job.json
 
-You can render just a part of the composition using `startFrame` and explicitly controlling duration.
-
-```javascript
-await renderer.render({
-  // ...
-  startFrame: 0,
-  duration: 2 // Render only first 2 seconds
-});
+helios job run render-job.json --concurrency 4
 ```
+
+For remote execution:
+
+- Treat the generated `startFrame` and `frameCount` as authoritative.
+- Give every chunk a stable output identity so retries are idempotent.
+- Let the coordinator own retries, sibling cancellation, and incomplete output cleanup.
+- Concatenate successful chunks in plan order and mix explicit audio once at the final output stage.
+- Validate boundaries by comparing the distributed output with the same frame numbers from a single render.
+
+## Timeouts and diagnostics
+
+`stabilityTimeout` bounds asset and custom stability waits. In DOM mode it also bounds each screenshot capture so a compositor stall fails with frame context instead of leaving the render pending indefinitely.
+
+Run `renderer.diagnose()` in the target worker image before a production render, especially when browser codecs, WebCodecs, FFmpeg encoders, or hardware acceleration differ from local development.

--- a/packages/renderer/src/core/BrowserPool.ts
+++ b/packages/renderer/src/core/BrowserPool.ts
@@ -6,6 +6,7 @@ import { CanvasStrategy } from '../strategies/CanvasStrategy.js';
 import { DomStrategy } from '../strategies/DomStrategy.js';
 import { TimeDriver } from '../drivers/TimeDriver.js';
 import { CdpTimeDriver } from '../drivers/CdpTimeDriver.js';
+import { SeekTimeDriver } from '../drivers/SeekTimeDriver.js';
 import { RendererOptions, RenderJobOptions } from '../types.js';
 
 const DEFAULT_BROWSER_ARGS = [
@@ -60,6 +61,12 @@ export class BrowserPool {
     const config = this.options.browserConfig || {};
     const userArgs = config.args || [];
     const gpuArgs = config.gpu !== true ? GPU_DISABLED_ARGS : [];
+    const defaultArgs = this.options.mode === 'dom'
+      ? DEFAULT_BROWSER_ARGS.filter(arg =>
+          arg !== '--enable-begin-frame-control' &&
+          arg !== '--run-all-compositor-stages-before-draw'
+        )
+      : DEFAULT_BROWSER_ARGS;
 
     let executablePath = config.executablePath;
 
@@ -95,7 +102,7 @@ export class BrowserPool {
     return {
       headless: config.headless ?? true,
       executablePath: executablePath,
-      args: [...DEFAULT_BROWSER_ARGS, ...gpuArgs, ...userArgs],
+      args: [...defaultArgs, ...gpuArgs, ...userArgs],
       pipe: true,
     };
   }
@@ -123,10 +130,9 @@ export class BrowserPool {
 
         const page = await context.newPage();
         const strategy = this.options.mode === 'dom' ? new DomStrategy(this.options) : new CanvasStrategy(this.options);
-        // Both capture strategies advance through CDP virtual time. DOM capture
-        // uses Page.captureScreenshot rather than the platform-limited
-        // HeadlessExperimental.beginFrame API.
-        const timeDriver = new CdpTimeDriver(this.options.stabilityTimeout, 'canvas');
+        const timeDriver = this.options.mode === 'dom'
+          ? new SeekTimeDriver(this.options.stabilityTimeout)
+          : new CdpTimeDriver(this.options.stabilityTimeout, 'canvas');
 
         page.on('console', (msg: ConsoleMessage) => console.log(`PAGE LOG [${index}]: ${msg.text()}`));
         page.on('pageerror', (err: Error) => {

--- a/packages/renderer/src/strategies/DomStrategy.ts
+++ b/packages/renderer/src/strategies/DomStrategy.ts
@@ -176,17 +176,34 @@ export class DomStrategy implements RenderStrategy {
   }
 
   async capture(page: Page, frameTime: number): Promise<any> {
-    const result = await this.cdpSession!.send('Page.captureScreenshot', {
-      ...this.cdpScreenshotParams,
-      fromSurface: true,
-      ...(this.beginFrameParams.screenshot?.clip
-        ? { clip: this.beginFrameParams.screenshot.clip }
-        : {}),
-    });
-    return {
-      hasDamage: true,
-      screenshotData: result.data,
-    };
+    const timeoutMs = this.options.stabilityTimeout ?? 30000;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      const result = await Promise.race([
+        this.cdpSession!.send('Page.captureScreenshot', {
+          ...this.cdpScreenshotParams,
+          fromSurface: true,
+          ...(this.beginFrameParams.screenshot?.clip
+            ? { clip: this.beginFrameParams.screenshot.clip }
+            : {}),
+        }),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(new Error(
+              `DomStrategy.capture watchdog: Page.captureScreenshot exceeded ${timeoutMs}ms (frameTime=${frameTime})`
+            ));
+          }, timeoutMs);
+        }),
+      ]);
+
+      return {
+        hasDamage: true,
+        screenshotData: result.data,
+      };
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
+    }
   }
 
   async finish(page: Page): Promise<void> {

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -223,7 +223,8 @@ export interface RendererOptions {
   ffmpegPath?: string;
 
   /**
-   * Timeout in milliseconds to wait for the frame to stabilize (e.g., loading fonts, images, custom hooks).
+   * Timeout in milliseconds to wait for frame stability and DOM screenshot capture.
+   * This covers assets, custom hooks, and compositor stalls.
    * Defaults to 30000ms.
    */
   stabilityTimeout?: number;

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -35,6 +35,7 @@ const tests = [
   'tests/verify-diagnose-ffmpeg.ts',
   'tests/verify-dom-audio-fades.ts',
   'tests/verify-dom-media-attributes.ts',
+  'tests/verify-dom-renderer-hardening.ts',
 
   'tests/verify-enhanced-dom-preload.ts',
   'tests/verify-frame-count.ts',

--- a/packages/renderer/tests/verify-dom-renderer-hardening.ts
+++ b/packages/renderer/tests/verify-dom-renderer-hardening.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { BrowserPool } from '../src/core/BrowserPool.js';
+import { CdpTimeDriver } from '../src/drivers/CdpTimeDriver.js';
+import { SeekTimeDriver } from '../src/drivers/SeekTimeDriver.js';
+import { DomStrategy } from '../src/strategies/DomStrategy.js';
+import type { RendererOptions } from '../src/types.js';
+
+const baseOptions: RendererOptions = {
+  width: 320,
+  height: 180,
+  fps: 30,
+  durationInSeconds: 1,
+  stabilityTimeout: 100,
+};
+
+async function verifyModeSpecificLaunchArguments(): Promise<void> {
+  const domArgs = new BrowserPool({ ...baseOptions, mode: 'dom' }).getLaunchOptions().args;
+  const canvasArgs = new BrowserPool({ ...baseOptions, mode: 'canvas' }).getLaunchOptions().args;
+
+  assert.ok(!domArgs.includes('--enable-begin-frame-control'), 'DOM mode must not enable explicit begin-frame control');
+  assert.ok(!domArgs.includes('--run-all-compositor-stages-before-draw'), 'DOM mode must not require begin-frame compositor stages');
+  assert.ok(canvasArgs.includes('--enable-begin-frame-control'), 'Canvas mode must preserve its existing begin-frame launch behavior');
+  assert.ok(canvasArgs.includes('--run-all-compositor-stages-before-draw'), 'Canvas mode must preserve its existing compositor launch behavior');
+}
+
+async function verifyModeSelectsTheCorrectClock(): Promise<void> {
+  const domPool = new BrowserPool({ ...baseOptions, mode: 'dom' });
+  const canvasPool = new BrowserPool({ ...baseOptions, mode: 'canvas' });
+
+  try {
+    await domPool.init('data:text/html,<html><body><div>DOM</div></body></html>');
+    assert.ok(domPool.workers[0].timeDriver instanceof SeekTimeDriver, 'DOM mode must use SeekTimeDriver');
+
+    await canvasPool.init('data:text/html,<html><body><canvas width="320" height="180"></canvas></body></html>');
+    assert.ok(canvasPool.workers[0].timeDriver instanceof CdpTimeDriver, 'Canvas mode must use CdpTimeDriver');
+  } finally {
+    await Promise.all([
+      domPool.close().catch(() => {}),
+      canvasPool.close().catch(() => {}),
+    ]);
+    await Promise.all([
+      domPool.cleanupStrategies().catch(() => {}),
+      canvasPool.cleanupStrategies().catch(() => {}),
+    ]);
+  }
+}
+
+async function verifyDomCaptureHasAWatchdog(): Promise<void> {
+  const strategy = new DomStrategy({
+    ...baseOptions,
+    mode: 'dom',
+    stabilityTimeout: 20,
+  });
+
+  (strategy as any).cdpSession = {
+    send: () => new Promise(() => {}),
+  };
+
+  let guard: ReturnType<typeof setTimeout> | undefined;
+  const guardedCapture = Promise.race([
+    strategy.capture({} as any, 125),
+    new Promise((_, reject) => {
+      guard = setTimeout(() => reject(new Error('acceptance check timed out waiting for the capture watchdog')), 250);
+    }),
+  ]);
+
+  try {
+    await assert.rejects(
+      guardedCapture,
+      /DomStrategy\.capture watchdog: Page\.captureScreenshot exceeded 20ms \(frameTime=125\)/,
+    );
+  } finally {
+    if (guard) clearTimeout(guard);
+  }
+}
+
+const checks: Array<[string, () => Promise<void>]> = [
+  ['mode-specific browser launch arguments', verifyModeSpecificLaunchArguments],
+  ['mode-specific time drivers', verifyModeSelectsTheCorrectClock],
+  ['DOM screenshot capture watchdog', verifyDomCaptureHasAWatchdog],
+];
+
+let failures = 0;
+
+for (const [name, check] of checks) {
+  try {
+    await check();
+    console.log(`✅ ${name}`);
+  } catch (error) {
+    failures++;
+    console.error(`❌ ${name}`);
+    console.error(error);
+  }
+}
+
+if (failures > 0) {
+  throw new Error(`${failures} DOM renderer hardening acceptance check(s) failed`);
+}


### PR DESCRIPTION
## What changed

- DOM renders now use SeekTimeDriver. Canvas continues to use CdpTimeDriver.
- BrowserPool drops the begin-frame launch flags in DOM mode.
- DOM screenshot capture uses stabilityTimeout and reports the stalled frame time.
- The rendering guide now documents exact frame ranges, local orchestration, portable jobs, and remote execution boundaries.

## Why

Under headless Linux, paused CDP virtual time can leave a DOM screenshot pending indefinitely. Seek timing leaves the event loop available for media seeks and compositor updates, and the watchdog gives distributed workers a terminal error if capture still stalls.

## Verification

- The focused acceptance check failed against origin/main before the implementation and passed afterward.
- npm run build -w packages/renderer
- npm test -w packages/renderer
- npm exec -- tsx tests/verify-dom-renderer-hardening.ts
- git diff --check

Closes #4977
Closes #4978
Closes #4979
Closes #4983