### PR TITLE
feat(studio): complete authenticated Kody video workflow

### DIFF
--- a/docs/site/guides/kody.md
+++ b/docs/site/guides/kody.md
@@ -1,0 +1,136 @@
+# Brief to playable video with Kody
+
+The Helios integration includes a complete template workflow: create a title
+composition, render with Studio's existing render manager, inspect progress,
+and play the completed MP4 in a private Kody package app. Chromium, FFmpeg,
+project files, and rendering stay on the Helios machine.
+
+```mermaid
+sequenceDiagram
+  participant Package as Private Kody package
+  participant MCP as Authenticated Helios MCP
+  participant Studio as Studio render manager
+  Package->>MCP: create_composition with explicit template
+  Package->>MCP: render_composition with composition ID
+  MCP->>Studio: startRender
+  Package->>MCP: get_render_status with bounded wait
+  MCP-->>Package: completed and output metadata
+  Package->>MCP: read_render_output for video ranges
+  Package-->>Package: Play in owner-authenticated app
+```
+
+## Build and start
+
+This workflow is currently source-distributed on the linked draft integration
+branch. Do not assume an older npm release has these tools or flags. From a
+checkout containing this change:
+
+```sh
+npm ci
+npm run build -w packages/core
+npm run build -w packages/player
+npm run build -w packages/renderer
+npm run build -w packages/infrastructure
+npm run build -w packages/studio
+npm run build -w packages/cli
+npx playwright install chromium --only-shell
+```
+
+Install the built packages in your Helios project using your normal local
+package workflow. From that project launch the built CLI's `bin/helios.js` (or
+`npx helios` after a release containing this change):
+
+```sh
+helios studio --port 5173 --mcp-port 5174 \
+  --mcp-public-url https://video.example.com \
+  --mcp-secret-service helios-video-owner
+```
+
+Use a dedicated random credential of at least 32 characters stored by the
+owner directly in the OS secret store and Kody's MCP account form. No agent
+needs to see it. On macOS create a Generic Password in Keychain Access with
+service `helios-video-owner` and account `helios-mcp`. On Linux use the desktop
+Secret Service (with `secret-tool` available), attributes `service` and
+`account` with those same values. Provision it using the secret manager UI;
+do not pass the value as a shell argument. Allow the Studio process to read
+that entry when the OS prompts. Missing or inaccessible entries fail closed.
+
+The gateway reads the dedicated entry for each request, so credential changes
+apply to the next request. Update Kody's saved credential when rotating it.
+Use one process, root, and credential per owner. Studio is not a multitenant
+render service; sharing its credential grants access to the whole project.
+
+The separate listener binds only `127.0.0.1:5174`. Publish that listener using
+the maintained [Caddy configuration](../../../integrations/kody/Caddyfile.example)
+with your DNS name. Caddy supplies HTTPS and streaming proxying; authentication
+and the route allowlist live in Helios. Keep port 5173 private. Do not publish
+Vite, the file editor, REST APIs, or the local MCP route. A tunnel may forward
+the gateway port if it preserves the configured Host, paths, query strings,
+and streams, but never forward the unauthenticated Studio port.
+
+## Connect and install the package
+
+1. In Kody's MCP servers page, name the connection `helios`, set the URL to
+   `https://video.example.com/mcp`, and enter the dedicated credential in its
+   account form. Streamable HTTP is preferred; `/mcp/sse` and `/mcp/messages`
+   remain supported for legacy clients. Every method on these routes and
+   `/mcp/outputs/:jobId` requires authentication. Unknown routes fail closed.
+2. Confirm `mcpServerList` is ready. Search `mcp:helios` for `list_compositions`,
+   `create_composition`, `render_composition`, `get_render_status`,
+   `cancel_render`, `get_render_output`, and `read_render_output`.
+3. Create a private saved package via `packageGetGitRemote` with `create: true`
+   and `kody_id: 'helios-video'`. Use its returned setup commands in your own
+   coding environment. Copy the files from
+   [integrations/kody/package](../../../integrations/kody/package) to that
+   package root, changing `@owner` to your Kody username. Commit and push using
+   the identity supplied by Kody. This is maintained source, not an existing
+   community listing or an arbitrary GitHub-URL installer.
+4. Run the supported package checks and use `packagePublishExternalPush` when
+   you authorize publication in your own account. If it returns an approval
+   URL, the owner promotes that commit. Keep visibility private. Set the
+   configure export's `appUrl` to the returned `hosted_app_url`, or open the
+   app once so it can save its own mount URL.
+5. Grant the connector to this package using **Specific packages only**. Calls
+   must execute in the package context: use the private app's POST /start and
+   POST /cancel via `packageAppFetch`, or an existing package job/workflow.
+   Static imports from ad hoc execute do not enter the package context.
+
+The package README contains the brief and export contracts. On success, open
+`playbackUrl` to see progress and play the actual result. Polling stops after
+two minutes in the app; refresh to continue. `waitMs` expiry leaves the job
+running, and status never submits another render. An interrupted start is
+reported for inspection rather than silently creating duplicate work.
+
+## Output and failure contracts
+
+`get_render_output` returns MIME type, byte length, an authenticated relative
+output path, and the maximum chunk size. No filesystem path or credential is
+needed by Kody. `read_render_output` transfers up to 256 KiB per call; the
+package requests 64 KiB chunks and supports Range/HEAD playback up to 64 MiB.
+The provider's direct output route also supports Range and HEAD, with the same
+authentication as MCP. It is not a public sharing URL.
+
+Unknown jobs, incomplete output, missing files, empty output, invalid byte
+ranges, and unsafe paths have distinct errors. Output is resolved only from a
+completed manager job and its managed filename; symlinks and paths outside
+the render directory are rejected. Sessions expire, are capped, and belong
+to their authenticated identity. Authentication is rechecked on each request.
+
+## Verify locally
+
+The decoded-video check also requires `ffmpeg` and `ffprobe` on the command
+path. The renderer itself uses its bundled FFmpeg.
+
+```sh
+node --test integrations/kody/workflow.test.mjs
+npx tsx integrations/kody/verify-local.mts /tmp/helios-kody-demo.mp4
+```
+
+The local demo creates a temporary project and runs the package workflow
+through the actual SDK transport, renderer, browser, encoder, MCP output
+reads, and HTTP output route. It compares actual bytes and saves an MP4 outside
+the repository, decodes frames to reject black/frozen output, and verifies
+browser playback/seeking through the package app. It also exercises an actual
+browser error and cancellation. Its loopback fixture identity does not validate production
+secret-store pairing, public TLS, or a signed-in Kody account. Those remain
+installation smoke tests, not claims made by fixture coverage.

--- a/docs/site/guides/using-studio.md
+++ b/docs/site/guides/using-studio.md
@@ -17,6 +17,10 @@ npx helios studio
 
 The Studio will start a local server (typically at `http://localhost:3000`) and open in your default browser.
 
+For authenticated remote MCP and the brief-to-video package, see
+[Make a video with Kody](./kody.md). That workflow publishes a separate,
+authenticated listener while keeping the Studio editor local.
+
 ## Features
 
 ### Omnibar (Command Palette)

--- a/docs/specs/kody-render-workflow.md
+++ b/docs/specs/kody-render-workflow.md
@@ -1,0 +1,44 @@
+# Helios remote video workflow acceptance contract
+
+One Studio process owns one project and one remote owner. Kody owns the user's
+package, invocation state, and private playback app. Helios owns all browser,
+filesystem, and encoder work. Sharing a Studio credential between Kody users is
+unsupported; use separate processes, roots, and secret-store entries.
+
+- Given an explicit `title-explainer` template and bounded brief, when the
+  package starts, then Helios creates a deterministic composition, returns its
+  stable ID, submits a render using that composition's metadata, and records a
+  stable job ID in the calling package's storage.
+- Given a submitted job, when inspected with a bounded wait, then progress and
+  queued/rendering/completed/failed/cancelled state are returned. Wait expiry
+  leaves the render running and reports `timedOut`. Cancellation remains
+  terminal even if the renderer resolves or rejects after abort.
+- Given unknown composition/job IDs, unavailable output, invalid dimensions,
+  unsafe paths or symlinks, when tools are called, then clear machine-readable
+  errors are returned without disclosing local paths or serving other files.
+- Given completed output, when requested through MCP or the authorized output
+  route, then actual MP4 bytes are available with bounded reads and correct
+  HTTP Range/HEAD semantics. Incomplete or empty output is never playable.
+- Given no valid authentication, an unapproved Host/Origin, or another owner's
+  session, when any remote MCP or output route is requested, then access fails
+  closed before routing or file access. Only the dedicated MCP listener may be
+  published; Vite, REST editing, and arbitrary files are unreachable there.
+- Given concurrent MCP clients, when using Streamable HTTP or legacy SSE, then
+  each has a separate server/transport, working session paths, bounded session
+  lifetime, and cleanup. Authentication is rechecked for every HTTP request.
+- Given the operating-system secret store cannot authenticate, when the remote
+  listener starts or handles a request, then it fails closed without printing
+  secret-store output. No credentials are passed in CLI arguments or URLs.
+- Given the maintained package is installed privately using Kody's supported
+  package authoring lane, when a job completes, then its app serves a playable
+  video through authenticated MCP reads. Other package stores cannot retrieve
+  an unrecorded job. Polling is bounded and resuming never resubmits a render.
+- Given an isolated local project and real browser/FFmpeg, when the demo runs
+  through MCP and the package workflow, then its actual video bytes are saved
+  outside this repository, probed, played, and shown to the owner.
+
+Release gates: behavioral red/green tests, actual SDK transport integration,
+real render/output demo, relevant Studio/CLI type and build gates, package
+behavior and manifest checks, and Kody guide discovery/format checks. Hosted
+TLS, real secret-store pairing, and signed-in Kody execution require an owner
+installation and must not be claimed from fixtures.

--- a/integrations/kody/Caddyfile.example
+++ b/integrations/kody/Caddyfile.example
@@ -1,0 +1,8 @@
+# Replace video.example.com with the DNS name you operate. Point its DNS at
+# this host. Caddy owns TLS; Helios authenticates every request before routing.
+# Keep both local ports private. Never proxy the Studio/Vite port (5173).
+video.example.com {
+    reverse_proxy 127.0.0.1:5174 {
+        flush_interval -1
+    }
+}

--- a/integrations/kody/VALIDATION.md
+++ b/integrations/kody/VALIDATION.md
@@ -1,0 +1,67 @@
+# Integration validation
+
+Verified locally on 2026-09-08. No public listener, account publication, or
+customer data mutation was used.
+
+## Behavioral evidence
+
+The acceptance contract is [the Given/When/Then spec](../../docs/specs/kody-render-workflow.md).
+Tests were added before the corresponding implementations. Red checks included
+missing lifecycle operations, missing startup support, late cancellation,
+failed-render decoding, dynamic local Origin handling, and concurrent session
+initialization exceeding the configured cap.
+
+The real render exposed additional failures that queue mocks could not detect:
+
+- Raw `/@fs` HTML left imports unresolved. User-project renders now use Vite's
+  transformed composition route.
+- Reusing an already-enabled CDP Runtime left the seek driver's context list
+  empty. The driver now refreshes Runtime context discovery.
+- Flooring fractional frame calculations selected frame 6 for requested frame
+  7 at 24 fps, causing incorrect images and stability waits. Seeking rounds to
+  the requested frame.
+
+## Passing checks
+
+- Studio server behavior: 94 tests across 16 suites, including real MCP SDK
+  Streamable HTTP and SSE sessions, authentication/Host/Origin rejection,
+  session ownership, expiration/capacity, output range reads, symlinks, unknown
+  jobs, wait expiry, and cancellation.
+- CLI Studio command: 9 tests, including project ownership, separate listener
+  configuration, and incomplete configuration rejection.
+- Kody package workflow/app: 4 behavioral suites for success, retries, progress,
+  errors, ownership, range playback, and package-context entry.
+- Kody's actual `authoredPackageJsonSchema` accepts the provider package.
+- Real-browser shared-session seeking regression plus existing seek-driver
+  determinism, offset, and stability scripts.
+- Core, Player, Renderer, Infrastructure, Studio, and CLI builds; Studio's
+  TypeScript/lint gate. No internal package versions were synchronized.
+- Six targeted mutation checks killed authentication, Host-validation,
+  session-owner, output-path, package-owner, and late-cancellation mutants.
+  This is targeted mutation coverage, not a repository-wide mutation score.
+- Kody focused guide/catalog/downstream-MCP checks: 3 suites, 6 tests. Exact
+  changed-file Oxfmt and Mermaid checks passed.
+
+## Actual demo
+
+`verify-local.mts` runs the same package workflow over a real SDK transport,
+Vite, Chromium, and FFmpeg. It verifies identical output bytes through the
+package's MCP reads and the provider HTTP route, decodes frames to reject
+black/frozen output, plays and seeks the video through the package app, then
+exercises an actual browser render error and cancellation.
+
+The verified silent demo is H.264, 1280×720, 24 fps, 192 frames, 8.000 seconds.
+The MP4 and playback screenshot are saved outside the repository and were shown
+to the owner. Reproduce with the command in the provider guide.
+
+## Remaining installation checks
+
+Public DNS/TLS and proxy behavior, a real OS secret-store credential paired with
+Kody's account form, signed-in hosted Kody invocation/playback, cross-account
+hosted access, and reconnect across a public proxy remain unverified. The local
+fixture identity and isolated package store do not establish these live facts.
+
+Kody's authoritative `npm run validate` was attempted with Node 26.8.1 and
+npm 11.11.1 after a successful isolated install. Its E2E web server timed out
+after 180 seconds; the remaining broad run was stopped. The full gate is not
+green. No release, merge, upstream submission, or reviewer request is implied.

--- a/integrations/kody/package/AGENTS.md
+++ b/integrations/kody/package/AGENTS.md
@@ -1,0 +1,22 @@
+# Helios video agent runbook
+
+Use `start`, `status`, and `cancel` from this package's declared exports. Always
+choose `template: 'title-explainer'` explicitly. Obtain `playbackUrl` from the
+result; do not invent a provider URL or put a credential in a link.
+
+`runtime.js` uses `kody.mcp['helios']` and `packageStorage()`. The provider's JSON
+text blocks arrive through Kody's `__mcpContent` and `__mcpIsError` markers.
+Do not treat a failed render's `error` field as a transport failure.
+
+Before using a locked MCP connection, enter the package through its private app
+or an existing package workflow/job. Static imports from execute retain the
+execute context. The app exposes same-origin POST /start and POST /cancel.
+
+Smoke tests: configure with the actual hosted_app_url, start a uniquely named
+eight-second sample, inspect status, open playback, seek, and cancel a second
+sample. Report queued, failed, cancelled, and timeout accurately. Never retry an
+incomplete start blindly. Do not pass arbitrary paths to output operations.
+
+Maintain per-user package storage and private app access. Never supervise local
+processes inside Kody. Never publish a community listing or change visibility
+without the owner's explicit authorization.

--- a/integrations/kody/package/README.md
+++ b/integrations/kody/package/README.md
@@ -1,0 +1,61 @@
+# Helios video
+
+## Intent
+
+Turn an explicit short title/explainer brief into a real video. Helios owns the
+project, browser, and FFmpeg. This personal Kody package owns the request record,
+progress view, and playback through authenticated MCP reads.
+
+## Install
+
+This directory is maintained source for a user package, not an npm package or
+an existing community listing. Follow [the integration guide](https://github.com/BintzGavin/helios/blob/gavin/feat-kody-render-workflow/docs/site/guides/kody.md)
+to connect Helios and copy these files into a private saved package through
+Kody's supported Git authoring lane. Change `@owner` in package.json and examples
+to your Kody username. Run repo checks before publishing. Publishing in your
+account is a separate owner action; copying source does not install anything.
+
+Name the remote MCP connection `helios`. Open the private app or save its
+`hosted_app_url` with the configure export after publish. Keep Studio running.
+The package needs no browser, encoder dependencies, or additional secrets.
+
+## Make a video
+
+```js
+import configure from 'kody:@owner/helios-video/configure'
+import start from 'kody:@owner/helios-video'
+import status from 'kody:@owner/helios-video/status'
+
+// Use the actual hosted_app_url returned by your package publish.
+await configure({ appUrl: 'https://owner.kody.run/packages/helios-video' })
+const job = await start({
+  requestId: 'welcome-1',
+  template: 'title-explainer',
+  title: 'Make an idea move.',
+  subtitle: 'One brief. A composition. A finished film.',
+  duration: 8,
+})
+return await status({ jobId: job.jobId, waitMs: 1000 })
+```
+
+Open the returned `playbackUrl`: it displays progress and then a normal video
+player. `completed` means actual MP4 bytes exist. A wait timeout leaves the
+render running; resume with status and the same job ID. Repeating start with
+the same request ID and brief returns the recorded job. After an uncertain
+start failure, inspect Studio before using a new request ID. Start is not an
+exactly-once distributed transaction.
+
+The title template is 1280×720 at 24 fps, with 2–30 second duration, a title of
+up to 100 characters, and a subtitle of up to 85. Playback streams chunks and
+supports seeking and HEAD; output is capped at 64 MiB. This is an explicit
+template workflow, not arbitrary generated composition code.
+
+Kody authenticates the app owner. Keep the saved package private and grant the
+`helios` connector to this package using Specific packages only. Run starts in
+the package context when using that lock (an imported function in ad hoc
+execute does not change the calling package context). See the integration
+guide for `packageAppFetch` use with the locked connection.
+
+Use a separate Studio process, project root, and dedicated OS secret-store
+entry per owner. Sharing one Studio credential across Kody users shares the
+entire project and is unsupported.

--- a/integrations/kody/package/app-handler.js
+++ b/integrations/kody/package/app-handler.js
@@ -1,0 +1,62 @@
+// Keep the saved package private: Kody authenticates its owner before ingress.
+export function createApp(workflow, getContext) {
+  return {
+    async fetch(request) {
+      const url = new URL(request.url);
+      const api = workflow();
+      const packageContext = getContext();
+      if (packageContext?.hostedUrl) await api.configure({ appUrl: packageContext.hostedUrl });
+      if (request.method === 'POST' && ['/start', '/cancel'].includes(url.pathname)) {
+        if (
+          request.headers.get('Kody-Synthetic') !== 'true' &&
+          request.headers.get('origin') !== url.origin
+        )
+          return new Response('Untrusted origin', { status: 403 });
+        try {
+          const body = await request.text();
+          if (body.length > 4096) return new Response('Brief too large', { status: 413 });
+          const input = JSON.parse(body);
+          return Response.json(
+            await (url.pathname === '/start' ? api.start(input) : api.cancel(input)),
+            { headers: { 'Cache-Control': 'no-store' } },
+          );
+        } catch (error) {
+          return Response.json({ error: error.message }, { status: 400 });
+        }
+      }
+      if (!['GET', 'HEAD'].includes(request.method))
+        return new Response('Method not allowed', { status: 405 });
+      const match = /^\/(watch|status|video)\/([a-zA-Z0-9-]{1,100})$/.exec(url.pathname);
+      if (!match)
+        return new Response(
+          'Use POST /start through packageAppFetch to create a video, then open its playback URL.',
+          { headers: { 'Content-Type': 'text/plain' } },
+        );
+      const [, route, jobId] = match;
+      try {
+        if (route === 'video') return await api.video(request, jobId);
+        const status = await api.status({ jobId });
+        if (route === 'status')
+          return Response.json(status, { headers: { 'Cache-Control': 'no-store' } });
+        if (!packageContext?.hostedUrl) throw new Error('Package app context is required.');
+        const base = packageContext.appBasePath;
+        const html = `<!doctype html><html><head><meta name="viewport" content="width=device-width"><title>Helios video</title><style>body{margin:0;background:#0c1622;color:#f2f0df;font:18px system-ui;padding:6vw}main{max-width:1080px;margin:auto}h1{font-size:clamp(30px,5vw,60px);margin-bottom:12px}p{color:#b5c7bc}video{width:100%;border-radius:12px}progress{accent-color:#d8f5a2;width:100%}a{color:#d8f5a2}</style></head><body><main><p>HELIOS / KODY</p><h1>Your idea, in motion.</h1><p id="state">Checking render…</p><progress id="progress" max="1" value="0"></progress><video id="video" controls playsinline hidden></video><p><a href="">Refresh progress</a></p></main><script>
+const state=document.getElementById('state'), progress=document.getElementById('progress'), video=document.getElementById('video');let polls=0;
+async function check(){try{const r=await fetch(${JSON.stringify(base + '/status/' + jobId)});if(!r.ok)throw new Error('Could not read render progress. Refresh to retry.');const job=await r.json();state.textContent=job.status==='completed'?'Ready to play':job.status;progress.value=job.progress||0;if(job.status==='completed'){progress.hidden=true;video.hidden=false;video.src=${JSON.stringify(base + '/video/' + jobId)};return;}if(['failed','cancelled'].includes(job.status)){state.textContent=job.error||job.status;return;}if(++polls<120)setTimeout(check,1000);else state.textContent='Still rendering. Refresh to continue checking.';}catch(e){state.textContent=e.message;}}check();
+</script></body></html>`;
+        return new Response(request.method === 'HEAD' ? null : html, {
+          headers: {
+            'Content-Type': 'text/html;charset=utf-8',
+            'Cache-Control': 'private, no-store',
+            'Referrer-Policy': 'no-referrer',
+            'X-Content-Type-Options': 'nosniff',
+          },
+        });
+      } catch {
+        return new Response('Video unavailable. Check this package’s render status.', {
+          status: 404,
+        });
+      }
+    },
+  };
+}

--- a/integrations/kody/package/app.js
+++ b/integrations/kody/package/app.js
@@ -1,0 +1,4 @@
+import { packageContext } from 'kody:runtime';
+import { workflow } from './runtime.js';
+import { createApp } from './app-handler.js';
+export default createApp(workflow, () => packageContext);

--- a/integrations/kody/package/cancel.js
+++ b/integrations/kody/package/cancel.js
@@ -1,0 +1,12 @@
+import { workflow } from './runtime.js';
+/**
+ * Cancel a render recorded in this user's package.
+ * @param {object} input - jobId returned by start.
+ * @returns {Promise<object>} Terminal state or cancellation acknowledgment.
+ * @example
+ * import cancel from 'kody:@owner/helios-video/cancel'
+ * await cancel({jobId:'returned-job-id'})
+ */
+export default async function cancel(input) {
+  return workflow().cancel(input);
+}

--- a/integrations/kody/package/configure.js
+++ b/integrations/kody/package/configure.js
@@ -1,0 +1,12 @@
+import { workflow } from './runtime.js';
+/**
+ * Save the private app's published URL so exports return playable links.
+ * @param {object} input - appUrl from hosted_app_url in the publish response.
+ * @returns {Promise<object>} Non-secret playback configuration.
+ * @example
+ * import configure from 'kody:@owner/helios-video/configure'
+ * await configure({appUrl:'https://owner.kody.run/packages/helios-video'})
+ */
+export default async function configure(input) {
+  return workflow().configure(input);
+}

--- a/integrations/kody/package/package.json
+++ b/integrations/kody/package/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@owner/helios-video",
+  "type": "module",
+  "exports": {
+    ".": "./start.js",
+    "./status": "./status.js",
+    "./cancel": "./cancel.js",
+    "./configure": "./configure.js"
+  },
+  "kody": {
+    "description": "Turn a short brief into a rendered title video with progress and private playback.",
+    "tags": ["helios", "video", "render", "explainer"],
+    "category": "integrations",
+    "app": { "entry": "./app.js" }
+  }
+}

--- a/integrations/kody/package/runtime.js
+++ b/integrations/kody/package/runtime.js
@@ -1,0 +1,3 @@
+import { kody, packageStorage } from 'kody:runtime';
+import { createWorkflow } from './workflow.js';
+export const workflow = () => createWorkflow(kody.mcp['helios'], packageStorage());

--- a/integrations/kody/package/start.js
+++ b/integrations/kody/package/start.js
@@ -1,0 +1,12 @@
+import { workflow } from './runtime.js';
+/**
+ * Create and start an explicit title-explainer video. Resume with status.
+ * @param {object} input - Unique requestId, template, title, subtitle, optional duration.
+ * @returns {Promise<object>} Stable job ID and private playback URL after configuration.
+ * @example
+ * import start from 'kody:@owner/helios-video'
+ * await start({requestId:'launch-1',template:'title-explainer',title:'Make an idea move',subtitle:'Brief to playable video'})
+ */
+export default async function start(input) {
+  return workflow().start(input);
+}

--- a/integrations/kody/package/status.js
+++ b/integrations/kody/package/status.js
@@ -1,0 +1,12 @@
+import { workflow } from './runtime.js';
+/**
+ * Inspect progress or completion without submitting another render.
+ * @param {object} input - jobId and optional waitMs (0–10000).
+ * @returns {Promise<object>} Status, progress, bounded wait result, and playback URL.
+ * @example
+ * import status from 'kody:@owner/helios-video/status'
+ * await status({jobId:'returned-job-id',waitMs:1000})
+ */
+export default async function status(input) {
+  return workflow().status(input);
+}

--- a/integrations/kody/package/workflow.js
+++ b/integrations/kody/package/workflow.js
@@ -1,0 +1,180 @@
+// Runtime-independent workflow, shared by exports, the app, and the local demo.
+function unwrap(result) {
+  const blocks = result.__mcpContent ?? result.content;
+  let value = result.__mcpStructuredContent ?? result.structuredContent;
+  if (!value && blocks) {
+    const text = blocks.find((block) => block.type === 'text')?.text;
+    try {
+      value = JSON.parse(text);
+    } catch {
+      throw new Error(text || 'Malformed MCP response');
+    }
+  }
+  value ??= result;
+  if (result.__mcpIsError || result.isError)
+    throw new Error(value.error || value.code || 'Helios operation failed');
+  return value;
+}
+const validId = (value) => typeof value === 'string' && /^[a-zA-Z0-9-]{1,100}$/.test(value);
+export function createWorkflow(mcp, storage) {
+  const call = async (tool, args) => unwrap(await mcp[tool](args));
+  const owned = async (id) => {
+    const job = validId(id) && (await storage.get(`job:${id}`));
+    if (!job) throw new Error('Render job not found in this package.');
+    return job;
+  };
+  const link = async (jobId) => {
+    const config = await storage.get('config');
+    return config?.appUrl ? `${config.appUrl}/watch/${jobId}` : undefined;
+  };
+  const api = {
+    async configure({ appUrl }) {
+      const url = new URL(appUrl);
+      if (url.protocol !== 'https:' || url.username || url.password || url.search || url.hash)
+        throw new Error('Use the HTTPS hosted_app_url returned by package publish.');
+      const config = { appUrl: url.href.replace(/\/$/, '') };
+      await storage.set('config', config);
+      return config;
+    },
+    async start(input) {
+      if (input.template !== 'title-explainer')
+        throw new Error('Choose the explicit title-explainer template.');
+      if (!validId(input.requestId))
+        throw new Error('Use a unique requestId of 1–100 letters, digits, or hyphens.');
+      if (
+        typeof input.title !== 'string' ||
+        input.title.length < 1 ||
+        input.title.length > 100 ||
+        typeof input.subtitle !== 'string' ||
+        input.subtitle.length > 85
+      )
+        throw new Error('Brief needs a title (1–100 characters) and subtitle (0–85 characters).');
+      const duration = input.duration ?? 8;
+      if (!Number.isFinite(duration) || duration < 2 || duration > 30)
+        throw new Error('Duration must be 2–30 seconds.');
+      const brief = {
+        template: input.template,
+        title: input.title,
+        subtitle: input.subtitle,
+        duration,
+      };
+      const key = `request:${input.requestId}`;
+      const previous = await storage.get(key);
+      if (previous) {
+        if (JSON.stringify(previous.brief) !== JSON.stringify(brief))
+          throw new Error('requestId already belongs to a different brief.');
+        if (!previous.jobId)
+          throw new Error(
+            'Previous start is incomplete. Inspect Studio before using a new requestId.',
+          );
+        return { ...previous, playbackUrl: await link(previous.jobId) };
+      }
+      // Reserve before mutations. An uncertain failure is never retried blindly.
+      await storage.set(key, { brief, status: 'starting' });
+      const composition = await call('create_composition', {
+        name: `kody-${input.requestId}`,
+        template: input.template,
+        width: 1280,
+        height: 720,
+        fps: 24,
+        duration,
+        defaultProps: { title: input.title, subtitle: input.subtitle },
+      });
+      // DOM capture uses Helios's stateless seek driver, including for this
+      // Canvas artwork. It avoids document-clock offsets during page loading.
+      const render = await call('render_composition', {
+        compositionId: composition.id,
+        mode: 'dom',
+        videoCodec: 'libx264',
+      });
+      if (!validId(render.jobId)) throw new Error('Helios returned an invalid job ID.');
+      const record = {
+        brief,
+        compositionId: composition.id,
+        jobId: render.jobId,
+        status: render.status,
+      };
+      await storage.set(`job:${render.jobId}`, record);
+      await storage.set(key, record);
+      return { ...record, playbackUrl: await link(render.jobId) };
+    },
+    async status({ jobId, waitMs = 0 }) {
+      await owned(jobId);
+      if (!Number.isInteger(waitMs) || waitMs < 0 || waitMs > 10000)
+        throw new Error('waitMs must be 0–10000.');
+      const status = await call('get_render_status', { jobId, waitMs });
+      const output =
+        status.status === 'completed' ? await call('get_render_output', { jobId }) : undefined;
+      return { ...status, output, playbackUrl: await link(jobId) };
+    },
+    async cancel({ jobId }) {
+      await owned(jobId);
+      return call('cancel_render', { jobId });
+    },
+    async video(request, jobId) {
+      await owned(jobId);
+      const status = await call('get_render_status', { jobId });
+      if (status.status !== 'completed') throw new Error('Render has not completed.');
+      const output = await call('get_render_output', { jobId });
+      const size = output.size;
+      if (!Number.isSafeInteger(size) || size <= 0 || size > 64 * 1024 * 1024)
+        throw new Error('Video exceeds the package playback limit of 64 MiB.');
+      let start = 0;
+      let end = size - 1;
+      const range = request.headers.get('range');
+      if (range) {
+        const match = /^bytes=(\d*)-(\d*)$/.exec(range);
+        if (!match || (!match[1] && !match[2])) start = size;
+        else if (!match[1]) start = Math.max(0, size - Number(match[2]));
+        else {
+          start = Number(match[1]);
+          if (match[2]) end = Math.min(end, Number(match[2]));
+        }
+        if (
+          !Number.isSafeInteger(start) ||
+          !Number.isSafeInteger(end) ||
+          start > end ||
+          start >= size
+        )
+          return new Response(null, {
+            status: 416,
+            headers: { 'Content-Range': `bytes */${size}` },
+          });
+      }
+      const headers = {
+        'Content-Type': 'video/mp4',
+        'Content-Length': String(end - start + 1),
+        'Accept-Ranges': 'bytes',
+        'Cache-Control': 'private, no-store',
+        'X-Content-Type-Options': 'nosniff',
+        ...(range ? { 'Content-Range': `bytes ${start}-${end}/${size}` } : {}),
+      };
+      let offset = start;
+      const stream =
+        request.method === 'HEAD'
+          ? null
+          : new ReadableStream({
+              async pull(controller) {
+                try {
+                  const length = Math.min(65536, end - offset + 1);
+                  const chunk = await call('read_render_output', { jobId, offset, length });
+                  const data = Uint8Array.from(atob(chunk.data), (c) => c.charCodeAt(0));
+                  if (
+                    data.length !== length ||
+                    chunk.nextOffset !== offset + length ||
+                    chunk.size !== size
+                  )
+                    throw new Error('Invalid video chunk from Helios.');
+                  controller.enqueue(data);
+                  offset += length;
+                  if (offset > end) controller.close();
+                } catch (error) {
+                  controller.error(error);
+                }
+              },
+            });
+      return new Response(stream, { status: range ? 206 : 200, headers });
+    },
+  };
+  return api;
+}

--- a/integrations/kody/verify-local.mts
+++ b/integrations/kody/verify-local.mts
@@ -1,0 +1,131 @@
+/** Real local workflow smoke: never reads credentials or publishes a listener. */
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createServer as createHttpServer, request as httpRequest } from 'node:http';
+import { createServer } from 'vite';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { studioApiPlugin } from '../../packages/studio/src/server/plugin';
+import { createMcpHttpHandler } from '../../packages/studio/src/server/mcp-http';
+import { createWorkflow } from './package/workflow.js';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { Readable } from 'node:stream';
+import { chromium } from 'playwright';
+import { createApp } from './package/app-handler.js';
+
+const output = path.resolve(process.argv[2] ?? path.join(os.tmpdir(), 'helios-kody-demo.mp4'));
+const repository = path.resolve(import.meta.dirname, '../..');
+if (output.startsWith(repository + path.sep)) throw new Error('Save demo output outside the repository.');
+const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'helios-kody-demo-')));
+const vite = await createServer({
+  configFile: false, root, logLevel: 'error',
+  resolve: { alias: { '@helios-project/core': path.join(repository, 'packages/core/dist/index.js') } },
+  server: { host: '127.0.0.1', port: 0, fs: { allow: [root, path.join(repository, 'packages/core/dist')] } },
+  plugins: [studioApiPlugin({ projectRoot: root })],
+});
+const client = new Client({ name: 'helios-kody-local-check', version: '1' });
+const store = new Map();
+let handler: ReturnType<typeof createMcpHttpHandler> | undefined;
+let gateway: ReturnType<typeof createHttpServer> | undefined;
+let playbackServer: ReturnType<typeof createHttpServer> | undefined;
+try {
+  await vite.listen();
+  const port = (vite.httpServer!.address() as any).port;
+  const malformedHost = await new Promise<number | undefined>((resolve, reject) => {
+    const req = httpRequest({ host: '127.0.0.1', port, path: '/api/renders/render-missing.mp4', headers: { host: '%' } }, res => { res.resume(); resolve(res.statusCode); });
+    req.on('error', reject); req.setTimeout(1000, () => req.destroy(new Error('Malformed Host request hung'))); req.end();
+  });
+  if (malformedHost !== 403) throw new Error('Malformed local output Host was not rejected.');
+  // The test identity is supplied inside the process. Remote production uses
+  // the OS secret-store authenticator; these are different validation scopes.
+  handler = createMcpHttpHandler(() => port, {
+    projectRoot: root, allowedHosts: ['127.0.0.1'], allowedOrigins: [],
+    authenticate: async req => req.socket.remoteAddress === '127.0.0.1' ? 'local-fixture-owner' : undefined,
+  });
+  gateway = createHttpServer(handler.handle);
+  await new Promise<void>(resolve => gateway!.listen(0, '127.0.0.1', resolve));
+  const endpoint = `http://127.0.0.1:${(gateway.address() as any).port}`;
+  await client.connect(new StreamableHTTPClientTransport(new URL(endpoint + '/mcp')));
+  const mcp = new Proxy({}, { get: (_target, name) => async (args: any) => {
+    const result = await client.callTool({ name: String(name), arguments: args });
+    // Kody's documented downstream wrapping contract.
+    return { __mcpContent: result.content, __mcpIsError: result.isError };
+  } });
+  const workflow = createWorkflow(mcp, { get: async (key: string) => store.get(key), set: async (key: string, value: unknown) => { store.set(key, value); } });
+  const job = await workflow.start({ requestId: 'make-an-idea-move', template: 'title-explainer', title: 'Make an idea move.', subtitle: 'One brief. A composition. A finished film.', duration: 8 });
+  console.log(`Created composition ${job.compositionId}; render ${job.jobId}`);
+  const deadline = Date.now() + 180000;
+  let status;
+  do {
+    status = await workflow.status({ jobId: job.jobId, waitMs: 10000 });
+    console.log(`Render ${status.status}: ${Math.round(status.progress * 100)}%`);
+    if (Date.now() > deadline) { await workflow.cancel({ jobId: job.jobId }); throw new Error('Real render exceeded 180 seconds.'); }
+  } while (['queued', 'rendering'].includes(status.status));
+  if (status.status !== 'completed') throw new Error(`Render ${status.status}: ${status.error ?? ''}`);
+  const response = await workflow.video(new Request('https://local-check.invalid/video/' + job.jobId), job.jobId);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  await fs.mkdir(path.dirname(output), { recursive: true });
+  await fs.writeFile(output, bytes);
+  // Verify the direct output route returns the same actual bytes as the package.
+  const direct = await fetch(`${endpoint}/mcp/outputs/${job.jobId}`);
+  if (!bytes.equals(Buffer.from(await direct.arrayBuffer()))) throw new Error('MCP and HTTP output differ.');
+  // Decode actual video frames: black/frozen output must fail this smoke even
+  // when the renderer and byte transfer both report success.
+  const run = promisify(execFile);
+  const probe = JSON.parse((await run('ffprobe', ['-v', 'error', '-show_entries', 'format=duration:stream=width,height,nb_frames,avg_frame_rate', '-of', 'json', output])).stdout);
+  if (Number(probe.format.duration) !== 8 || probe.streams[0].nb_frames !== '192' || probe.streams[0].avg_frame_rate !== '24/1') throw new Error('Unexpected video duration or frame rate.');
+  const { stdout: pixels } = await run('ffmpeg', ['-v', 'error', '-i', output, '-vf', 'select=eq(n\\,0)+eq(n\\,96),crop=1000:330:70:100,scale=100:33', '-fps_mode', 'passthrough', '-f', 'rawvideo', '-pix_fmt', 'rgb24', '-'], { encoding: 'buffer', maxBuffer: 1024 * 1024 });
+  const frameBytes = 100 * 33 * 3;
+  const lightPixels = (frame: Buffer) => { let count = 0; for (let i = 0; i < frame.length; i += 3) if (frame[i] > 170 && frame[i + 1] > 170 && frame[i + 2] > 150) count++; return count; };
+  if (pixels.length !== frameBytes * 2 || lightPixels(pixels.subarray(frameBytes)) <= lightPixels(pixels.subarray(0, frameBytes)) + 80) throw new Error('Decoded title frames are black, frozen, or start at the wrong time.');
+  const app = createApp(() => workflow, () => ({ hostedUrl: 'https://local-check.invalid', appBasePath: '' }));
+  playbackServer = createHttpServer(async (req, res) => {
+    const response = await app.fetch(new Request(`http://127.0.0.1${req.url}`, { method: req.method, headers: req.headers as Record<string, string> }));
+    res.writeHead(response.status, Object.fromEntries(response.headers));
+    if (response.body) Readable.fromWeb(response.body as any).pipe(res); else res.end();
+  });
+  await new Promise<void>(resolve => playbackServer!.listen(0, '127.0.0.1', resolve));
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+    await page.goto(`http://127.0.0.1:${(playbackServer.address() as any).port}/watch/${job.jobId}`);
+    await page.waitForFunction(() => { const video = document.querySelector('video')!; return video.readyState >= 2 && video.videoWidth === 1280; });
+    await page.evaluate(async () => {
+      const video = document.querySelector('video')!;
+      video.muted = true;
+      const sought = new Promise(resolve => video.addEventListener('seeked', resolve, { once: true }));
+      video.currentTime = 4; await sought; await video.play();
+    });
+    await page.waitForFunction(() => document.querySelector('video')!.currentTime > 4.2);
+    await page.evaluate(() => document.querySelector('video')!.pause());
+    await page.screenshot({ path: output.replace(/\.mp4$/, '-playback.png') });
+    console.log('Browser playback and seeking passed through the package app and MCP chunk reads.');
+  } finally { await browser.close(); }
+
+  // Actual browser failure, then real cancellation through the same tool path.
+  const tool = async (name: string, args: Record<string, unknown>) => {
+    const result = await client.callTool({ name, arguments: args });
+    return JSON.parse((result.content as any[])[0].text);
+  };
+  const broken = await tool('create_composition', { name: 'broken-render-check', template: 'title-explainer', width: 160, height: 90, fps: 24, duration: .25 });
+  const file = path.join(root, broken.id, 'composition.html');
+  await fs.appendFile(file, '<script>throw new Error("Intentional render failure fixture")</script>');
+  const failedJob = await tool('render_composition', { compositionId: broken.id, mode: 'dom' });
+  let failure;
+  do { failure = await tool('get_render_status', { jobId: failedJob.jobId, waitMs: 1000 }); }
+  while (['queued', 'rendering'].includes(failure.status) && Date.now() < deadline);
+  if (failure.status !== 'failed') throw new Error('Browser failure did not become a failed render job.');
+  const cancelledJob = await tool('render_composition', { compositionId: job.compositionId, mode: 'dom' });
+  const cancellation = await tool('cancel_render', { jobId: cancelledJob.jobId });
+  if (cancellation.status !== 'cancelled') throw new Error('Render cancellation was not recorded.');
+  console.log('Real browser failure and render cancellation passed through MCP.');
+  console.log(`Verified ${bytes.length} bytes through package, MCP, and output route. Saved ${output}`);
+} finally {
+  await client.close();
+  await handler?.close(); gateway?.closeAllConnections(); gateway?.close();
+  playbackServer?.closeAllConnections(); playbackServer?.close();
+  await vite.close();
+  await fs.rm(root, { recursive: true, force: true });
+}

--- a/integrations/kody/workflow.test.mjs
+++ b/integrations/kody/workflow.test.mjs
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createWorkflow } from './package/workflow.js';
+import { createApp } from './package/app-handler.js';
+
+function fixture() {
+  const store = new Map(); let state = 'rendering'; let renders = 0;
+  const wrap = value => ({ __mcpContent: [{ type: 'text', text: JSON.stringify(value) }] });
+  const calls = {
+    list_compositions: async () => wrap({ compositions: [] }),
+    create_composition: async () => wrap({ id: 'sample' }),
+    render_composition: async () => { renders++; return wrap({ jobId: 'job-1', status: 'queued' }); },
+    get_render_status: async () => wrap({ jobId: 'job-1', status: state, progress: state === 'completed' ? 1 : .5, timedOut: state === 'rendering' }),
+    get_render_output: async () => wrap({ size: 9, mimeType: 'video/mp4', maxChunkBytes: 262144 }),
+    read_render_output: async ({ offset, length }) => wrap({ data: Buffer.from('testvideo').subarray(offset, offset + length).toString('base64'), nextOffset: Math.min(9, offset + length), size: 9 }),
+    cancel_render: async () => { state = 'cancelled'; return wrap({ status: state }); },
+  };
+  const storage = { get: async k => store.get(k), set: async (k, v) => store.set(k, v) };
+  return { workflow: createWorkflow(calls, storage), calls, storage, setState: s => { state = s; }, renders: () => renders };
+}
+const brief = { requestId: 'demo-one', template: 'title-explainer', title: 'Make an idea move', subtitle: 'Brief to playable video' };
+test('brief to resumable progress to a playable private video, with no duplicate render on retry', async () => {
+  const f = fixture();
+  await f.workflow.configure({ appUrl: 'https://person.kody.run/packages/helios-video' });
+  const started = await f.workflow.start(brief);
+  assert.equal(started.jobId, 'job-1');
+  assert.equal(started.playbackUrl, 'https://person.kody.run/packages/helios-video/watch/job-1');
+  assert.equal((await f.workflow.start(brief)).jobId, 'job-1'); assert.equal(f.renders(), 1);
+  assert.equal((await f.workflow.status({ jobId: started.jobId, waitMs: 1 })).timedOut, true);
+  f.setState('completed');
+  assert.equal((await f.workflow.status({ jobId: started.jobId })).status, 'completed');
+  const response = await f.workflow.video(new Request('https://example.test/video/job-1', { headers: { range: 'bytes=2-5' } }), 'job-1');
+  assert.equal(response.status, 206); assert.equal(response.headers.get('content-range'), 'bytes 2-5/9'); assert.equal(await response.text(), 'stvi');
+  assert.equal(await (await f.workflow.video(new Request('https://example.test/video/job-1'), 'job-1')).text(), 'testvideo');
+});
+test('handles provider errors, wait limits, failure, cancellation and unknown jobs', async () => {
+  const f = fixture();
+  await assert.rejects(f.workflow.status({ jobId: 'other-owner' }), /not found/);
+  await assert.rejects(f.workflow.start({ ...brief, template: 'invented' }), /template/);
+  await f.workflow.start(brief);
+  await assert.rejects(f.workflow.status({ jobId: 'job-1', waitMs: 30001 }), /wait/);
+  await assert.rejects(f.workflow.video(new Request('https://example.test'), 'job-1'), /not completed/);
+  f.setState('failed'); assert.equal((await f.workflow.status({ jobId: 'job-1' })).status, 'failed');
+  const getStatus = f.calls.get_render_status;
+  f.calls.get_render_status = async () => ({ __mcpContent: [{ type: 'text', text: JSON.stringify({ status: 'failed', error: 'Encoder failed' }) }] });
+  assert.equal((await f.workflow.status({ jobId: 'job-1' })).error, 'Encoder failed');
+  f.calls.get_render_status = getStatus;
+  assert.equal((await f.workflow.cancel({ jobId: 'job-1' })).status, 'cancelled');
+  const other = createWorkflow(f.calls, { get: async () => undefined, set: async () => {} });
+  await assert.rejects(other.video(new Request('https://example.test'), 'job-1'), /not found/);
+  f.calls.create_composition = async () => ({ __mcpIsError: true, __mcpContent: [{ type: 'text', text: 'Creation failed' }] });
+  await assert.rejects(f.workflow.start({ ...brief, requestId: 'failed' }), /Creation failed/);
+  await assert.rejects(f.workflow.start({ ...brief, requestId: 'failed' }), /incomplete/);
+});
+test('rejects unsafe playback URLs, conflicting retries, malformed output chunks and unsatisfiable ranges', async () => {
+  const f = fixture();
+  await assert.rejects(f.workflow.configure({ appUrl: 'http://insecure.test' }), /HTTPS/);
+  await f.workflow.start(brief); f.setState('completed');
+  await assert.rejects(f.workflow.start({ ...brief, title: 'Different' }), /different brief/);
+  assert.equal((await f.workflow.video(new Request('https://example.test', { headers: { range: 'bytes=30-40' } }), 'job-1')).status, 416);
+  f.calls.read_render_output = async () => ({ nextOffset: 0, data: '' });
+  await assert.rejects(async () => { await (await f.workflow.video(new Request('https://example.test'), 'job-1')).arrayBuffer(); }, /chunk/);
+});
+test('package app enters its own context, rejects foreign-origin writes, and mounts playback URLs correctly', async () => {
+  const f = fixture();
+  const context = { hostedUrl: 'https://person.kody.run/packages/helios-video', appBasePath: '/packages/helios-video' };
+  const app = createApp(() => f.workflow, () => context);
+  const start = headers => new Request('https://person.kody.run/start', { method: 'POST', headers, body: JSON.stringify(brief) });
+  assert.equal((await app.fetch(start({ origin: 'https://attacker.test' }))).status, 403);
+  assert.equal((await app.fetch(start({}))).status, 403);
+  const result = await app.fetch(start({ 'Kody-Synthetic': 'true' }));
+  assert.equal(result.status, 200);
+  assert.equal((await result.json()).playbackUrl, context.hostedUrl + '/watch/job-1');
+  const watch = await app.fetch(new Request('https://person.kody.run/watch/job-1'));
+  assert.match(await watch.text(), /\/packages\/helios-video\/video\/job-1/);
+  assert.equal((await app.fetch(new Request('https://person.kody.run/video/another-owner'))).status, 404);
+});

--- a/packages/cli/src/commands/__tests__/studio.test.ts
+++ b/packages/cli/src/commands/__tests__/studio.test.ts
@@ -5,6 +5,7 @@ import { createServer } from 'vite';
 import fs from 'fs';
 import { loadConfig } from '../../utils/config.js';
 import { RegistryClient } from '../../registry/client.js';
+import { studioApiPlugin } from '@helios-project/studio/cli';
 
 vi.mock('vite', () => ({
   createServer: vi.fn(),
@@ -90,6 +91,20 @@ describe('studio command', () => {
     expect(loadConfig).toHaveBeenCalled();
     expect(RegistryClient).toHaveBeenCalledWith(undefined);
     expect(createServer).toHaveBeenCalled();
+  });
+
+  it('starts the local listener with an explicit project and separate remote configuration', async () => {
+    vi.mocked(createServer).mockResolvedValue({ listen: vi.fn(), printUrls: vi.fn() } as any);
+    await program.parseAsync(['node', 'test', 'studio', '--mcp-public-url', 'https://video.example.com', '--mcp-secret-service', 'helios-owner']);
+    expect(createServer).toHaveBeenCalledWith(expect.objectContaining({ server: expect.objectContaining({ host: '127.0.0.1' }) }));
+    expect(studioApiPlugin).toHaveBeenCalledWith(expect.objectContaining({ projectRoot: process.cwd(), remoteMcp: { publicUrl: 'https://video.example.com', secretService: 'helios-owner', port: 5174 } }));
+  });
+
+  it('rejects incomplete remote configuration before starting a server', async () => {
+    vi.mocked(createServer).mockClear();
+    await program.parseAsync(['node', 'test', 'studio', '--mcp-public-url', 'https://video.example.com']);
+    expect(createServer).not.toHaveBeenCalled();
+    expect(exitMock).toHaveBeenCalledWith(1);
   });
 
   it('should error when server fails to start', async () => {

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -16,8 +16,14 @@ export function registerStudioCommand(program: Command) {
     .command('studio')
     .description('Launch the Helios Studio')
     .option('-p, --port <number>', 'Port to listen on', '5173')
+    .option('--mcp-public-url <origin>', 'HTTPS origin for the separate authenticated MCP listener')
+    .option('--mcp-secret-service <name>', 'OS secret-store service (account: helios-mcp)')
+    .option('--mcp-port <number>', 'Loopback port for the authenticated MCP listener', '5174')
     .action(async (options) => {
       try {
+        if (Boolean(options.mcpPublicUrl) !== Boolean(options.mcpSecretService)) {
+          throw new Error('Use --mcp-public-url and --mcp-secret-service together.');
+        }
         console.log(chalk.blue('Starting Studio...'));
 
         const config = loadConfig(process.cwd());
@@ -48,11 +54,18 @@ export function registerStudioCommand(program: Command) {
           // configFile: false, // Removed to allow loading user config (crucial for framework plugins)
           root: process.cwd(),
           server: {
+            host: '127.0.0.1',
             port: parseInt(options.port, 10),
             strictPort: false
           },
           plugins: [
             studioApiPlugin({
+              projectRoot: process.cwd(),
+              remoteMcp: options.mcpPublicUrl ? {
+                publicUrl: options.mcpPublicUrl,
+                secretService: options.mcpSecretService,
+                port: Number(options.mcpPort),
+              } : undefined,
               studioRoot: studioDist,
               skillsRoot: skillsRoot,
               components: components,

--- a/packages/renderer/src/drivers/SeekTimeDriver.ts
+++ b/packages/renderer/src/drivers/SeekTimeDriver.ts
@@ -123,6 +123,10 @@ export class SeekTimeDriver implements TimeDriver {
     this.cdpSession!.on('Runtime.executionContextCreated', this.handleExecutionContextCreated);
     this.cdpSession!.on('Runtime.executionContextDestroyed', this.handleExecutionContextDestroyed);
     this.cdpSession!.on('Runtime.executionContextsCleared', this.handleExecutionContextsCleared);
+    // DomStrategy may already have enabled Runtime on this shared session.
+    // Re-enable from a disabled state so Chrome reports existing contexts to
+    // our newly attached listeners; otherwise every seek silently becomes a no-op.
+    await this.cdpSession!.send('Runtime.disable');
     await this.cdpSession!.send('Runtime.enable');
 
     // Inject the seek script once during initialization
@@ -194,7 +198,7 @@ export class SeekTimeDriver implements TimeDriver {
             try {
               const helios = window.helios;
               const fps = helios.fps ? helios.fps.value : 30;
-              const frame = Math.floor(t * fps);
+              const frame = Math.round(t * fps);
 
               helios.seek(frame);
               heliosSeeked = true;
@@ -287,7 +291,7 @@ export class SeekTimeDriver implements TimeDriver {
                   try {
                     const helios = window.helios;
                     const fps = helios.fps ? helios.fps.value : 30;
-                    const frame = Math.floor(t * fps);
+                    const frame = Math.round(t * fps);
                     helios.seek(frame);
                   } catch (e) {
                     console.warn('[SeekTimeDriver] Error seeking Helios:', e);

--- a/packages/renderer/tests/run-all.ts
+++ b/packages/renderer/tests/run-all.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'child_process';
 import * as path from 'path';
 
 const tests = [
+  'tests/seek-shared-session.test.ts',
   'tests/verify-asset-timeout.ts',
   'tests/verify-audio-codecs.ts',
   'tests/verify-audio-fades.ts',

--- a/packages/renderer/tests/seek-shared-session.test.ts
+++ b/packages/renderer/tests/seek-shared-session.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { chromium } from 'playwright';
+import { SeekTimeDriver } from '../src/drivers/SeekTimeDriver.js';
+
+// DomStrategy enables Runtime on the shared CDP session before the seek driver.
+// Enabling it a second time does not replay executionContextCreated events.
+const browser = await chromium.launch();
+try {
+  const page = await browser.newPage();
+  const driver = new SeekTimeDriver(1000);
+  await driver.init(page);
+  await page.goto('data:text/html,<body>seek-check</body>');
+  await page.evaluate(() => {
+    (window as any).helios = { fps: { value: 24 }, currentFrame: { value: 0 }, isVirtualTimeBound: true,
+      seek(frame: number) { this.currentFrame.value = frame; },
+    };
+  });
+  const cdp = await page.context().newCDPSession(page);
+  (page as any)._sharedCdpSession = cdp;
+  await cdp.send('Runtime.enable');
+  await driver.prepare(page);
+  for (const frame of [96, 0, 191, 36, 7, 14, 25, 31, 62, 107]) {
+    await driver.setTime(page, frame * (1 / 24));
+    const actual = await page.evaluate(() => (window as any).helios.currentFrame.value);
+    assert.equal(actual, frame, 'Seeking must update the page even when Runtime was already enabled');
+  }
+  console.log('Shared-session stateless seek passed at frames 96, 0, 191, and 36.');
+} finally { await browser.close(); }

--- a/packages/studio/src/server/discovery.ts
+++ b/packages/studio/src/server/discovery.ts
@@ -32,7 +32,15 @@ async function exists(filePath: string): Promise<boolean> {
   }
 }
 
+let configuredProjectRoot: string | undefined;
+export function configureProjectRoot(root: string) {
+  const resolved = path.resolve(root);
+  if (configuredProjectRoot && configuredProjectRoot !== resolved) throw new Error('Studio is already bound to another project.');
+  configuredProjectRoot = resolved;
+}
+
 export function getProjectRoot(cwd: string): string {
+  if (configuredProjectRoot) return configuredProjectRoot;
   if (process.env.HELIOS_PROJECT_ROOT) {
     return path.resolve(process.env.HELIOS_PROJECT_ROOT);
   }

--- a/packages/studio/src/server/mcp-http.test.ts
+++ b/packages/studio/src/server/mcp-http.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment node
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { createServer, request, type Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { createMcpHttpHandler } from './mcp-http';
+
+const state = vi.hoisted(() => ({ jobs: new Map<string, any>() }));
+vi.mock('./render-manager', () => ({
+  getJob: (id: string) => state.jobs.get(id),
+  cancelJob: async (id: string) => { const j = state.jobs.get(id); if (!j || !['queued', 'rendering'].includes(j.status)) return false; j.status = 'cancelled'; return true; },
+  startRender: async (options: any) => {
+    const id = 'job-' + state.jobs.size;
+    state.jobs.set(id, { id, status: 'rendering', progress: .25, compositionId: options.compositionId });
+    return id;
+  },
+}));
+vi.mock('./discovery', () => ({
+  findCompositions: async () => [{ id: 'demo', name: 'Demo', url: '/demo/composition.html', metadata: { width: 640, height: 360, fps: 24, duration: 3 } }],
+  createComposition: async () => ({ id: 'demo', name: 'Demo' }),
+  findAssets: async () => [],
+  getProjectRoot: (root: string) => root,
+}));
+vi.mock('./documentation', () => ({ findDocumentation: () => [] }));
+let server: Server;
+let endpoint: string;
+let root: string;
+let handler: ReturnType<typeof createMcpHttpHandler>;
+let clients: Client[];
+// Ephemeral in-memory credentials: never persisted or printed, even on assertion failure.
+let owner: string;
+let other: string;
+function headers(identity = owner) { return { authorization: `Bearer ${identity}` }; }
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'helios-http-'));
+  await fs.mkdir(path.join(root, 'renders'));
+  state.jobs.clear(); clients = []; owner = randomUUID(); other = randomUUID();
+  handler = createMcpHttpHandler(() => 5173, {
+    projectRoot: root,
+    authenticate: async req => req.headers.authorization === `Bearer ${owner}` ? 'owner' : req.headers.authorization === `Bearer ${other}` ? 'other' : undefined,
+    allowedHosts: ['127.0.0.1'], allowedOrigins: ['https://video.example.com'],
+  });
+  server = createServer(handler.handle);
+  await new Promise<void>(r => server.listen(0, '127.0.0.1', r));
+  endpoint = `http://127.0.0.1:${(server.address() as any).port}`;
+});
+afterEach(async () => {
+  await Promise.all(clients.map(c => c.close()));
+  await handler.close();
+  server.closeAllConnections();
+  await new Promise<void>(r => server.close(() => r()));
+  await fs.rm(root, { recursive: true, force: true });
+});
+async function connect(legacy = false) {
+  const client = new Client({ name: 'workflow-check', version: '1' }); clients.push(client);
+  const transport = legacy
+    ? new SSEClientTransport(new URL(endpoint + '/mcp/sse'), { requestInit: { headers: headers() }, eventSourceInit: { fetch: (url, init) => fetch(url, { ...init, headers: headers() }) } })
+    : new StreamableHTTPClientTransport(new URL(endpoint + '/mcp'), { requestInit: { headers: headers() } });
+  await client.connect(transport);
+  return { client, transport };
+}
+const unpack = (result: any) => JSON.parse(result.content[0].text);
+
+it('fails closed on every route and denies unexpected hosts, origins, and editor routes', async () => {
+  for (const route of ['/mcp', '/mcp/sse', '/mcp/messages?sessionId=unknown', '/mcp/outputs/one', '/api/renders/one.mp4']) {
+    expect((await fetch(endpoint + route)).status).toBe(401);
+  }
+  expect((await fetch(endpoint + '/mcp', { headers: { ...headers(), origin: 'https://attacker.example' } })).status).toBe(403);
+  const badHostStatus = await new Promise<number | undefined>(resolve => {
+    request(endpoint + '/mcp', { headers: { ...headers(), host: 'attacker.example' } }, res => { res.resume(); resolve(res.statusCode); }).end();
+  });
+  expect(badHostStatus).toBe(403);
+  for (const route of ['/api/jobs', '/@fs/private', '/renders/jobs.json', '/mcp/sse/extra']) {
+    expect((await fetch(endpoint + route, { headers: headers() })).status).toBe(404);
+  }
+});
+
+it.each([false, true])('supports the complete tool lifecycle over real SDK transport (legacy=%s)', async legacy => {
+  const { client } = await connect(legacy);
+  expect((await client.listTools()).tools.map(t => t.name)).toEqual(expect.arrayContaining(['list_compositions', 'get_render_status', 'get_render_output', 'read_render_output', 'cancel_render']));
+  expect(unpack(await client.callTool({ name: 'list_compositions', arguments: {} })).compositions[0].id).toBe('demo');
+  expect((await client.callTool({ name: 'render_composition', arguments: { compositionId: '../absent' } })).isError).toBe(true);
+  const created = unpack(await client.callTool({ name: 'create_composition', arguments: { name: 'demo', template: 'title-explainer' } }));
+  const started = unpack(await client.callTool({ name: 'render_composition', arguments: { compositionId: created.id } }));
+  const jobId = started.jobId;
+  expect(unpack(await client.callTool({ name: 'get_render_status', arguments: { jobId, waitMs: 10 } }))).toMatchObject({ status: 'rendering', timedOut: true });
+  expect(unpack(await client.callTool({ name: 'get_render_output', arguments: { jobId } })).code).toBe('OUTPUT_NOT_READY');
+  expect(unpack(await client.callTool({ name: 'cancel_render', arguments: { jobId } })).status).toBe('cancelled');
+  expect(unpack(await client.callTool({ name: 'get_render_status', arguments: { jobId: 'missing' } })).code).toBe('JOB_NOT_FOUND');
+  const file = path.join(root, 'renders', `render-${jobId}.mp4`);
+  await fs.writeFile(file, 'video-fixture');
+  Object.assign(state.jobs.get(jobId), { status: 'completed', progress: 1, outputPath: file });
+  expect(unpack(await client.callTool({ name: 'get_render_output', arguments: { jobId } })).size).toBe(13);
+  const out = await fetch(endpoint + '/mcp/outputs/' + jobId, { headers: { ...headers(), range: 'bytes=1-4' } });
+  expect(out.status).toBe(206); expect(out.headers.get('content-range')).toBe('bytes 1-4/13'); expect(await out.text()).toBe('ideo');
+  expect((await fetch(endpoint + '/mcp/outputs/' + jobId, { method: 'HEAD', headers: headers() })).headers.get('content-length')).toBe('13');
+});
+
+it('isolates concurrent sessions and rejects replay by a different identity', async () => {
+  const a = await connect(); const b = await connect();
+  const id = (a.transport as StreamableHTTPClientTransport).sessionId!;
+  expect((await fetch(endpoint + '/mcp', { method: 'POST', headers: { 'mcp-session-id': id }, body: '{}' })).status).toBe(401);
+  expect(id === (b.transport as StreamableHTTPClientTransport).sessionId).toBe(false);
+  const response = await fetch(endpoint + '/mcp', { method: 'DELETE', headers: { ...headers(other), 'mcp-session-id': id } });
+  expect(response.status).toBe(404);
+  expect((await a.client.listTools()).tools.length > 0).toBe(true);
+  expect((await b.client.listTools()).tools.length > 0).toBe(true);
+  await (a.transport as StreamableHTTPClientTransport).terminateSession();
+  expect((await fetch(endpoint + '/mcp', { method: 'DELETE', headers: { ...headers(), 'mcp-session-id': id } })).status).toBe(404);
+});
+
+it('bounds sessions, expires them, and rejects malformed requests without creating a session', async () => {
+  const bad = await fetch(endpoint + '/mcp', { method: 'POST', headers: headers(), body: '{' });
+  expect(bad.status).toBe(400);
+  expect((await fetch(endpoint + '/mcp', { method: 'POST', headers: headers(), body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }) })).status).toBe(400);
+  await handler.close();
+  handler = createMcpHttpHandler(() => 5173, {
+    projectRoot: root, authenticate: async () => 'owner', allowedHosts: ['127.0.0.1'], allowedOrigins: [], maxSessions: 1, sessionTtlMs: 500,
+  });
+  server.removeAllListeners('request'); server.on('request', handler.handle);
+  const a = await connect();
+  const id = (a.transport as StreamableHTTPClientTransport).sessionId!;
+  const initialize = { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', clientInfo: { name: 'limit-test', version: '1' }, capabilities: {} } };
+  expect((await fetch(endpoint + '/mcp', { method: 'POST', headers: headers(), body: JSON.stringify(initialize) })).status).toBe(503);
+  await new Promise(r => setTimeout(r, 550));
+  expect((await fetch(endpoint + '/mcp', { method: 'DELETE', headers: { ...headers(), 'mcp-session-id': id } })).status).toBe(404);
+});
+
+it('accepts a local Origin resolved after the listener chooses its port', async () => {
+  await handler.close();
+  handler = createMcpHttpHandler(() => 5173, {
+    projectRoot: root, authenticate: async () => 'owner', allowedHosts: ['127.0.0.1'], allowedOrigins: () => [endpoint],
+  });
+  server.removeAllListeners('request'); server.on('request', handler.handle);
+  const response = await fetch(endpoint + '/mcp', { headers: { ...headers(), origin: endpoint } });
+  expect(response.status).toBe(405);
+});
+
+it('enforces the session limit for concurrent initialization requests', async () => {
+  await handler.close();
+  handler = createMcpHttpHandler(() => 5173, { projectRoot: root, authenticate: async () => 'owner', allowedHosts: ['127.0.0.1'], allowedOrigins: [], maxSessions: 1 });
+  server.removeAllListeners('request'); server.on('request', handler.handle);
+  const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', clientInfo: { name: 'concurrent-limit', version: '1' }, capabilities: {} } });
+  const pending: ReturnType<typeof request>[] = [];
+  const responses = Array.from({ length: 8 }, () => new Promise<number | undefined>(resolve => {
+    const req = request(endpoint + '/mcp', { method: 'POST', headers: { ...headers(), 'content-type': 'application/json', accept: 'application/json, text/event-stream' } }, res => { res.resume(); res.on('end', () => resolve(res.statusCode)); });
+    req.write(body.slice(0, 10)); pending.push(req);
+  }));
+  await new Promise(r => setTimeout(r, 50));
+  pending.forEach(req => req.end(body.slice(10)));
+  const statuses = await Promise.all(responses);
+  expect(statuses.filter(status => status === 200)).toHaveLength(1);
+  expect(statuses.filter(status => status === 503)).toHaveLength(7);
+});

--- a/packages/studio/src/server/mcp-http.ts
+++ b/packages/studio/src/server/mcp-http.ts
@@ -1,0 +1,189 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createMcpServer } from './mcp';
+import { RenderAccessError, serveRenderOutput } from './render-access';
+import type { StudioPluginOptions } from './types';
+
+export interface McpHttpOptions extends StudioPluginOptions {
+  projectRoot: string;
+  /** Stable identity, not a credential. Revalidated for every request. */
+  authenticate: (req: IncomingMessage) => Promise<string | undefined>;
+  allowedHosts: string[];
+  allowedOrigins: string[] | (() => string[]);
+  maxSessions?: number;
+  sessionTtlMs?: number;
+}
+
+async function readJson(req: IncomingMessage) {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > 1024 * 1024)
+      throw new RenderAccessError('BODY_TOO_LARGE', 'MCP request exceeds 1 MiB.', 413);
+    chunks.push(Buffer.from(chunk));
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString());
+  } catch {
+    throw new RenderAccessError('INVALID_JSON', 'Invalid JSON request.');
+  }
+}
+
+/** Narrow listener shared by local Studio and the authenticated remote gateway. */
+export function createMcpHttpHandler(getPort: () => number, options: McpHttpOptions) {
+  type Session = {
+    owner: string;
+    server: ReturnType<typeof createMcpServer>;
+    transport: SSEServerTransport | StreamableHTTPServerTransport;
+    expires: number;
+  };
+  const sessions = new Map<string, Session>();
+  let pendingSessions = 0;
+  const ttl = options.sessionTtlMs ?? 30 * 60 * 1000;
+  const sweep = setInterval(
+    () => {
+      for (const [id, session] of sessions)
+        if (session.expires <= Date.now()) {
+          sessions.delete(id);
+          void session.server.close();
+        }
+    },
+    Math.min(ttl, 60000),
+  );
+  sweep.unref();
+  const send = (res: ServerResponse, status: number, code: string) => {
+    res.writeHead(status, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' });
+    res.end(JSON.stringify({ error: code }));
+  };
+  const remember = (id: string, session: Session) => {
+    sessions.set(id, session);
+    // McpServer.connect installs transport.onclose. Preserve its cleanup hook.
+    const previous = session.transport.onclose;
+    session.transport.onclose = () => {
+      sessions.delete(id);
+      previous?.();
+    };
+  };
+  async function handle(req: IncomingMessage, res: ServerResponse) {
+    try {
+      const owner = await options.authenticate(req);
+      if (!owner) {
+        res.setHeader('WWW-Authenticate', 'Bearer realm="Helios"');
+        send(res, 401, 'UNAUTHORIZED');
+        return;
+      }
+      let hostname: string;
+      try {
+        hostname = new URL(`http://${req.headers.host}`).hostname;
+      } catch {
+        send(res, 403, 'INVALID_HOST');
+        return;
+      }
+      const origins =
+        typeof options.allowedOrigins === 'function'
+          ? options.allowedOrigins()
+          : options.allowedOrigins;
+      if (
+        !options.allowedHosts.includes(hostname) ||
+        (req.headers.origin && !origins.includes(req.headers.origin))
+      ) {
+        send(res, 403, 'UNTRUSTED_ORIGIN');
+        return;
+      }
+      const url = new URL(req.url ?? '/', 'http://localhost');
+      const output = /^\/mcp\/outputs\/([a-zA-Z0-9-]{1,100})$/.exec(url.pathname);
+      if (output) {
+        await serveRenderOutput(output[1], options.projectRoot, req, res);
+        return;
+      }
+      if (!['/mcp', '/mcp/sse', '/mcp/messages'].includes(url.pathname)) {
+        send(res, 404, 'NOT_FOUND');
+        return;
+      }
+      const legacy = url.pathname !== '/mcp';
+      const sessionId = legacy ? url.searchParams.get('sessionId') : req.headers['mcp-session-id'];
+      if (sessionId) {
+        const session = typeof sessionId === 'string' ? sessions.get(sessionId) : undefined;
+        if (
+          !session ||
+          session.owner !== owner ||
+          session.expires <= Date.now() ||
+          legacy !== session.transport instanceof SSEServerTransport
+        ) {
+          send(res, 404, 'SESSION_NOT_FOUND');
+          return;
+        }
+        session.expires = Date.now() + ttl;
+        if (session.transport instanceof SSEServerTransport) {
+          if (url.pathname !== '/mcp/messages' || req.method !== 'POST') {
+            send(res, 405, 'METHOD_NOT_ALLOWED');
+            return;
+          }
+          await session.transport.handlePostMessage(req, res, await readJson(req));
+        } else
+          await session.transport.handleRequest(
+            req,
+            res,
+            req.method === 'POST' ? await readJson(req) : undefined,
+          );
+        return;
+      }
+      if (url.pathname === '/mcp/messages') {
+        send(res, 400, 'SESSION_REQUIRED');
+        return;
+      }
+      if ((legacy && req.method !== 'GET') || (!legacy && req.method !== 'POST')) {
+        send(res, 405, 'METHOD_NOT_ALLOWED');
+        return;
+      }
+      if (sessions.size + pendingSessions >= (options.maxSessions ?? 32)) {
+        send(res, 503, 'SESSION_LIMIT');
+        return;
+      }
+      pendingSessions++;
+      try {
+        const body = legacy ? undefined : await readJson(req);
+        if (!legacy && !isInitializeRequest(body)) {
+          send(res, 400, 'INITIALIZE_REQUIRED');
+          return;
+        }
+        const server = createMcpServer(getPort, options);
+        const transport = legacy
+          ? new SSEServerTransport('/mcp/messages', res)
+          : new StreamableHTTPServerTransport({ sessionIdGenerator: randomUUID });
+        const session: Session = { owner, server, transport, expires: Date.now() + ttl };
+        await server.connect(transport);
+        if (transport instanceof SSEServerTransport) remember(transport.sessionId, session);
+        else {
+          await transport.handleRequest(req, res, body);
+          if (transport.sessionId) remember(transport.sessionId, session);
+          else await server.close();
+        }
+      } finally {
+        pendingSessions--;
+      }
+    } catch (error) {
+      if (res.headersSent) {
+        res.destroy();
+        return;
+      }
+      send(
+        res,
+        error instanceof RenderAccessError ? error.status : 500,
+        error instanceof RenderAccessError ? error.code : 'MCP_REQUEST_FAILED',
+      );
+    }
+  }
+  return {
+    handle,
+    close: async () => {
+      clearInterval(sweep);
+      await Promise.all([...sessions.values()].map((s) => s.server.close()));
+      sessions.clear();
+    },
+  };
+}

--- a/packages/studio/src/server/mcp.ts
+++ b/packages/studio/src/server/mcp.ts
@@ -1,12 +1,21 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { z } from "zod";
 import { findCompositions, createComposition, findAssets } from './discovery';
-import { startRender } from './render-manager';
+import { startRender, cancelJob } from './render-manager';
+import { getRenderStatus, getRenderOutput, readRenderOutput, requireJob, RenderAccessError, MAX_CHUNK_BYTES } from './render-access';
+import { getProjectRoot } from './discovery';
 import { StudioPluginOptions } from './types';
 import { findDocumentation } from './documentation';
 
 export function createMcpServer(getPort: () => number, options: StudioPluginOptions = {}) {
+  const root = () => options.projectRoot ?? getProjectRoot(process.cwd());
+  const json = (value: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(value) }] });
+  const guarded = async (fn: () => Promise<unknown>) => {
+    try { return json(await fn()); }
+    catch (error) {
+      return { ...json({ code: error instanceof RenderAccessError ? error.code : 'RENDER_ERROR', error: error instanceof RenderAccessError ? error.message : 'Render operation failed. Check Studio diagnostics.' }), isError: true };
+    }
+  };
   const server = new McpServer({
     name: "Helios Studio",
     version: "0.72.1"
@@ -76,11 +85,11 @@ export function createMcpServer(getPort: () => number, options: StudioPluginOpti
     "create_composition",
     {
       name: z.string(),
-      template: z.enum(['vanilla', 'react', 'vue', 'svelte', 'solid', 'threejs']).optional(),
-      width: z.number().optional(),
-      height: z.number().optional(),
-      fps: z.number().optional(),
-      duration: z.number().optional(),
+      template: z.enum(['vanilla', 'react', 'vue', 'svelte', 'solid', 'threejs', 'title-explainer']).optional(),
+      width: z.number().int().min(16).max(3840).optional(),
+      height: z.number().int().min(16).max(2160).optional(),
+      fps: z.number().int().min(1).max(60).optional(),
+      duration: z.number().positive().max(300).optional(),
       defaultProps: z.record(z.string(), z.any()).optional()
     },
     async (args) => {
@@ -118,10 +127,11 @@ export function createMcpServer(getPort: () => number, options: StudioPluginOpti
     "render_composition",
     {
       compositionId: z.string(),
-      width: z.number().optional(),
-      height: z.number().optional(),
-      fps: z.number().optional(),
-      duration: z.number().optional(),
+      width: z.number().int().min(16).max(3840).optional(),
+      height: z.number().int().min(16).max(2160).optional(),
+      fps: z.number().int().min(1).max(60).optional(),
+      duration: z.number().positive().max(300).optional(),
+      mode: z.enum(['canvas', 'dom']).optional(),
       inputProps: z.record(z.string(), z.any()).optional(),
       videoBitrate: z.string().optional(),
       videoCodec: z.string().optional()
@@ -140,11 +150,17 @@ export function createMcpServer(getPort: () => number, options: StudioPluginOpti
 
            const port = getPort();
            const jobId = await startRender({
-               compositionUrl: comp.url,
-               width: args.width,
-               height: args.height,
-               fps: args.fps,
-               duration: args.duration,
+               // User-project HTML must pass through Vite's HTML transform;
+               // /@fs serves raw HTML and leaves bare module imports unresolved.
+               compositionUrl: options.projectRoot ? `/${[...comp.id.split('/').filter(Boolean), 'composition.html'].map(encodeURIComponent).join('/')}` : comp.url,
+               compositionId: comp.id,
+               width: args.width ?? comp.metadata?.width,
+               height: args.height ?? comp.metadata?.height,
+               fps: args.fps ?? comp.metadata?.fps,
+               duration: args.duration ?? comp.metadata?.duration,
+               mode: args.mode,
+               // Image capture keeps the requested frame rate across platforms.
+               webCodecsPreference: 'disabled',
                inputProps: args.inputProps,
                videoBitrate: args.videoBitrate,
                videoCodec: args.videoCodec
@@ -161,6 +177,27 @@ export function createMcpServer(getPort: () => number, options: StudioPluginOpti
        }
     }
   );
+
+  server.tool('list_compositions', 'Discover composition IDs and render metadata in this project.', {}, async () => {
+    const compositions = await findCompositions(process.cwd());
+    return json({ compositions: compositions.map(({ id, name, metadata }) => ({ id, name, metadata })) });
+  });
+  server.tool('get_render_status', 'Inspect progress or wait up to 30 seconds. Wait expiry does not cancel the render.', {
+    jobId: z.string(), waitMs: z.number().int().min(0).max(30000).optional(),
+  }, (args, extra) => guarded(() => getRenderStatus(args.jobId, args.waitMs, extra.signal)));
+  server.tool('cancel_render', 'Cancel a queued or running render. Terminal jobs retain their final state.', {
+    jobId: z.string(),
+  }, args => guarded(async () => {
+    requireJob(args.jobId);
+    const cancelled = await cancelJob(args.jobId);
+    return { ...await getRenderStatus(args.jobId), cancelled };
+  }));
+  server.tool('get_render_output', 'Get completed MP4 metadata. The output path requires the same authentication as MCP.', {
+    jobId: z.string(),
+  }, args => guarded(() => getRenderOutput(args.jobId, root())));
+  server.tool('read_render_output', 'Read a bounded base64 MP4 chunk over the authenticated MCP connection.', {
+    jobId: z.string(), offset: z.number().int().min(0).optional(), length: z.number().int().min(1).max(MAX_CHUNK_BYTES).optional(),
+  }, args => guarded(() => readRenderOutput(args.jobId, root(), args.offset, args.length)));
 
   server.tool(
     "install_component",

--- a/packages/studio/src/server/plugin.ts
+++ b/packages/studio/src/server/plugin.ts
@@ -2,12 +2,13 @@ import { Plugin, ViteDevServer, PreviewServer } from 'vite';
 import { AddressInfo } from 'net';
 import fs from 'fs';
 import path from 'path';
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import { createMcpServer } from './mcp';
-import { findCompositions, findAssets, getProjectRoot, createComposition, deleteComposition, updateCompositionMetadata, duplicateComposition, renameComposition, renameAsset, deleteAsset, createDirectory, moveAsset } from './discovery';
+import { createMcpHttpHandler } from './mcp-http';
+import { startRemoteMcp } from './remote-startup';
+import { RenderAccessError, serveRenderOutput } from './render-access';
+import { findCompositions, findAssets, getProjectRoot, configureProjectRoot, createComposition, deleteComposition, updateCompositionMetadata, duplicateComposition, renameComposition, renameAsset, deleteAsset, createDirectory, moveAsset } from './discovery';
 import { templates } from './templates';
 import { findDocumentation, resolveDocumentationPath } from './documentation';
-import { startRender, getRenderJobSpec, getJob, getJobs, cancelJob, deleteJob, diagnoseServer } from './render-manager';
+import { initializeRenderManager, startRender, getRenderJobSpec, getJob, getJobs, cancelJob, deleteJob, diagnoseServer } from './render-manager';
 import { StudioPluginOptions } from './types';
 
 export type { StudioPluginOptions, StudioComponentDefinition } from './types';
@@ -82,51 +83,39 @@ function configureMiddlewares(server: ViteDevServer | PreviewServer, isPreview: 
           });
       }
 
-      // MCP Server Setup
-      const mcpServer = createMcpServer(() => {
+      // Local Studio and remote MCP are separate network surfaces.
+      const projectRoot = options.projectRoot ?? getProjectRoot(process.cwd());
+      configureProjectRoot(projectRoot);
+      void initializeRenderManager(projectRoot);
+      const getPort = () => {
           const address = server.httpServer?.address();
-          return (typeof address === 'object' && address !== null) ? address.port : 5173;
-      }, options);
-      const mcpTransports = new Map<string, SSEServerTransport>();
-
-      server.middlewares.use('/mcp/sse', async (req, res, next) => {
-          const transport = new SSEServerTransport("/mcp/messages", res);
-          const sessionId = transport.sessionId;
-          mcpTransports.set(sessionId, transport);
-
-          transport.onclose = () => {
-              mcpTransports.delete(sessionId);
-          };
-
-          await mcpServer.connect(transport);
+          return typeof address === 'object' && address !== null ? address.port : 5173;
+      };
+      const localMcp = createMcpHttpHandler(getPort, {
+          ...options, projectRoot,
+          allowedHosts: ['localhost', '127.0.0.1', '[::1]'],
+          allowedOrigins: () => [`http://localhost:${getPort()}`, `http://127.0.0.1:${getPort()}`, `http://[::1]:${getPort()}`],
+          authenticate: async req => ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.socket.remoteAddress ?? '') ? 'local-owner' : undefined,
       });
-
-      server.middlewares.use('/mcp/messages', async (req, res, next) => {
-          if (req.method !== 'POST') return next();
-
-          const urlStr = req.url || '/';
-          const qIndex = urlStr.indexOf('?');
-          let sessionId: string | null = null;
-          if (qIndex !== -1) {
-              const params = new URLSearchParams(urlStr.substring(qIndex));
-              sessionId = params.get('sessionId');
-          }
-
-          if (!sessionId) {
-              res.statusCode = 400;
-              res.end("Missing sessionId");
-              return;
-          }
-
-          const transport = mcpTransports.get(sessionId);
-          if (!transport) {
-              res.statusCode = 404;
-              res.end("Session not found");
-              return;
-          }
-
-          await transport.handlePostMessage(req, res);
+      server.middlewares.use((req, res, next) => {
+          if (req.url?.split('?')[0].startsWith('/mcp')) { void localMcp.handle(req, res); return; }
+          next();
       });
+      server.httpServer?.once('close', () => { void localMcp.close(); });
+      if (options.remoteMcp) {
+          // Vite calls configureServer before binding. Start the gateway only
+          // after the renderer's loopback origin is available.
+          server.httpServer?.once('listening', () => {
+              void startRemoteMcp(getPort, { ...options, projectRoot }, options.remoteMcp!).then(remote => {
+                  server.httpServer?.once('close', () => { void remote.close(); });
+                  console.log(`Authenticated MCP: ${options.remoteMcp!.publicUrl}/mcp (loopback gateway port ${options.remoteMcp!.port})`);
+              }).catch(() => {
+                  console.error('Remote MCP startup failed. Check the dedicated OS secret-store entry and listener port.');
+                  void server.close();
+                  process.exitCode = 1;
+              });
+          });
+      }
 
       server.middlewares.use('/api/components', async (req, res, next) => {
         if (req.url === '/' || req.url === '') {
@@ -750,32 +739,23 @@ function configureMiddlewares(server: ViteDevServer | PreviewServer, isPreview: 
         next();
       });
 
-      server.middlewares.use('/api/renders', async (req, res, next) => {
-        const match = req.url!.match(/^\/([^\/]+)$/);
-        if (match) {
-            const filename = match[1];
-            // Security check: simple basename check to avoid traversal
-            if (filename.includes('/') || filename.includes('\\') || filename.includes('..')) {
-                res.statusCode = 400;
-                res.end('Invalid filename');
-                return;
-            }
-
-            const projectRoot = getProjectRoot(process.cwd());
-            const rendersDir = path.resolve(projectRoot, 'renders');
-            const filePath = path.join(rendersDir, filename);
-
-            if (fs.existsSync(filePath)) {
-                res.setHeader('Content-Type', 'video/mp4');
-                const stream = fs.createReadStream(filePath);
-                stream.pipe(res);
-            } else {
-                res.statusCode = 404;
-                res.end('File not found');
-            }
-            return;
+      server.middlewares.use('/api/renders', async (req, res) => {
+        // Legacy browser URL shares the managed-output validation. Remote
+        // access uses /mcp/outputs exclusively on the authenticated listener.
+        const local = ['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.socket.remoteAddress ?? '');
+        let host: string;
+        try { host = new URL(`http://${req.headers.host}`).hostname; }
+        catch { res.statusCode = 403; res.end(); return; }
+        const allowedOrigin = !req.headers.origin || [`http://localhost:${getPort()}`, `http://127.0.0.1:${getPort()}`].includes(req.headers.origin);
+        if (!local || !['localhost', '127.0.0.1', '[::1]'].includes(host) || !allowedOrigin) { res.statusCode = 403; res.end(); return; }
+        const match = /^\/render-([a-zA-Z0-9-]{1,100})\.mp4$/.exec((req.url ?? '').split('?')[0]);
+        if (!match) { res.statusCode = 404; res.end(); return; }
+        try { await serveRenderOutput(match[1], projectRoot, req, res); }
+        catch (error) {
+          if (res.headersSent) { res.destroy(); return; }
+          res.statusCode = error instanceof RenderAccessError ? error.status : 500;
+          res.end(error instanceof RenderAccessError ? error.code : 'OUTPUT_ERROR');
         }
-        next();
       });
 
       server.middlewares.use('/api/jobs', async (req, res, next) => {

--- a/packages/studio/src/server/remote-startup.test.ts
+++ b/packages/studio/src/server/remote-startup.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment node
+import { expect, it, vi } from 'vitest';
+import { randomBytes } from 'node:crypto';
+import { createSecretStoreAuthenticator, validateRemoteOptions } from './remote-startup';
+
+it('requires HTTPS and an explicit OS secret store service with no path or URL credentials', () => {
+  expect(() => validateRemoteOptions({ publicUrl: 'http://example.com', secretService: 'helios', port: 5174 })).toThrow();
+  expect(() => validateRemoteOptions({ publicUrl: 'https://example.com/prefix', secretService: 'helios', port: 5174 })).toThrow();
+  expect(() => validateRemoteOptions({ publicUrl: 'https://example.com', secretService: '', port: 5174 })).toThrow();
+  expect(validateRemoteOptions({ publicUrl: 'https://example.com', secretService: 'helios-owner', port: 5174 }).publicUrl).toBe('https://example.com');
+});
+it('checks the store per request, accepts only exact bearer values, and fails closed on store errors', async () => {
+  let material = randomBytes(32).toString('hex');
+  const read = vi.fn(async () => Buffer.from(material));
+  const auth = createSecretStoreAuthenticator(read);
+  const req = (value?: string) => ({ headers: value ? { authorization: value } : {} }) as any;
+  expect(await auth(req())).toBeUndefined();
+  expect(Boolean(await auth(req(`Bearer ${material}`)))).toBe(true);
+  const stale = material; material = randomBytes(32).toString('hex');
+  expect(Boolean(await auth(req(`Bearer ${stale}`)))).toBe(false);
+  expect(Boolean(await auth(req(`Basic ${material}`)))).toBe(false);
+  read.mockRejectedValueOnce(new Error('Store unavailable'));
+  expect(Boolean(await auth(req(`Bearer ${material}`)))).toBe(false);
+});

--- a/packages/studio/src/server/remote-startup.ts
+++ b/packages/studio/src/server/remote-startup.ts
@@ -1,0 +1,118 @@
+import { execFile } from 'node:child_process';
+import { timingSafeEqual } from 'node:crypto';
+import { createServer, type IncomingMessage } from 'node:http';
+import { createMcpHttpHandler } from './mcp-http';
+import type { StudioPluginOptions } from './types';
+
+export interface RemoteMcpOptions {
+  publicUrl: string;
+  secretService: string;
+  port: number;
+}
+export function validateRemoteOptions(options: RemoteMcpOptions) {
+  const url = new URL(options.publicUrl);
+  if (
+    url.protocol !== 'https:' ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.pathname !== '/'
+  ) {
+    throw new Error(
+      'Remote MCP public URL must be an HTTPS origin with no path, query, or credentials.',
+    );
+  }
+  if (!/^[a-zA-Z0-9._-]{1,100}$/.test(options.secretService))
+    throw new Error('A dedicated OS secret-store service name is required.');
+  if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65535)
+    throw new Error('Invalid remote MCP port.');
+  return { ...options, publicUrl: url.origin };
+}
+
+/** Secret-store stdout stays inside the provider process and is never logged. */
+function readSecretService(service: string): Promise<Buffer> {
+  const command = process.platform === 'darwin' ? '/usr/bin/security' : 'secret-tool';
+  const args =
+    process.platform === 'darwin'
+      ? ['find-generic-password', '-s', service, '-a', 'helios-mcp', '-w']
+      : ['lookup', 'service', service, 'account', 'helios-mcp'];
+  return new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      { encoding: 'buffer', timeout: 5000, maxBuffer: 4096 },
+      (error, stdout) => {
+        if (error) {
+          stdout?.fill(0);
+          reject(new Error('OS secret store unavailable.'));
+          return;
+        }
+        // OS secret-store CLIs append one newline.
+        const value = Buffer.from(stdout.toString('utf8').trim());
+        stdout.fill(0);
+        if (value.length < 32 || value.length > 1024) {
+          value.fill(0);
+          reject(new Error('Use a dedicated random credential of 32–1024 characters.'));
+          return;
+        }
+        resolve(value);
+      },
+    );
+  });
+}
+export function createSecretStoreAuthenticator(read: () => Promise<Buffer>) {
+  return async (req: IncomingMessage): Promise<string | undefined> => {
+    const auth = req.headers.authorization;
+    if (!auth?.startsWith('Bearer ') || auth.length > 1031) return;
+    let expected: Buffer | undefined;
+    const supplied = Buffer.from(auth.slice(7));
+    try {
+      expected = await read();
+      return supplied.length === expected.length && timingSafeEqual(supplied, expected)
+        ? 'studio-owner'
+        : undefined;
+    } catch {
+      return undefined;
+    } finally {
+      supplied.fill(0);
+      expected?.fill(0);
+    }
+  };
+}
+
+/** Publish only this authenticated listener through an HTTPS reverse proxy. */
+export async function startRemoteMcp(
+  getPort: () => number,
+  studio: StudioPluginOptions & { projectRoot: string },
+  input: RemoteMcpOptions,
+) {
+  const options = validateRemoteOptions(input);
+  const probe = await readSecretService(options.secretService);
+  probe.fill(0);
+  const handler = createMcpHttpHandler(getPort, {
+    ...studio,
+    allowedHosts: [new URL(options.publicUrl).hostname],
+    allowedOrigins: [options.publicUrl],
+    authenticate: createSecretStoreAuthenticator(() => readSecretService(options.secretService)),
+  });
+  const server = createServer(handler.handle);
+  server.requestTimeout = 45000;
+  server.headersTimeout = 10000;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(options.port, '127.0.0.1', resolve);
+    });
+  } catch {
+    await handler.close();
+    throw new Error('Could not bind the remote MCP listener.');
+  }
+  return {
+    close: async () => {
+      await handler.close();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}

--- a/packages/studio/src/server/render-access.test.ts
+++ b/packages/studio/src/server/render-access.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { getRenderStatus, getRenderOutput, readRenderOutput } from './render-access';
+
+const state = vi.hoisted(() => ({ jobs: new Map<string, any>() }));
+vi.mock('./render-manager', () => ({ getJob: (id: string) => state.jobs.get(id) }));
+let root: string;
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'helios-access-'));
+  await fs.mkdir(path.join(root, 'renders'));
+  state.jobs.clear();
+});
+afterEach(async () => { await fs.rm(root, { recursive: true, force: true }); });
+
+it('reports unknown jobs, bounded wait expiry, real progress, and terminal failure', async () => {
+  await expect(getRenderStatus('missing')).rejects.toMatchObject({ code: 'JOB_NOT_FOUND' });
+  state.jobs.set('one', { id: 'one', status: 'rendering', progress: 0.4, compositionId: 'title' });
+  expect(await getRenderStatus('one', 15)).toMatchObject({ jobId: 'one', status: 'rendering', progress: 0.4, timedOut: true });
+  state.jobs.get('one').status = 'failed';
+  state.jobs.get('one').error = 'Encoder failed';
+  expect(await getRenderStatus('one', 15)).toMatchObject({ status: 'failed', error: 'Encoder failed', timedOut: false });
+  await expect(getRenderStatus('one', 30001)).rejects.toMatchObject({ code: 'INVALID_WAIT' });
+});
+
+it('returns completed bytes in bounded chunks without exposing local paths', async () => {
+  const bytes = Buffer.from('deterministic-output-fixture');
+  const file = path.join(root, 'renders', 'render-one.mp4');
+  await fs.writeFile(file, bytes);
+  state.jobs.set('one', { id: 'one', status: 'completed', outputPath: file });
+  const output = await getRenderOutput('one', root);
+  expect(output).toEqual({ jobId: 'one', mimeType: 'video/mp4', size: bytes.length, path: '/mcp/outputs/one', maxChunkBytes: 262144 });
+  const chunk = await readRenderOutput('one', root, 3, 5);
+  expect(Buffer.from(chunk.data, 'base64')).toEqual(bytes.subarray(3, 8));
+  expect(chunk).toMatchObject({ offset: 3, nextOffset: 8, eof: false });
+  await expect(readRenderOutput('one', root, 0, 262145)).rejects.toMatchObject({ code: 'INVALID_RANGE' });
+  await expect(readRenderOutput('one', root, 100, 1)).rejects.toMatchObject({ code: 'INVALID_RANGE' });
+});
+
+it('rejects not-ready, missing, empty, external and symlink outputs', async () => {
+  state.jobs.set('one', { id: 'one', status: 'rendering' });
+  await expect(getRenderOutput('one', root)).rejects.toMatchObject({ code: 'OUTPUT_NOT_READY' });
+  const job = state.jobs.get('one'); job.status = 'completed';
+  job.outputPath = path.join(root, 'outside.mp4');
+  await fs.writeFile(job.outputPath, 'private');
+  await expect(getRenderOutput('one', root)).rejects.toMatchObject({ code: 'UNSAFE_OUTPUT' });
+  const link = path.join(root, 'renders', 'render-one.mp4');
+  await fs.symlink(job.outputPath, link); job.outputPath = link;
+  await expect(getRenderOutput('one', root)).rejects.toMatchObject({ code: 'UNSAFE_OUTPUT' });
+  await fs.unlink(link);
+  await expect(getRenderOutput('one', root)).rejects.toMatchObject({ code: 'OUTPUT_MISSING' });
+  await fs.writeFile(link, '');
+  await expect(getRenderOutput('one', root)).rejects.toMatchObject({ code: 'OUTPUT_EMPTY' });
+  await fs.rm(path.join(root, 'renders'), { recursive: true });
+  await fs.mkdir(path.join(root, 'elsewhere'));
+  await fs.writeFile(path.join(root, 'elsewhere', 'render-one.mp4'), 'private');
+  await fs.symlink(path.join(root, 'elsewhere'), path.join(root, 'renders'));
+  await expect(getRenderOutput('one', root)).rejects.toMatchObject({ code: 'UNSAFE_OUTPUT' });
+});

--- a/packages/studio/src/server/render-access.ts
+++ b/packages/studio/src/server/render-access.ts
@@ -1,0 +1,174 @@
+import fs from 'node:fs/promises';
+import { constants } from 'node:fs';
+import path from 'node:path';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { getJob } from './render-manager';
+
+export class RenderAccessError extends Error {
+  constructor(
+    public code: string,
+    message: string,
+    public status = 400,
+  ) {
+    super(message);
+  }
+}
+export const MAX_CHUNK_BYTES = 256 * 1024;
+const terminal = new Set(['completed', 'failed', 'cancelled']);
+export function requireJob(id: string) {
+  const job = /^[a-zA-Z0-9-]{1,100}$/.test(id) ? getJob(id) : undefined;
+  if (!job) throw new RenderAccessError('JOB_NOT_FOUND', 'Render job not found.', 404);
+  return job;
+}
+export async function getRenderStatus(id: string, waitMs = 0, signal?: AbortSignal) {
+  if (!Number.isInteger(waitMs) || waitMs < 0 || waitMs > 30000) {
+    throw new RenderAccessError('INVALID_WAIT', 'waitMs must be an integer from 0 to 30000.');
+  }
+  const deadline = Date.now() + waitMs;
+  let job = requireJob(id);
+  while (!terminal.has(job.status) && Date.now() < deadline && !signal?.aborted) {
+    await new Promise((r) => setTimeout(r, Math.min(100, deadline - Date.now())));
+    job = requireJob(id);
+  }
+  return {
+    jobId: job.id,
+    status: job.status,
+    progress: job.progress,
+    error: job.error,
+    timedOut: waitMs > 0 && !terminal.has(job.status),
+  };
+}
+
+// Never accept a caller-supplied file path. Validate persisted history too.
+async function openOutput(id: string, root: string) {
+  const job = requireJob(id);
+  if (job.status !== 'completed')
+    throw new RenderAccessError('OUTPUT_NOT_READY', 'Render has not completed.', 409);
+  const dir = path.resolve(root, 'renders');
+  const expected = path.join(dir, `render-${id}.mp4`);
+  if (job.outputPath !== expected)
+    throw new RenderAccessError(
+      'UNSAFE_OUTPUT',
+      'Output is outside the managed render location.',
+      403,
+    );
+  try {
+    const realRoot = await fs.realpath(root);
+    if (
+      (await fs.realpath(dir)) !== path.join(realRoot, 'renders') ||
+      (await fs.lstat(expected)).isSymbolicLink() ||
+      (await fs.realpath(expected)) !== path.join(realRoot, 'renders', `render-${id}.mp4`)
+    ) {
+      throw new RenderAccessError('UNSAFE_OUTPUT', 'Output links are not supported.', 403);
+    }
+    const file = await fs.open(expected, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stat = await file.stat();
+    if (!stat.isFile() || stat.size === 0) {
+      await file.close();
+      throw new RenderAccessError('OUTPUT_EMPTY', 'Render output is not a nonempty file.', 409);
+    }
+    return { file, size: stat.size };
+  } catch (error) {
+    if (error instanceof RenderAccessError) throw error;
+    throw new RenderAccessError('OUTPUT_MISSING', 'Render output is no longer available.', 404);
+  }
+}
+export async function getRenderOutput(id: string, root: string) {
+  const { file, size } = await openOutput(id, root);
+  await file.close();
+  return {
+    jobId: id,
+    mimeType: 'video/mp4',
+    size,
+    path: `/mcp/outputs/${id}`,
+    maxChunkBytes: MAX_CHUNK_BYTES,
+  };
+}
+export async function readRenderOutput(
+  id: string,
+  root: string,
+  offset = 0,
+  length = MAX_CHUNK_BYTES,
+) {
+  if (
+    !Number.isSafeInteger(offset) ||
+    offset < 0 ||
+    !Number.isInteger(length) ||
+    length < 1 ||
+    length > MAX_CHUNK_BYTES
+  ) {
+    throw new RenderAccessError('INVALID_RANGE', 'Invalid output offset or chunk length.', 416);
+  }
+  const { file, size } = await openOutput(id, root);
+  try {
+    if (offset >= size)
+      throw new RenderAccessError('INVALID_RANGE', 'Offset exceeds output size.', 416);
+    const buffer = Buffer.alloc(Math.min(length, size - offset));
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, offset);
+    return {
+      jobId: id,
+      offset,
+      nextOffset: offset + bytesRead,
+      size,
+      eof: offset + bytesRead === size,
+      data: buffer.subarray(0, bytesRead).toString('base64'),
+    };
+  } finally {
+    await file.close();
+  }
+}
+
+export async function serveRenderOutput(
+  id: string,
+  root: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+) {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.writeHead(405, { Allow: 'GET, HEAD' });
+    res.end();
+    return;
+  }
+  const { file, size } = await openOutput(id, root);
+  let start = 0;
+  let end = size - 1;
+  const range = req.headers.range;
+  if (range) {
+    const match = /^bytes=(\d*)-(\d*)$/.exec(range);
+    if (match && (match[1] || match[2])) {
+      if (!match[1]) start = Math.max(0, size - Number(match[2]));
+      else {
+        start = Number(match[1]);
+        if (match[2]) end = Math.min(end, Number(match[2]));
+      }
+    } else start = size;
+    if (
+      !Number.isSafeInteger(start) ||
+      !Number.isSafeInteger(end) ||
+      start > end ||
+      start >= size
+    ) {
+      await file.close();
+      res.writeHead(416, { 'Content-Range': `bytes */${size}` });
+      res.end();
+      return;
+    }
+  }
+  res.writeHead(range ? 206 : 200, {
+    'Content-Type': 'video/mp4',
+    'Content-Length': end - start + 1,
+    'Accept-Ranges': 'bytes',
+    'Cache-Control': 'private, no-store',
+    'X-Content-Type-Options': 'nosniff',
+    ...(range ? { 'Content-Range': `bytes ${start}-${end}/${size}` } : {}),
+  });
+  if (req.method === 'HEAD') {
+    await file.close();
+    res.end();
+    return;
+  }
+  const stream = file.createReadStream({ start, end });
+  res.on('close', () => stream.destroy());
+  stream.on('error', () => res.destroy());
+  stream.pipe(res);
+}

--- a/packages/studio/src/server/render-lifecycle.test.ts
+++ b/packages/studio/src/server/render-lifecycle.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment node
+import { afterEach, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+const fixture = vi.hoisted(() => ({ render: vi.fn() }));
+vi.mock('@helios-project/renderer', () => ({ RenderOrchestrator: { render: fixture.render }, Renderer: class {} }));
+import { initializeRenderManager, startRender, getJob, cancelJob } from './render-manager';
+let root: string;
+afterEach(async () => { if (root) await fs.rm(root, { recursive: true, force: true }); });
+it('pins project ownership, uses unique IDs, and keeps cancellation terminal after late renderer completion', async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'helios-lifecycle-'));
+  await initializeRenderManager(root);
+  const pending: (() => void)[] = [];
+  fixture.render.mockImplementation((_url, output) => new Promise<void>(resolve => {
+    pending.push(async () => { await fs.writeFile(output, 'fixture-video'); resolve(); });
+  }));
+  const [a, b] = await Promise.all([startRender({ compositionUrl: '/a/composition.html' }, 5173), startRender({ compositionUrl: '/b/composition.html' }, 5173)]);
+  expect(a === b).toBe(false);
+  await expect(initializeRenderManager(path.join(root, 'another-owner'))).rejects.toThrow('project');
+  await vi.waitFor(() => expect(pending.length).toBe(2));
+  expect(await cancelJob(a)).toBe(true);
+  pending.forEach(f => f());
+  await vi.waitFor(() => expect(getJob(b)?.status).toBe('completed'));
+  expect(getJob(a)?.status).toBe('cancelled');
+  fixture.render.mockRejectedValueOnce(new Error('Encoder failed'));
+  const c = await startRender({ compositionUrl: '/broken/composition.html' }, 5173);
+  await vi.waitFor(() => expect(getJob(c)).toMatchObject({ status: 'failed', error: 'Encoder failed' }));
+});

--- a/packages/studio/src/server/render-manager.ts
+++ b/packages/studio/src/server/render-manager.ts
@@ -1,6 +1,7 @@
 import { Renderer, RenderOrchestrator, DistributedRenderOptions, RendererOptions } from '@helios-project/renderer';
 import path from 'path';
 import fs from 'fs';
+import { randomUUID } from 'node:crypto';
 import { pathToFileURL } from 'url';
 import { getProjectRoot } from './discovery';
 
@@ -43,9 +44,18 @@ const jobs = new Map<string, RenderJob>();
 const jobControllers = new Map<string, AbortController>();
 
 const JOBS_FILE = 'jobs.json';
+let activeProjectRoot: string | undefined;
+const projectRootForJobs = () => activeProjectRoot ?? getProjectRoot(process.cwd());
+
+/** A process is an owner boundary. Never mix another project's history into it. */
+export async function initializeRenderManager(root: string) {
+  const resolved = path.resolve(root);
+  if (activeProjectRoot && activeProjectRoot !== resolved) throw new Error('Studio is already bound to another project. Start a separate process.');
+  if (!activeProjectRoot) { activeProjectRoot = resolved; loadJobs(); }
+}
 
 function getJobsFilePath() {
-  const projectRoot = getProjectRoot(process.cwd());
+  const projectRoot = projectRootForJobs();
   return path.resolve(projectRoot, 'renders', JOBS_FILE);
 }
 
@@ -110,10 +120,10 @@ function loadJobs() {
   }
 }
 
-// Initialize jobs from disk
-loadJobs();
+// Load explicitly at startup, after the project root has been pinned.
 
 export interface StartRenderOptions {
+  compositionId?: string;
   compositionUrl: string; // The URL to visit (e.g. /@fs/...)
   width?: number;
   height?: number;
@@ -238,9 +248,9 @@ export function getRenderJobSpec(options: StartRenderOptions): JobSpec {
 }
 
 export async function startRender(options: StartRenderOptions, serverPort: number): Promise<string> {
-  const jobId = Date.now().toString();
+  const jobId = randomUUID();
   // Save to project root 'renders' directory
-  const projectRoot = getProjectRoot(process.cwd());
+  const projectRoot = projectRootForJobs();
   const rendersDir = path.resolve(projectRoot, 'renders');
   if (!fs.existsSync(rendersDir)) {
     fs.mkdirSync(rendersDir, { recursive: true });
@@ -253,7 +263,7 @@ export async function startRender(options: StartRenderOptions, serverPort: numbe
     id: jobId,
     status: 'queued',
     progress: 0,
-    compositionId: options.compositionUrl,
+    compositionId: options.compositionId ?? options.compositionUrl,
     outputPath,
     outputUrl,
     createdAt: Date.now(),
@@ -262,14 +272,14 @@ export async function startRender(options: StartRenderOptions, serverPort: numbe
   };
 
   jobs.set(jobId, job);
-  await saveJobs();
-
   const controller = new AbortController();
   jobControllers.set(jobId, controller);
+  await saveJobs();
 
   // Run in background
   (async () => {
     try {
+      controller.signal.throwIfAborted();
       job.status = 'rendering';
       await saveJobs();
 
@@ -297,7 +307,7 @@ export async function startRender(options: StartRenderOptions, serverPort: numbe
         videoCodec: options.videoCodec,
         pixelFormat: options.pixelFormat,
         inputProps: options.inputProps,
-        concurrency: options.concurrency,
+        concurrency: options.concurrency ?? 1,
         hwAccel: options.hwAccel,
         webCodecsPreference: options.webCodecsPreference
       };
@@ -308,6 +318,7 @@ export async function startRender(options: StartRenderOptions, serverPort: numbe
         },
         signal: controller.signal
       });
+      controller.signal.throwIfAborted();
 
       // Verify file exists and has size
       if (fs.existsSync(outputPath)) {
@@ -324,7 +335,7 @@ export async function startRender(options: StartRenderOptions, serverPort: numbe
       await saveJobs();
       console.log(`[RenderManager] Job ${jobId} completed: ${outputPath}`);
     } catch (e: any) {
-      if (e.message === 'Aborted') {
+      if (controller.signal.aborted || e.message === 'Aborted') {
         console.log(`[RenderManager] Job ${jobId} was cancelled.`);
         job.status = 'cancelled';
       } else {

--- a/packages/studio/src/server/templates/index.ts
+++ b/packages/studio/src/server/templates/index.ts
@@ -5,8 +5,10 @@ import { svelteTemplate } from './svelte';
 import { solidTemplate } from './solid';
 import { threejsTemplate } from './threejs';
 import { Template } from './types';
+import { titleExplainerTemplate } from './title-explainer';
 
 export const templates: Record<string, Template> = {
+  'title-explainer': titleExplainerTemplate,
   vanilla: vanillaTemplate,
   react: reactTemplate,
   vue: vueTemplate,

--- a/packages/studio/src/server/templates/title-explainer.test.ts
+++ b/packages/studio/src/server/templates/title-explainer.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment node
+import { expect, it } from 'vitest';
+import vm from 'node:vm';
+import { templates } from './index';
+
+it('draws the explicit brief deterministically when seeking without prior frames', () => {
+  const template = templates['title-explainer'];
+  expect(template).toBeDefined();
+  const html = template.generate('Safe </title><script>bad()</script>', { width: 1280, height: 720, fps: 24, duration: 8, defaultProps: { title: 'From a thought to a film', subtitle: 'Create. Render. Play.' } })[0].content;
+  expect(html).not.toContain('<script>bad()');
+  const text: string[] = [];
+  const ctx = new Proxy({ measureText: (s: string) => ({ width: s.length * 20 }), fillText: (s: string) => text.push(s), createLinearGradient: () => ({ addColorStop() {} }) }, { get: (o: any, k) => o[k] ?? (() => {}) });
+  let subscriber: (state: any) => void;
+  const helios = { fps: { value: 24 }, bindToDocumentTimeline() {}, subscribe(fn: any) { subscriber = fn; }, getState: () => ({ currentFrame: 0, fps: 24, inputProps: {} }) };
+  const context = { document: { getElementById: () => ({ getContext: () => ctx }) }, window: {} as any, Helios: class { constructor() { return helios; } } };
+  const script = html.match(/<script type="module">([\s\S]*)<\/script>/)![1].replace(/import .*?;/, '');
+  vm.runInNewContext(script, context);
+  expect(context.window.helios).toBe(helios);
+  const seek = () => { text.length = 0; subscriber!({ currentFrame: 100, fps: 24, inputProps: { title: 'From a thought to a film', subtitle: 'Create. Render. Play.' } }); return [...text]; };
+  const a = seek(); subscriber!({ currentFrame: 180, fps: 24, inputProps: {} });
+  expect(seek()).toEqual(a);
+  expect(a.join(' ')).toContain('From a thought to a film');
+});

--- a/packages/studio/src/server/templates/title-explainer.ts
+++ b/packages/studio/src/server/templates/title-explainer.ts
@@ -1,0 +1,73 @@
+import type { Template } from './types';
+
+/** Self-contained vector artwork. No network fonts, random state, or media. */
+export const titleExplainerTemplate: Template = {
+  id: 'title-explainer', label: 'Title explainer',
+  generate(name, options) {
+    const data = JSON.stringify({ title: name, subtitle: 'A thought. A composition. A finished film.', ...options.defaultProps }).replace(/</g, '\\u003c');
+    return [{ path: 'composition.html', content: `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Helios title explainer</title>
+<style>html,body{margin:0;width:100%;height:100%;overflow:hidden;background:#0c1622}canvas{width:100%;height:100%;display:block}</style></head>
+<body><canvas id="scene" width="${options.width}" height="${options.height}"></canvas>
+<script type="module">
+import { Helios } from '@helios-project/core';
+const defaults = ${data};
+const canvas = document.getElementById('scene');
+const ctx = canvas.getContext('2d');
+const duration = ${options.duration};
+const helios = new Helios({ duration, fps: ${options.fps}, inputProps: defaults });
+window.helios = helios;
+helios.bindToDocumentTimeline();
+const clamp = x => Math.max(0, Math.min(1, x));
+const ease = x => Math.sqrt(1 - Math.pow(clamp(x) - 1, 2));
+function draw(state) {
+  const t = state.currentFrame / state.fps;
+  const p = clamp(t / duration);
+  const props = { ...defaults, ...state.inputProps };
+  ctx.save(); ctx.scale(${options.width} / 1280, ${options.height} / 720);
+  const gradient = ctx.createLinearGradient(0, 0, 1280, 720);
+  gradient.addColorStop(0, '#0c1622'); gradient.addColorStop(1, '#153632');
+  ctx.fillStyle = gradient; ctx.fillRect(0, 0, 1280, 720);
+  // Persistent drafting grid and a slow orbital field.
+  ctx.strokeStyle = '#bed7c810'; ctx.lineWidth = 1;
+  for (let x = -80; x < 1400; x += 80) { ctx.beginPath(); ctx.moveTo(x + p * 36, 0); ctx.lineTo(x + p * 36, 720); ctx.stroke(); }
+  for (let y = 0; y < 800; y += 80) { ctx.beginPath(); ctx.moveTo(0, y - p * 24); ctx.lineTo(1280, y - p * 24); ctx.stroke(); }
+  ctx.save(); ctx.translate(1060, 280); ctx.rotate(-0.3 + p * 0.45);
+  for (let i = 0; i < 4; i++) { ctx.strokeStyle = '#b8efb4' + ['20','16','10','08'][i]; ctx.lineWidth = 1.5; ctx.beginPath(); ctx.ellipse(0, 0, 120 + i * 42, 210 + i * 26, 0, 0, Math.PI * 2); ctx.stroke(); }
+  ctx.fillStyle = '#d8f5a2'; ctx.beginPath(); ctx.arc(120 * Math.cos(p * 4), 210 * Math.sin(p * 4), 7, 0, Math.PI * 2); ctx.fill(); ctx.restore();
+  ctx.fillStyle = '#d8f5a2'; ctx.font = '600 18px Arial'; ctx.fillText('HELIOS  /  KODY', 80, 82);
+  ctx.fillStyle = '#a6bab1'; ctx.font = '14px monospace'; ctx.fillText('IDEAS INTO MOTION', 990, 82);
+  const title = String(props.title).slice(0, 100);
+  const words = title.split(/\\s+/); const lines = []; let line = '';
+  ctx.font = '700 78px Arial';
+  for (const word of words) { const candidate = line ? line + ' ' + word : word; if (ctx.measureText(candidate).width > 920 && line) { lines.push(line); line = word; } else line = candidate; }
+  if (line) lines.push(line);
+  lines.slice(0, 3).forEach((text, i) => {
+    const enter = ease((t - 0.2 - i * 0.12) / 0.8);
+    ctx.globalAlpha = enter; ctx.fillStyle = '#f2f0df';
+    ctx.fillText(text, 80, 230 + i * 88 + (1 - enter) * 45);
+  });
+  ctx.globalAlpha = 1; ctx.fillStyle = '#d8f5a2'; ctx.fillRect(82, 250 + Math.min(lines.length - 1, 2) * 88, 170 * ease((t - 0.7) / 0.8), 5);
+  ctx.globalAlpha = ease((t - 1) / 0.8); ctx.font = '24px Arial'; ctx.fillStyle = '#b5c7bc';
+  ctx.fillText(String(props.subtitle).slice(0, 85), 82, 308 + Math.min(lines.length - 1, 2) * 88);
+  ctx.globalAlpha = 1;
+  const labels = ['01  BRIEF', '02  COMPOSE', '03  RENDER', '04  PLAY'];
+  const active = Math.min(3, Math.floor(p * 4.3));
+  ctx.fillStyle = '#ffffff16'; ctx.fillRect(80, 587, 1120, 2);
+  ctx.fillStyle = '#d8f5a2'; ctx.fillRect(80, 587, 1120 * ease(p), 2);
+  labels.forEach((label, i) => {
+    const x = 80 + i * 294; const enter = ease((t - 0.4 - i * 0.1) / 0.6);
+    ctx.globalAlpha = enter; ctx.fillStyle = i <= active ? '#d8f5a2' : '#697d76';
+    ctx.beginPath(); ctx.arc(x + 4, 588, i === active ? 7 : 4, 0, Math.PI * 2); ctx.fill();
+    ctx.font = '600 16px monospace'; ctx.fillText(label, x, 632);
+  });
+  ctx.globalAlpha = 1; ctx.fillStyle = '#82978e'; ctx.font = '13px monospace';
+  ctx.fillText('BROWSER-NATIVE VIDEO', 80, 685);
+  ctx.fillText(p > 0.9 ? 'READY TO PLAY' : 'FRAME ' + String(Math.floor(state.currentFrame)).padStart(4, '0'), 1050, 685);
+  ctx.restore();
+}
+helios.subscribe(draw);
+draw(helios.getState());
+</script></body></html>` }];
+  },
+};

--- a/packages/studio/src/server/types.ts
+++ b/packages/studio/src/server/types.ts
@@ -7,6 +7,9 @@ export interface StudioComponentDefinition {
 }
 
 export interface StudioPluginOptions {
+  /** Explicit project directory, pinned for the lifetime of this Studio process. */
+  projectRoot?: string;
+  remoteMcp?: import('./remote-startup').RemoteMcpOptions;
   studioRoot?: string;
   skillsRoot?: string;
   components?: StudioComponentDefinition[];


### PR DESCRIPTION
**Review-hold incident:** This PR was created with `--draft` for owner review. The repository's existing `Auto-merge Jules PRs` workflow targets owner-authored PRs, calls `gh pr ready`, and enables merging. GitHub Actions marked this draft ready at 2026-09-08 21:19:50 UTC and merged it at 21:19:53 UTC without a requested merge. An immediate attempt to restore draft status found the PR already closed. No revert or workflow change has been made. Publication, deployment, upstream submission, and reviewer requests remain on hold. [Automation run](https://github.com/BintzGavin/helios/actions/runs/34279942237).

A brief submitted from Kody can now become a composition, a tracked render, and a playable MP4. Previously MCP stopped at a queued job ID, and remote connection setup required handwritten authentication infrastructure.

This adds composition discovery, bounded render-status waits, cancellation, completed-output metadata, authenticated chunk reads, and HTTP Range/HEAD output access using the existing Studio render manager. A separate loopback MCP listener authenticates every route against a dedicated OS secret-store entry, restricts Host/Origin and paths, and supports independent Streamable HTTP/SSE sessions. The supplied Caddy configuration handles TLS without exposing Studio/Vite editing routes.

The provider-owned user package in `integrations/kody/package` creates the explicit deterministic title-explainer template, records jobs in the user's package storage, shows progress, and serves playback through authenticated MCP reads. It uses Kody's supported saved-package and package-app contracts. One Studio process/project/credential is one owner boundary.

The real demo also exposed and fixed two deterministic-seeking defects: a shared CDP Runtime session omitted execution contexts, and floating-point flooring selected the previous frame. User-project render URLs now pass through Vite's HTML transform.

```mermaid
sequenceDiagram
  participant Kody as Private Kody package
  participant MCP as Authenticated Helios MCP
  participant Studio as Studio render manager
  participant Browser as Chromium and FFmpeg
  Kody->>MCP: create_composition with title brief
  Kody->>MCP: render_composition with stable composition ID
  MCP->>Studio: startRender and stable job ID
  Studio->>Browser: Seek deterministic frames and encode MP4
  Kody->>MCP: get_render_status with bounded wait
  MCP-->>Kody: completed or failed or cancelled
  Kody->>MCP: read_render_output for authorized byte ranges
  Kody-->>Kody: Play video in the private package app
```

Validation: Studio server 94 tests/16 suites; CLI Studio 9 tests; package workflow/app 4 behavior suites; actual Kody authored-manifest schema; real-browser shared-session seek regression plus existing determinism/offset/stability checks; Core/Player/Renderer/Infrastructure/Studio/CLI builds and Studio TypeScript gate. Six targeted authentication/ownership/path/cancellation mutants were killed.

The real local demo passed tool → render → output → package-app browser playback/seeking, plus real browser failure and cancellation. Decoded output checks reject black/frozen frames and verify 1280×720, H.264, 24 fps, 192 frames, and 8.000 seconds. The video and screenshots were saved outside the repository and shown to the owner. Reproduce with `npx tsx integrations/kody/verify-local.mts /tmp/helios-kody-demo.mp4` after building prerequisites; see `integrations/kody/VALIDATION.md`.

Remaining live checks: public DNS/TLS/proxy behavior, OS secret-store pairing with Kody, signed-in hosted execution/playback and cross-account access. Fixture authentication does not establish those facts. The Kody full validation attempt hit its E2E web-server startup timeout and was stopped; focused Kody tests and formatting passed.

Companion Kody draft: https://github.com/BintzGavin/kody/pull/1. Hold for owner review. No upstream submission, ready-for-review change, reviewers, merge, deployment, or package release is requested.
